### PR TITLE
Add support for drawing images with rounded corners.

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -1,4 +1,4 @@
-// dear imgui, v1.50 WIP
+﻿// dear imgui, v1.50 WIP
 // (headers)
 
 // See imgui.cpp file for documentation.
@@ -1188,7 +1188,7 @@ struct ImDrawList
     IMGUI_API void  AddCircleFilled(const ImVec2& centre, float radius, ImU32 col, int num_segments = 12);
     IMGUI_API void  AddText(const ImVec2& pos, ImU32 col, const char* text_begin, const char* text_end = NULL);
     IMGUI_API void  AddText(const ImFont* font, float font_size, const ImVec2& pos, ImU32 col, const char* text_begin, const char* text_end = NULL, float wrap_width = 0.0f, const ImVec4* cpu_fine_clip_rect = NULL);
-    IMGUI_API void  AddImage(ImTextureID user_texture_id, const ImVec2& a, const ImVec2& b, const ImVec2& uv0 = ImVec2(0,0), const ImVec2& uv1 = ImVec2(1,1), ImU32 col = 0xFFFFFFFF);
+    IMGUI_API void  AddImage(ImTextureID user_texture_id, const ImVec2& a, const ImVec2& b, const ImVec2& uv0 = ImVec2(0,0), const ImVec2& uv1 = ImVec2(1,1), ImU32 col = 0xFFFFFFFF, float rounding = 0.0f, int rounding_corners = 0x0F);
     IMGUI_API void  AddPolyline(const ImVec2* points, const int num_points, ImU32 col, bool closed, float thickness, bool anti_aliased);
     IMGUI_API void  AddConvexPolyFilled(const ImVec2* points, const int num_points, ImU32 col, bool anti_aliased);
     IMGUI_API void  AddBezierCurve(const ImVec2& pos0, const ImVec2& cp0, const ImVec2& cp1, const ImVec2& pos1, ImU32 col, float thickness, int num_segments = 0);
@@ -1228,6 +1228,7 @@ struct ImDrawList
     inline    void  PrimVtx(const ImVec2& pos, const ImVec2& uv, ImU32 col)     { PrimWriteIdx((ImDrawIdx)_VtxCurrentIdx); PrimWriteVtx(pos, uv, col); }
     IMGUI_API void  UpdateClipRect();
     IMGUI_API void  UpdateTextureID();
+    IMGUI_API void  PrimDistributeUV(ImDrawVert* start, ImDrawVert* end, const ImVec2& a, const ImVec2& b, const ImVec2& uv_a, const ImVec2& uv_b, bool clamp);
 };
 
 // All draw data to render an ImGui frame

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -423,12 +423,12 @@ void ImDrawList::PrimDistributeUV(ImDrawVert* start, ImDrawVert* end, const ImVe
         const ImVec2 max = ImMax(uv_a, uv_b);
 
         for (ImDrawVert* vertex = start; vertex < end; ++vertex)
-            vertex->uv = ImClamp(uv_a + ImProduct(vertex->pos - a, scale), min, max);
+            vertex->uv = ImClamp(uv_a + ImProduct(ImVec2(vertex->pos.x, vertex->pos.y) - a, scale), min, max);
     }
     else
     {
         for (ImDrawVert* vertex = start; vertex < end; ++vertex)
-            vertex->uv = uv_a + ImProduct(vertex->pos - a, scale);
+            vertex->uv = uv_a + ImProduct(ImVec2(vertex->pos.x, vertex->pos.y) - a, scale);
     }
 }
 

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -134,6 +134,9 @@ static inline float  ImLengthSqr(const ImVec4& lhs)                             
 static inline float  ImInvLength(const ImVec2& lhs, float fail_value)           { float d = lhs.x*lhs.x + lhs.y*lhs.y; if (d > 0.0f) return 1.0f / sqrtf(d); return fail_value; }
 static inline float  ImFloor(float f)                                           { return (float)(int)f; }
 static inline ImVec2 ImFloor(ImVec2 v)                                          { return ImVec2((float)(int)v.x, (float)(int)v.y); }
+static inline ImVec2 ImProduct(const ImVec2& lhs, const ImVec2& rhs)            { return ImVec2(lhs.x * rhs.x, lhs.y * rhs.y); }
+static inline ImVec2 ImQuotient(const ImVec2& lhs, const ImVec2& rhs)           { return ImVec2(lhs.x / rhs.x, lhs.y / rhs.y); }
+static inline ImVec2 ImSafeQuotient(const ImVec2& lhs, const ImVec2& rhs, const ImVec2& alt) { return ImVec2(rhs.x ? (lhs.x / rhs.x) : alt.x, rhs.y ? (lhs.y / rhs.y) : alt.y); }
 
 // We call C++ constructor on own allocated memory via the placement "new(ptr) Type()" syntax.
 // Defining a custom placement new() with a dummy parameter allows us to bypass including <new> which on some platforms complains when user has disabled exceptions.


### PR DESCRIPTION
This PR add `rounding` and `rounding_corners` to `ImDrawList::AddImage`.

With rounding it is easier to draw over already rounded rectangles. This is for ImDrawList only. Widgets does not take advantage of this feature.

```cpp
-     IMGUI_API void  AddImage(ImTextureID user_texture_id, const ImVec2& a, const ImVec2& b, const ImVec2& uv0 = ImVec2(0,0), const ImVec2& uv1 = ImVec2(1,1), ImU32 col = 0xFFFFFFFF);
+     IMGUI_API void  AddImage(ImTextureID user_texture_id, const ImVec2& a, const ImVec2& b, const ImVec2& uv0 = ImVec2(0,0), const ImVec2& uv1 = ImVec2(1,1), ImU32 col = 0xFFFFFFFF, float rounding = 0.0f, int rounding_corners = 0x0F);
```

![image](https://cloud.githubusercontent.com/assets/1197433/18051086/be937112-6df2-11e6-90d0-5696af6a9dce.png)
