### PR TITLE
Negative-sized clip rects are forbidden in GL

### DIFF
--- a/examples/opengl3_example/imgui_impl_glfw_gl3.cpp
+++ b/examples/opengl3_example/imgui_impl_glfw_gl3.cpp
@@ -1,6 +1,9 @@
 // ImGui GLFW binding with OpenGL3 + shaders
 // https://github.com/ocornut/imgui
 
+#include <algorithm>
+#include <cassert>
+
 #include <imgui.h>
 #include "imgui_impl_glfw_gl3.h"
 
@@ -98,7 +101,13 @@ static void ImGui_ImplGlfwGL3_RenderDrawLists(ImDrawList** const cmd_lists, int 
             else
             {
                 glBindTexture(GL_TEXTURE_2D, (GLuint)(intptr_t)pcmd->texture_id);
-                glScissor((int)pcmd->clip_rect.x, (int)(height - pcmd->clip_rect.w), (int)(pcmd->clip_rect.z - pcmd->clip_rect.x), (int)(pcmd->clip_rect.w - pcmd->clip_rect.y));
+                int scissor_width = (int)(pcmd->clip_rect.z - pcmd->clip_rect.x);
+                int scissor_height = (int)(pcmd->clip_rect.w - pcmd->clip_rect.y);
+                assert(scissor_width >= 0);
+                assert(scissor_height >= 0);
+                scissor_width = std::max(scissor_width, 0);
+                scissor_height = std::max(scissor_height, 0);
+                glScissor((int)pcmd->clip_rect.x, (int)(height - pcmd->clip_rect.w), scissor_width, scissor_height);
                 glDrawArrays(GL_TRIANGLES, vtx_offset, pcmd->vtx_count);
             }
             vtx_offset += pcmd->vtx_count;

--- a/examples/opengl3_example/imgui_impl_glfw_gl3.cpp
+++ b/examples/opengl3_example/imgui_impl_glfw_gl3.cpp
@@ -2,7 +2,6 @@
 // https://github.com/ocornut/imgui
 
 #include <algorithm>
-#include <cassert>
 
 #include <imgui.h>
 #include "imgui_impl_glfw_gl3.h"
@@ -103,8 +102,6 @@ static void ImGui_ImplGlfwGL3_RenderDrawLists(ImDrawList** const cmd_lists, int 
                 glBindTexture(GL_TEXTURE_2D, (GLuint)(intptr_t)pcmd->texture_id);
                 int scissor_width = (int)(pcmd->clip_rect.z - pcmd->clip_rect.x);
                 int scissor_height = (int)(pcmd->clip_rect.w - pcmd->clip_rect.y);
-                assert(scissor_width >= 0);
-                assert(scissor_height >= 0);
                 scissor_width = std::max(scissor_width, 0);
                 scissor_height = std::max(scissor_height, 0);
                 glScissor((int)pcmd->clip_rect.x, (int)(height - pcmd->clip_rect.w), scissor_width, scissor_height);

--- a/examples/opengl3_example/imgui_impl_glfw_gl3.cpp
+++ b/examples/opengl3_example/imgui_impl_glfw_gl3.cpp
@@ -2,6 +2,7 @@
 // https://github.com/ocornut/imgui
 
 #include <algorithm>
+#include <cassert>
 
 #include <imgui.h>
 #include "imgui_impl_glfw_gl3.h"
@@ -102,6 +103,8 @@ static void ImGui_ImplGlfwGL3_RenderDrawLists(ImDrawList** const cmd_lists, int 
                 glBindTexture(GL_TEXTURE_2D, (GLuint)(intptr_t)pcmd->texture_id);
                 int scissor_width = (int)(pcmd->clip_rect.z - pcmd->clip_rect.x);
                 int scissor_height = (int)(pcmd->clip_rect.w - pcmd->clip_rect.y);
+                assert(scissor_width >= 0);
+                assert(scissor_height >= 0);
                 scissor_width = std::max(scissor_width, 0);
                 scissor_height = std::max(scissor_height, 0);
                 glScissor((int)pcmd->clip_rect.x, (int)(height - pcmd->clip_rect.w), scissor_width, scissor_height);

--- a/examples/opengl3_example/imgui_impl_glfw_gl3.cpp
+++ b/examples/opengl3_example/imgui_impl_glfw_gl3.cpp
@@ -2,7 +2,6 @@
 // https://github.com/ocornut/imgui
 
 #include <algorithm>
-#include <cassert>
 
 #include <imgui.h>
 #include "imgui_impl_glfw_gl3.h"
@@ -103,8 +102,7 @@ static void ImGui_ImplGlfwGL3_RenderDrawLists(ImDrawList** const cmd_lists, int 
                 glBindTexture(GL_TEXTURE_2D, (GLuint)(intptr_t)pcmd->texture_id);
                 int scissor_width = (int)(pcmd->clip_rect.z - pcmd->clip_rect.x);
                 int scissor_height = (int)(pcmd->clip_rect.w - pcmd->clip_rect.y);
-                assert(scissor_width >= 0);
-                assert(scissor_height >= 0);
+                IM_ASSERT(scissor_width >= 0 && scissor_height >= 0); // this would usually indicate something wrong inside imgui
                 scissor_width = std::max(scissor_width, 0);
                 scissor_height = std::max(scissor_height, 0);
                 glScissor((int)pcmd->clip_rect.x, (int)(height - pcmd->clip_rect.w), scissor_width, scissor_height);

--- a/examples/opengl_example/imgui_impl_glfw.cpp
+++ b/examples/opengl_example/imgui_impl_glfw.cpp
@@ -2,7 +2,6 @@
 // https://github.com/ocornut/imgui
 
 #include <algorithm>
-#include <cassert>
 
 #include <imgui.h>
 #include "imgui_impl_glfw.h"
@@ -80,8 +79,7 @@ static void ImGui_ImplGlfw_RenderDrawLists(ImDrawList** const cmd_lists, int cmd
                 glBindTexture(GL_TEXTURE_2D, (GLuint)(intptr_t)pcmd->texture_id);
                 int scissor_width = (int)(pcmd->clip_rect.z - pcmd->clip_rect.x);
                 int scissor_height = (int)(pcmd->clip_rect.w - pcmd->clip_rect.y);
-                assert(scissor_width >= 0);
-                assert(scissor_height >= 0);
+                IM_ASSERT(scissor_width >= 0 && scissor_height >= 0); // this would usually indicate something wrong inside imgui
                 scissor_width = std::max(scissor_width, 0);
                 scissor_height = std::max(scissor_height, 0);
                 glScissor((int)pcmd->clip_rect.x, (int)(height - pcmd->clip_rect.w), scissor_width, scissor_height);

--- a/examples/opengl_example/imgui_impl_glfw.cpp
+++ b/examples/opengl_example/imgui_impl_glfw.cpp
@@ -2,6 +2,7 @@
 // https://github.com/ocornut/imgui
 
 #include <algorithm>
+#include <cassert>
 
 #include <imgui.h>
 #include "imgui_impl_glfw.h"
@@ -79,6 +80,8 @@ static void ImGui_ImplGlfw_RenderDrawLists(ImDrawList** const cmd_lists, int cmd
                 glBindTexture(GL_TEXTURE_2D, (GLuint)(intptr_t)pcmd->texture_id);
                 int scissor_width = (int)(pcmd->clip_rect.z - pcmd->clip_rect.x);
                 int scissor_height = (int)(pcmd->clip_rect.w - pcmd->clip_rect.y);
+                assert(scissor_width >= 0);
+                assert(scissor_height >= 0);
                 scissor_width = std::max(scissor_width, 0);
                 scissor_height = std::max(scissor_height, 0);
                 glScissor((int)pcmd->clip_rect.x, (int)(height - pcmd->clip_rect.w), scissor_width, scissor_height);

--- a/examples/opengl_example/imgui_impl_glfw.cpp
+++ b/examples/opengl_example/imgui_impl_glfw.cpp
@@ -1,6 +1,9 @@
 // ImGui GLFW binding with OpenGL
 // https://github.com/ocornut/imgui
 
+#include <algorithm>
+#include <cassert>
+
 #include <imgui.h>
 #include "imgui_impl_glfw.h"
 
@@ -75,7 +78,13 @@ static void ImGui_ImplGlfw_RenderDrawLists(ImDrawList** const cmd_lists, int cmd
             else
             {
                 glBindTexture(GL_TEXTURE_2D, (GLuint)(intptr_t)pcmd->texture_id);
-                glScissor((int)pcmd->clip_rect.x, (int)(height - pcmd->clip_rect.w), (int)(pcmd->clip_rect.z - pcmd->clip_rect.x), (int)(pcmd->clip_rect.w - pcmd->clip_rect.y));
+                int scissor_width = (int)(pcmd->clip_rect.z - pcmd->clip_rect.x);
+                int scissor_height = (int)(pcmd->clip_rect.w - pcmd->clip_rect.y);
+                assert(scissor_width >= 0);
+                assert(scissor_height >= 0);
+                scissor_width = std::max(scissor_width, 0);
+                scissor_height = std::max(scissor_height, 0);
+                glScissor((int)pcmd->clip_rect.x, (int)(height - pcmd->clip_rect.w), scissor_width, scissor_height);
                 glDrawArrays(GL_TRIANGLES, vtx_offset, pcmd->vtx_count);
             }
             vtx_offset += pcmd->vtx_count;

--- a/examples/opengl_example/imgui_impl_glfw.cpp
+++ b/examples/opengl_example/imgui_impl_glfw.cpp
@@ -2,7 +2,6 @@
 // https://github.com/ocornut/imgui
 
 #include <algorithm>
-#include <cassert>
 
 #include <imgui.h>
 #include "imgui_impl_glfw.h"
@@ -80,8 +79,6 @@ static void ImGui_ImplGlfw_RenderDrawLists(ImDrawList** const cmd_lists, int cmd
                 glBindTexture(GL_TEXTURE_2D, (GLuint)(intptr_t)pcmd->texture_id);
                 int scissor_width = (int)(pcmd->clip_rect.z - pcmd->clip_rect.x);
                 int scissor_height = (int)(pcmd->clip_rect.w - pcmd->clip_rect.y);
-                assert(scissor_width >= 0);
-                assert(scissor_height >= 0);
                 scissor_width = std::max(scissor_width, 0);
                 scissor_height = std::max(scissor_height, 0);
                 glScissor((int)pcmd->clip_rect.x, (int)(height - pcmd->clip_rect.w), scissor_width, scissor_height);


### PR DESCRIPTION
At first I assert()d ImDrawList::AddDrawCmd() to detect these at their source, but it seems that ImGui generates these pretty often, so I just made the GL example implementations clamp their sizes down to 0 in these cases.
