### PR TITLE
Example fix PopStyleVar on Vertical Slider to avoid assertion

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -10345,6 +10345,7 @@ void ImGui::ShowTestWindow(bool* opened)
                 ImGui::PopID();
             }
             ImGui::PopID();
+            ImGui::PopStyleVar();
 
             ImGui::Indent();
             ImGui::TreePop();


### PR DESCRIPTION
Adding an explicit ImGui::PopStyleVar to avoid assertion in
CheckStacksSize