### PR TITLE
fixed text referencing GLFW library in SDL examples

### DIFF
--- a/examples/sdl_opengl3_example/imgui_impl_sdl_gl3.cpp
+++ b/examples/sdl_opengl3_example/imgui_impl_sdl_gl3.cpp
@@ -356,7 +356,7 @@ void ImGui_ImplSdlGL3_NewFrame()
 	g_Time = current_time;
 
 	// Setup inputs
-	// (we already got mouse wheel, keyboard keys & characters from glfw callbacks polled in glfwPollEvents())
+	// (we already got mouse wheel, keyboard keys & characters from SDL_PollEvent())
 	int mx, my;
 	Uint32 mouseMask = SDL_GetMouseState(&mx, &my);
 	if (SDL_GetWindowFlags(g_Window) & SDL_WINDOW_MOUSE_FOCUS)

--- a/examples/sdl_opengl_example/imgui_impl_sdl.cpp
+++ b/examples/sdl_opengl_example/imgui_impl_sdl.cpp
@@ -242,7 +242,7 @@ void ImGui_ImplSdl_NewFrame(SDL_Window *window)
     g_Time = current_time;
 
     // Setup inputs
-    // (we already got mouse wheel, keyboard keys & characters from glfw callbacks polled in glfwPollEvents())
+    // (we already got mouse wheel, keyboard keys & characters from SDL_PollEvent())
     int mx, my;
     Uint32 mouseMask = SDL_GetMouseState(&mx, &my);
     if (SDL_GetWindowFlags(window) & SDL_WINDOW_MOUSE_FOCUS)


### PR DESCRIPTION
I think I found these typos in the SDL examples (which I assume were based on the GLFW examples since they shared similar flow).