### PR TITLE
Set focus to root window when given a child window.

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -3127,6 +3127,17 @@ void ImGui::End()
 static void FocusWindow(ImGuiWindow* window)
 {
     ImGuiState& g = *GImGui;
+
+    // Find root (if we are a child window)
+    size_t root_idx = g.CurrentWindowStack.size() - 1;
+    while (root_idx > 0)
+    {
+        if ((g.CurrentWindowStack[root_idx]->Flags & ImGuiWindowFlags_ChildWindow) == 0)
+            break;
+        root_idx--;
+    }
+    window = g.CurrentWindowStack[root_idx];
+
     g.FocusedWindow = window;
 
     if (g.Windows.back() == window)


### PR DESCRIPTION
Hey Omar!

Found another issue which I might have a fix for.

```
ImGui::Begin("Bottom window");

ImGui::Text("Buttons in this region do not take focus");
ImGui::BeginChild("child", ImVec2(0.0f, 100.0f), true);
ImGui::Button("Won't focus 1");
ImGui::Button("Won't focus 2");
ImGui::Button("Won't focus 3");
ImGui::Button("Won't focus 4");
ImGui::EndChild();

ImGui::Text("But these do");
ImGui::Button("Focus 1");
ImGui::Button("Focus 2");
ImGui::Button("Focus 3");
ImGui::Button("Focus 4");
ImGui::End();

ImGui::Begin("Top window");
ImGui::End();
```

When "Top window" has focus and you click on buttons inside the child region of "Bottom window", the bottom window does not take focus.

Sleuthing around the code, I noticed that ImGui::Begin() has some logic to find the root of the window and FocusWindow() doesn't do this.  I copied the code from https://github.com/ocornut/imgui/blob/17685dae87a94c6501d09e968fe53505181fcc87/imgui.cpp#L2722-L2730, which seems to fix the issue.

-Dale Kim