### PR TITLE
Makefile tweaks

### DIFF
--- a/examples/opengl3_example/Makefile
+++ b/examples/opengl3_example/Makefile
@@ -1,52 +1,62 @@
 #
 # Cross Platform Makefile
-# Compatible with Ubuntu 14.04.1 and Mac OS X
 #
-#
-# if you using Mac OS X:
-# You'll need glfw
-#    http://www.glfw.org
-#
-
-#CXX = g++
 
 OBJS = main.o imgui_impl_glfw_gl3.o
 OBJS += ../../imgui.o ../../imgui_demo.o ../../imgui_draw.o
 OBJS += ../libs/gl3w/GL/gl3w.o
 
-UNAME_S := $(shell uname -s)
+CXXFLAGS = -I../.. -I../libs/gl3w -O2 -g -Wall -Wformat
 
-
-ifeq ($(UNAME_S), Linux) #LINUX
-	ECHO_MESSAGE = "Linux"
-	LIBS = `pkg-config --static --libs glfw3`
-
-	CXXFLAGS = -I../../ -I../libs/gl3w `pkg-config --cflags glfw3`
-	CXXFLAGS += -Wall -Wformat
-	CFLAGS = $(CXXFLAGS)
+ifneq (, $(HOSTPREFIX))
+    PLATFORM = $(HOSTPREFIX)
+    CXX := $(HOSTPREFIX)-$(CXX)
+    CC := $(HOSTPREFIX)-$(CC)
+    PKG_CONFIG = $(HOSTPREFIX)-pkg-config
+else
+    PLATFORM = $(shell uname -s)
+    PKG_CONFIG = pkg-config
 endif
 
-ifeq ($(UNAME_S), Darwin) #APPLE
-	ECHO_MESSAGE = "Mac OS X"
-	LIBS = -framework OpenGL -framework Cocoa -framework IOKit -framework CoreVideo
-	LIBS += -L/usr/local/lib
-	LIBS += -lglfw3
+PLATFORM := $(shell echo $(PLATFORM) | tr '[:upper:]' '[:lower:]')
 
-	CXXFLAGS = -I../../ -I../libs/gl3w -I/usr/local/Cellar/glew/1.10.0/include -I/usr/local/include
-	CXXFLAGS += -Wall -Wformat
-#	CXXFLAGS += -D__APPLE__
-	CFLAGS = $(CXXFLAGS)
+ifneq (,$(findstring darwin,$(PLATFORM))) #APPLE
+    ECHO_MESSAGE = "Mac OS X"
+    LIBS = -framework OpenGL -framework Cocoa -framework IOKit -framework CoreVideo
+    LIBS += -lglfw
+
+    LIBDIRS = -L/usr/local/lib -L/opt/local/lib
+    INCDIRS = -I../../ -I../libs/gl3w -I/usr/local/Cellar/glew/1.10.0/include -I/usr/local/include -I/opt/local/include
 endif
 
-.cpp.o:
-	$(CXX) $(CXXFLAGS) -c -o $@ $<
+ifneq (,$(findstring mingw,$(PLATFORM))) #MINGW
+    ECHO_MESSAGE = "MinGW"
+    EXESUFFIX = .exe
+    LIBS = -lglfw3 -lopengl32 -luser32 -limm32
+    LDFLAGS = -mwindows
+endif
+
+ifeq (, $(LIBS)) #UNIX GENERIC
+    ECHO_MESSAGE = "Unix"
+    LIBS = -ldl `$(PKG_CONFIG) --libs glfw3 gl 2>/dev/null || echo -lglfw -lgl`
+
+    CXXFLAGS += `$(PKG_CONFIG) --cflags glfw3 gl 2>/dev/null`
+endif
+
+ifneq (, $(HOSTPREFIX))
+    LIBDIRS=
+    INCDIRS=
+endif
+
+CFLAGS = $(INCDIRS) $(CXXFLAGS)
+CXXFLAGS := $(INCDIRS) $(CXXFLAGS)
+LDFLAGS := $(LIBDIRS) $(LIBS) $(LDFLAGS)
 
 all:imgui_example
 	@echo Build complete for $(ECHO_MESSAGE)
 
 imgui_example:$(OBJS)
-	$(CXX) -o imgui_example $(OBJS) $(CXXFLAGS) $(LIBS)
+	$(CXX) -o imgui_example$(EXESUFFIX) $(OBJS) $(CXXFLAGS) $(LDFLAGS)
 
 clean:
-	rm $(OBJS)
-
+	rm -f $(OBJS) imgui_example{,.exe}

--- a/examples/opengl_example/Makefile
+++ b/examples/opengl_example/Makefile
@@ -1,51 +1,60 @@
 #
 # Cross Platform Makefile
-# Compatible with Ubuntu 14.04.1 and Mac OS X
 #
-#
-# if you using Mac OS X:
-# You'll need glfw
-#    http://www.glfw.org
-#
-
-#CXX = g++
 
 OBJS = main.o imgui_impl_glfw.o
 OBJS += ../../imgui.o ../../imgui_demo.o ../../imgui_draw.o
 
-UNAME_S := $(shell uname -s)
+CXXFLAGS = -I../.. -O2 -g -Wall -Wformat
 
-
-ifeq ($(UNAME_S), Linux) #LINUX
-	ECHO_MESSAGE = "Linux"
-	LIBS = `pkg-config --static --libs glfw3`
-
-	CXXFLAGS = -I../../ `pkg-config --cflags glfw3`
-	CXXFLAGS += -Wall -Wformat
-	CFLAGS = $(CXXFLAGS)
+ifneq (, $(HOSTPREFIX))
+    PLATFORM = $(HOSTPREFIX)
+    CXX := $(HOSTPREFIX)-$(CXX)
+    PKG_CONFIG = $(HOSTPREFIX)-pkg-config
+else
+    PLATFORM = $(shell uname -s)
+    PKG_CONFIG = pkg-config
 endif
 
-ifeq ($(UNAME_S), Darwin) #APPLE
-	ECHO_MESSAGE = "Mac OS X"
-	LIBS = -framework OpenGL -framework Cocoa -framework IOKit -framework CoreVideo
-	LIBS += -L/usr/local/lib
-	LIBS += -lglfw3
+PLATFORM := $(shell echo $(PLATFORM) | tr '[:upper:]' '[:lower:]')
 
-	CXXFLAGS = -I../../ -I/usr/local/include
-	CXXFLAGS += -Wall -Wformat
-#	CXXFLAGS += -D__APPLE__
-	CFLAGS = $(CXXFLAGS)
+ifneq (,$(findstring darwin,$(PLATFORM))) #APPLE
+    ECHO_MESSAGE = "Mac OS X"
+    LIBS = -framework OpenGL -framework Cocoa -framework IOKit -framework CoreVideo
+    LIBS += -lglfw
+
+    LIBDIRS = -L/usr/local/lib -L/opt/local/lib
+    INCDIRS = -I/usr/local/include -I/opt/local/include
 endif
 
-.cpp.o:
-	$(CXX) $(CXXFLAGS) -c -o $@ $<
+ifneq (,$(findstring mingw,$(PLATFORM))) #MINGW
+    ECHO_MESSAGE = "MinGW"
+    EXESUFFIX = .exe
+    LIBS = -lglfw3 -lopengl32 -luser32 -limm32
+    LDFLAGS = -mwindows
+endif
+
+ifeq (, $(LIBS)) #UNIX GENERIC
+    ECHO_MESSAGE = "Unix"
+    LIBS = `$(PKG_CONFIG) --libs glfw3 gl 2>/dev/null || echo -lglfw -lgl`
+
+    CXXFLAGS += `$(PKG_CONFIG) --cflags glfw3 gl 2>/dev/null`
+endif
+
+ifneq (, $(HOSTPREFIX))
+    LIBDIRS=
+    INCDIRS=
+endif
+
+CXXFLAGS := $(INCDIRS) $(CXXFLAGS)
+LDFLAGS := $(LIBDIRS) $(LIBS) $(LDFLAGS)
 
 all:imgui_example
 	@echo Build complete for $(ECHO_MESSAGE)
 
 imgui_example:$(OBJS)
-	$(CXX) -o imgui_example $(OBJS) $(CXXFLAGS) $(LIBS)
+	$(CXX) -o imgui_example$(EXESUFFIX) $(OBJS) $(CXXFLAGS) $(LDFLAGS)
 
 clean:
-	rm $(OBJS)
+	rm -f $(OBJS) imgui_example{,.exe}
 


### PR DESCRIPTION
- Added MinGW support
- Added cross compilation support, see below
- Removed unused `-D__APPLE__`, `__APPLE__` is always defined there anyway
- Removed `-static` from `pkg-config` flags and added the missing gl dependency instead
- Added /opt/local includes for MacPorts on Mac OS X
- Fall back to `-lglfw -lgl` in case `pkg-config` fails
- Made the Linux target "Unix Generic" (**should** now compile on real Unices too)
- Added `-O2` and `-g` - with `-O2` there are two new GCC warnings, see below

---

Cross Compilation Support:

I am using MinGW on (Arch-)Linux, while MinGW should now work on Windows too.

Example:

Cross Compiling for MinGW-w64 x86_64:

```
$ make HOSTPREFIX=x86_64-w64-mingw32
x86_64-w64-mingw32-g++  -I../.. -Wall -Wformat -c -o main.o main.cpp
x86_64-w64-mingw32-g++  -I../.. -Wall -Wformat -c -o imgui_impl_glfw.o imgui_impl_glfw.cpp
x86_64-w64-mingw32-g++  -I../.. -Wall -Wformat -c -o ../../imgui.o ../../imgui.cpp
x86_64-w64-mingw32-g++  -I../.. -Wall -Wformat -c -o ../../imgui_demo.o ../../imgui_demo.cpp
x86_64-w64-mingw32-g++  -I../.. -Wall -Wformat -c -o ../../imgui_draw.o ../../imgui_draw.cpp
[unused function warnings removed...]
x86_64-w64-mingw32-g++ -o imgui_example main.o imgui_impl_glfw.o ../../imgui.o ../../imgui_demo.o ../../imgui_draw.o  -I../.. -Wall -Wformat  -lglfw3 -lopengl32 -luser32 -limm32
Build complete for MinGW
```

Cross Compiling for MinGW-w64 i686 using clang:

```
$ make HOSTPREFIX=i686-w64-mingw32 CXX=i686-w64-mingw32-clang++
i686-w64-mingw32-clang++  -I../.. -Wall -Wformat -c -o main.o main.cpp
i686-w64-mingw32-clang++  -I../.. -Wall -Wformat -c -o imgui_impl_glfw.o imgui_impl_glfw.cpp
i686-w64-mingw32-clang++  -I../.. -Wall -Wformat -c -o ../../imgui.o ../../imgui.cpp
i686-w64-mingw32-clang++  -I../.. -Wall -Wformat -c -o ../../imgui_demo.o ../../imgui_demo.cpp
i686-w64-mingw32-clang++  -I../.. -Wall -Wformat -c -o ../../imgui_draw.o ../../imgui_draw.cpp
i686-w64-mingw32-clang++ -o imgui_example main.o imgui_impl_glfw.o ../../imgui.o ../../imgui_demo.o ../../imgui_draw.o  -I../.. -Wall -Wformat  -lglfw3 -lopengl32 -luser32 -limm32
Build complete for MinGW
```

---

New GCC (5.2.0) Warnings:

```
../../imgui.cpp: In function ‘ImGuiWindow* ImGui::GetParentWindow()’:
../../imgui.cpp:8917:1: warning: assuming signed overflow does not occur when assuming that (X - c) > X is always false [-Wstrict-overflow]
 }
 ^

../../imgui_demo.cpp: In member function ‘void ExampleAppConsole::Run(const char*, bool*)’:
../../imgui_demo.cpp:1719:13: warning: assuming signed overflow does not occur when assuming that (X - c) > X is always false [-Wstrict-overflow]
     void    Run(const char* title, bool* opened)
             ^
```

The line numbers are wrong, the first warning is caused by the assert in imgui.h @ line 778:

`inline value_type&          operator[](int i)               { IM_ASSERT(i < Size); return Data[i]; }`

For the second one, I don't know.
