### PR TITLE
Fixed font loading when building on Emscripten

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -4866,7 +4866,12 @@ bool	ImBitmapFont::LoadFromMemory(const void* data, int data_size)
 	{
 		const unsigned char block_type = *(unsigned char*)p;
 		p += sizeof(unsigned char);
+#ifdef __EMSCRIPTEN__
+		ImU32 block_size;
+		memcpy(&block_size, p, sizeof(ImU32));
+#else
 		const ImU32 block_size = *(ImU32*)p;
+#endif
 		p += sizeof(ImU32);
 
 		switch (block_type)


### PR DESCRIPTION
Emscripten is 4 bytes aligned in memory and fails unaligned reads silently unless you specify "-s SAFE_HEAP=1" on the linker command line. This was resulting on the block_size to be read incorrectly and the default embedded font not to be loaded. 
memcpy bypasses the alignment and sets a correct block_size.
