### PR TITLE
Added ability to center per axis by passing -FLT_MAX to which ever axis

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -1729,7 +1729,8 @@ ImGuiWindow::ImGuiWindow(const char* name)
     AutoPosLastDirection = -1;
     HiddenFrames = 0;
     SetWindowPosAllowFlags = SetWindowSizeAllowFlags = SetWindowCollapsedAllowFlags = ImGuiSetCond_Always | ImGuiSetCond_Once | ImGuiSetCond_FirstUseEver | ImGuiSetCond_Appearing;
-    SetWindowPosCenterWanted = false;
+    SetWindowPosXAxisCenterWanted = false;
+    SetWindowPosYAxisCenterWanted = false;
 
     LastFrameActive = -1;
     ItemWidthDefault = 0.0f;
@@ -3844,11 +3845,13 @@ bool ImGui::Begin(const char* name, bool* p_open, const ImVec2& size_on_first_us
         const ImVec2 backup_cursor_pos = window->DC.CursorPos;                  // FIXME: not sure of the exact reason of this saving/restore anymore :( need to look into that.
         if (!window_was_active || window_appearing_after_being_hidden) window->SetWindowPosAllowFlags |= ImGuiSetCond_Appearing;
         window_pos_set_by_api = (window->SetWindowPosAllowFlags & g.SetNextWindowPosCond) != 0;
-        if (window_pos_set_by_api && ImLengthSqr(g.SetNextWindowPosVal - ImVec2(-FLT_MAX,-FLT_MAX)) < 0.001f)
-        {
-            window->SetWindowPosCenterWanted = true;                            // May be processed on the next frame if this is our first frame and we are measuring size
+
+		if (window_pos_set_by_api && ((g.SetNextWindowPosVal.x == -FLT_MAX) || (g.SetNextWindowPosVal.y == -FLT_MAX))) {
+
             window->SetWindowPosAllowFlags &= ~(ImGuiSetCond_Once | ImGuiSetCond_FirstUseEver | ImGuiSetCond_Appearing);
-        }
+			if (g.SetNextWindowPosVal.x == -FLT_MAX) window->SetWindowPosXAxisCenterWanted = true;
+			if (g.SetNextWindowPosVal.y == -FLT_MAX) window->SetWindowPosYAxisCenterWanted = true;
+		}
         else
         {
             SetWindowPos(window, g.SetNextWindowPosVal, g.SetNextWindowPosCond);
@@ -4030,12 +4033,15 @@ bool ImGui::Begin(const char* name, bool* p_open, const ImVec2& size_on_first_us
         }
 
         bool window_pos_center = false;
-        window_pos_center |= (window->SetWindowPosCenterWanted && window->HiddenFrames == 0);
+		window_pos_center |= ((window->SetWindowPosXAxisCenterWanted | window->SetWindowPosYAxisCenterWanted) && window->HiddenFrames == 0);
         window_pos_center |= ((flags & ImGuiWindowFlags_Modal) && !window_pos_set_by_api && window_appearing_after_being_hidden);
         if (window_pos_center)
         {
             // Center (any sort of window)
-            SetWindowPos(ImMax(style.DisplaySafeAreaPadding, fullscreen_rect.GetCenter() - window->SizeFull * 0.5f));
+			ImVec2 centerv = fullscreen_rect.GetCenter() - window->SizeFull * 0.5f;
+			if (!window->SetWindowPosXAxisCenterWanted) centerv.x = g.SetNextWindowPosVal.x;
+			if (!window->SetWindowPosYAxisCenterWanted) centerv.y = g.SetNextWindowPosVal.y;
+			SetWindowPos(ImMax(style.DisplaySafeAreaPadding, centerv));
         }
         else if (flags & ImGuiWindowFlags_ChildMenu)
         {
@@ -4819,7 +4825,8 @@ static void SetWindowPos(ImGuiWindow* window, const ImVec2& pos, ImGuiSetCond co
     if (cond && (window->SetWindowPosAllowFlags & cond) == 0)
         return;
     window->SetWindowPosAllowFlags &= ~(ImGuiSetCond_Once | ImGuiSetCond_FirstUseEver | ImGuiSetCond_Appearing);
-    window->SetWindowPosCenterWanted = false;
+    window->SetWindowPosXAxisCenterWanted = false;
+    window->SetWindowPosYAxisCenterWanted = false;
 
     // Set
     const ImVec2 old_pos = window->Pos;

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -3845,13 +3845,12 @@ bool ImGui::Begin(const char* name, bool* p_open, const ImVec2& size_on_first_us
         const ImVec2 backup_cursor_pos = window->DC.CursorPos;                  // FIXME: not sure of the exact reason of this saving/restore anymore :( need to look into that.
         if (!window_was_active || window_appearing_after_being_hidden) window->SetWindowPosAllowFlags |= ImGuiSetCond_Appearing;
         window_pos_set_by_api = (window->SetWindowPosAllowFlags & g.SetNextWindowPosCond) != 0;
-
-		if (window_pos_set_by_api && ((g.SetNextWindowPosVal.x == -FLT_MAX) || (g.SetNextWindowPosVal.y == -FLT_MAX))) {
-
+	    if (window_pos_set_by_api && ((g.SetNextWindowPosVal.x == -FLT_MAX) || (g.SetNextWindowPosVal.y == -FLT_MAX))) 
+	    {
             window->SetWindowPosAllowFlags &= ~(ImGuiSetCond_Once | ImGuiSetCond_FirstUseEver | ImGuiSetCond_Appearing);
-			if (g.SetNextWindowPosVal.x == -FLT_MAX) window->SetWindowPosXAxisCenterWanted = true;
-			if (g.SetNextWindowPosVal.y == -FLT_MAX) window->SetWindowPosYAxisCenterWanted = true;
-		}
+		    if (g.SetNextWindowPosVal.x == -FLT_MAX) window->SetWindowPosXAxisCenterWanted = true;
+		    if (g.SetNextWindowPosVal.y == -FLT_MAX) window->SetWindowPosYAxisCenterWanted = true;
+	    }
         else
         {
             SetWindowPos(window, g.SetNextWindowPosVal, g.SetNextWindowPosCond);

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -628,7 +628,8 @@ struct IMGUI_API ImGuiWindow
     int                     SetWindowPosAllowFlags;             // bit ImGuiSetCond_*** specify if SetWindowPos() call will succeed with this particular flag.
     int                     SetWindowSizeAllowFlags;            // bit ImGuiSetCond_*** specify if SetWindowSize() call will succeed with this particular flag.
     int                     SetWindowCollapsedAllowFlags;       // bit ImGuiSetCond_*** specify if SetWindowCollapsed() call will succeed with this particular flag.
-    bool                    SetWindowPosCenterWanted;
+    bool                    SetWindowPosXAxisCenterWanted;
+    bool                    SetWindowPosYAxisCenterWanted;
 
     ImGuiDrawContext        DC;                                 // Temporary per-window data, reset at the beginning of the frame
     ImVector<ImGuiID>       IDStack;                            // ID stack. ID are hashes seeded with the value at the top of the stack


### PR DESCRIPTION
you want to have centered, ie; ImGui::SetNextWindowPos(ImVec2(-FLT_MAX, 100);

Unsure if you want to have a specific flag to replace -FLT_MAX (ie, windowCenterAxis).

SetNextWindowPos(ImVec2(-FLT_MAX,100)); 
![imgui-x-center](https://cloud.githubusercontent.com/assets/5660591/17444297/8d151398-5b82-11e6-9e6a-ec1a442b4c4d.png)

SetNextWindowPos(ImVec2(10,-FLT_MAX)); 
![imgui-y-center](https://cloud.githubusercontent.com/assets/5660591/17444298/8d201fa4-5b82-11e6-864e-453ae9cc5e47.png)

SetNextWindowPos(ImVec2(-FLT_MAX,-FLT_MAX));
![imgui-xy-center](https://cloud.githubusercontent.com/assets/5660591/17444363/e7853e7a-5b82-11e6-85d3-250fbcbcf1e7.png)
