### PR TITLE
Fixed modifier key state setting in GLFW callbacks.

### DIFF
--- a/examples/opengl3_example/imgui_impl_glfw_gl3.cpp
+++ b/examples/opengl3_example/imgui_impl_glfw_gl3.cpp
@@ -134,50 +134,24 @@ void ImGui_ImplGlfwGL3_ScrollCallback(GLFWwindow*, double /*xoffset*/, double yo
     g_MouseWheel += (float)yoffset; // Use fractional mouse wheel, 1.0 unit 5 lines.
 }
 
-void ImGui_ImplGlfwGL3_KeyCallback(GLFWwindow*, int key, int, int action, int mods)
+void ImGui_ImplGlfwGL3_KeyCallback(GLFWwindow* window, int key, int, int action, int mods)
 {
     ImGuiIO& io = ImGui::GetIO();
     if (action == GLFW_PRESS)
-    {
-        switch (key)
-        {
-        case GLFW_KEY_LEFT_CONTROL:
-        case GLFW_KEY_RIGHT_CONTROL:
-            io.KeyCtrl = true;
-            break;
-        case GLFW_KEY_LEFT_SHIFT:
-        case GLFW_KEY_RIGHT_SHIFT:
-            io.KeyShift = true;
-            break;
-        case GLFW_KEY_LEFT_ALT:
-        case GLFW_KEY_RIGHT_ALT:
-            io.KeyAlt = true;
-            break;
-        default:
-            io.KeysDown[key] = true;
-        }
-    }
-
+        io.KeysDown[key] = true;
     if (action == GLFW_RELEASE)
-    {
-        switch (key)
-        {
-        case GLFW_KEY_LEFT_CONTROL:
-        case GLFW_KEY_RIGHT_CONTROL:
-            io.KeyCtrl = false;
-            break;
-        case GLFW_KEY_LEFT_SHIFT:
-        case GLFW_KEY_RIGHT_SHIFT:
-            io.KeyShift = false;
-            break;
-        case GLFW_KEY_LEFT_ALT:
-        case GLFW_KEY_RIGHT_ALT:
-            io.KeyAlt = false;
-            break;
-        default:
-            io.KeysDown[key] = false;
-        }
-    }
+        io.KeysDown[key] = false;
+
+    bool leftCtrl = glfwGetKey(window, GLFW_KEY_LEFT_CONTROL) == GLFW_PRESS;
+    bool rightCtrl = glfwGetKey(window, GLFW_KEY_RIGHT_CONTROL) == GLFW_PRESS;
+    bool leftShift = glfwGetKey(window, GLFW_KEY_LEFT_SHIFT) == GLFW_PRESS;
+    bool rightShift = glfwGetKey(window, GLFW_KEY_RIGHT_SHIFT) == GLFW_PRESS;
+    bool leftAlt = glfwGetKey(window, GLFW_KEY_LEFT_ALT) == GLFW_PRESS;
+    bool rightAlt = glfwGetKey(window, GLFW_KEY_RIGHT_ALT) == GLFW_PRESS;
+
+    io.KeyCtrl = leftCtrl || rightCtrl;
+    io.KeyShift = leftShift || rightShift;
+    io.KeyAlt = leftAlt || rightAlt;
 }
 
 void ImGui_ImplGlfwGL3_CharCallback(GLFWwindow*, unsigned int c)

--- a/examples/opengl3_example/imgui_impl_glfw_gl3.cpp
+++ b/examples/opengl3_example/imgui_impl_glfw_gl3.cpp
@@ -138,12 +138,46 @@ void ImGui_ImplGlfwGL3_KeyCallback(GLFWwindow*, int key, int, int action, int mo
 {
     ImGuiIO& io = ImGui::GetIO();
     if (action == GLFW_PRESS)
-        io.KeysDown[key] = true;
+    {
+        switch (key)
+        {
+        case GLFW_KEY_LEFT_CONTROL:
+        case GLFW_KEY_RIGHT_CONTROL:
+            io.KeyCtrl = true;
+            break;
+        case GLFW_KEY_LEFT_SHIFT:
+        case GLFW_KEY_RIGHT_SHIFT:
+            io.KeyShift = true;
+            break;
+        case GLFW_KEY_LEFT_ALT:
+        case GLFW_KEY_RIGHT_ALT:
+            io.KeyAlt = true;
+            break;
+        default:
+            io.KeysDown[key] = true;
+        }
+    }
+
     if (action == GLFW_RELEASE)
-        io.KeysDown[key] = false;
-    io.KeyCtrl = (mods & GLFW_MOD_CONTROL) != 0;
-    io.KeyShift = (mods & GLFW_MOD_SHIFT) != 0;
-    io.KeyAlt = (mods & GLFW_MOD_ALT) != 0;
+    {
+        switch (key)
+        {
+        case GLFW_KEY_LEFT_CONTROL:
+        case GLFW_KEY_RIGHT_CONTROL:
+            io.KeyCtrl = false;
+            break;
+        case GLFW_KEY_LEFT_SHIFT:
+        case GLFW_KEY_RIGHT_SHIFT:
+            io.KeyShift = false;
+            break;
+        case GLFW_KEY_LEFT_ALT:
+        case GLFW_KEY_RIGHT_ALT:
+            io.KeyAlt = false;
+            break;
+        default:
+            io.KeysDown[key] = false;
+        }
+    }
 }
 
 void ImGui_ImplGlfwGL3_CharCallback(GLFWwindow*, unsigned int c)

--- a/examples/opengl_example/imgui_impl_glfw.cpp
+++ b/examples/opengl_example/imgui_impl_glfw.cpp
@@ -119,12 +119,46 @@ void ImGui_ImplGlFw_KeyCallback(GLFWwindow*, int key, int, int action, int mods)
 {
     ImGuiIO& io = ImGui::GetIO();
     if (action == GLFW_PRESS)
-        io.KeysDown[key] = true;
+    {
+        switch (key)
+        {
+        case GLFW_KEY_LEFT_CONTROL:
+        case GLFW_KEY_RIGHT_CONTROL:
+            io.KeyCtrl = true;
+            break;
+        case GLFW_KEY_LEFT_SHIFT:
+        case GLFW_KEY_RIGHT_SHIFT:
+            io.KeyShift = true;
+            break;
+        case GLFW_KEY_LEFT_ALT:
+        case GLFW_KEY_RIGHT_ALT:
+            io.KeyAlt = true;
+            break;
+        default:
+            io.KeysDown[key] = true;
+        }
+    }
+
     if (action == GLFW_RELEASE)
-        io.KeysDown[key] = false;
-    io.KeyCtrl = (mods & GLFW_MOD_CONTROL) != 0;
-    io.KeyShift = (mods & GLFW_MOD_SHIFT) != 0;
-    io.KeyAlt = (mods & GLFW_MOD_ALT) != 0;
+    {
+        switch (key)
+        {
+        case GLFW_KEY_LEFT_CONTROL:
+        case GLFW_KEY_RIGHT_CONTROL:
+            io.KeyCtrl = false;
+            break;
+        case GLFW_KEY_LEFT_SHIFT:
+        case GLFW_KEY_RIGHT_SHIFT:
+            io.KeyShift = false;
+            break;
+        case GLFW_KEY_LEFT_ALT:
+        case GLFW_KEY_RIGHT_ALT:
+            io.KeyAlt = false;
+            break;
+        default:
+            io.KeysDown[key] = false;
+        }
+    }
 }
 
 void ImGui_ImplGlfw_CharCallback(GLFWwindow*, unsigned int c)

--- a/examples/opengl_example/imgui_impl_glfw.cpp
+++ b/examples/opengl_example/imgui_impl_glfw.cpp
@@ -115,50 +115,24 @@ void ImGui_ImplGlfw_ScrollCallback(GLFWwindow*, double /*xoffset*/, double yoffs
     g_MouseWheel += (float)yoffset; // Use fractional mouse wheel, 1.0 unit 5 lines.
 }
 
-void ImGui_ImplGlFw_KeyCallback(GLFWwindow*, int key, int, int action, int mods)
+void ImGui_ImplGlFw_KeyCallback(GLFWwindow* window, int key, int, int action, int mods)
 {
     ImGuiIO& io = ImGui::GetIO();
     if (action == GLFW_PRESS)
-    {
-        switch (key)
-        {
-        case GLFW_KEY_LEFT_CONTROL:
-        case GLFW_KEY_RIGHT_CONTROL:
-            io.KeyCtrl = true;
-            break;
-        case GLFW_KEY_LEFT_SHIFT:
-        case GLFW_KEY_RIGHT_SHIFT:
-            io.KeyShift = true;
-            break;
-        case GLFW_KEY_LEFT_ALT:
-        case GLFW_KEY_RIGHT_ALT:
-            io.KeyAlt = true;
-            break;
-        default:
-            io.KeysDown[key] = true;
-        }
-    }
-
+        io.KeysDown[key] = true;
     if (action == GLFW_RELEASE)
-    {
-        switch (key)
-        {
-        case GLFW_KEY_LEFT_CONTROL:
-        case GLFW_KEY_RIGHT_CONTROL:
-            io.KeyCtrl = false;
-            break;
-        case GLFW_KEY_LEFT_SHIFT:
-        case GLFW_KEY_RIGHT_SHIFT:
-            io.KeyShift = false;
-            break;
-        case GLFW_KEY_LEFT_ALT:
-        case GLFW_KEY_RIGHT_ALT:
-            io.KeyAlt = false;
-            break;
-        default:
-            io.KeysDown[key] = false;
-        }
-    }
+        io.KeysDown[key] = false;
+
+    bool leftCtrl = glfwGetKey(window, GLFW_KEY_LEFT_CONTROL) == GLFW_PRESS;
+    bool rightCtrl = glfwGetKey(window, GLFW_KEY_RIGHT_CONTROL) == GLFW_PRESS;
+    bool leftShift = glfwGetKey(window, GLFW_KEY_LEFT_SHIFT) == GLFW_PRESS;
+    bool rightShift = glfwGetKey(window, GLFW_KEY_RIGHT_SHIFT) == GLFW_PRESS;
+    bool leftAlt = glfwGetKey(window, GLFW_KEY_LEFT_ALT) == GLFW_PRESS;
+    bool rightAlt = glfwGetKey(window, GLFW_KEY_RIGHT_ALT) == GLFW_PRESS;
+
+    io.KeyCtrl = leftCtrl || rightCtrl;
+    io.KeyShift = leftShift || rightShift;
+    io.KeyAlt = leftAlt || rightAlt;
 }
 
 void ImGui_ImplGlfw_CharCallback(GLFWwindow*, unsigned int c)


### PR DESCRIPTION
On my Linux system, GLFW 3.1.1, the key callback handles modifier keys incorrectly.  Pressing the modifier will set the flag true, but releasing it does not.  The only way to unset the modifiers is to hit a non-modifier key.

This issue does not seem to be present on my MacBook Pro.