### PR TITLE
fix BindVertexArray/BindBuffer order

### DIFF
--- a/examples/opengl3_example/imgui_impl_glfw_gl3.cpp
+++ b/examples/opengl3_example/imgui_impl_glfw_gl3.cpp
@@ -103,8 +103,8 @@ void ImGui_ImplGlfwGL3_RenderDrawLists(ImDrawData* draw_data)
     glUseProgram(last_program);
     glBindTexture(GL_TEXTURE_2D, last_texture);
     glBindBuffer(GL_ARRAY_BUFFER, last_array_buffer);
-    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, last_element_array_buffer);
     glBindVertexArray(last_vertex_array);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, last_element_array_buffer);
 	glBlendEquationSeparate(last_blend_equation_rgb, last_blend_equation_alpha);
 	glBlendFunc(last_blend_src, last_blend_dst);
 	if (last_enable_blend) glEnable(GL_BLEND); else glDisable(GL_BLEND);


### PR DESCRIPTION
When `glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ebo)` is called with a non-0 VAO bound, it attaches `ebo` to that VAO's state. This code used to restore the state by calling `glBindBuffer(GL_ELEMENT_ARRAY_BUFFER)` followed by `glBindVertexArray`, and since `g_VaoHandle` is the currently bound VAO it attaches `last_element_array_buffer` to `g_VaoHandle`. 

Luckily this wasn't a problem because this code always calls `glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, g_ElementsHandle)` before drawing, which undoes the mistake.

Still, it seems wrong to hold on to a buffer that doesn't actually belong to you.

I think the new call to `glBindBuffer(GL_ELEMENT_ARRAY_BUFFER)` is actually a no-op, since that state is automatically restored when the old VAO is re-bound. Oh well.