### PR TITLE
add a quick and dirty makefile to build on linux

### DIFF
--- a/examples/opengl_example/Makefile
+++ b/examples/opengl_example/Makefile
@@ -1,0 +1,18 @@
+#
+# Quick and dirty makefile to build on Linux
+# tested on Ubuntu 14.04.1 32bit
+#
+
+SRC = main.cpp ../../imgui.cpp
+
+OBJ = $(SRC:.cpp=.o)
+
+CXXFLAGS = -I../../ `pkg-config --cflags glfw3`
+
+LIBS = `pkg-config --static --libs glfw3` -lGLEW
+
+all: $(OBJ)
+	$(CXX) $(OBJ) $(LIBS)
+
+clean:
+	$(RM) -f $(OBJ)


### PR DESCRIPTION
Build without hassles on Linux except for this benign warning:

imgui.cpp: In function ‘void ImGui::TextUnformatted(const char_, const char_)’:
../../imgui.cpp:2375:14: warning: zero-length gnu_printf format string [-Wformat-zero-length]
     printf("");
              ^
