### PR TITLE
fixed rendering of histogram with a lot of values

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -6613,7 +6613,7 @@ void ImGui::PlotEx(ImGuiPlotType plot_type, const char* label, float (*values_ge
     for (int n = 0; n < res_w; n++)
     {
         const float t1 = t0 + t_step;
-        const int v_idx = (int)(t0 * values_count);
+        const int v_idx = (int)(t0 * values_count + 0.5f);
         IM_ASSERT(v_idx >= 0 && v_idx < values_count);
         const float v1 = values_getter(data, (v_idx + values_offset + 1) % values_count);
         const ImVec2 p1 = ImVec2( t1, 1.0f - ImSaturate((v1 - scale_min) / (scale_max - scale_min)) );


### PR DESCRIPTION
When I draw a histogram with many elements (40+ on my computer), some values are rendered twice and some are skipped. It is caused by this code in ImGui::PlotEx:

```cpp
    ...
    for (int n = 0; n < res_w; n++)
    {
        const float t1 = t0 + t_step;
        const int v_idx = (int)(t0 * values_count);
    ...
```

Problem is the int cast. 

n == 23 -> t0 * values_count == 23.0000019 -> v_idx == 23
n == 24 -> t0 * values_count == 23.9999987 -> v_idx == 23
