### PR TITLE
Add printf attribute to printf like text formatting functions

### DIFF
--- a/examples/opengl3_example/Makefile
+++ b/examples/opengl3_example/Makefile
@@ -22,7 +22,7 @@ ifeq ($(UNAME_S), Linux) #LINUX
 	LIBS = `pkg-config --static --libs glfw3`
 
 	CXXFLAGS = -I../../ -I../libs/gl3w `pkg-config --cflags glfw3`
-	CXXFLAGS += -Wall
+	CXXFLAGS += -Wall -Wformat
 	CFLAGS = $(CXXFLAGS)
 endif
 
@@ -33,7 +33,7 @@ ifeq ($(UNAME_S), Darwin) #APPLE
 	LIBS += -lglfw3
 
 	CXXFLAGS = -I../../ -I../libs/gl3w -I/usr/local/Cellar/glew/1.10.0/include -I/usr/local/include
-	CXXFLAGS += -Wall
+	CXXFLAGS += -Wall -Wformat
 #	CXXFLAGS += -D__APPLE__
 	CFLAGS = $(CXXFLAGS)
 endif

--- a/examples/opengl_example/Makefile
+++ b/examples/opengl_example/Makefile
@@ -21,7 +21,7 @@ ifeq ($(UNAME_S), Linux) #LINUX
 	LIBS = `pkg-config --static --libs glfw3`
 
 	CXXFLAGS = -I../../ `pkg-config --cflags glfw3`
-	CXXFLAGS += -Wall
+	CXXFLAGS += -Wall -Wformat
 	CFLAGS = $(CXXFLAGS)
 endif
 
@@ -32,7 +32,7 @@ ifeq ($(UNAME_S), Darwin) #APPLE
 	LIBS += -lglfw3
 
 	CXXFLAGS = -I../../ -I/usr/local/include
-	CXXFLAGS += -Wall
+	CXXFLAGS += -Wall -Wformat
 #	CXXFLAGS += -D__APPLE__
 	CFLAGS = $(CXXFLAGS)
 endif

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -458,7 +458,6 @@
  - input: rework IO to be able to pass actual events to fix temporal aliasing issues.
  - input: support track pad style scrolling & slider edit.
  - memory: add a way to discard allocs of unused/transient windows. with the current architecture new windows (including popup, opened combos, listbox) perform at least 3 allocs.
- - misc: mark printf compiler attributes on relevant functions
  - misc: provide a way to compile out the entire implementation while providing a dummy API (e.g. #define IMGUI_DUMMY_IMPL)
  - misc: double-clicking on title bar to minimize isn't consistent, perhaps move to single-click on left-most collapse icon?
  - style editor: have a more global HSV setter (e.g. alter hue on all elements). consider replacing active/hovered by offset in HSV space?
@@ -2071,7 +2070,7 @@ static void LoadSettings()
         if (line_start[0] == '[' && line_end > line_start && line_end[-1] == ']')
         {
             char name[64];
-            ImFormatString(name, IM_ARRAYSIZE(name), "%.*s", line_end-line_start-2, line_start+1);
+            ImFormatString(name, IM_ARRAYSIZE(name), "%.*s", (int)(line_end-line_start-2), line_start+1);
             settings = FindWindowSettings(name);
             if (!settings)
                 settings = AddWindowSettings(name);
@@ -8881,7 +8880,7 @@ void ImGui::ShowMetricsWindow(bool* opened)
                 NodeDrawList(window->DrawList, "DrawList");
                 if (window->RootWindow != window) NodeWindow(window->RootWindow, "RootWindow");
                 if (window->DC.ChildWindows.Size > 0) NodeWindows(window->DC.ChildWindows, "ChildWindows");
-                ImGui::BulletText("Storage: %d bytes", window->StateStorage.Data.Size * sizeof(ImGuiStorage::Pair));
+                ImGui::BulletText("Storage: %d bytes", window->StateStorage.Data.Size * (int)sizeof(ImGuiStorage::Pair));
                 ImGui::TreePop();
             }
         };

--- a/imgui.h
+++ b/imgui.h
@@ -25,6 +25,14 @@
 #define IM_ASSERT(_EXPR)    assert(_EXPR)
 #endif
 
+#ifdef __GNUC__
+// warning : format string is not a string literal (potentially insecure)
+#pragma GCC diagnostic ignored "-Wformat-security"
+#define IM_PRINTFARGS(fmt, args) __attribute__((format(printf, fmt, args)))
+#else
+#define IM_PRINTFARGS(fmt, args)
+#endif
+
 // Define attributes of all API symbols declarations, e.g. for DLL under Windows.
 #ifndef IMGUI_API
 #define IMGUI_API
@@ -213,19 +221,19 @@ namespace ImGui
     IMGUI_API ImGuiID       GetID(const void* ptr_id);
 
     // Widgets
-    IMGUI_API void          Text(const char* fmt, ...);
+    IMGUI_API void          Text(const char* fmt, ...) IM_PRINTFARGS(1, 2);
     IMGUI_API void          TextV(const char* fmt, va_list args);
-    IMGUI_API void          TextColored(const ImVec4& col, const char* fmt, ...);               // shortcut for PushStyleColor(ImGuiCol_Text, col); Text(fmt, ...); PopStyleColor();
+    IMGUI_API void          TextColored(const ImVec4& col, const char* fmt, ...) IM_PRINTFARGS(2, 3);   // shortcut for PushStyleColor(ImGuiCol_Text, col); Text(fmt, ...); PopStyleColor();
     IMGUI_API void          TextColoredV(const ImVec4& col, const char* fmt, va_list args);
-    IMGUI_API void          TextDisabled(const char* fmt, ...);                                 // shortcut for PushStyleColor(ImGuiCol_Text, style.Colors[ImGuiCol_TextDisabled]); Text(fmt, ...); PopStyleColor();
+    IMGUI_API void          TextDisabled(const char* fmt, ...) IM_PRINTFARGS(1, 2);                     // shortcut for PushStyleColor(ImGuiCol_Text, style.Colors[ImGuiCol_TextDisabled]); Text(fmt, ...); PopStyleColor();
     IMGUI_API void          TextDisabledV(const char* fmt, va_list args);
-    IMGUI_API void          TextWrapped(const char* fmt, ...);                                  // shortcut for PushTextWrapPos(0.0f); Text(fmt, ...); PopTextWrapPos();. Note that this won't work on an auto-resizing window if there's no other widgets to extend the window width, yoy may need to set a size using SetNextWindowSize().
+    IMGUI_API void          TextWrapped(const char* fmt, ...) IM_PRINTFARGS(1, 2);                      // shortcut for PushTextWrapPos(0.0f); Text(fmt, ...); PopTextWrapPos();. Note that this won't work on an auto-resizing window if there's no other widgets to extend the window width, yoy may need to set a size using SetNextWindowSize().
     IMGUI_API void          TextWrappedV(const char* fmt, va_list args);
-    IMGUI_API void          TextUnformatted(const char* text, const char* text_end = NULL);     // doesn't require null terminated string if 'text_end' is specified. no copy done to any bounded stack buffer, recommended for long chunks of text
-    IMGUI_API void          LabelText(const char* label, const char* fmt, ...);                 // display text+label aligned the same way as value+label widgets 
+    IMGUI_API void          TextUnformatted(const char* text, const char* text_end = NULL);             // doesn't require null terminated string if 'text_end' is specified. no copy done to any bounded stack buffer, recommended for long chunks of text
+    IMGUI_API void          LabelText(const char* label, const char* fmt, ...) IM_PRINTFARGS(2, 3);     // display text+label aligned the same way as value+label widgets 
     IMGUI_API void          LabelTextV(const char* label, const char* fmt, va_list args);
     IMGUI_API void          Bullet();
-    IMGUI_API void          BulletText(const char* fmt, ...);
+    IMGUI_API void          BulletText(const char* fmt, ...) IM_PRINTFARGS(1, 2);
     IMGUI_API void          BulletTextV(const char* fmt, va_list args);
     IMGUI_API bool          Button(const char* label, const ImVec2& size = ImVec2(0,0));
     IMGUI_API bool          SmallButton(const char* label);
@@ -287,15 +295,15 @@ namespace ImGui
     IMGUI_API bool          VSliderInt(const char* label, const ImVec2& size, int* v, int v_min, int v_max, const char* display_format = "%.0f");
 
     // Widgets: Trees
-    IMGUI_API bool          TreeNode(const char* str_label_id);                                 // if returning 'true' the node is open and the user is responsible for calling TreePop
-    IMGUI_API bool          TreeNode(const char* str_id, const char* fmt, ...);                 // "
-    IMGUI_API bool          TreeNode(const void* ptr_id, const char* fmt, ...);                 // "
-    IMGUI_API bool          TreeNodeV(const char* str_id, const char* fmt, va_list args);       // "
-    IMGUI_API bool          TreeNodeV(const void* ptr_id, const char* fmt, va_list args);       // "
-    IMGUI_API void          TreePush(const char* str_id = NULL);                                // already called by TreeNode(), but you can call Push/Pop yourself for layouting purpose
-    IMGUI_API void          TreePush(const void* ptr_id = NULL);                                // "
+    IMGUI_API bool          TreeNode(const char* str_label_id);                                       // if returning 'true' the node is open and the user is responsible for calling TreePop
+    IMGUI_API bool          TreeNode(const char* str_id, const char* fmt, ...) IM_PRINTFARGS(2, 3);   // "
+    IMGUI_API bool          TreeNode(const void* ptr_id, const char* fmt, ...) IM_PRINTFARGS(2, 3);   // "
+    IMGUI_API bool          TreeNodeV(const char* str_id, const char* fmt, va_list args);             // "
+    IMGUI_API bool          TreeNodeV(const void* ptr_id, const char* fmt, va_list args);             // "
+    IMGUI_API void          TreePush(const char* str_id = NULL);                                      // already called by TreeNode(), but you can call Push/Pop yourself for layouting purpose
+    IMGUI_API void          TreePush(const void* ptr_id = NULL);                                      // "
     IMGUI_API void          TreePop();
-    IMGUI_API void          SetNextTreeNodeOpened(bool opened, ImGuiSetCond cond = 0);          // set next tree node to be opened.
+    IMGUI_API void          SetNextTreeNodeOpened(bool opened, ImGuiSetCond cond = 0);                // set next tree node to be opened.
 
     // Widgets: Selectable / Lists
     IMGUI_API bool          Selectable(const char* label, bool selected = false, ImGuiSelectableFlags flags = 0, const ImVec2& size = ImVec2(0,0));  // size.x==0.0: use remaining width, size.x>0.0: specify width. size.y==0.0: use label height, size.y>0.0: specify height 
@@ -315,7 +323,7 @@ namespace ImGui
     IMGUI_API void          Color(const char* prefix, unsigned int v);
 
     // Tooltip
-    IMGUI_API void          SetTooltip(const char* fmt, ...);                                   // set tooltip under mouse-cursor, typically use with ImGui::IsHovered(). last call wins
+    IMGUI_API void          SetTooltip(const char* fmt, ...) IM_PRINTFARGS(1, 2);               // set tooltip under mouse-cursor, typically use with ImGui::IsHovered(). last call wins
     IMGUI_API void          SetTooltipV(const char* fmt, va_list args);
     IMGUI_API void          BeginTooltip();                                                     // use to create full-featured tooltip windows that aren't just text
     IMGUI_API void          EndTooltip();
@@ -346,7 +354,7 @@ namespace ImGui
     IMGUI_API void          LogToClipboard(int max_depth = -1);                                 // start logging to OS clipboard
     IMGUI_API void          LogFinish();                                                        // stop logging (close file, etc.)
     IMGUI_API void          LogButtons();                                                       // helper to display buttons for logging to tty/file/clipboard
-    IMGUI_API void          LogText(const char* fmt, ...);                                      // pass text data straight to log (without being displayed)
+    IMGUI_API void          LogText(const char* fmt, ...) IM_PRINTFARGS(1, 2);                  // pass text data straight to log (without being displayed)
 
     // Utilities
     IMGUI_API bool          IsItemHovered();                                                    // was the last item hovered by mouse?
@@ -861,7 +869,7 @@ struct ImGuiTextBuffer
     int                 size() const { return Buf.Size-1; }
     bool                empty() { return size() >= 1; }
     void                clear() { Buf.clear(); Buf.push_back(0); }
-    IMGUI_API void      append(const char* fmt, ...);
+    IMGUI_API void      append(const char* fmt, ...) IM_PRINTFARGS(2, 3);
     IMGUI_API void      appendv(const char* fmt, va_list args);
 };
 

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -1121,7 +1121,7 @@ void ImGui::ShowTestWindow(bool* opened)
                 selected = i;
             ImGui::NextColumn();
             ImGui::Text(names[i]); ImGui::NextColumn();
-            ImGui::Text(paths[i]); ImGui::NextColumn(); 
+            ImGui::Text(paths[i]); ImGui::NextColumn();
             ImGui::Text("...."); ImGui::NextColumn();
         }
         ImGui::Columns(1);
@@ -1424,7 +1424,7 @@ void ImGui::ShowStyleEditor(ImGuiStyle* ref)
                 const ImVec4& col = style.Colors[i];
                 const char* name = ImGui::GetStyleColName(i);
                 if (!output_only_modified || memcmp(&col, (ref ? &ref->Colors[i] : &def.Colors[i]), sizeof(ImVec4)) != 0)
-                    ImGui::LogText("style.Colors[ImGuiCol_%s]%*s= ImVec4(%.2ff, %.2ff, %.2ff, %.2ff);" IM_NEWLINE, name, 22 - strlen(name), "", col.x, col.y, col.z, col.w);
+                    ImGui::LogText("style.Colors[ImGuiCol_%s]%*s= ImVec4(%.2ff, %.2ff, %.2ff, %.2ff);" IM_NEWLINE, name, 22 - (int)strlen(name), "", col.x, col.y, col.z, col.w);
             }
             ImGui::LogFinish();
         }
@@ -1702,7 +1702,7 @@ struct ExampleAppConsole
         ScrollToBottom = true;
     }
 
-    void    AddLog(const char* fmt, ...)
+    void    AddLog(const char* fmt, ...) IM_PRINTFARGS(2, 3)
     {
         char buf[1024];
         va_list args;
@@ -1862,7 +1862,7 @@ struct ExampleAppConsole
                 if (candidates.Size == 0)
                 {
                     // No match
-                    AddLog("No match for \"%.*s\"!\n", word_end-word_start, word_start);
+                    AddLog("No match for \"%.*s\"!\n", (int)(word_end-word_start), word_start);
                 }
                 else if (candidates.Size == 1)
                 {

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -90,7 +90,7 @@ char*               ImStrdup(const char* str);
 int                 ImStrlenW(const ImWchar* str);
 const ImWchar*      ImStrbolW(const ImWchar* buf_mid_line, const ImWchar* buf_begin); // Find beginning-of-line
 const char*         ImStristr(const char* haystack, const char* needle, const char* needle_end);
-int                 ImFormatString(char* buf, int buf_size, const char* fmt, ...);
+int                 ImFormatString(char* buf, int buf_size, const char* fmt, ...) IM_PRINTFARGS(3, 4);
 int                 ImFormatStringV(char* buf, int buf_size, const char* fmt, va_list args);
 
 // Helpers: Math


### PR DESCRIPTION
Code like

    const char *text = "<some non hardcoded text that may contain printf specifiers>";
    ImGui::Text(text);

can be really dangerous, let the compiler warn about it.

I also fixed these warnings:

    ../../imgui.cpp:2073:57: warning: field precision should have type 'int', but argument has type 'long' [-Wformat]
                ImFormatString(name, IM_ARRAYSIZE(name), "%.*s", line_end-line_start-2, line_start+1);
                                                          ~~^~   ~~~~~~~~~~~~~~~~~~~~~

    ../../imgui.cpp:8884:56: warning: format specifies type 'int' but the argument has type 'unsigned long' [-Wformat]
                    ImGui::BulletText("Storage: %d bytes", window->StateStorage.Data.Size * sizeof(ImGuiStorage::Pair));
                                                ~~         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                %lu

    ../../imgui_demo.cpp:59:27: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
            ImGui::SetTooltip(desc);
                              ^~~~
    ../../imgui_demo.cpp:964:25: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
                ImGui::Text(selected_fish == -1 ? "<None>" : names[selected_fish]);
                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ../../imgui_demo.cpp:1123:25: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
                ImGui::Text(names[i]); ImGui::NextColumn();
                            ^~~~~~~~
    ../../imgui_demo.cpp:1124:25: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
                ImGui::Text(paths[i]); ImGui::NextColumn(); 
                            ^~~~~~~~
    ../../imgui_demo.cpp:1427:64: warning: field width should have type 'int', but argument has type 'unsigned long' [-Wformat]
                        ImGui::LogText("style.Colors[ImGuiCol_%s]%*s= ImVec4(%.2ff, %.2ff, %.2ff, %.2ff);" IM_NEWLINE, name, 22 - strlen(name), "", col.x, col.y, col.z, col.w);

    ../../imgui_demo.cpp:1865:46: warning: field precision should have type 'int', but argument has type 'long' [-Wformat]
                        AddLog("No match for \"%.*s\"!\n", word_end-word_start, word_start);
                                              ~~^~        ~~~~~~~~~~~~~~~~~~~
