### PR TITLE
Fix unchecked access to command buffer.

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -4660,10 +4660,14 @@ void ImDrawList::ReserveVertices(unsigned int vtx_count)
 {
 	if (vtx_count > 0)
 	{
-		ImDrawCmd& draw_cmd = commands.back();
-		draw_cmd.vtx_count += vtx_count;
-		vtx_buffer.resize(vtx_buffer.size() + vtx_count);
-		vtx_write = &vtx_buffer[vtx_buffer.size() - vtx_count];
+            if (!commands.empty())
+            {
+                ImDrawCmd& draw_cmd = commands.back();
+                draw_cmd.vtx_count += vtx_count;
+            }
+
+            vtx_buffer.resize(vtx_buffer.size() + vtx_count);
+            vtx_write = &vtx_buffer[vtx_buffer.size() - vtx_count];
 	}
 }
 


### PR DESCRIPTION
In the example application, clicking on the Combo list under Widgets
will cause an assert.  This commit checks if the command buffer is empty
before attempting to access it.

I'm not too familiar with the inner workings of your library, so you'll probably want to check that this doesn't interfere with other commands, but a quick check through the example application seems like it works ok...

Also, may have ruined indenting with emacs.
