### PR TITLE
Add SameColumn() to have symmetry with SameLine() method.

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -9182,6 +9182,32 @@ void ImGui::SameLine(float pos_x, float spacing_w)
     window->DC.CurrentLineTextBaseOffset = window->DC.PrevLineTextBaseOffset;
 }
 
+// Gets back to previous widget and continue with vertical layout
+//      pos_y == 0      : follow right after previous item
+//      pos_y != 0      : align to specified y position
+//      spacing_h < 0   : use default spacing if pos_y == 0, no spacing if pos_y != 0
+//      spacing_h >= 0  : enforce spacing amount
+void ImGui::SameColumn(float pos_y, float spacing_h)
+{
+    ImGuiWindow* window = GetCurrentWindow();
+    if (window->SkipItems)
+        return;
+
+    ImGuiContext& g = *GImGui;
+    if (pos_y != 0.0f)
+    {
+        if (spacing_h < 0.0f) spacing_h = 0.0f;
+        window->DC.CursorPos.x = window->DC.CursorPos.x;
+        window->DC.CursorPos.y = window->Pos.y - window->Scroll.y + pos_y + spacing_h;
+    }
+    else
+    {
+        if (spacing_h < 0.0f) spacing_h = g.Style.ItemSpacing.y;
+        window->DC.CursorPos.x = window->DC.CursorPos.x;
+        window->DC.CursorPos.y = window->DC.CursorPosPrevLine.y + window->DC.PrevLineHeight + spacing_h;
+    }
+}
+
 void ImGui::NewLine()
 {
     ImGuiWindow* window = GetCurrentWindow();

--- a/imgui.h
+++ b/imgui.h
@@ -199,6 +199,7 @@ namespace ImGui
     // Cursor / Layout
     IMGUI_API void          Separator();                                                        // horizontal line
     IMGUI_API void          SameLine(float pos_x = 0.0f, float spacing_w = -1.0f);              // call between widgets or groups to layout them horizontally
+    IMGUI_API void          SameColumn(float pos_y = 0.0f, float spacing_h = -1.0f);            // call between widgets or groups to layout them vertically
     IMGUI_API void          NewLine();                                                          // undo a SameLine()
     IMGUI_API void          Spacing();                                                          // add vertical spacing
     IMGUI_API void          Dummy(const ImVec2& size);                                          // add a dummy item of given size


### PR DESCRIPTION
`SameLine()` is useful to tie two groups together without changing style and drawing dummy control (also taking into account previous padding). I added `SameColumn()` function to mimic `SameLine()`.

```cpp
// call between widgets or groups to layout them vertically
IMGUI_API void SameColumn(float pos_y = 0.0f, float spacing_h = -1.0f);
```

```cpp
// drawRect() and fillItemBounds() are at very end of this comment
drawRect(40, 400, ImColor(255, 0, 0, 128), 2);
ImGui::BeginGroup();
ImGui::Dummy(ImVec2(40, 100));
ImGui::SameColumn(50, 0);
fillItemBounds(ImColor(255, 128, 128));
ImGui::Dummy(ImVec2(40, 250));
fillItemBounds(ImColor(128, 255, 128));
ImGui::EndGroup();
```

![image](https://cloud.githubusercontent.com/assets/1197433/17078158/8580c506-50eb-11e6-8c67-4a738984a0a9.png)

Used utility functions. Make sure you include `imgui_internal.h` with `IMGUI_DEFINE_MATH_OPERATORS` defined.
```cpp
auto fillItemBounds = [](ImColor color, float expand = 0.0f)
{
    ImGui::GetWindowDrawList()->AddRectFilled(
        ImGui::GetItemRectMin() - ImVec2(expand, expand),
        ImGui::GetItemRectMax() + ImVec2(expand, expand),
        color);
};

auto drawRect = [](float w, float h, ImColor color, float expand = 0.0f)
{
    ImGui::GetWindowDrawList()->AddRect(
        ImGui::GetCursorScreenPos() - ImVec2(expand, expand),
        ImGui::GetCursorScreenPos() + ImVec2(w + expand, h + expand),
        color);
};
```


