### PR TITLE
NULL out font texture on invalidate

### DIFF
--- a/examples/directx9_example/imgui_impl_dx9.cpp
+++ b/examples/directx9_example/imgui_impl_dx9.cpp
@@ -285,6 +285,7 @@ void ImGui_ImplDX9_InvalidateDeviceObjects()
         tex->Release();
         ImGui::GetIO().Fonts->TexID = 0;
     }
+    g_FontTexture = NULL;
 }
 
 void ImGui_ImplDX9_NewFrame()


### PR DESCRIPTION
If this isn't done, NewFrame won't re-create the font.