### PR TITLE
opengl3+opengl example: if content window doesn't have focus, tell ImGui...

### DIFF
--- a/examples/opengl3_example/imgui_impl_glfw_gl3.cpp
+++ b/examples/opengl3_example/imgui_impl_glfw_gl3.cpp
@@ -329,11 +329,18 @@ void ImGui_ImplGlfwGL3_NewFrame()
 
     // Setup inputs
     // (we already got mouse wheel, keyboard keys & characters from glfw callbacks polled in glfwPollEvents())
-    double mouse_x, mouse_y;
-    glfwGetCursorPos(g_Window, &mouse_x, &mouse_y);
-    mouse_x *= (float)display_w / w;                                                    // Convert mouse coordinates to pixels
-    mouse_y *= (float)display_h / h;
-    io.MousePos = ImVec2((float)mouse_x, (float)mouse_y);                               // Mouse position, in pixels (set to -1,-1 if no mouse / on another screen, etc.)
+    if (glfwGetWindowAttrib(g_Window, GLFW_FOCUSED))
+    {
+    	double mouse_x, mouse_y;
+    	glfwGetCursorPos(g_Window, &mouse_x, &mouse_y);
+    	mouse_x *= (float)display_w / w;                                                    // Convert mouse coordinates to pixels
+    	mouse_y *= (float)display_h / h;
+    	io.MousePos = ImVec2((float)mouse_x, (float)mouse_y);                               // Mouse position, in pixels (set to -1,-1 if no mouse / on another screen, etc.)
+    }
+    else
+    {
+    	io.MousePos = ImVec2(-1,-1);
+    }
 
     for (int i = 0; i < 3; i++)
     {

--- a/examples/opengl_example/imgui_impl_glfw.cpp
+++ b/examples/opengl_example/imgui_impl_glfw.cpp
@@ -233,11 +233,18 @@ void ImGui_ImplGlfw_NewFrame()
 
     // Setup inputs
     // (we already got mouse wheel, keyboard keys & characters from glfw callbacks polled in glfwPollEvents())
-    double mouse_x, mouse_y;
-    glfwGetCursorPos(g_Window, &mouse_x, &mouse_y);
-    mouse_x *= (float)display_w / w;                                                    // Convert mouse coordinates to pixels
-    mouse_y *= (float)display_h / h;
-    io.MousePos = ImVec2((float)mouse_x, (float)mouse_y);                               // Mouse position, in pixels (set to -1,-1 if no mouse / on another screen, etc.)
+    if (glfwGetWindowAttrib(g_Window, GLFW_FOCUSED))
+    {
+    	double mouse_x, mouse_y;
+    	glfwGetCursorPos(g_Window, &mouse_x, &mouse_y);
+    	mouse_x *= (float)display_w / w;                                                    // Convert mouse coordinates to pixels
+    	mouse_y *= (float)display_h / h;
+    	io.MousePos = ImVec2((float)mouse_x, (float)mouse_y);                               // Mouse position, in pixels (set to -1,-1 if no mouse / on another screen, etc.)
+    }
+    else
+    {
+    	io.MousePos = ImVec2(-1,-1);
+    }
    
     for (int i = 0; i < 3; i++)
     {


### PR DESCRIPTION
... we don't have a mouse position.  e.g. avoids tooltips popping up in imgui app when you're interacting with a different app window that overlaps it.

Note, this doesn't spoil (for example) trying to drag an ImGui window off the edge of the content area, since Glfw keeps a mouse grab when mouse buttons are down.