### PR TITLE
Use fabs() instead of abs() to ensure we use floating point.

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -4826,7 +4826,7 @@ static bool SliderBehavior(const ImRect& frame_bb, const ImRect& slider_bb, ImGu
     RenderFrame(frame_bb.Min, frame_bb.Max, window->Color(ImGuiCol_FrameBg), true, style.FrameRounding);
 
     const bool is_finite = (v_min != -FLT_MAX && v_min != FLT_MAX && v_max != -FLT_MAX && v_max != FLT_MAX);
-    const bool is_non_linear = abs(power - 1.0f) > 0.0001f;
+    const bool is_non_linear = fabs(power - 1.0f) > 0.0001f;
 
     const float slider_sz = horizontal ? slider_bb.GetWidth() : slider_bb.GetHeight();
     float grab_sz;


### PR DESCRIPTION
Compiling with clang results in this warning:

```
dalekim1@lispy:/home/dalekim1/imgui/examples/opengl_example [master]> time make -j8
clang++ -I../../ `pkg-config --cflags glfw3` -Wall -c -o ../../imgui.o ../../imgui.cpp
../../imgui.cpp:4829:32: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
    const bool is_non_linear = abs(power - 1.0f) > 0.0001f;
                               ^
../../imgui.cpp:4829:32: note: use function 'std::abs' instead
    const bool is_non_linear = abs(power - 1.0f) > 0.0001f;
                               ^~~
                               std::abs
../../imgui.cpp:4829:32: note: include the header <cmath> or explicitly provide a declaration for 'std::abs'
1 warning generated.
clang++ -o imgui_example main.o imgui_impl_glfw.o ../../imgui.o -I../../ `pkg-config --cflags glfw3` -Wall `pkg-config --static --libs glfw3`
Build complete for Linux
```