### PR TITLE
Defined bool ImGui::GetWindowCollapsed().

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -3487,6 +3487,12 @@ void ImGui::SetWindowCollapsed(bool collapsed, ImGuiSetCond cond)
     SetWindowCollapsed(window, collapsed, cond);
 }
 
+bool ImGui::GetWindowCollapsed()
+{
+    ImGuiWindow* window = GetCurrentWindow();
+    return window->Collapsed;
+}
+
 void ImGui::SetWindowCollapsed(const char* name, bool collapsed, ImGuiSetCond cond)
 {
     ImGuiWindow* window = FindWindowByName(name);


### PR DESCRIPTION
The function was declared in the header, but when I tried to call it in my own code, I hit a linker error since it wasn't defined!