### PR TITLE
Patch for SDL2 Implementation

### DIFF
--- a/examples/sdl_opengl_example/imgui_impl_sdl.cpp
+++ b/examples/sdl_opengl_example/imgui_impl_sdl.cpp
@@ -165,6 +165,10 @@ bool ImGui_ImplSdl_CreateDeviceObjects()
     glBindTexture(GL_TEXTURE_2D, g_FontTexture);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
+    glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+    glPixelStorei(GL_UNPACK_IMAGE_HEIGHT, 0);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_ALPHA, width, height, 0, GL_ALPHA, GL_UNSIGNED_BYTE, pixels);
 
     // Store our identifier


### PR DESCRIPTION
Hi,

The SDL_CreateTexture* functions modify "GL_UNPACK_ROW_LENGTH" internally.  So, if you use SDL2 to create OpenGL textures before fully loading ImGui, ImGui's text texture will not load correctly.

This is a small fix to address this issue.

The other three function calls were added for completion and extra safety.  The "GL_UNPACK_ROW_LENGTH" is the only call technically required.

In addition, I would imagine the SDL2 OpenGL 3 implementation also has this issue.  Since I personally do not use that implementation, I did not want to mess with it and break something.

Thanks.