### PR TITLE
Add null terminator to ShowStyleEditor output_type combo options

### DIFF
--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -1670,7 +1670,7 @@ void ImGui::ShowStyleEditor(ImGuiStyle* ref)
             }
             ImGui::LogFinish();
         }
-        ImGui::SameLine(); ImGui::PushItemWidth(120); ImGui::Combo("##output_type", &output_dest, "To Clipboard\0To TTY"); ImGui::PopItemWidth();
+        ImGui::SameLine(); ImGui::PushItemWidth(120); ImGui::Combo("##output_type", &output_dest, "To Clipboard\0To TTY\0"); ImGui::PopItemWidth();
         ImGui::SameLine(); ImGui::Checkbox("Only Modified Fields", &output_only_modified);
 
         static ImGuiColorEditMode edit_mode = ImGuiColorEditMode_RGB;


### PR DESCRIPTION
Without a null terminator the Combo() function indexes outside of the "items_separated_by_zeros" string.