### PR TITLE
Fixed a couple of problems found by CppCat code analyzer.

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -5592,7 +5592,7 @@ bool ImGui::CollapsingHeader(const char* label, const char* str_id, bool display
     else
     {
         // Unframed typed for tree nodes
-        if ((held && hovered) || hovered)
+        if (hovered)
             RenderFrame(bb.Min, bb.Max, col, false);
         RenderCollapseTriangle(bb.Min + ImVec2(style.FramePadding.x, g.FontSize*0.15f), opened, 0.70f, false);
         if (g.LogEnabled)

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -117,7 +117,7 @@ static inline ImVec2& operator+=(ImVec2& lhs, const ImVec2& rhs)                
 static inline ImVec2& operator-=(ImVec2& lhs, const ImVec2& rhs)                { lhs.x -= rhs.x; lhs.y -= rhs.y; return lhs; }
 static inline ImVec2& operator*=(ImVec2& lhs, const float rhs)                  { lhs.x *= rhs; lhs.y *= rhs; return lhs; }
 static inline ImVec2& operator/=(ImVec2& lhs, const float rhs)                  { lhs.x /= rhs; lhs.y /= rhs; return lhs; }
-static inline ImVec4 operator-(const ImVec4& lhs, const ImVec4& rhs)            { return ImVec4(lhs.x-rhs.x, lhs.y-rhs.y, lhs.z-rhs.z, lhs.w-lhs.w); }
+static inline ImVec4 operator-(const ImVec4& lhs, const ImVec4& rhs)            { return ImVec4(lhs.x-rhs.x, lhs.y-rhs.y, lhs.z-rhs.z, lhs.w-rhs.w); }
 #endif
 
 static inline int    ImMin(int lhs, int rhs)                                    { return lhs < rhs ? lhs : rhs; }


### PR DESCRIPTION
* incorrect implementation of ImVec4 operator- which always gives a w value of 0
* boolean formula of ((A && B) || B) can be simplified to just (B)