### PR TITLE
Fix SetColumnOffset() subtracting a bool value instead of scrollbar width

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -6378,7 +6378,7 @@ void ImGui::SetColumnOffset(int column_index, float offset)
     const ImGuiID column_id = window->DC.ColumnsSetID + ImGuiID(column_index);
 
     const float min_x = window->DC.ColumnsStartX;
-    const float max_x = window->Size.x - (window->ScrollbarY);// - window->WindowPadding().x;
+    const float max_x = window->Size.x - (g.Style.ScrollBarWidth);// - window->WindowPadding().x;
     const float t = (offset - min_x) / (max_x - min_x);
     window->StateStorage.SetFloat(column_id, t);
     window->DC.ColumnsOffsetsT[column_index] = t;


### PR DESCRIPTION
Saw the new commits and version you pushed out.  I noticed a regression when I updated my programs with it, where clicking on column borders to resize would cause them to quickly move to the left, even if I didn't move the mouse.

Looked at the code real quick and noticed something a little fishy when x values were subtracted with something referencing y, and then noticed it was also a bool.  Switched it back to g.Style.ScrollBarWidth and things seemed to get back to normal!