### PR TITLE
Vulkan example fixes

### DIFF
--- a/examples/vulkan_example/imgui_impl_glfw_vulkan.cpp
+++ b/examples/vulkan_example/imgui_impl_glfw_vulkan.cpp
@@ -661,19 +661,16 @@ bool ImGui_ImplGlfwVulkan_CreateDeviceObjects()
 
     if (!g_PipelineLayout)
     {
-        VkPushConstantRange push_constants[2] = {};
+        VkPushConstantRange push_constants[1] = {};
         push_constants[0].stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
         push_constants[0].offset = sizeof(float) * 0;
-        push_constants[0].size = sizeof(float) * 2;
-        push_constants[1].stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
-        push_constants[1].offset = sizeof(float) * 2;
-        push_constants[1].size = sizeof(float) * 2;
+        push_constants[0].size = sizeof(float) * 4;
         VkDescriptorSetLayout set_layout[1] = {g_DescriptorSetLayout};
         VkPipelineLayoutCreateInfo layout_info = {};
         layout_info.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
         layout_info.setLayoutCount = 1;
         layout_info.pSetLayouts = set_layout;
-        layout_info.pushConstantRangeCount = 2;
+        layout_info.pushConstantRangeCount = 1;
         layout_info.pPushConstantRanges = push_constants;
         err = vkCreatePipelineLayout(g_Device, &layout_info, g_Allocator, &g_PipelineLayout);
         ImGui_ImplGlfwVulkan_VkResult(err);
@@ -750,7 +747,8 @@ bool ImGui_ImplGlfwVulkan_CreateDeviceObjects()
 
     VkDynamicState dynamic_states[2] = { VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR };
     VkPipelineDynamicStateCreateInfo dynamic_state = {};
-    dynamic_state.dynamicStateCount = 2;
+	dynamic_state.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
+	dynamic_state.dynamicStateCount = 2;
     dynamic_state.pDynamicStates = dynamic_states;
 
     VkGraphicsPipelineCreateInfo info = {};

--- a/examples/vulkan_example/imgui_impl_glfw_vulkan.cpp
+++ b/examples/vulkan_example/imgui_impl_glfw_vulkan.cpp
@@ -747,8 +747,8 @@ bool ImGui_ImplGlfwVulkan_CreateDeviceObjects()
 
     VkDynamicState dynamic_states[2] = { VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR };
     VkPipelineDynamicStateCreateInfo dynamic_state = {};
-	dynamic_state.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
-	dynamic_state.dynamicStateCount = 2;
+    dynamic_state.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
+    dynamic_state.dynamicStateCount = 2;
     dynamic_state.pDynamicStates = dynamic_states;
 
     VkGraphicsPipelineCreateInfo info = {};

--- a/examples/vulkan_example/main.cpp
+++ b/examples/vulkan_example/main.cpp
@@ -88,14 +88,10 @@ static void resize_vulkan(GLFWwindow* /*window*/, int w, int h)
         VkSurfaceCapabilitiesKHR cap;
         err = vkGetPhysicalDeviceSurfaceCapabilitiesKHR(g_Gpu, g_Surface, &cap);
         check_vk_result(err);
-		if (cap.maxImageCount > 0)
-		{
-			info.minImageCount = (cap.minImageCount + 2 < cap.maxImageCount) ? (cap.minImageCount + 2) : cap.maxImageCount;
-		}
-		else 
-		{
-			info.minImageCount = cap.minImageCount + 2;
-		}
+        if (cap.maxImageCount > 0)
+            info.minImageCount = (cap.minImageCount + 2 < cap.maxImageCount) ? (cap.minImageCount + 2) : cap.maxImageCount;
+        else
+            info.minImageCount = cap.minImageCount + 2;
         if (cap.currentExtent.width == 0xffffffff)
         {
             fb_width = w;

--- a/examples/vulkan_example/main.cpp
+++ b/examples/vulkan_example/main.cpp
@@ -88,7 +88,14 @@ static void resize_vulkan(GLFWwindow* /*window*/, int w, int h)
         VkSurfaceCapabilitiesKHR cap;
         err = vkGetPhysicalDeviceSurfaceCapabilitiesKHR(g_Gpu, g_Surface, &cap);
         check_vk_result(err);
-        info.minImageCount = (cap.minImageCount + 2 < cap.maxImageCount) ? (cap.minImageCount + 2) : cap.maxImageCount;
+		if (cap.maxImageCount > 0)
+		{
+			info.minImageCount = (cap.minImageCount + 2 < cap.maxImageCount) ? (cap.minImageCount + 2) : cap.maxImageCount;
+		}
+		else 
+		{
+			info.minImageCount = cap.minImageCount + 2;
+		}
         if (cap.currentExtent.width == 0xffffffff)
         {
             fb_width = w;


### PR DESCRIPTION
- maxImageCount may be 0, means unlimited, handle this

- add missing sType

- change to using 1 push constant range, this results in the same functionality, but using 2 crashes my driver 
  - using 2 ranges for 1 push constant block may or may not be valid, spec unclear (filed a bug against Vulkan spec to figure out)