### PR TITLE
set pixel shader and vertex shader to NULL

### DIFF
--- a/examples/directx9_example/imgui_impl_dx9.cpp
+++ b/examples/directx9_example/imgui_impl_dx9.cpp
@@ -57,7 +57,8 @@ static void ImGui_ImplDX9_RenderDrawLists(ImDrawList** const cmd_lists, int cmd_
         }
     }
     g_pVB->Unlock();
-
+    g_pd3dDevice->SetPixelShader(NULL);
+    g_pd3dDevice->SetVertexShader(NULL);
     g_pd3dDevice->SetStreamSource( 0, g_pVB, 0, sizeof( CUSTOMVERTEX ) );
     g_pd3dDevice->SetFVF( D3DFVF_CUSTOMVERTEX );
 


### PR DESCRIPTION
Previous graphic render may use shaders,so set pixel shader and vertex shader to NULL to force use fixed pipeline.