### PR TITLE
Stack Layout implementation

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -9508,7 +9508,6 @@ static void PropagateLayoutSpace(ImGuiLayout* layout, const ImVec2& extents)
 {
     layout->AvailableSize = extents;
 
-    ImVec2 maximum_extent = ImVec2(0.0f, 0.0f);
     for (ImGuiLayout* child = layout->FirstChild; child; child = child->NextSibling)
     {
         ImVec2 new_available_size;
@@ -9616,13 +9615,10 @@ static void DistributeAvailableLayoutSpace(ImGuiLayout* layout)
     layout->Dirty = ImGuiLayoutDirtyFlags_None;
 }
 
-extern "C" __declspec(dllimport) void __stdcall OutputDebugStringA(const char*);
-
 static void ReflowLayouts()
 {
     ImGuiContext& g = *GImGui;
 
-//    int count = 0;
     for (int i = 0; i < g.Layouts.size(); ++i)
     {
         ImGuiLayout* layout = g.Layouts[i];
@@ -9630,19 +9626,8 @@ static void ReflowLayouts()
         {
             CalculateLayoutAvailableSpace(layout);
             DistributeAvailableLayoutSpace(layout);
-  //          ++count;
         }
     }
-
-    //if (count)
-//     {
-//         char buffer[64];
-//         if (count)
-//             snprintf(buffer, 63, "HIT! %d\n", count);
-//         else
-//             snprintf(buffer, 63, "MISS!\n");
-//         OutputDebugStringA(buffer);
-//     }
 }
 
 static ImGuiLayoutItem* PushNextLayoutItem(ImGuiLayout* layout, ImGuiLayoutItemType type)

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -9360,7 +9360,7 @@ static void EndLayout(ImGuiLayoutType type)
     if (layout->NextItemIndex < layout->Items.size())
     {
         layout->Items.resize(layout->NextItemIndex);
-        layout->Dirty |= ImGuiLayoutDirtyFlags_ItemAdded;
+        layout->Dirty |= ImGuiLayoutDirtyFlags_ItemRemoved;
     }
 
     PopLayout(layout);

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -9616,7 +9616,7 @@ static void BeginLayoutItem(ImGuiLayout* layout)
         ImGui::BeginGroup();
         if (layout->Bounds.y > item.Size.y)
         {
-            auto align = ImMax(0.0f, ImMin(1.0f, ImGui::GetStyle().LayoutAlign));
+            float align = ImMax(0.0f, ImMin(1.0f, ImGui::GetStyle().LayoutAlign));
 
             float align_offset = floorf(align * (layout->Bounds.y - item.Size.y));
             float new_position = ImGui::GetCursorPosY() + align_offset;
@@ -9629,7 +9629,7 @@ static void BeginLayoutItem(ImGuiLayout* layout)
         ImGui::BeginGroup();
         if (layout->Bounds.x > item.Size.x)
         {
-            auto align = ImMax(0.0f, ImMin(1.0f, ImGui::GetStyle().LayoutAlign));
+            float align = ImMax(0.0f, ImMin(1.0f, ImGui::GetStyle().LayoutAlign));
 
             float align_offset = floorf(align * (layout->Bounds.x - item.Size.x));
             float new_position = ImGui::GetCursorPosX() + align_offset;

--- a/imgui.h
+++ b/imgui.h
@@ -220,15 +220,17 @@ namespace ImGui
     IMGUI_API float         GetTextLineHeightWithSpacing();                                     // distance (in pixels) between 2 consecutive lines of text == GetWindowFontSize() + GetStyle().ItemSpacing.y
     IMGUI_API float         GetItemsLineHeightWithSpacing();                                    // distance (in pixels) between 2 consecutive lines of standard height widgets == GetWindowFontSize() + GetStyle().FramePadding.y*2 + GetStyle().ItemSpacing.y
 
-    IMGUI_API void          BeginHorizontal(const char* str_id, const ImVec2& size = ImVec2(0, 0));
-    IMGUI_API void          BeginHorizontal(const void* ptr_id, const ImVec2& size = ImVec2(0, 0));
-    IMGUI_API void          BeginHorizontal(int id, const ImVec2& size = ImVec2(0, 0));
+    IMGUI_API void          BeginHorizontal(const char* str_id, const ImVec2& size = ImVec2(0, 0), float align = -1);
+    IMGUI_API void          BeginHorizontal(const void* ptr_id, const ImVec2& size = ImVec2(0, 0), float align = -1);
+    IMGUI_API void          BeginHorizontal(int id, const ImVec2& size = ImVec2(0, 0), float align = -1);
     IMGUI_API void          EndHorizontal();
-    IMGUI_API void          BeginVertical(const char* str_id, const ImVec2& size = ImVec2(0, 0));
-    IMGUI_API void          BeginVertical(const void* ptr_id, const ImVec2& size = ImVec2(0, 0));
-    IMGUI_API void          BeginVertical(int id, const ImVec2& size = ImVec2(0, 0));
+    IMGUI_API void          BeginVertical(const char* str_id, const ImVec2& size = ImVec2(0, 0), float align = -1);
+    IMGUI_API void          BeginVertical(const void* ptr_id, const ImVec2& size = ImVec2(0, 0), float align = -1);
+    IMGUI_API void          BeginVertical(int id, const ImVec2& size = ImVec2(0, 0), float align = -1);
     IMGUI_API void          EndVertical();
     IMGUI_API void          Spring(float weight = 1.0f, float spacing = -1.0f);
+    IMGUI_API void          SuspendLayout();
+    IMGUI_API void          ResumeLayout();
 
     // Columns
     // You can also use SameLine(pos_x) for simplified columning. The columns API is still work-in-progress and rather lacking.

--- a/imgui.h
+++ b/imgui.h
@@ -220,6 +220,14 @@ namespace ImGui
     IMGUI_API float         GetTextLineHeightWithSpacing();                                     // distance (in pixels) between 2 consecutive lines of text == GetWindowFontSize() + GetStyle().ItemSpacing.y
     IMGUI_API float         GetItemsLineHeightWithSpacing();                                    // distance (in pixels) between 2 consecutive lines of standard height widgets == GetWindowFontSize() + GetStyle().FramePadding.y*2 + GetStyle().ItemSpacing.y
 
+    IMGUI_API void          BeginHorizontal(const char* str_id, const ImVec2& size = ImVec2(0, 0));
+    IMGUI_API void          BeginHorizontal(const void* ptr_id, const ImVec2& size = ImVec2(0, 0));
+    IMGUI_API void          EndHorizontal();
+    IMGUI_API void          BeginVertical(const char* str_id, const ImVec2& size = ImVec2(0, 0));
+    IMGUI_API void          BeginVertical(const void* ptr_id, const ImVec2& size = ImVec2(0, 0));
+    IMGUI_API void          EndVertical();
+    IMGUI_API void          Spring(float weight = 1.0f, float spacing = -1.0f);
+
     // Columns
     // You can also use SameLine(pos_x) for simplified columning. The columns API is still work-in-progress and rather lacking.
     IMGUI_API void          Columns(int count = 1, const char* id = NULL, bool border = true);  // setup number of columns. use an identifier to distinguish multiple column sets. close with Columns(1).
@@ -646,7 +654,8 @@ enum ImGuiStyleVar_
     ImGuiStyleVar_ItemSpacing,         // ImVec2
     ImGuiStyleVar_ItemInnerSpacing,    // ImVec2
     ImGuiStyleVar_IndentSpacing,       // float
-    ImGuiStyleVar_GrabMinSize          // float
+    ImGuiStyleVar_GrabMinSize,         // float
+    ImGuiStyleVar_LayoutAlign          // float
 };
 
 enum ImGuiAlign_
@@ -712,6 +721,7 @@ struct ImGuiStyle
     float       ScrollbarRounding;          // Radius of grab corners for scrollbar
     float       GrabMinSize;                // Minimum width/height of a grab box for slider/scrollbar
     float       GrabRounding;               // Radius of grabs corners rounding. Set to 0.0f to have rectangular slider grabs.
+    float       LayoutAlign;                // Element alignment inside horizontal and vertical layouts (0.0f - left/top, 1.0f - right/bottom, 0.5f - center).
     ImVec2      DisplayWindowPadding;       // Window positions are clamped to be visible within the display area by at least this amount. Only covers regular windows.
     ImVec2      DisplaySafeAreaPadding;     // If you cannot see the edge of your screen (e.g. on a TV) increase the safe area padding. Covers popups/tooltips as well regular windows.
     bool        AntiAliasedLines;           // Enable anti-aliasing on lines/borders. Disable if you are really tight on CPU/GPU.

--- a/imgui.h
+++ b/imgui.h
@@ -222,9 +222,11 @@ namespace ImGui
 
     IMGUI_API void          BeginHorizontal(const char* str_id, const ImVec2& size = ImVec2(0, 0));
     IMGUI_API void          BeginHorizontal(const void* ptr_id, const ImVec2& size = ImVec2(0, 0));
+    IMGUI_API void          BeginHorizontal(int id, const ImVec2& size = ImVec2(0, 0));
     IMGUI_API void          EndHorizontal();
     IMGUI_API void          BeginVertical(const char* str_id, const ImVec2& size = ImVec2(0, 0));
     IMGUI_API void          BeginVertical(const void* ptr_id, const ImVec2& size = ImVec2(0, 0));
+    IMGUI_API void          BeginVertical(int id, const ImVec2& size = ImVec2(0, 0));
     IMGUI_API void          EndVertical();
     IMGUI_API void          Spring(float weight = 1.0f, float spacing = -1.0f);
 

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -1160,6 +1160,104 @@ void ImGui::ShowTestWindow(bool* p_open)
         }
     }
 
+    if (ImGui::CollapsingHeader("Stack Layout"))
+    {
+        float indent = ImGui::GetStyle().IndentSpacing;
+        ImVec2 bounds = ImVec2(ImGui::GetWindowContentRegionWidth() - indent, 120);
+        ImGui::Indent(indent);
+
+        static bool spanToWindow = true;
+        static bool showBounds = true;
+        static bool showVertical = false;
+        static bool noPadding = false;
+
+        ImGui::BeginHorizontal("ctrl_group");
+            ImGui::BeginVertical("ctrl_1");
+                ImGui::Checkbox("Span to window", &spanToWindow);
+                ImGui::Checkbox("Show bounds", &showBounds);
+            ImGui::EndVertical();
+            ImGui::BeginVertical("ctrl_2");
+                ImGui::Checkbox("Show vertical", &showVertical);
+                ImGui::Checkbox("No padding", &noPadding);
+            ImGui::EndVertical();
+        ImGui::EndHorizontal();
+
+        static float middleWeight = 0.3f;
+        static float centerWeight = 0.3f;
+        ImGui::DragFloat("Middle position", &middleWeight, 0.002f, 0.0f, 1.0f);
+        if (showVertical)
+            ImGui::DragFloat("Center position", &centerWeight, 0.002f, 0.0f, 1.0f);
+
+        ImGui::Spacing();
+        ImGui::Unindent(indent / 2);
+
+        if (noPadding)
+            ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0, 0));
+
+        if (!showVertical)
+        {
+            ImGui::BeginHorizontal("example_h1", spanToWindow ? bounds : ImVec2(0, 0));
+                ImGui::TextUnformatted("Left");
+                ImGui::Spring(middleWeight);
+                ImGui::TextUnformatted("Middle");
+                ImGui::Spring(1.0f - middleWeight);
+                ImGui::TextUnformatted("Right");
+            ImGui::EndHorizontal();
+
+            if (showBounds)
+            {
+                ImVec2 boundMin = ImGui::GetItemRectMin();
+                ImVec2 boundMax = ImGui::GetItemRectMax();
+                boundMin.x -= 2; boundMin.y -= 2;
+                boundMax.x += 2; boundMax.y += 2;
+                ImGui::GetWindowDrawList()->AddRect(boundMin, boundMax, 0xC0FF8060);
+            }
+        }
+        else
+        {
+            ImGui::BeginHorizontal("example_h2", spanToWindow ? bounds : ImVec2(0, 0));
+                ImGui::TextUnformatted("Left");
+                ImGui::Spring(middleWeight);
+                ImGui::BeginVertical("example_v1", spanToWindow ? bounds : ImVec2(0, 0));
+                ImGui::TextUnformatted("Middle");
+                ImGui::Spring(centerWeight);
+                ImGui::TextUnformatted("Center");
+                ImGui::Spring(1.0f - centerWeight);
+                ImGui::TextUnformatted("Bottom");
+            ImGui::EndVertical();
+
+            if (showBounds)
+            {
+                ImVec2 boundMin = ImGui::GetItemRectMin();
+                ImVec2 boundMax = ImGui::GetItemRectMax();
+                boundMin.x -= 2; boundMin.y -= 2;
+                boundMax.x += 2; boundMax.y += 2;
+                ImGui::GetWindowDrawList()->AddRect(boundMin, boundMax, 0xC0FF8060);
+            }
+
+            ImGui::Spring(1.0f - middleWeight);
+            ImGui::TextUnformatted("Right");
+            ImGui::EndHorizontal();
+
+            if (showBounds)
+            {
+                ImVec2 boundMin = ImGui::GetItemRectMin();
+                ImVec2 boundMax = ImGui::GetItemRectMax();
+                boundMin.x -= 2; boundMin.y -= 2;
+                boundMax.x += 2; boundMax.y += 2;
+                ImGui::GetWindowDrawList()->AddRect(boundMin, boundMax, 0xC0FF8060);
+            }
+        }
+
+        if (noPadding)
+            ImGui::PopStyleVar();
+
+        ImGui::Indent(indent / 2);
+        ImGui::Spacing();
+
+        ImGui::Unindent(indent);
+    }
+
     if (ImGui::CollapsingHeader("Popups & Modal windows"))
     {
         if (ImGui::TreeNode("Popups"))

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -388,11 +388,12 @@ struct ImGuiLayout
     ImGuiLayout*                FirstChild;
     ImGuiLayout*                NextSibling;
     float                       Align;
+    bool                        IsStable;
 
     ImVec2                      StartPos;
     float                       MaxExtent;
 
-    ImGuiLayout(ImGuiID id, ImGuiLayoutType type): Id(id), Type(type), Size(0, 0), Items(), NextItemIndex(0), Dirty(0), Parent(NULL), FirstChild(NULL), NextSibling(NULL), Align(-1.0f) {}
+    ImGuiLayout(ImGuiID id, ImGuiLayoutType type): Id(id), Type(type), Size(0, 0), Items(), NextItemIndex(0), Dirty(0), Parent(NULL), FirstChild(NULL), NextSibling(NULL), Align(-1.0f), IsStable(false) {}
 };
 
 // Main state for ImGui

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -180,7 +180,8 @@ enum ImGuiLayoutDirtyFlags_
     ImGuiLayoutDirtyFlags_ItemSize          = 1 << 5,
     ImGuiLayoutDirtyFlags_SpringWeight      = 1 << 6,
     ImGuiLayoutDirtyFlags_SpringSpacing     = 1 << 7,
-    ImGuiLayoutDirtyFlags_Bounds            = 1 << 8
+    ImGuiLayoutDirtyFlags_Bounds            = 1 << 8,
+    ImGuiLayoutDirtyFlags_ChildDirty        = 1 << 9
 };
 
 enum ImGuiSelectableFlagsPrivate_
@@ -384,11 +385,13 @@ struct ImGuiLayout
     int                         NextItemIndex;
     ImGuiLayoutDirtyFlags       Dirty;
     ImGuiLayout*                Parent;
+    ImGuiLayout*                FirstChild;
+    ImGuiLayout*                NextSibling;
 
     ImVec2                      StartPos;
     float                       MaxExtent;
 
-    ImGuiLayout(ImGuiID id, ImGuiLayoutType type): Id(id), Type(type), Size(0, 0), Items(), NextItemIndex(0), Dirty(0), Parent(NULL) {}
+    ImGuiLayout(ImGuiID id, ImGuiLayoutType type): Id(id), Type(type), Size(0, 0), Items(), NextItemIndex(0), Dirty(0), Parent(NULL), FirstChild(NULL), NextSibling(NULL) {}
 };
 
 // Main state for ImGui
@@ -435,7 +438,6 @@ struct ImGuiContext
     ImGuiLayout*            CurrentLayout;
     ImVector<ImGuiLayout*>  LayoutStack;
     ImVector<ImGuiLayout*>  Layouts;
-    ImVector<ImGuiLayout*>  ReflowQueue;
 
     // Storage for SetNexWindow** and SetNextTreeNode*** functions
     ImVec2                  SetNextWindowPosVal;

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -42,10 +42,12 @@ struct ImGuiMouseCursorData;
 struct ImGuiPopupRef;
 struct ImGuiWindow;
 
-typedef int ImGuiLayoutType;      // enum ImGuiLayoutType_
-typedef int ImGuiButtonFlags;     // enum ImGuiButtonFlags_
-typedef int ImGuiTreeNodeFlags;   // enum ImGuiTreeNodeFlags_
-typedef int ImGuiSliderFlags;     // enum ImGuiSliderFlags_
+typedef int ImGuiLayoutType;        // enum ImGuiLayoutType_
+typedef int ImGuiLayoutItemType;    // enum ImGuiLayoutItemType_
+typedef int ImGuiLayoutDirtyFlags;  // enum ImGuiLayoutDirtyFlags_
+typedef int ImGuiButtonFlags;       // enum ImGuiButtonFlags_
+typedef int ImGuiTreeNodeFlags;     // enum ImGuiTreeNodeFlags_
+typedef int ImGuiSliderFlags;       // enum ImGuiSliderFlags_
 
 //-------------------------------------------------------------------------
 // STB libraries
@@ -167,6 +169,20 @@ enum ImGuiSliderFlags_
     ImGuiSliderFlags_Vertical               = 1 << 0
 };
 
+enum ImGuiLayoutDirtyFlags_
+{
+    ImGuiLayoutDirtyFlags_None              = 0,
+    ImGuiLayoutDirtyFlags_Uninitialized     = 1 << 0,
+    ImGuiLayoutDirtyFlags_LayoutSize        = 1 << 1,
+    ImGuiLayoutDirtyFlags_ItemAdded         = 1 << 2,
+    ImGuiLayoutDirtyFlags_ItemRemoved       = 1 << 3,
+    ImGuiLayoutDirtyFlags_ItemReplaced      = 1 << 4,
+    ImGuiLayoutDirtyFlags_ItemSize          = 1 << 5,
+    ImGuiLayoutDirtyFlags_SpringWeight      = 1 << 6,
+    ImGuiLayoutDirtyFlags_SpringSpacing     = 1 << 7,
+    ImGuiLayoutDirtyFlags_Bounds            = 1 << 8
+};
+
 enum ImGuiSelectableFlagsPrivate_
 {
     // NB: need to be in sync with last value of ImGuiSelectableFlags_
@@ -181,6 +197,12 @@ enum ImGuiLayoutType_
 {
     ImGuiLayoutType_Vertical,
     ImGuiLayoutType_Horizontal
+};
+
+enum ImGuiLayoutItemType_
+{
+    ImGuiLayoutItemType_Item,
+    ImGuiLayoutItemType_Spring
 };
 
 enum ImGuiPlotType
@@ -340,6 +362,35 @@ struct ImGuiPopupRef
     ImGuiPopupRef(ImGuiID id, ImGuiWindow* parent_window, ImGuiID parent_menu_set, const ImVec2& mouse_pos) { PopupId = id; Window = NULL; ParentWindow = parent_window; ParentMenuSet = parent_menu_set; MousePosOnOpen = mouse_pos; }
 };
 
+struct ImGuiLayoutItem
+{
+    ImGuiLayoutItemType         Type;           // Type of an item
+    ImVec2                      Size;           // Last size of an item
+    float                       SpringWeight;   // Weight of a spring
+    float                       SpringSpacing;  // Spring spacing
+    float                       SpringSize;     // Calculated spring size
+
+    ImGuiLayoutItem(ImGuiLayoutItemType type): Type(type), Size(0, 0), SpringWeight(1.0f), SpringSpacing(-1.0f), SpringSize(0.0f) {}
+};
+
+struct ImGuiLayout
+{
+    ImGuiID                     Id;
+    ImGuiLayoutType             Type;
+    ImVec2                      Size;           // Size from user
+    ImVec2                      Bounds;         // Actual bounds determined by BeginGroup/EndGroup
+    ImVec2                      AvailableSize;  // Bounds when taking into account parent layout
+    ImVector<ImGuiLayoutItem>   Items;
+    int                         NextItemIndex;
+    ImGuiLayoutDirtyFlags       Dirty;
+    ImGuiLayout*                Parent;
+
+    ImVec2                      StartPos;
+    float                       MaxExtent;
+
+    ImGuiLayout(ImGuiID id, ImGuiLayoutType type): Id(id), Type(type), Size(0, 0), Items(), NextItemIndex(0), Dirty(0), Parent(NULL) {}
+};
+
 // Main state for ImGui
 struct ImGuiContext
 {
@@ -381,6 +432,10 @@ struct ImGuiContext
     ImVector<ImFont*>       FontStack;                          // Stack for PushFont()/PopFont()
     ImVector<ImGuiPopupRef> OpenPopupStack;                     // Which popups are open (persistent)
     ImVector<ImGuiPopupRef> CurrentPopupStack;                  // Which level of BeginPopup() we are in (reset every frame)
+    ImGuiLayout*            CurrentLayout;
+    ImVector<ImGuiLayout*>  LayoutStack;
+    ImVector<ImGuiLayout*>  Layouts;
+    ImVector<ImGuiLayout*>  ReflowQueue;
 
     // Storage for SetNexWindow** and SetNextTreeNode*** functions
     ImVec2                  SetNextWindowPosVal;
@@ -464,6 +519,7 @@ struct ImGuiContext
         MovedWindow = NULL;
         MovedWindowMoveId = 0;
         SettingsDirtyTimer = 0.0f;
+        CurrentLayout = NULL;
 
         SetNextWindowPosVal = ImVec2(0.0f, 0.0f);
         SetNextWindowSizeVal = ImVec2(0.0f, 0.0f);
@@ -543,7 +599,7 @@ struct IMGUI_API ImGuiDrawContext
     ImVector<bool>          ButtonRepeatStack;
     ImVector<ImGuiGroupData>GroupStack;
     ImGuiColorEditMode      ColorEditMode;
-    int                     StackSizesBackup[6];    // Store size of various stacks for asserting
+    int                     StackSizesBackup[7];    // Store size of various stacks for asserting
 
     ImVec2                  Indent;                 // Indentation / start position from left of window (increased by TreePush/TreePop, etc.)
     ImVec2                  GroupOffset;

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -387,11 +387,12 @@ struct ImGuiLayout
     ImGuiLayout*                Parent;
     ImGuiLayout*                FirstChild;
     ImGuiLayout*                NextSibling;
+    float                       Align;
 
     ImVec2                      StartPos;
     float                       MaxExtent;
 
-    ImGuiLayout(ImGuiID id, ImGuiLayoutType type): Id(id), Type(type), Size(0, 0), Items(), NextItemIndex(0), Dirty(0), Parent(NULL), FirstChild(NULL), NextSibling(NULL) {}
+    ImGuiLayout(ImGuiID id, ImGuiLayoutType type): Id(id), Type(type), Size(0, 0), Items(), NextItemIndex(0), Dirty(0), Parent(NULL), FirstChild(NULL), NextSibling(NULL), Align(-1.0f) {}
 };
 
 // Main state for ImGui

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -436,9 +436,6 @@ struct ImGuiContext
     ImVector<ImFont*>       FontStack;                          // Stack for PushFont()/PopFont()
     ImVector<ImGuiPopupRef> OpenPopupStack;                     // Which popups are open (persistent)
     ImVector<ImGuiPopupRef> CurrentPopupStack;                  // Which level of BeginPopup() we are in (reset every frame)
-    ImGuiLayout*            CurrentLayout;
-    ImVector<ImGuiLayout*>  LayoutStack;
-    ImVector<ImGuiLayout*>  Layouts;
 
     // Storage for SetNexWindow** and SetNextTreeNode*** functions
     ImVec2                  SetNextWindowPosVal;
@@ -522,7 +519,6 @@ struct ImGuiContext
         MovedWindow = NULL;
         MovedWindowMoveId = 0;
         SettingsDirtyTimer = 0.0f;
-        CurrentLayout = NULL;
 
         SetNextWindowPosVal = ImVec2(0.0f, 0.0f);
         SetNextWindowSizeVal = ImVec2(0.0f, 0.0f);
@@ -590,6 +586,9 @@ struct IMGUI_API ImGuiDrawContext
     ImVector<ImGuiWindow*>  ChildWindows;
     ImGuiStorage*           StateStorage;
     ImGuiLayoutType         LayoutType;
+    ImGuiLayout*            CurrentLayout;
+    ImVector<ImGuiLayout*>  LayoutStack;
+    ImGuiStorage            Layouts;
 
     // We store the current settings outside of the vectors to increase memory locality (reduce cache misses). The vectors are rarely modified. Also it allows us to not heap allocate for short-lived windows which are not using those settings.
     float                   ItemWidth;              // == ItemWidthStack.back(). 0.0: default, >0.0: width in pixels, <0.0: align xx pixels to the right of window
@@ -632,6 +631,7 @@ struct IMGUI_API ImGuiDrawContext
         MenuBarOffsetX = 0.0f;
         StateStorage = NULL;
         LayoutType = ImGuiLayoutType_Vertical;
+        CurrentLayout = NULL;
         ItemWidth = 0.0f;
         ButtonRepeat = false;
         AllowKeyboardFocus = true;

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -256,8 +256,8 @@ struct ImGuiGroupData
 {
     ImVec2      BackupCursorPos;
     ImVec2      BackupCursorMaxPos;
-    float       BackupIndentX;
-    float       BackupCurrentLineHeight;
+    ImVec2      BackupIndent;
+    ImVec2      BackupCurrentLineSize;
     float       BackupCurrentLineTextBaseOffset;
     float       BackupLogLinePosY;
     bool        AdvanceCursor;
@@ -514,11 +514,11 @@ struct IMGUI_API ImGuiDrawContext
 {
     ImVec2                  CursorPos;
     ImVec2                  CursorPosPrevLine;
-    ImVec2                  CursorStartPos;
+    ImVec2                  CursorStartPos;         // Initial position in client area with padding
     ImVec2                  CursorMaxPos;           // Implicitly calculate the size of our contents, always extending. Saved into window->SizeContents at the end of the frame
-    float                   CurrentLineHeight;
+    ImVec2                  CurrentLineSize;
     float                   CurrentLineTextBaseOffset;
-    float                   PrevLineHeight;
+    ImVec2                  PrevLineSize;
     float                   PrevLineTextBaseOffset;
     float                   LogLinePosY;
     int                     TreeDepth;
@@ -545,9 +545,9 @@ struct IMGUI_API ImGuiDrawContext
     ImGuiColorEditMode      ColorEditMode;
     int                     StackSizesBackup[6];    // Store size of various stacks for asserting
 
-    float                   IndentX;                // Indentation / start position from left of window (increased by TreePush/TreePop, etc.)
-    float                   GroupOffsetX;
-    float                   ColumnsOffsetX;         // Offset to the current column (if ColumnsCurrent > 0). FIXME: This and the above should be a stack to allow use cases like Tree->Column->Tree. Need revamp columns API.
+    ImVec2                  Indent;                 // Indentation / start position from left of window (increased by TreePush/TreePop, etc.)
+    ImVec2                  GroupOffset;
+    ImVec2                  ColumnsOffset;          // Offset to the current column (if ColumnsCurrent > 0). FIXME: This and the above should be a stack to allow use cases like Tree->Column->Tree. Need revamp columns API.
     int                     ColumnsCurrent;
     int                     ColumnsCount;
     float                   ColumnsMinX;
@@ -562,7 +562,7 @@ struct IMGUI_API ImGuiDrawContext
     ImGuiDrawContext()
     {
         CursorPos = CursorPosPrevLine = CursorStartPos = CursorMaxPos = ImVec2(0.0f, 0.0f);
-        CurrentLineHeight = PrevLineHeight = 0.0f;
+        CurrentLineSize = PrevLineSize = ImVec2(0.0f,0.0f);
         CurrentLineTextBaseOffset = PrevLineTextBaseOffset = 0.0f;
         LogLinePosY = -1.0f;
         TreeDepth = 0;
@@ -580,8 +580,8 @@ struct IMGUI_API ImGuiDrawContext
         ColorEditMode = ImGuiColorEditMode_RGB;
         memset(StackSizesBackup, 0, sizeof(StackSizesBackup));
 
-        IndentX = 0.0f;
-        ColumnsOffsetX = 0.0f;
+        Indent = ImVec2(0.0f,0.0f);
+        ColumnsOffset = ImVec2(0.0f, 0.0f);
         ColumnsCurrent = 0;
         ColumnsCount = 1;
         ColumnsMinX = ColumnsMaxX = 0.0f;


### PR DESCRIPTION
After searching for some layout related solution I decided to pull my own after everything I found was only issues listed on this repository (#97).

I think BeginHorizontal/EndHorizontal API was promissing, so I gave it a shot. There is how code look like and what results it produce.
```cpp
            ImGui::BeginHorizontal("example_h1", spanToWindow ? bounds : ImVec2(0, 0));
                ImGui::TextUnformatted("Left");
                ImGui::Spring(middleWeight);
                ImGui::TextUnformatted("Middle");
                ImGui::Spring(1.0f - middleWeight);
                ImGui::TextUnformatted("Right");
            ImGui::EndHorizontal();
```

![stack_layout](https://cloud.githubusercontent.com/assets/1197433/17041261/2d94a62e-4fa5-11e6-8a0e-4e5e20dfbbab.gif)

I tried to bend ImGui to help me layout widgets easly. This is what API I came up with:
```cpp
    IMGUI_API void BeginHorizontal(const char* str_id, const ImVec2& size = ImVec2(0, 0));
    IMGUI_API void BeginHorizontal(const void* ptr_id, const ImVec2& size = ImVec2(0, 0));
    IMGUI_API void EndHorizontal();
    IMGUI_API void BeginVertical(const char* str_id, const ImVec2& size = ImVec2(0, 0));
    IMGUI_API void BeginVertical(const void* ptr_id, const ImVec2& size = ImVec2(0, 0));
    IMGUI_API void EndVertical();
    IMGUI_API void Spring(float weight = 1.0f, float spacing = -1.0f);
```

This code works by caching sizes of widgets in first frame and positioning them in next. Layout is evaluated only if something related to size changes.

Code was crafted in a few hours so it may be cruel in some places. I tried to be as consistent with ImGui code style. Please grab this code and try to use it. Let me know what you think about this solution. : )

Example code show one use case. There are however many more. Widgets can be interleaved by Springs which may have zero (sticking widgets together) weight or greater than zero. Free space will be divide according to them. There is an option to provide spacing which acts like in SameLine() function but works for both horizontal and vertical layouts. Layouts can be mixed together, you may put one in another as you can see on example gif.