### PR TITLE
Disable client state in OpenGL example after rendering.

### DIFF
--- a/examples/opengl_example/main.cpp
+++ b/examples/opengl_example/main.cpp
@@ -61,6 +61,9 @@ static void ImImpl_RenderDrawLists(ImDrawList** const cmd_lists, int cmd_lists_c
         }
     }
     glDisable(GL_SCISSOR_TEST);
+    glDisableClientState(GL_COLOR_ARRAY);
+    glDisableClientState(GL_TEXTURE_COORD_ARRAY);
+    glDisableClientState(GL_VERTEX_ARRAY);
 }
 
 static const char* ImImpl_GetClipboardTextFn()


### PR DESCRIPTION
Using the example code in another application that has other rendering
code can cause rendering bugs or memory access errors if client state
is not disabled.
