### PR TITLE
Checking if multiple editing widgets have changed the given data

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -3113,47 +3113,47 @@ ImVec2 ImGui::CalcItemRectClosestPoint(const ImVec2& pos, bool on_edge, float ou
 void ImGui::BeginChangeCheck()
 {
     ImGuiWindow* window = GetCurrentWindow();
-	ImChangeItem ci = { ImChangeItemType_Check, 0 };
-	window->ChangeStack.push_back(ci);
+    ImChangeItem ci = { ImChangeItemType_Check, 0 };
+    window->ChangeStack.push_back(ci);
 }
 
 ImU32 ImGui::EndChangeCheck()
 {
     ImGuiWindow* window = GetCurrentWindow();
-	IM_ASSERT(window->ChangeStack.size() > 0);
-	IM_ASSERT(window->ChangeStack.back().Type == ImChangeItemType_Check);
-	ImU32 flags = window->ChangeStack.back().Flags;
-	window->ChangeStack.pop_back();
-	return flags;
+    IM_ASSERT(window->ChangeStack.size() > 0);
+    IM_ASSERT(window->ChangeStack.back().Type == ImChangeItemType_Check);
+    ImU32 flags = window->ChangeStack.back().Flags;
+    window->ChangeStack.pop_back();
+    return flags;
 }
 
 void ImGui::BeginChangeMask(ImU32 mask)
 {
     ImGuiWindow* window = GetCurrentWindow();
-	ImChangeItem ci = { ImChangeItemType_Mask, mask };
-	window->ChangeStack.push_back(ci);
+    ImChangeItem ci = { ImChangeItemType_Mask, mask };
+    window->ChangeStack.push_back(ci);
 }
 
 void ImGui::EndChangeMask()
 {
     ImGuiWindow* window = GetCurrentWindow();
-	IM_ASSERT(window->ChangeStack.size() > 0);
-	IM_ASSERT(window->ChangeStack.back().Type == ImChangeItemType_Mask);
-	window->ChangeStack.pop_back();
+    IM_ASSERT(window->ChangeStack.size() > 0);
+    IM_ASSERT(window->ChangeStack.back().Type == ImChangeItemType_Mask);
+    window->ChangeStack.pop_back();
 }
 
 void ImGui::TriggerChangeCheck(ImU32 mask)
 {
     ImGuiWindow* window = GetCurrentWindow();
-	int at = window->ChangeStack.size() - 1;
-	while (mask && at >= 0)
-	{
-		if (window->ChangeStack[at].Type == ImChangeItemType_Check)
-			window->ChangeStack[at].Flags |= mask;
-		else
-			mask &= window->ChangeStack[at].Flags;
-		at--;
-	}
+    int at = window->ChangeStack.size() - 1;
+    while (mask && at >= 0)
+    {
+        if (window->ChangeStack[at].Type == ImChangeItemType_Check)
+            window->ChangeStack[at].Flags |= mask;
+        else
+            mask &= window->ChangeStack[at].Flags;
+        at--;
+    }
 }
 
 // Tooltip is stored and turned into a BeginTooltip()/EndTooltip() sequence at the end of the frame. Each call override previous value.
@@ -3500,7 +3500,7 @@ static void CheckStacksSize(ImGuiWindow* window, bool write)
     ImGuiState& g = *GImGui;
     int* p_backup = &window->DC.StackSizesBackup[0];
     { int current = window->IDStack.Size;       if (write) *p_backup = current; else IM_ASSERT(*p_backup == current); p_backup++; }    // User forgot PopID()
-	{ int current = window->ChangeStack.Size;   if (write) *p_backup = current; else IM_ASSERT(*p_backup == current); p_backup++; }    // User forgot EndChangeCheck()/EndChangeMask()
+    { int current = window->ChangeStack.Size;   if (write) *p_backup = current; else IM_ASSERT(*p_backup == current); p_backup++; }    // User forgot EndChangeCheck()/EndChangeMask()
     { int current = window->DC.GroupStack.Size; if (write) *p_backup = current; else IM_ASSERT(*p_backup == current); p_backup++; }    // User forgot EndGroup()
     { int current = g.CurrentPopupStack.Size;   if (write) *p_backup = current; else IM_ASSERT(*p_backup == current); p_backup++; }    // User forgot EndPopup()/EndMenu()
     { int current = g.ColorModifiers.Size;      if (write) *p_backup = current; else IM_ASSERT(*p_backup == current); p_backup++; }    // User forgot PopStyleColor()
@@ -6245,8 +6245,8 @@ bool ImGui::SliderBehavior(const ImRect& frame_bb, ImGuiID id, float* v, float v
         grab_bb = ImRect(ImVec2(frame_bb.Min.x + grab_padding, grab_pos - grab_sz*0.5f), ImVec2(frame_bb.Max.x - grab_padding, grab_pos + grab_sz*0.5f));
     window->DrawList->AddRectFilled(grab_bb.Min, grab_bb.Max, GetColorU32(g.ActiveId == id ? ImGuiCol_SliderGrabActive : ImGuiCol_SliderGrab), style.GrabRounding);
 
-	if (value_changed)
-		TriggerChangeCheck();
+    if (value_changed)
+        TriggerChangeCheck();
     return value_changed;
 }
 
@@ -6315,8 +6315,8 @@ bool ImGui::SliderFloat(const char* label, float* v, float v_min, float v_max, c
     if (label_size.x > 0.0f)
         RenderText(ImVec2(frame_bb.Max.x + style.ItemInnerSpacing.x, frame_bb.Min.y + style.FramePadding.y), label);
 
-	if (value_changed)
-		TriggerChangeCheck();
+    if (value_changed)
+        TriggerChangeCheck();
     return value_changed;
 }
 
@@ -6363,8 +6363,8 @@ bool ImGui::VSliderFloat(const char* label, const ImVec2& size, float* v, float 
     if (label_size.x > 0.0f)
         RenderText(ImVec2(frame_bb.Max.x + style.ItemInnerSpacing.x, frame_bb.Min.y + style.FramePadding.y), label);
 
-	if (value_changed)
-		TriggerChangeCheck();
+    if (value_changed)
+        TriggerChangeCheck();
     return value_changed;
 }
 
@@ -6553,8 +6553,8 @@ bool ImGui::DragBehavior(const ImRect& frame_bb, ImGuiID id, float* v, float v_s
         }
     }
 
-	if (value_changed)
-		TriggerChangeCheck();
+    if (value_changed)
+        TriggerChangeCheck();
     return value_changed;
 }
 
@@ -6988,8 +6988,8 @@ bool ImGui::Checkbox(const char* label, bool* v)
     if (label_size.x > 0.0f)
         RenderText(text_bb.GetTL(), label);
 
-	if (pressed)
-		TriggerChangeCheck();
+    if (pressed)
+        TriggerChangeCheck();
     return pressed;
 }
 
@@ -7062,8 +7062,8 @@ bool ImGui::RadioButton(const char* label, bool active)
     if (label_size.x > 0.0f)
         RenderText(text_bb.GetTL(), label);
 
-	if (pressed)
-		TriggerChangeCheck();
+    if (pressed)
+        TriggerChangeCheck();
     return pressed;
 }
 
@@ -7888,13 +7888,13 @@ bool ImGui::InputTextEx(const char* label, char* buf, int buf_size, const ImVec2
     if (label_size.x > 0)
         RenderText(ImVec2(frame_bb.Max.x + style.ItemInnerSpacing.x, frame_bb.Min.y + style.FramePadding.y), label);
 
-	bool trigger;
+    bool trigger;
     if ((flags & ImGuiInputTextFlags_EnterReturnsTrue) != 0)
         trigger = enter_pressed;
-	else
-		trigger = value_changed;
-	if (trigger)
-		TriggerChangeCheck();
+    else
+        trigger = value_changed;
+    if (trigger)
+        TriggerChangeCheck();
     return trigger;
 }
 
@@ -7965,8 +7965,8 @@ bool ImGui::InputScalarEx(const char* label, ImGuiDataType data_type, void* data
     }
     ImGui::EndGroup();
 
-	if (value_changed)
-		TriggerChangeCheck();
+    if (value_changed)
+        TriggerChangeCheck();
     return value_changed;
 }
 
@@ -8227,8 +8227,8 @@ bool ImGui::Combo(const char* label, int* current_item, bool (*items_getter)(voi
         }
         ImGui::PopStyleVar();
     }
-	if (value_changed)
-		TriggerChangeCheck();
+    if (value_changed)
+        TriggerChangeCheck();
     return value_changed;
 }
 
@@ -8317,7 +8317,7 @@ bool ImGui::Selectable(const char* label, bool* p_selected, ImGuiSelectableFlags
     if (ImGui::Selectable(label, *p_selected, flags, size_arg))
     {
         *p_selected = !*p_selected;
-		TriggerChangeCheck();
+        TriggerChangeCheck();
         return true;
     }
     return false;
@@ -8413,8 +8413,8 @@ bool ImGui::ListBox(const char* label, int* current_item, bool (*items_getter)(v
     }
     clipper.End();
     ImGui::ListBoxFooter();
-	if (value_changed)
-		TriggerChangeCheck();
+    if (value_changed)
+        TriggerChangeCheck();
     return value_changed;
 }
 
@@ -8650,8 +8650,8 @@ bool ImGui::ColorButton(const ImVec4& col, bool small_height, bool outline_borde
     if (hovered)
         ImGui::SetTooltip("Color:\n(%.2f,%.2f,%.2f,%.2f)\n#%02X%02X%02X%02X", col.x, col.y, col.z, col.w, IM_F32_TO_INT8(col.x), IM_F32_TO_INT8(col.y), IM_F32_TO_INT8(col.z), IM_F32_TO_INT8(col.z));
 
-	if (pressed)
-		TriggerChangeCheck();
+    if (pressed)
+        TriggerChangeCheck();
     return pressed;
 }
 
@@ -8798,7 +8798,7 @@ bool ImGui::ColorEdit4(const char* label, float col[4], bool alpha)
         col[2] = f[2];
         if (alpha)
             col[3] = f[3];
-		TriggerChangeCheck();
+        TriggerChangeCheck();
     }
 
     ImGui::PopID();

--- a/imgui.h
+++ b/imgui.h
@@ -334,12 +334,12 @@ namespace ImGui
     IMGUI_API void          ValueColor(const char* prefix, const ImVec4& v);
     IMGUI_API void          ValueColor(const char* prefix, unsigned int v);
 
-	// Widgets: Change checking. Use this to check for changes coming from multiple widgets at once.
-	IMGUI_API void          BeginChangeCheck();
-	IMGUI_API ImU32         EndChangeCheck();
-	IMGUI_API void          BeginChangeMask(ImU32 mask); // which flags to let through from changes inside
-	IMGUI_API void          EndChangeMask();
-	IMGUI_API void          TriggerChangeCheck(ImU32 mask = 0xffffffff); // trigger the check as any widget would
+    // Widgets: Change checking. Use this to check for changes coming from multiple widgets at once.
+    IMGUI_API void          BeginChangeCheck();
+    IMGUI_API ImU32         EndChangeCheck();
+    IMGUI_API void          BeginChangeMask(ImU32 mask); // which flags to let through from changes inside
+    IMGUI_API void          EndChangeMask();
+    IMGUI_API void          TriggerChangeCheck(ImU32 mask = 0xffffffff); // trigger the check as any widget would
 
     // Tooltips
     IMGUI_API void          SetTooltip(const char* fmt, ...) IM_PRINTFARGS(1);                  // set tooltip under mouse-cursor, typically use with ImGui::IsHovered(). last call wins

--- a/imgui.h
+++ b/imgui.h
@@ -334,6 +334,13 @@ namespace ImGui
     IMGUI_API void          ValueColor(const char* prefix, const ImVec4& v);
     IMGUI_API void          ValueColor(const char* prefix, unsigned int v);
 
+	// Widgets: Change checking. Use this to check for changes coming from multiple widgets at once.
+	IMGUI_API void          BeginChangeCheck();
+	IMGUI_API ImU32         EndChangeCheck();
+	IMGUI_API void          BeginChangeMask(ImU32 mask); // which flags to let through from changes inside
+	IMGUI_API void          EndChangeMask();
+	IMGUI_API void          TriggerChangeCheck(ImU32 mask = 0xffffffff); // trigger the check as any widget would
+
     // Tooltips
     IMGUI_API void          SetTooltip(const char* fmt, ...) IM_PRINTFARGS(1);                  // set tooltip under mouse-cursor, typically use with ImGui::IsHovered(). last call wins
     IMGUI_API void          SetTooltipV(const char* fmt, va_list args);

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -139,6 +139,7 @@ void ImGui::ShowTestWindow(bool* p_opened)
     static bool no_scrollbar = false;
     static bool no_collapse = false;
     static bool no_menu = false;
+	static int version = 0;
 
     // Demonstrate the various window flags. Typically you would just use the default.
     ImGuiWindowFlags window_flags = 0;
@@ -156,6 +157,7 @@ void ImGui::ShowTestWindow(bool* p_opened)
         ImGui::End();
         return;
     }
+	ImGui::BeginChangeCheck();
 
     //ImGui::PushItemWidth(ImGui::GetWindowWidth() * 0.65f);    // 2/3 of the space for widget and 1/3 for labels
     ImGui::PushItemWidth(-140);                                 // Right align, keep 140 pixels for labels
@@ -191,6 +193,10 @@ void ImGui::ShowTestWindow(bool* p_opened)
             ImGui::MenuItem("About ImGui", NULL, &show_app_about);
             ImGui::EndMenu();
         }
+		char bfr[32];
+		sprintf(bfr, "[data version %d]", version);
+        if (ImGui::BeginMenu(bfr))
+			ImGui::EndMenu();
         ImGui::EndMenuBar();
     }
 
@@ -700,6 +706,45 @@ void ImGui::ShowTestWindow(bool* p_opened)
             ImGui::PopStyleVar();
 
             ImGui::Indent();
+            ImGui::TreePop();
+        }
+
+        if (ImGui::TreeNode("Change checks"))
+        {
+			static float group1changed = 0;
+			static float group2changed = 0;
+			static bool cc_value1 = 1;
+			static int cc_value2 = 0;
+			static float cc_value3 = 3.14f;
+
+			ImGui::TextColored(ImVec4(1, 1, 1, group1changed * 0.8f + 0.2f), "Group 1 changed");
+			ImGui::TextColored(ImVec4(1, 1, 1, group2changed * 0.8f + 0.2f), "Group 2 changed");
+
+			ImGui::BeginChangeCheck();
+
+			ImGui::Checkbox("Group 1 / 2 value", &cc_value1);
+
+			ImGui::BeginChangeMask(2);
+			ImGui::RadioButton("Group 2", &cc_value2, 0);
+			ImGui::SameLine();
+			ImGui::RadioButton("value", &cc_value2, 1);
+			ImGui::EndChangeMask();
+
+			ImGui::BeginChangeMask(1);
+			ImGui::SliderFloat("Group 1 value", &cc_value3, -10, 10);
+			ImGui::EndChangeMask();
+
+			ImU32 results = ImGui::EndChangeCheck();
+			if (results & 1)
+				group1changed = 1;
+			if (results & 2)
+				group2changed = 1;
+
+			if (group1changed > 0)
+				group1changed -= ImGui::GetIO().DeltaTime;
+			if (group2changed > 0)
+				group2changed -= ImGui::GetIO().DeltaTime;
+
             ImGui::TreePop();
         }
     }
@@ -1530,6 +1575,8 @@ void ImGui::ShowTestWindow(bool* p_opened)
         }
     }
 
+	if (ImGui::EndChangeCheck())
+		version++;
     ImGui::End();
 }
 

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -139,7 +139,7 @@ void ImGui::ShowTestWindow(bool* p_opened)
     static bool no_scrollbar = false;
     static bool no_collapse = false;
     static bool no_menu = false;
-	static int version = 0;
+    static int version = 0;
 
     // Demonstrate the various window flags. Typically you would just use the default.
     ImGuiWindowFlags window_flags = 0;
@@ -157,7 +157,7 @@ void ImGui::ShowTestWindow(bool* p_opened)
         ImGui::End();
         return;
     }
-	ImGui::BeginChangeCheck();
+    ImGui::BeginChangeCheck();
 
     //ImGui::PushItemWidth(ImGui::GetWindowWidth() * 0.65f);    // 2/3 of the space for widget and 1/3 for labels
     ImGui::PushItemWidth(-140);                                 // Right align, keep 140 pixels for labels
@@ -193,10 +193,10 @@ void ImGui::ShowTestWindow(bool* p_opened)
             ImGui::MenuItem("About ImGui", NULL, &show_app_about);
             ImGui::EndMenu();
         }
-		char bfr[32];
-		sprintf(bfr, "[data version %d]", version);
+        char bfr[32];
+        sprintf(bfr, "[data version %d]", version);
         if (ImGui::BeginMenu(bfr))
-			ImGui::EndMenu();
+            ImGui::EndMenu();
         ImGui::EndMenuBar();
     }
 
@@ -711,39 +711,39 @@ void ImGui::ShowTestWindow(bool* p_opened)
 
         if (ImGui::TreeNode("Change checks"))
         {
-			static float group1changed = 0;
-			static float group2changed = 0;
-			static bool cc_value1 = 1;
-			static int cc_value2 = 0;
-			static float cc_value3 = 3.14f;
+            static float group1changed = 0;
+            static float group2changed = 0;
+            static bool cc_value1 = 1;
+            static int cc_value2 = 0;
+            static float cc_value3 = 3.14f;
 
-			ImGui::TextColored(ImVec4(1, 1, 1, group1changed * 0.8f + 0.2f), "Group 1 changed");
-			ImGui::TextColored(ImVec4(1, 1, 1, group2changed * 0.8f + 0.2f), "Group 2 changed");
+            ImGui::TextColored(ImVec4(1, 1, 1, group1changed * 0.8f + 0.2f), "Group 1 changed");
+            ImGui::TextColored(ImVec4(1, 1, 1, group2changed * 0.8f + 0.2f), "Group 2 changed");
 
-			ImGui::BeginChangeCheck();
+            ImGui::BeginChangeCheck();
 
-			ImGui::Checkbox("Group 1 / 2 value", &cc_value1);
+            ImGui::Checkbox("Group 1 / 2 value", &cc_value1);
 
-			ImGui::BeginChangeMask(2);
-			ImGui::RadioButton("Group 2", &cc_value2, 0);
-			ImGui::SameLine();
-			ImGui::RadioButton("value", &cc_value2, 1);
-			ImGui::EndChangeMask();
+            ImGui::BeginChangeMask(2);
+            ImGui::RadioButton("Group 2", &cc_value2, 0);
+            ImGui::SameLine();
+            ImGui::RadioButton("value", &cc_value2, 1);
+            ImGui::EndChangeMask();
 
-			ImGui::BeginChangeMask(1);
-			ImGui::SliderFloat("Group 1 value", &cc_value3, -10, 10);
-			ImGui::EndChangeMask();
+            ImGui::BeginChangeMask(1);
+            ImGui::SliderFloat("Group 1 value", &cc_value3, -10, 10);
+            ImGui::EndChangeMask();
 
-			ImU32 results = ImGui::EndChangeCheck();
-			if (results & 1)
-				group1changed = 1;
-			if (results & 2)
-				group2changed = 1;
+            ImU32 results = ImGui::EndChangeCheck();
+            if (results & 1)
+                group1changed = 1;
+            if (results & 2)
+                group2changed = 1;
 
-			if (group1changed > 0)
-				group1changed -= ImGui::GetIO().DeltaTime;
-			if (group2changed > 0)
-				group2changed -= ImGui::GetIO().DeltaTime;
+            if (group1changed > 0)
+                group1changed -= ImGui::GetIO().DeltaTime;
+            if (group2changed > 0)
+                group2changed -= ImGui::GetIO().DeltaTime;
 
             ImGui::TreePop();
         }
@@ -1575,8 +1575,8 @@ void ImGui::ShowTestWindow(bool* p_opened)
         }
     }
 
-	if (ImGui::EndChangeCheck())
-		version++;
+    if (ImGui::EndChangeCheck())
+        version++;
     ImGui::End();
 }
 

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -204,8 +204,8 @@ enum ImGuiDataType
 
 enum ImChangeItemType
 {
-	ImChangeItemType_Check,
-	ImChangeItemType_Mask,
+    ImChangeItemType_Check,
+    ImChangeItemType_Mask,
 };
 
 // 2D axis aligned bounding-box
@@ -356,8 +356,8 @@ struct ImGuiPopupRef
 // Change info
 struct ImChangeItem
 {
-	ImChangeItemType Type;
-	ImU32            Flags;
+    ImChangeItemType Type;
+    ImU32            Flags;
 };
 
 // Main state for ImGui
@@ -642,7 +642,7 @@ struct IMGUI_API ImGuiWindow
 
     ImGuiDrawContext        DC;                                 // Temporary per-window data, reset at the beginning of the frame
     ImVector<ImGuiID>       IDStack;                            // ID stack. ID are hashes seeded with the value at the top of the stack
-	ImVector<ImChangeItem>  ChangeStack;                        // Change (checking) stack.
+    ImVector<ImChangeItem>  ChangeStack;                        // Change (checking) stack.
     ImRect                  ClipRect;                           // = DrawList->clip_rect_stack.back(). Scissoring / clipping rectangle. x1, y1, x2, y2.
     ImRect                  ClippedWindowRect;                  // = ClipRect just after setup in Begin()
     int                     LastFrameActive;

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -202,6 +202,12 @@ enum ImGuiDataType
     ImGuiDataType_Float
 };
 
+enum ImChangeItemType
+{
+	ImChangeItemType_Check,
+	ImChangeItemType_Mask,
+};
+
 // 2D axis aligned bounding-box
 // NB: we can't rely on ImVec2 math operators being available here
 struct IMGUI_API ImRect
@@ -345,6 +351,13 @@ struct ImGuiPopupRef
     ImVec2          MousePosOnOpen; // Copy of mouse position at the time of opening popup
 
     ImGuiPopupRef(ImGuiID id, ImGuiWindow* parent_window, ImGuiID parent_menu_set, const ImVec2& mouse_pos) { PopupID = id; Window = NULL; ParentWindow = parent_window; ParentMenuSet = parent_menu_set; MousePosOnOpen = mouse_pos; }
+};
+
+// Change info
+struct ImChangeItem
+{
+	ImChangeItemType Type;
+	ImU32            Flags;
 };
 
 // Main state for ImGui
@@ -542,7 +555,7 @@ struct IMGUI_API ImGuiDrawContext
     ImVector<bool>          ButtonRepeatStack;
     ImVector<ImGuiGroupData>GroupStack;
     ImGuiColorEditMode      ColorEditMode;
-    int                     StackSizesBackup[6];    // Store size of various stacks for asserting
+    int                     StackSizesBackup[7];    // Store size of various stacks for asserting
 
     float                   IndentX;                // Indentation / start position from left of window (increased by TreePush/TreePop, etc.)
     float                   ColumnsOffsetX;         // Offset to the current column (if ColumnsCurrent > 0). FIXME: This and the above should be a stack to allow use cases like Tree->Column->Tree. Need revamp columns API.
@@ -629,6 +642,7 @@ struct IMGUI_API ImGuiWindow
 
     ImGuiDrawContext        DC;                                 // Temporary per-window data, reset at the beginning of the frame
     ImVector<ImGuiID>       IDStack;                            // ID stack. ID are hashes seeded with the value at the top of the stack
+	ImVector<ImChangeItem>  ChangeStack;                        // Change (checking) stack.
     ImRect                  ClipRect;                           // = DrawList->clip_rect_stack.back(). Scissoring / clipping rectangle. x1, y1, x2, y2.
     ImRect                  ClippedWindowRect;                  // = ClipRect just after setup in Begin()
     int                     LastFrameActive;


### PR DESCRIPTION
I needed [this](http://docs.unity3d.com/ScriptReference/EditorGUI.BeginChangeCheck.html) in my own editor so I just implemented it.

It turned out to be a bit more advanced since I needed at least two editing groups (one for updating data version, another for updating realtime preview which takes more time).

Is anyone else in need of this feature?

P.S. I also added two new parts to the demo - "data version" menu "button" that increments with every change and a "Widgets/Change checks" section that also features masking behavior.