### PR TITLE
Remove imconfig.h include.

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -14,7 +14,6 @@ struct ImGuiStorage;
 struct ImGuiStyle;
 struct ImGuiWindow;
 
-#include "imconfig.h"
 #include <float.h>          // FLT_MAX
 #include <stdarg.h>         // va_list
 #include <stdlib.h>         // NULL, malloc


### PR DESCRIPTION
I think that [imconfig.h](https://github.com/ocornut/imgui/blob/master/imconfig.h) should _not_ be included globaly, but included on the project level.

When it's global it's difficult to create shared libraries because now you have **two** header files to deal with. And, no one wants an extra header files that they don't need hanging around in `/usr/lib/`.

It would be better for the user to include this at the top of their main file before including [imgui.h](https://github.com/ocornut/imgui/blob/master/imgui.h) on as-needed basis.

I created an [AUR package](https://aur.archlinux.org/packages/imgui/) and it's kinda hack-ish to remove this line with sed. I'd rather it not be the default.
