### PR TITLE
Add high DPI support to GLFW example

### DIFF
--- a/examples/opengl_example/main.cpp
+++ b/examples/opengl_example/main.cpp
@@ -77,7 +77,9 @@ int main(int, char**)
         }
 
         // Rendering
-        glViewport(0, 0, (int)ImGui::GetIO().DisplaySize.x, (int)ImGui::GetIO().DisplaySize.y);
+        int display_w, display_h;
+        glfwGetFramebufferSize(window, &display_w, &display_h);
+        glViewport(0, 0, display_w, display_h);
         glClearColor(clear_color.x, clear_color.y, clear_color.z, clear_color.w);
         glClear(GL_COLOR_BUFFER_BIT);
         ImGui::Render();


### PR DESCRIPTION
- Pass framebuffer size to "GL screen space" (i.e. pixels) calls:
  glViewport, glScissor
- Pass OS screen coordinates to rendering and mouse IO
- Use GL_NEAREST magnification for font atlas since it's all sharp
  raster images

<img width="1392" alt="glfw_hidpi_osx" src="https://cloud.githubusercontent.com/assets/38979/8897934/2b6ac15c-33d2-11e5-90bd-70faaedf4e4b.png">
