### PR TITLE
DX10/11: Remove d3dcompiler.lib dependency

### DIFF
--- a/examples/directx10_example/directx10_example.vcxproj
+++ b/examples/directx10_example/directx10_example.vcxproj
@@ -85,7 +85,7 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>d3d10.lib;d3dcompiler.lib;dxgi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d10.lib;dxgi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(DXSDK_DIR)/Lib/x86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <SubSystem>Console</SubSystem>
     </Link>
@@ -115,7 +115,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>d3d10.lib;d3dcompiler.lib;dxgi.lib;imm32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d10.lib;dxgi.lib;imm32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(DXSDK_DIR)/Lib/x86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <SubSystem>Console</SubSystem>
     </Link>

--- a/examples/directx10_example/imgui_impl_dx10.cpp
+++ b/examples/directx10_example/imgui_impl_dx10.cpp
@@ -9,10 +9,12 @@
 #include "imgui.h"
 #include "imgui_impl_dx10.h"
 
+// For sprintf
+#include <stdio.h>
+
 // DirectX
 #include <d3d10_1.h>
 #include <d3d10.h>
-#include <d3dcompiler.h>
 #define DIRECTINPUT_VERSION 0x0800
 #include <dinput.h>
 
@@ -330,12 +332,30 @@ static void ImGui_ImplDX10_CreateFontsTexture()
     io.Fonts->ClearTexData();
 }
 
+typedef HRESULT (__stdcall *D3DCompile_t)(LPCVOID, SIZE_T, LPCSTR, D3D_SHADER_MACRO*, ID3DInclude*, LPCSTR, LPCSTR, UINT, UINT, ID3DBlob**, ID3DBlob*);
+
 bool    ImGui_ImplDX10_CreateDeviceObjects()
 {
     if (!g_pd3dDevice)
         return false;
     if (g_pFontSampler)
         ImGui_ImplDX10_InvalidateDeviceObjects();
+
+    // Detect which d3dcompiler_XX.dll is present in the system and grab a pointer to D3DCompile.
+    // Without this, you must link d3dcompiler.lib with the project.
+    D3DCompile_t D3DCompile = NULL;
+    {
+        char dllBuffer[20];
+        for (int i = 47; i > 30 && !D3DCompile; i--)
+        {
+            sprintf(dllBuffer, "d3dcompiler_%d.dll", i);
+            HMODULE hDll = LoadLibraryA(dllBuffer);
+            if (hDll)
+                D3DCompile = (D3DCompile_t)GetProcAddress(hDll, "D3DCompile");
+        }
+        if (!D3DCompile)
+            return false;
+    }
 
     // Create the vertex shader
     {

--- a/examples/directx10_example/main.cpp
+++ b/examples/directx10_example/main.cpp
@@ -5,7 +5,6 @@
 #include "imgui_impl_dx10.h"
 #include <d3d10_1.h>
 #include <d3d10.h>
-#include <d3dcompiler.h>
 #define DIRECTINPUT_VERSION 0x0800
 #include <dinput.h>
 #include <tchar.h>

--- a/examples/directx11_example/directx11_example.vcxproj
+++ b/examples/directx11_example/directx11_example.vcxproj
@@ -85,7 +85,7 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>d3d11.lib;d3dcompiler.lib;dxgi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d11.lib;dxgi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(DXSDK_DIR)/Lib/x86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <SubSystem>Console</SubSystem>
     </Link>
@@ -115,7 +115,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>d3d11.lib;d3dcompiler.lib;dxgi.lib;imm32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d11.lib;dxgi.lib;imm32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(DXSDK_DIR)/Lib/x86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <SubSystem>Console</SubSystem>
     </Link>

--- a/examples/directx11_example/imgui_impl_dx11.cpp
+++ b/examples/directx11_example/imgui_impl_dx11.cpp
@@ -11,9 +11,9 @@
 
 // DirectX
 #include <d3d11.h>
-#include <d3dcompiler.h>
 #define DIRECTINPUT_VERSION 0x0800
 #include <dinput.h>
+#include <string>
 
 // Data
 static INT64                    g_Time = 0;
@@ -332,12 +332,27 @@ static void ImGui_ImplDX11_CreateFontsTexture()
     }
 }
 
+typedef HRESULT (__stdcall *D3DCompile_t)(LPCVOID, SIZE_T, LPCSTR, D3D_SHADER_MACRO*, ID3DInclude*, LPCSTR, LPCSTR, UINT, UINT, ID3DBlob**, ID3DBlob*);
+
 bool    ImGui_ImplDX11_CreateDeviceObjects()
 {
     if (!g_pd3dDevice)
         return false;
     if (g_pFontSampler)
         ImGui_ImplDX11_InvalidateDeviceObjects();
+
+	HMODULE hDll = NULL;
+	D3DCompile_t D3DCompile = NULL;
+	int i = 47;
+	std::wstring m;
+	while((!hDll || !D3DCompile) && i > 30){
+		m = L"d3dcompiler_" + std::to_wstring(i) + L".dll";
+		hDll = LoadLibrary(m.c_str());
+		if(hDll){
+			D3DCompile = (D3DCompile_t)GetProcAddress(hDll, "D3DCompile");
+		}
+		i--;
+	}
 
     // Create the vertex shader
     {

--- a/examples/directx11_example/main.cpp
+++ b/examples/directx11_example/main.cpp
@@ -4,7 +4,6 @@
 #include <imgui.h>
 #include "imgui_impl_dx11.h"
 #include <d3d11.h>
-#include <d3dcompiler.h>
 #define DIRECTINPUT_VERSION 0x0800
 #include <dinput.h>
 #include <tchar.h>


### PR DESCRIPTION
#### **MOD: If you come here from the links in imgui_impl_dx10.cpp and imgui_impl_dx11.cpp to remove dependency on d3dcompiler_XX.dll, you can use A) https://github.com/ocornut/imgui/pull/638#issuecomment-217665189 to find a DLL available in the system or preferably B) https://github.com/ocornut/imgui/pull/638#issuecomment-217671027 to use a precompiled shader.**

The idea is to remove the d3dcompiler.lib dependency by dynamically loading D3DCompiler_XX.dll and finding the address of D3DCompile with GetProcAddress.

This is the solution that I came up with after seeing some users complaining about "D3DCompiler_47.dll missing" errors when running my application built on Release configuration.

From what I read, there are 3 common solutions to this problem:
- Include the DLL with the application
- Dynamically try to find a D3DCompiler_XX.dll in the system
- Pre-compile the shaders and load them at runtime

Is there another better way to remove this dependency?

I'm currently using VS 2015 and I only have VS 2015 Platform Toolset installed (v140) on my Win10, but I thought it would be a nice idea to install an old Platform Toolset (e.g. 2010) to "force" load an older D3DCompiler_XX.dll. Not sure if it will work though.