### PR TITLE
Child Windows: support the ImGuiWindowFlags_AlwaysAutoResize flag for ch...

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -2597,13 +2597,13 @@ bool ImGui::BeginChild(const char* str_id, const ImVec2& size_arg, bool border, 
     ImVec2 size = size_arg;
     if (size.x <= 0.0f)
     {
-        if (size.x == 0.0f)
+        if (size.x == 0.0f && !(extra_flags & ImGuiWindowFlags_AlwaysAutoResize))
             flags |= ImGuiWindowFlags_ChildWindowAutoFitX;
         size.x = ImMax(content_max.x - cursor_pos.x, g.Style.WindowMinSize.x) - fabsf(size.x);
     }
     if (size.y <= 0.0f)
     {
-        if (size.y == 0.0f)
+        if (size.y == 0.0f && !(extra_flags & ImGuiWindowFlags_AlwaysAutoResize))
             flags |= ImGuiWindowFlags_ChildWindowAutoFitY;
         size.y = ImMax(content_max.y - cursor_pos.y, g.Style.WindowMinSize.y) - fabsf(size.y);
     }
@@ -2827,7 +2827,10 @@ bool ImGui::Begin(const char* name, bool* p_opened, const ImVec2& size, float bg
         {
             parent_window->DC.ChildWindows.push_back(window);
             window->Pos = window->PosFloat = parent_window->DC.CursorPos;
-            window->SizeFull = size;
+            if (!(flags & ImGuiWindowFlags_AlwaysAutoResize))
+            {
+            	window->SizeFull = size;
+            }
         }
     }
 

--- a/imgui.h
+++ b/imgui.h
@@ -163,7 +163,7 @@ namespace ImGui
     // See implementation in .cpp for details
     IMGUI_API bool          Begin(const char* name = "Debug", bool* p_opened = NULL, const ImVec2& initial_size = ImVec2(0,0), float bg_alpha = -1.0f, ImGuiWindowFlags flags = 0); // return false when window is collapsed, so you can early out in your code. passing 'bool* p_opened' displays a Close button on the upper-right corner of the window, the pointed value will be set to false when the button is pressed.
     IMGUI_API void          End();
-    IMGUI_API bool          BeginChild(const char* str_id, const ImVec2& size = ImVec2(0,0), bool border = false, ImGuiWindowFlags extra_flags = 0);            // size==0.0f: use remaining window size, size<0.0f: use remaining window size minus abs(size). on each axis.
+    IMGUI_API bool          BeginChild(const char* str_id, const ImVec2& size = ImVec2(0,0), bool border = false, ImGuiWindowFlags extra_flags = 0);            // if not AlwaysAutoResize then: size==0.0f: use remaining window size, size<0.0f: use remaining window size minus abs(size). on each axis.
     IMGUI_API bool          BeginChild(ImGuiID id, const ImVec2& size = ImVec2(0,0), bool border = false, ImGuiWindowFlags extra_flags = 0);                    // "
     IMGUI_API void          EndChild();
     IMGUI_API ImVec2        GetContentRegionMax();                                              // window or current column boundaries, in windows coordinates


### PR DESCRIPTION
...ild windows.

This appears to do the right thing in my testing, and has no impact on paths where the flag is not set.