### PR TITLE
SDL Examples: Automatically updating DisplayFrameBufferScale

### DIFF
--- a/examples/sdl_opengl3_example/imgui_impl_sdl_gl3.cpp
+++ b/examples/sdl_opengl3_example/imgui_impl_sdl_gl3.cpp
@@ -348,7 +348,10 @@ void ImGui_ImplSdlGL3_NewFrame()
 	int w, h;
 	SDL_GetWindowSize(g_Window, &w, &h);
 	io.DisplaySize = ImVec2((float)w, (float)h);
-	io.DisplayFramebufferScale = ImVec2(1.0f, 1.0f);
+
+	int glW, glH;
+	SDL_GL_GetDrawableSize(window, &glW, &glH);
+	io.DisplayFramebufferScale = ImVec2(glW / io.DisplaySize.x, glH / io.DisplaySize.y);
 
 	// Setup time step
 	Uint32	time = SDL_GetTicks();

--- a/examples/sdl_opengl_example/imgui_impl_sdl.cpp
+++ b/examples/sdl_opengl_example/imgui_impl_sdl.cpp
@@ -236,9 +236,9 @@ void ImGui_ImplSdl_NewFrame(SDL_Window *window)
 	SDL_GetWindowSize(window, &w, &h);
     io.DisplaySize = ImVec2((float)w, (float)h);
 
-    int glW, glH;
-    SDL_GL_GetDrawableSize(window, &glW, &glH);
-    io.DisplayFramebufferScale = ImVec2(glW / io.DisplaySize.x, glH / io.DisplaySize.y);
+	int glW, glH;
+	SDL_GL_GetDrawableSize(window, &glW, &glH);
+	io.DisplayFramebufferScale = ImVec2(glW / io.DisplaySize.x, glH / io.DisplaySize.y);
 
     // Setup time step
 	Uint32	time = SDL_GetTicks();

--- a/examples/sdl_opengl_example/imgui_impl_sdl.cpp
+++ b/examples/sdl_opengl_example/imgui_impl_sdl.cpp
@@ -236,6 +236,10 @@ void ImGui_ImplSdl_NewFrame(SDL_Window *window)
 	SDL_GetWindowSize(window, &w, &h);
     io.DisplaySize = ImVec2((float)w, (float)h);
 
+    int glW, glH;
+    SDL_GL_GetDrawableSize(window, &glW, &glH);
+    io.DisplayFramebufferScale = ImVec2(glW / io.DisplaySize.x, glH / io.DisplaySize.y);
+
     // Setup time step
 	Uint32	time = SDL_GetTicks();
 	double current_time = time / 1000.0;


### PR DESCRIPTION
I noticed when going from my external monitor to my laptop screen (non-retina to retina) that dear imgui wasn't automatically setting the DispalyFrameBufferScale. In SDL at least that's pretty easy by using [SDL_GL_GetDrawableSize](https://wiki.libsdl.org/SDL_GL_GetDrawableSize) and comparing against the window size.

Not sure how to implement for the other examples, but this should make it easier for devs to drop in the SDL impl code and get more logical behavior. 

Of course it assumes that one wants to always be in window space, but given that the mouse input only works in window space, it seems like everyone would either need this fix or need to modify the mouse input to scale inversely to handle high DPI.