### PR TITLE
add mac os x build instructions for sdl_opengl_example

### DIFF
--- a/examples/sdl_opengl_example/README.md
+++ b/examples/sdl_opengl_example/README.md
@@ -9,8 +9,15 @@
 cl /MD /I <sdl2path\include> /I ..\.. main.cpp imgui_impl_sdl.cpp ..\..\imgui*.cpp /link /LIBPATH:<sdl2path\lib> SDL2.lib SDL2main.lib
 ```
 
-- On Linux and similar Unices
+- On Linux and similar Unixes
 
 ```
 c++ `sdl2-config --cflags` -I ../.. main.cpp imgui_impl_sdl.cpp ../../imgui*.cpp `sdl2-config --libs` -lGL -o sdl2example
+```
+
+- On Mac OS X
+
+```
+brew install sdl2
+c++ `sdl2-config --cflags` -I ../.. main.cpp imgui_impl_sdl.cpp ../../imgui*.cpp `sdl2-config --libs` -framework OpenGl -o sdl2example
 ```


### PR DESCRIPTION
Mac OS X uses `-framework OpenGl` instead of typical `-lGL`.