### PR TITLE
Add IsRectVisible() taking actual rect as parameter

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -9102,6 +9102,12 @@ bool ImGui::IsRectVisible(const ImVec2& size)
     return window->ClipRect.Overlaps(ImRect(window->DC.CursorPos, window->DC.CursorPos + size));
 }
 
+bool ImGui::IsRectVisible(const ImVec2& a, const ImVec2& b)
+{
+    ImGuiWindow* window = GetCurrentWindowRead();
+    return window->ClipRect.Overlaps(ImRect(a, b));
+}
+
 // Lock horizontal starting position + capture group bounding box into one "item" (so you can use IsItemHovered() or layout primitives such as SameLine() on whole group, etc.)
 void ImGui::BeginGroup()
 {

--- a/imgui.h
+++ b/imgui.h
@@ -410,6 +410,7 @@ namespace ImGui
     IMGUI_API bool          IsRootWindowOrAnyChildFocused();                                    // is current root window or any of its child (including current window) focused
     IMGUI_API bool          IsRootWindowOrAnyChildHovered();                                    // is current root window or any of its child (including current window) hovered and hoverable (not blocked by a popup)
     IMGUI_API bool          IsRectVisible(const ImVec2& size);                                  // test if rectangle of given size starting from cursor pos is visible (not clipped). to perform coarse clipping on user's side (as an optimization)
+    IMGUI_API bool          IsRectVisible(const ImVec2& a, const ImVec2& b);                    // "
     IMGUI_API bool          IsPosHoveringAnyWindow(const ImVec2& pos);                          // is given position hovering any active imgui window
     IMGUI_API float         GetTime();
     IMGUI_API int           GetFrameCount();


### PR DESCRIPTION
New public function is added which allow to test arbitrary rectangle visibility without need of moving cursor.
```cpp
    IMGUI_API bool          IsRectVisible(const ImVec2& a, const ImVec2& b);
```

I found this function useful to discard elements drawn using ImDrawList. I'm drawing background under widgets by my own using channel splitting/merging and this function simplify visibility testing.

![image](https://cloud.githubusercontent.com/assets/1197433/17433403/b893d924-5b04-11e6-9325-b6ab99eaab31.png)
