### PR TITLE
Examples: DirectX9/11: Remove dependency on the UNICODE #define.

### DIFF
--- a/examples/directx11_example/build_win32.bat
+++ b/examples/directx11_example/build_win32.bat
@@ -1,4 +1,4 @@
 @REM Build for Visual Studio compiler. Run your copy of vcvars32.bat or vcvarsall.bat to setup command-line compiler.
 mkdir Debug
-cl /nologo /MD /I ..\.. /I "%WindowsSdkDir%Include\um" /I "%WindowsSdkDir%Include\shared" /I "%DXSDK_DIR%Include" /D UNICODE *.cpp ..\..\*.cpp /FeDebug/directx11_example.exe /FoDebug/ /link /LIBPATH:"%DXSDK_DIR%/Lib/x86" d3d11.lib d3dcompiler.lib
+cl /nologo /MD /I ..\.. /I "%WindowsSdkDir%Include\um" /I "%WindowsSdkDir%Include\shared" /I "%DXSDK_DIR%Include" *.cpp ..\..\*.cpp /FeDebug/directx11_example.exe /FoDebug/ /link /LIBPATH:"%DXSDK_DIR%/Lib/x86" d3d11.lib d3dcompiler.lib
 

--- a/examples/directx11_example/main.cpp
+++ b/examples/directx11_example/main.cpp
@@ -125,21 +125,21 @@ LRESULT WINAPI WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
         PostQuitMessage(0);
         return 0;
     }
-    return DefWindowProc(hWnd, msg, wParam, lParam);
+    return DefWindowProcW(hWnd, msg, wParam, lParam);
 }
 
 int main(int, char**)
 {
     // Create application window
-    WNDCLASSEX wc = { sizeof(WNDCLASSEX), CS_CLASSDC, WndProc, 0L, 0L, GetModuleHandle(NULL), NULL, LoadCursor(NULL, IDC_ARROW), NULL, NULL, L"ImGui Example", NULL };
-    RegisterClassEx(&wc);
-    HWND hwnd = CreateWindow(L"ImGui Example", L"ImGui DirectX11 Example", WS_OVERLAPPEDWINDOW, 100, 100, 1280, 800, NULL, NULL, wc.hInstance, NULL);
+    WNDCLASSEXW wc = { sizeof(WNDCLASSEXW), CS_CLASSDC, WndProc, 0L, 0L, GetModuleHandle(NULL), NULL, LoadCursor(NULL, IDC_ARROW), NULL, NULL, L"ImGui Example", NULL };
+    RegisterClassExW(&wc);
+    HWND hwnd = CreateWindowW(L"ImGui Example", L"ImGui DirectX11 Example", WS_OVERLAPPEDWINDOW, 100, 100, 1280, 800, NULL, NULL, wc.hInstance, NULL);
 
     // Initialize Direct3D
     if (CreateDeviceD3D(hwnd) < 0)
     {
         CleanupDeviceD3D();
-        UnregisterClass(L"ImGui Example", wc.hInstance);
+        UnregisterClassW(L"ImGui Example", wc.hInstance);
         return 1;
     }
 
@@ -219,7 +219,7 @@ int main(int, char**)
 
     ImGui_ImplDX11_Shutdown();
     CleanupDeviceD3D();
-    UnregisterClass(L"ImGui Example", wc.hInstance);
+    UnregisterClassW(L"ImGui Example", wc.hInstance);
 
     return 0;
 }

--- a/examples/directx9_example/build_win32.bat
+++ b/examples/directx9_example/build_win32.bat
@@ -1,3 +1,3 @@
 @REM Build for Visual Studio compiler. Run your copy of vcvars32.bat or vcvarsall.bat to setup command-line compiler.
 mkdir Debug
-cl /nologo /MD /I ..\.. /I "%DXSDK_DIR%/Include" /D UNICODE *.cpp ..\..\*.cpp /FeDebug/directx9_example.exe /FoDebug/ /link /LIBPATH:"%DXSDK_DIR%/Lib/x86" d3d9.lib d3dx9d.lib
+cl /nologo /MD /I ..\.. /I "%DXSDK_DIR%/Include" *.cpp ..\..\*.cpp /FeDebug/directx9_example.exe /FoDebug/ /link /LIBPATH:"%DXSDK_DIR%/Lib/x86" d3d9.lib d3dx9d.lib

--- a/examples/directx9_example/main.cpp
+++ b/examples/directx9_example/main.cpp
@@ -38,21 +38,21 @@ LRESULT WINAPI WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
         PostQuitMessage(0);
         return 0;
     }
-    return DefWindowProc(hWnd, msg, wParam, lParam);
+    return DefWindowProcW(hWnd, msg, wParam, lParam);
 }
 
 int main(int, char**)
 {
     // Create application window
-    WNDCLASSEX wc = { sizeof(WNDCLASSEX), CS_CLASSDC, WndProc, 0L, 0L, GetModuleHandle(NULL), NULL, LoadCursor(NULL, IDC_ARROW), NULL, NULL, L"ImGui Example", NULL };
-    RegisterClassEx(&wc);
-    HWND hwnd = CreateWindow(L"ImGui Example", L"ImGui DirectX9 Example", WS_OVERLAPPEDWINDOW, 100, 100, 1280, 800, NULL, NULL, wc.hInstance, NULL);
+    WNDCLASSEXW wc = { sizeof(WNDCLASSEXW), CS_CLASSDC, WndProc, 0L, 0L, GetModuleHandle(NULL), NULL, LoadCursor(NULL, IDC_ARROW), NULL, NULL, L"ImGui Example", NULL };
+    RegisterClassExW(&wc);
+    HWND hwnd = CreateWindowW(L"ImGui Example", L"ImGui DirectX9 Example", WS_OVERLAPPEDWINDOW, 100, 100, 1280, 800, NULL, NULL, wc.hInstance, NULL);
 
     // Initialize Direct3D
     LPDIRECT3D9 pD3D;
     if ((pD3D = Direct3DCreate9(D3D_SDK_VERSION)) == NULL)
     {
-        UnregisterClass(L"ImGui Example", wc.hInstance);
+        UnregisterClassW(L"ImGui Example", wc.hInstance);
         return 0;
     }
     ZeroMemory(&g_d3dpp, sizeof(g_d3dpp));
@@ -67,7 +67,7 @@ int main(int, char**)
     if (pD3D->CreateDevice(D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, hwnd, D3DCREATE_HARDWARE_VERTEXPROCESSING, &g_d3dpp, &g_pd3dDevice) < 0)
     {
         pD3D->Release();
-        UnregisterClass(L"ImGui Example", wc.hInstance);
+        UnregisterClassW(L"ImGui Example", wc.hInstance);
         return 0;
     }
 
@@ -154,7 +154,7 @@ int main(int, char**)
     ImGui_ImplDX9_Shutdown();
     if (g_pd3dDevice) g_pd3dDevice->Release();
     if (pD3D) pD3D->Release();
-    UnregisterClass(L"ImGui Example", wc.hInstance);
+    UnregisterClassW(L"ImGui Example", wc.hInstance);
 
     return 0;
 }


### PR DESCRIPTION
Since the code already implies Unicode through its use of wide strings, we can get rid of the #define on the build command line by explicitly calling the W functions.