### PR TITLE
Supporting TextHovered and TextActive colors

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -234,6 +234,10 @@ namespace ImGui
     IMGUI_API void          TextColoredV(const ImVec4& col, const char* fmt, va_list args);
     IMGUI_API void          TextDisabled(const char* fmt, ...) IM_PRINTFARGS(1);                    // shortcut for PushStyleColor(ImGuiCol_Text, style.Colors[ImGuiCol_TextDisabled]); Text(fmt, ...); PopStyleColor();
     IMGUI_API void          TextDisabledV(const char* fmt, va_list args);
+    IMGUI_API void          TextHovered(const char* fmt, ...) IM_PRINTFARGS(1);                    // shortcut for PushStyleColor(ImGuiCol_Text, style.Colors[ImGuiCol_TextHovered]); Text(fmt, ...); PopStyleColor();
+    IMGUI_API void          TextHoveredV(const char* fmt, va_list args);
+    IMGUI_API void          TextActive(const char* fmt, ...) IM_PRINTFARGS(1);                    // shortcut for PushStyleColor(ImGuiCol_Text, style.Colors[ImGuiCol_TextActive]); Text(fmt, ...); PopStyleColor();
+    IMGUI_API void          TextActiveV(const char* fmt, va_list args);
     IMGUI_API void          TextWrapped(const char* fmt, ...) IM_PRINTFARGS(1);                     // shortcut for PushTextWrapPos(0.0f); Text(fmt, ...); PopTextWrapPos();. Note that this won't work on an auto-resizing window if there's no other widgets to extend the window width, yoy may need to set a size using SetNextWindowSize().
     IMGUI_API void          TextWrappedV(const char* fmt, va_list args);
     IMGUI_API void          TextUnformatted(const char* text, const char* text_end = NULL);         // doesn't require null terminated string if 'text_end' is specified. no copy done to any bounded stack buffer, recommended for long chunks of text
@@ -537,6 +541,8 @@ enum ImGuiCol_
 {
     ImGuiCol_Text,
     ImGuiCol_TextDisabled,
+    ImGuiCol_TextHovered,
+    ImGuiCol_TextActive,
     ImGuiCol_WindowBg,
     ImGuiCol_ChildWindowBg,
     ImGuiCol_Border,


### PR DESCRIPTION
Hello,
These are minor changes in order to support TextHovered and TextActive colors.
It could be seen as nothing, but it is mandatory to have these 2 new colors when using high-contrast GUIs.