### PR TITLE
Fix SDL2-example for Linux

### DIFF
--- a/examples/sdl_opengl_example/README.md
+++ b/examples/sdl_opengl_example/README.md
@@ -8,3 +8,9 @@
 ```
 cl /MD /I <sdl2path\include> /I ..\.. main.cpp imgui_impl_sdl.cpp ..\..\imgui.cpp /link /LIBPATH:<sdl2path\lib> SDL2.lib SDL2main.lib
 ```
+
+- On Linux and similar Unices
+
+```
+c++ `sdl2-config --cflags` -I ../.. main.cpp imgui_impl_sdl.cpp ../../imgui.cpp `sdl2-config --libs` -lGL -o sdl2example
+```

--- a/examples/sdl_opengl_example/imgui_impl_sdl.cpp
+++ b/examples/sdl_opengl_example/imgui_impl_sdl.cpp
@@ -3,7 +3,7 @@
 
 #include <SDL.h>
 #include <SDL_syswm.h>
-#include <SDL_OpenGL.h>
+#include <SDL_opengl.h>
 #include <imgui.h>
 #include "imgui_impl_sdl.h"
 

--- a/examples/sdl_opengl_example/main.cpp
+++ b/examples/sdl_opengl_example/main.cpp
@@ -4,9 +4,9 @@
 #include "imgui_impl_sdl.h"
 #include <stdio.h>
 #include <SDL.h>
-#include <SDL_OpenGL.h>
+#include <SDL_opengl.h>
 
-int SDL_main(int, char**)
+int main(int, char**)
 {
     // Setup SDL
 	if (SDL_Init(SDL_INIT_EVERYTHING) != 0)


### PR DESCRIPTION
There was a case-mismatch in the includes, the `main` function should indeed be called `main` (SDL has a #define for SDL_main on Windows) and I added Linux build instructions to the example's README.md