### PR TITLE
Custom histogram labels and sample.

### DIFF
--- a/imconfig.h
+++ b/imconfig.h
@@ -26,10 +26,10 @@
 //#define IMGUI_DISABLE_TEST_WINDOWS
 
 //---- Include imgui_user.inl at the end of imgui.cpp so you can include code that extends ImGui using its private data/functions.
-//#define IMGUI_INCLUDE_IMGUI_USER_INL
+#define IMGUI_INCLUDE_IMGUI_USER_INL
 
 //---- Include imgui_user.h at the end of imgui.h
-//#define IMGUI_INCLUDE_IMGUI_USER_H
+#define IMGUI_INCLUDE_IMGUI_USER_H
 
 //---- Define constructor and implicit cast operators to convert back<>forth from your math types and ImVec2/ImVec4.
 /*

--- a/imgui_user.h
+++ b/imgui_user.h
@@ -1,0 +1,8 @@
+#ifndef _IMGUI_USER_H_
+#define _IMGUI_USER_H_
+
+namespace ImGui
+{
+    IMGUI_API void          PlotHistogram(const char* label, float (*values_getter)(void* data, int idx), const char* (*labels_getter)(void* data, int idx), void* data, void* labels_data, int values_count, int values_offset = 0, const char* overlay_text = NULL, float scale_min = FLT_MAX, float scale_max = FLT_MAX, ImVec2 graph_size = ImVec2(0,0));
+}
+#endif

--- a/imgui_user.inl
+++ b/imgui_user.inl
@@ -1,0 +1,4 @@
+void ImGui::PlotHistogram(const char* label, float (*values_getter)(void* data, int idx), const char* (*labels_getter)(void* data, int idx), void* data, void* labels_data, int values_count, int values_offset, const char* overlay_text, float scale_min, float scale_max, ImVec2 graph_size)
+{
+    Plot(ImGuiPlotType_Histogram, label, values_getter, data, values_count, values_offset, overlay_text, scale_min, scale_max, graph_size, labels_getter, labels_data);
+}


### PR DESCRIPTION
Unless I'm missing something, I couldn't find a way to have custom labels on histogram elements.  Looking at your code, I noticed that it probably wouldn't be very hard to at least hack something in, so I did.

The number of parameters to PlotHistogram() is kind of insane with this change (was a lot to begin with), but it does the job and gets the idea across.  I threw in some sample code in the opengl_example application to show a use case:

![screenshot-imgui opengl2 example-2](https://cloud.githubusercontent.com/assets/3121968/7196934/143b3c5e-e4a0-11e4-82ad-6649a4e7db1b.png)
![screenshot-imgui opengl2 example-3](https://cloud.githubusercontent.com/assets/3121968/7196935/1443c748-e4a0-11e4-9b64-b1a8afdd6616.png)

Hopefully we can find some way to make this a little nicer and get into master, it would be _super_ helpful to be able to identify those histogram elements with something more descriptive than an index! :)

-Dale Kim
