### PR TITLE
Correct name for linking opengl3_example

### DIFF
--- a/examples/opengl3_example/Makefile
+++ b/examples/opengl3_example/Makefile
@@ -30,7 +30,7 @@ endif
 ifeq ($(UNAME_S), Darwin) #APPLE
 	ECHO_MESSAGE = "Mac OS X"
 	LIBS = -framework OpenGL -framework Cocoa -framework IOKit -framework CoreVideo
-	LIBS += -L/usr/local/lib -lglfw3
+	LIBS += -L/usr/local/lib -lglfw
 
 	CXXFLAGS = -I../../ -I../libs/gl3w -I/usr/local/Cellar/glew/1.10.0/include -I/usr/local/include
 	CXXFLAGS += -Wall -Wformat


### PR DESCRIPTION
According to glfw offcial site, linking `libglfw.3.dylib` etc should
use `-lglfw`.

Changed this made the compilation on my Mac successfully.