### PR TITLE
Fix for not being able to enter certain characters in InputText on german keyboard

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -7217,7 +7217,7 @@ bool ImGui::InputTextEx(const char* label, char* buf, int buf_size, const ImVec2
         if (g.IO.InputCharacters[0])
         {
             // Process text input (before we check for Return because using some IME will effectively send a Return?)
-            if (!is_ctrl_down && is_editable)
+            if (!(is_ctrl_down && !is_alt_down) && is_editable)
             {
                 for (int n = 0; n < IM_ARRAYSIZE(g.IO.InputCharacters) && g.IO.InputCharacters[n]; n++)
                     if (unsigned int c = (unsigned int)g.IO.InputCharacters[n])


### PR DESCRIPTION
### Problem: 
On german keyboards the user can't enter lots of chars which use AltGr as a modifier (e.g '{' '[' ']' '}' '\' ) because of:
“Alt Gr” on german (and other) keyboards – “Alt Gr” is not the same as right-hand “Alt” on US keyboards, it essentially is a short-cut for “Control” and right-hand “Alt”. (from http://blog.molecular-matters.com/2011/09/05/properly-handling-keyboard-input/) 

With the existing code all chars are suppressed when CTRL-press is detected. 

### Solution: 
Don't suppress characters if CTRL AND ALT key press is detected in Imgui::InputTextEx. 

Ctrl+C, Ctrl+V etc still work as expected. 


