### PR TITLE
Add `emulateIndependentWindows` flag to DirectX example

### DIFF
--- a/examples/directx9_example/main.cpp
+++ b/examples/directx9_example/main.cpp
@@ -7,7 +7,7 @@
 
 #pragma warning (disable: 4996)		// 'This function or variable may be unsafe': strdup
 
-static bool emulateIndependentWindows = true;
+static bool emulateIndependentWindows = false;
 
 static HWND hWnd;
 static LPDIRECT3D9             g_pD3D = NULL;		// Used to create the D3DDevice

--- a/examples/directx9_example/main.cpp
+++ b/examples/directx9_example/main.cpp
@@ -7,6 +7,8 @@
 
 #pragma warning (disable: 4996)		// 'This function or variable may be unsafe': strdup
 
+static bool emulateIndependentWindows = true;
+
 static HWND hWnd;
 static LPDIRECT3D9             g_pD3D = NULL;		// Used to create the D3DDevice
 static LPDIRECT3DDEVICE9       g_pd3dDevice = NULL; // Our rendering device
@@ -251,12 +253,24 @@ void UpdateImGui()
 
 int WINAPI wWinMain(HINSTANCE hInst, HINSTANCE, LPWSTR, int)
 {
+    UINT style = emulateIndependentWindows? CS_HREDRAW | CS_VREDRAW : CS_CLASSDC;
     // Register the window class
-    WNDCLASSEX wc = { sizeof(WNDCLASSEX), CS_CLASSDC, MsgProc, 0L, 0L, GetModuleHandle(NULL), NULL, NULL, NULL, NULL, L"ImGui Example", NULL };
+    WNDCLASSEX wc = { sizeof(WNDCLASSEX), style, MsgProc, 0L, 0L, GetModuleHandle(NULL), NULL, NULL, NULL, NULL, L"ImGui Example", NULL };
     RegisterClassEx(&wc);
 
     // Create the application's window
-    hWnd = CreateWindow(L"ImGui Example", L"ImGui DirectX9 Example", WS_OVERLAPPEDWINDOW, 100, 100, 1280, 800, NULL, NULL, wc.hInstance, NULL);
+	if(emulateIndependentWindows)
+	{
+		int screenWidth = GetSystemMetrics(SM_CXSCREEN);
+		int screenHeight = GetSystemMetrics(SM_CYSCREEN);
+		hWnd = CreateWindowEx(WS_EX_LAYERED | WS_EX_TOPMOST, L"ImGui Example",
+			L"ImGui DirectX9 Example", WS_POPUP, 0, 0, screenWidth, screenHeight, NULL, NULL, wc.hInstance, NULL);
+		SetLayeredWindowAttributes(hWnd, RGB(204, 153, 153), 255, LWA_COLORKEY);
+	}
+	else
+	{
+		hWnd = CreateWindow(L"ImGui Example", L"ImGui DirectX9 Example", WS_OVERLAPPEDWINDOW, 100, 100, 1280, 800, NULL, NULL, wc.hInstance, NULL);
+	}
 
 	if (!QueryPerformanceFrequency((LARGE_INTEGER *)&ticks_per_second))
 		return 1;


### PR DESCRIPTION
If the flag is set, the example tries to behave as if the ImGui
windows were first-class citizens in OS windowing.
This does not, in anyway, modifies the ImGui functionality but only shows how it can be used to set up "independent" windows.

The current approach has a few limitations:
 - framerate is significantly lower than in the original example
 - mouse movements that start inside the window cannot extend to the outside
   it, that is, resizing, moving and scrolling does not work too good
 - the process is not closed when all of the windows are closed