### PR TITLE
Fixes MouseReleased double trigger (#359)

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -1848,7 +1848,7 @@ void ImGui::NewFrame()
     for (int i = 0; i < IM_ARRAYSIZE(g.IO.MouseDown); i++)
     {
         g.IO.MouseClicked[i] = g.IO.MouseDown[i] && g.IO.MouseDownDuration[i] < 0.0f;
-        g.IO.MouseReleased[i] = !g.IO.MouseDown[i] && g.IO.MouseDownDurationPrev[i] >= 0.0f;
+        g.IO.MouseReleased[i] = !g.IO.MouseReleased[i] && !g.IO.MouseDown[i] && g.IO.MouseDownDurationPrev[i] >= 0.0f;
         g.IO.MouseDownDurationPrev[i] = g.IO.MouseDownDuration[i];
         g.IO.MouseDownDuration[i] = g.IO.MouseDown[i] ? (g.IO.MouseDownDuration[i] < 0.0f ? 0.0f : g.IO.MouseDownDuration[i] + g.IO.DeltaTime) : -1.0f;
         g.IO.MouseDoubleClicked[i] = false;


### PR DESCRIPTION
- The idea is that you can't have two MouseReleased (for the same button) on two consecutive frames