### PR TITLE
Bug: popup always disappears if you don't access Debug window

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -2193,7 +2193,7 @@ void ImGui::Render()
         // Hide implicit window if it hasn't been used
         IM_ASSERT(g.CurrentWindowStack.size() == 1);    // Mismatched Begin/End 
         if (g.CurrentWindow && !g.CurrentWindow->Accessed)
-            g.CurrentWindow->Active = false;
+            g.CurrentWindow->HiddenFrames = ImMax(1, g.CurrentWindow->HiddenFrames);
         ImGui::End();
 
         if (g.ActiveId == 0 && g.HoveredId == 0 && g.IO.MouseClicked[0])


### PR DESCRIPTION
You can reproduce this by removing anything that goes to Debug window from one of the example projects and then try to open a popup in the ImGui Test window.

This seems to be introduced by commit a906738. Empty Debug window gets deactivated by ImGui::Render(), which causes WasActive getting incorrectly set to false on next NewFrame, which then causes Debug window to get focused as if it just got newly opened, therefore closing the popup.