### PR TITLE
add msys2/mingw64 target

### DIFF
--- a/examples/opengl3_example/Makefile
+++ b/examples/opengl3_example/Makefile
@@ -39,6 +39,16 @@ ifeq ($(UNAME_S), Darwin) #APPLE
 	CFLAGS = $(CXXFLAGS)
 endif
 
+ifeq ($(UNAME_S), MINGW64_NT-6.3)
+   ECHO_MESSAGE = "Windows"
+   LIBS = -lglfw3 -lgdi32 -lopengl32 -limm32
+
+   CXXFLAGS = -I../../ -I../libs/gl3w `pkg-config --cflags glfw3`
+   CXXFLAGS += -Wall -Wformat
+   CFLAGS = $(CXXFLAGS)
+endif
+
+
 .cpp.o:
 	$(CXX) $(CXXFLAGS) -c -o $@ $<
 
@@ -50,4 +60,3 @@ $(EXE): $(OBJS)
 
 clean:
 	rm $(EXE) $(OBJS)
-


### PR DESCRIPTION
this allows the GL3 example to build with msys2/mingw