### PR TITLE
Bug: popup always disappears if you don't access Debug window (fixed pull request)

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -2193,7 +2193,7 @@ void ImGui::Render()
         // Hide implicit window if it hasn't been used
         IM_ASSERT(g.CurrentWindowStack.size() == 1);    // Mismatched Begin/End 
         if (g.CurrentWindow && !g.CurrentWindow->Accessed)
-            g.CurrentWindow->HiddenFrames = ImMax(1, g.CurrentWindow->HiddenFrames);
+            g.CurrentWindow->Active = false;
         ImGui::End();
 
         if (g.ActiveId == 0 && g.HoveredId == 0 && g.IO.MouseClicked[0])
@@ -3160,6 +3160,7 @@ bool ImGui::Begin(const char* name, bool* p_opened, const ImVec2& size_on_first_
     // When reusing window again multiple times a frame, just append content (don't need to setup again)
     const int current_frame = ImGui::GetFrameCount();
     const bool first_begin_of_the_frame = (window->LastFrameDrawn != current_frame);
+    const bool was_recently_drawn = (window->LastFrameDrawn == current_frame - 1);
     if (first_begin_of_the_frame)
     {
         window->Active = true;
@@ -3179,7 +3180,7 @@ bool ImGui::Begin(const char* name, bool* p_opened, const ImVec2& size_on_first_
     if (first_begin_of_the_frame)
     {
         // New windows appears in front
-        if (!window->WasActive)
+        if (!window->WasActive && !was_recently_drawn)
         {
             window->AutoPosLastDirection = -1;
 

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -2193,7 +2193,7 @@ void ImGui::Render()
         // Hide implicit window if it hasn't been used
         IM_ASSERT(g.CurrentWindowStack.size() == 1);    // Mismatched Begin/End 
         if (g.CurrentWindow && !g.CurrentWindow->Accessed)
-            g.CurrentWindow->Active = false;
+            g.CurrentWindow->HiddenFrames = ImMax(1, g.CurrentWindow->HiddenFrames);
         ImGui::End();
 
         if (g.ActiveId == 0 && g.HoveredId == 0 && g.IO.MouseClicked[0])


### PR DESCRIPTION
You can reproduce this by removing anything that goes to Debug window from one of the example projects and then try to open a popup in the ImGui Test window.

This seems to be introduced by commit a906738. Empty Debug window gets deactivated by ImGui::Render(), which causes WasActive getting incorrectly set to false on next NewFrame, which then causes Debug window to get focused as if it just got newly opened, therefore closing the popup.

(this is a fixed pull request, the previous one did didn't fix the problem properly)