### PR TITLE
Support keypad-enter for text edit

### DIFF
--- a/examples/allegro5_example/imgui_impl_a5.cpp
+++ b/examples/allegro5_example/imgui_impl_a5.cpp
@@ -177,6 +177,7 @@ bool ImGui_ImplA5_Init(ALLEGRO_DISPLAY* display)
     io.KeyMap[ImGuiKey_Delete] = ALLEGRO_KEY_DELETE;
     io.KeyMap[ImGuiKey_Backspace] = ALLEGRO_KEY_BACKSPACE;
     io.KeyMap[ImGuiKey_Enter] = ALLEGRO_KEY_ENTER;
+    io.KeyMap[ImGuiKey_KP_Enter] = ALLEGRO_KEY_PAD_ENTER;
     io.KeyMap[ImGuiKey_Escape] = ALLEGRO_KEY_ESCAPE;
     io.KeyMap[ImGuiKey_A] = ALLEGRO_KEY_A;
     io.KeyMap[ImGuiKey_C] = ALLEGRO_KEY_C;

--- a/examples/directx10_example/imgui_impl_dx10.cpp
+++ b/examples/directx10_example/imgui_impl_dx10.cpp
@@ -450,6 +450,7 @@ bool    ImGui_ImplDX10_Init(void* hwnd, ID3D10Device* device)
     io.KeyMap[ImGuiKey_Delete] = VK_DELETE;
     io.KeyMap[ImGuiKey_Backspace] = VK_BACK;
     io.KeyMap[ImGuiKey_Enter] = VK_RETURN;
+    io.KeyMap[ImGuiKey_KP_Enter] = VK_RETURN;
     io.KeyMap[ImGuiKey_Escape] = VK_ESCAPE;
     io.KeyMap[ImGuiKey_A] = 'A';
     io.KeyMap[ImGuiKey_C] = 'C';

--- a/examples/directx11_example/imgui_impl_dx11.cpp
+++ b/examples/directx11_example/imgui_impl_dx11.cpp
@@ -447,6 +447,7 @@ bool    ImGui_ImplDX11_Init(void* hwnd, ID3D11Device* device, ID3D11DeviceContex
     io.KeyMap[ImGuiKey_Delete] = VK_DELETE;
     io.KeyMap[ImGuiKey_Backspace] = VK_BACK;
     io.KeyMap[ImGuiKey_Enter] = VK_RETURN;
+    io.KeyMap[ImGuiKey_KP_Enter] = VK_RETURN;
     io.KeyMap[ImGuiKey_Escape] = VK_ESCAPE;
     io.KeyMap[ImGuiKey_A] = 'A';
     io.KeyMap[ImGuiKey_C] = 'C';

--- a/examples/directx9_example/imgui_impl_dx9.cpp
+++ b/examples/directx9_example/imgui_impl_dx9.cpp
@@ -9,6 +9,7 @@
 
 // DirectX
 #include <d3dx9.h>
+#include <d3dx9math.h>
 #define DIRECTINPUT_VERSION 0x0800
 #include <dinput.h>
 
@@ -207,6 +208,7 @@ bool    ImGui_ImplDX9_Init(void* hwnd, IDirect3DDevice9* device)
     io.KeyMap[ImGuiKey_Delete] = VK_DELETE;
     io.KeyMap[ImGuiKey_Backspace] = VK_BACK;
     io.KeyMap[ImGuiKey_Enter] = VK_RETURN;
+    io.KeyMap[ImGuiKey_KP_Enter] = VK_RETURN;
     io.KeyMap[ImGuiKey_Escape] = VK_ESCAPE;
     io.KeyMap[ImGuiKey_A] = 'A';
     io.KeyMap[ImGuiKey_C] = 'C';

--- a/examples/ios_example/imguiex/imgui_impl_ios.mm
+++ b/examples/ios_example/imguiex/imgui_impl_ios.mm
@@ -488,6 +488,7 @@ void ImGui_ClipboardCallback(uSynergyCookie cookie, enum uSynergyClipboardFormat
     io.KeyMap[ImGuiKey_Delete] = kVK_ForwardDelete+1;
     io.KeyMap[ImGuiKey_Backspace] = kVK_Delete+1;
     io.KeyMap[ImGuiKey_Enter] = kVK_Return+1;
+    io.KeyMap[ImGuiKey_KP_Enter] = kVK_ANSI_KeypadEnter+1;
     io.KeyMap[ImGuiKey_Escape] = kVK_Escape+1;
     io.KeyMap[ImGuiKey_A] = kVK_ANSI_A+1;
     io.KeyMap[ImGuiKey_C] = kVK_ANSI_C+1;

--- a/examples/marmalade_example/imgui_impl_marmalade.cpp
+++ b/examples/marmalade_example/imgui_impl_marmalade.cpp
@@ -225,6 +225,7 @@ bool    ImGui_Marmalade_Init(bool install_callbacks)
     io.KeyMap[ImGuiKey_Delete] = s3eKeyDelete;
     io.KeyMap[ImGuiKey_Backspace] = s3eKeyBackspace;
     io.KeyMap[ImGuiKey_Enter] = s3eKeyEnter;
+    io.KeyMap[ImGuiKey_KP_Enter] = s3eKeyNumPadEnter;
     io.KeyMap[ImGuiKey_Escape] = s3eKeyEsc;
     io.KeyMap[ImGuiKey_A] = s3eKeyA;
     io.KeyMap[ImGuiKey_C] = s3eKeyC;

--- a/examples/opengl3_example/imgui_impl_glfw_gl3.cpp
+++ b/examples/opengl3_example/imgui_impl_glfw_gl3.cpp
@@ -308,6 +308,7 @@ bool    ImGui_ImplGlfwGL3_Init(GLFWwindow* window, bool install_callbacks)
     io.KeyMap[ImGuiKey_Delete] = GLFW_KEY_DELETE;
     io.KeyMap[ImGuiKey_Backspace] = GLFW_KEY_BACKSPACE;
     io.KeyMap[ImGuiKey_Enter] = GLFW_KEY_ENTER;
+    io.KeyMap[ImGuiKey_KP_Enter] = GLFW_KEY_KP_ENTER;
     io.KeyMap[ImGuiKey_Escape] = GLFW_KEY_ESCAPE;
     io.KeyMap[ImGuiKey_A] = GLFW_KEY_A;
     io.KeyMap[ImGuiKey_C] = GLFW_KEY_C;

--- a/examples/opengl_example/imgui_impl_glfw.cpp
+++ b/examples/opengl_example/imgui_impl_glfw.cpp
@@ -197,6 +197,7 @@ bool    ImGui_ImplGlfw_Init(GLFWwindow* window, bool install_callbacks)
     io.KeyMap[ImGuiKey_Delete] = GLFW_KEY_DELETE;
     io.KeyMap[ImGuiKey_Backspace] = GLFW_KEY_BACKSPACE;
     io.KeyMap[ImGuiKey_Enter] = GLFW_KEY_ENTER;
+    io.KeyMap[ImGuiKey_KP_Enter] = GLFW_KEY_KP_ENTER;
     io.KeyMap[ImGuiKey_Escape] = GLFW_KEY_ESCAPE;
     io.KeyMap[ImGuiKey_A] = GLFW_KEY_A;
     io.KeyMap[ImGuiKey_C] = GLFW_KEY_C;

--- a/examples/sdl_opengl3_example/imgui_impl_sdl_gl3.cpp
+++ b/examples/sdl_opengl3_example/imgui_impl_sdl_gl3.cpp
@@ -309,6 +309,7 @@ bool    ImGui_ImplSdlGL3_Init(SDL_Window *window)
 	io.KeyMap[ImGuiKey_Delete] = SDLK_DELETE;
 	io.KeyMap[ImGuiKey_Backspace] = SDLK_BACKSPACE;
 	io.KeyMap[ImGuiKey_Enter] = SDLK_RETURN;
+    io.KeyMap[ImGuiKey_KP_Enter] = SDLK_KP_ENTER;
 	io.KeyMap[ImGuiKey_Escape] = SDLK_ESCAPE;
 	io.KeyMap[ImGuiKey_A] = SDLK_a;
 	io.KeyMap[ImGuiKey_C] = SDLK_c;

--- a/examples/sdl_opengl_example/imgui_impl_sdl.cpp
+++ b/examples/sdl_opengl_example/imgui_impl_sdl.cpp
@@ -196,6 +196,7 @@ bool    ImGui_ImplSdl_Init(SDL_Window *window)
     io.KeyMap[ImGuiKey_Delete] = SDLK_DELETE;
     io.KeyMap[ImGuiKey_Backspace] = SDLK_BACKSPACE;
     io.KeyMap[ImGuiKey_Enter] = SDLK_RETURN;
+    io.KeyMap[ImGuiKey_KP_Enter] = SDLK_KP_ENTER;
     io.KeyMap[ImGuiKey_Escape] = SDLK_ESCAPE;
     io.KeyMap[ImGuiKey_A] = SDLK_a;
     io.KeyMap[ImGuiKey_C] = SDLK_c;

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -7414,7 +7414,7 @@ bool ImGui::InputTextEx(const char* label, char* buf, int buf_size, const ImVec2
         else if (IsKeyPressedMap(ImGuiKey_End))                         { edit_state.OnKeyPressed(is_ctrl_down ? STB_TEXTEDIT_K_TEXTEND | k_mask : STB_TEXTEDIT_K_LINEEND | k_mask); }
         else if (IsKeyPressedMap(ImGuiKey_Delete) && is_editable)       { edit_state.OnKeyPressed(STB_TEXTEDIT_K_DELETE | k_mask); }
         else if (IsKeyPressedMap(ImGuiKey_Backspace) && is_editable)    { edit_state.OnKeyPressed(STB_TEXTEDIT_K_BACKSPACE | k_mask); }
-        else if (IsKeyPressedMap(ImGuiKey_Enter))
+        else if (IsKeyPressedMap(ImGuiKey_Enter) || IsKeyPressedMap(ImGuiKey_KP_Enter))
         {
             bool ctrl_enter_for_new_line = (flags & ImGuiInputTextFlags_CtrlEnterForNewLine) != 0;
             if (!is_multiline || (ctrl_enter_for_new_line && !is_ctrl_down) || (!ctrl_enter_for_new_line && is_ctrl_down))

--- a/imgui.h
+++ b/imgui.h
@@ -523,6 +523,7 @@ enum ImGuiKey_
     ImGuiKey_Delete,    // for text edit
     ImGuiKey_Backspace, // for text edit
     ImGuiKey_Enter,     // for text edit
+    ImGuiKey_KP_Enter,  // for text edit
     ImGuiKey_Escape,    // for text edit
     ImGuiKey_A,         // for text edit CTRL+A: select all
     ImGuiKey_C,         // for text edit CTRL+C: copy


### PR DESCRIPTION
keypad-enter will be enabled by this change.

In `GLFW3`, keypad-enter is `GLFW_KEY_KP_ENTER`.
But in the others environments, whether they are correct did not know.