### PR TITLE
Ignore implicit conversion warnings

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -625,6 +625,8 @@
 #pragma GCC diagnostic ignored "-Wunused-function"          // warning: 'xxxx' defined but not used
 #pragma GCC diagnostic ignored "-Wint-to-pointer-cast"      // warning: cast to pointer from integer of different size
 #pragma GCC diagnostic ignored "-Wformat"                   // warning: format '%p' expects argument of type 'void*', but argument 6 has type 'ImGuiWindow*'
+#pragma GCC diagnostic ignored "-Wdouble-promotion"         // warning: implicit conversion from 'float' to 'double' when passing argument to function
+#pragma GCC diagnostic ignored "-Wconversion"               // warning: conversion to 'xxxx' from 'xxxx' may alter its value
 #endif
 
 //-------------------------------------------------------------------------

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -35,6 +35,8 @@
 #ifdef __GNUC__
 #pragma GCC diagnostic ignored "-Wint-to-pointer-cast"          // warning: cast to pointer from integer of different size
 #pragma GCC diagnostic ignored "-Wformat-security"              // warning : format string is not a string literal (potentially insecure)
+#pragma GCC diagnostic ignored "-Wdouble-promotion"             // warning: implicit conversion from 'float' to 'double' when passing argument to function
+#pragma GCC diagnostic ignored "-Wconversion"                   // warning: conversion to 'xxxx' from 'xxxx' may alter its value
 #endif
 
 // Play it nice with Windows users. Notepad in 2015 still doesn't display text data with Unix-style \n.

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -41,6 +41,8 @@
 #endif
 #ifdef __GNUC__
 #pragma GCC diagnostic ignored "-Wunused-function"          // warning: 'xxxx' defined but not used
+#pragma GCC diagnostic ignored "-Wdouble-promotion"         // warning: implicit conversion from 'float' to 'double' when passing argument to function
+#pragma GCC diagnostic ignored "-Wconversion"               // warning: conversion to 'xxxx' from 'xxxx' may alter its value
 #endif
 
 //-------------------------------------------------------------------------


### PR DESCRIPTION
This disables some strict implicit conversion warnings for GCC (and clang, since it alsso defines __GNUC__).
I was a bit hesitant about proposing this, but since we ignore all kinds of other warnings already it should be fine.
Without this I get hundreds of warnings, and it's a hassle to add every time I update to a new version.

-Wconversion is actually useful for catching float -> int conversion but it also requires to add a bunch of casts which you probably don't want to do :)