### PR TITLE
ImGuiIO::AddInputCharactersUTF8(utf8str), use it in SDL2 example

### DIFF
--- a/examples/sdl_opengl_example/imgui_impl_sdl.cpp
+++ b/examples/sdl_opengl_example/imgui_impl_sdl.cpp
@@ -118,9 +118,7 @@ bool ImGui_ImplSdl_ProcessEvent(SDL_Event* event)
     case SDL_TEXTINPUT:
         {
             ImGuiIO& io = ImGui::GetIO();
-            unsigned int c = event->text.text[0];
-            if (c > 0 && c < 0x10000)
-                io.AddInputCharacter((unsigned short)c);
+            io.AddInputCharactersUTF8(event->text.text);
             return true;
         }
     case SDL_KEYDOWN:

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -778,6 +778,18 @@ void ImGuiIO::AddInputCharacter(ImWchar c)
     }
 }
 
+void ImGuiIO::AddInputCharactersUTF8(const char* utf8chars)
+{
+    // we can't pass more wchars than ImGuiIO::InputCharacters[] can hold so don't convert more
+    static const int wcharBufLen = sizeof(ImGuiIO::InputCharacters)/sizeof(ImWchar);
+    ImWchar wchars[wcharBufLen];
+    ImTextStrFromUtf8(wchars, wcharBufLen, utf8chars, NULL);
+    for(int i=0; i<wcharBufLen && wchars[i] != 0; ++i)
+    {
+        AddInputCharacter(wchars[i]);
+    }
+}
+
 // Math bits
 // We are keeping those static in the .cpp file so as not to leak them outside, in the case the user has implicit cast operators between ImVec2 and its own types.
 static inline ImVec2 operator*(const ImVec2& lhs, const float rhs)              { return ImVec2(lhs.x*rhs, lhs.y*rhs); }

--- a/imgui.h
+++ b/imgui.h
@@ -705,6 +705,7 @@ struct ImGuiIO
 
     // Function
     IMGUI_API void AddInputCharacter(ImWchar c); // Helper to add a new character into InputCharacters[]
+    IMGUI_API void AddInputCharactersUTF8(const char* utf8chars); // Helper to add new characters into InputCharacters[] from an utf8-string
 
     //------------------------------------------------------------------
     // Output - Retrieve after calling NewFrame(), you can use them to discard inputs or hide them from the rest of your application


### PR DESCRIPTION
Now the SDL2 example has working Unicode text input (I tested with German umlauts, but I think everything that works with imgui should work - the limit probably is the 16bit wchar that can't hold all possible UTF-32 values).