### PR TITLE
Add CmakeList files to use as external library with Cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,2 @@
+file(GLOB FFIL "*.cpp")
+add_library(ImGui ${FFIL})


### PR DESCRIPTION
Now you can add ImGui as a cmake library dependency. 

` include_directories("${PROJECT_SOURCE_DIR}/src/ImGui") `
` add_subdirectory ("src/ImGui")  `
` set (EXTRA_LIBS ${EXTRA_LIBS} ImGui) `

` target_link_libraries(ProjectName ${EXTRA_LIBS}) `