### PR TITLE
Fix Mac OS X build and remove cruft from Makefile

### DIFF
--- a/examples/apple_example/imguiex.xcodeproj/project.pbxproj
+++ b/examples/apple_example/imguiex.xcodeproj/project.pbxproj
@@ -97,7 +97,7 @@
 			isa = PBXGroup;
 			children = (
 				1A1A0F4D1CB3C54D0090F036 /* libglfw3.dylib */,
-				1A1A0F351CB3A1B20090F036 /* opengl_example */,
+				1A1A0F351CB3A1B20090F036 /* opengl2_example */,
 				1A1A0F211CB39FB50090F036 /* AppDelegate.h */,
 				1A1A0F221CB39FB50090F036 /* AppDelegate.m */,
 				1A1A0F271CB39FB50090F036 /* Assets.xcassets */,
@@ -114,15 +114,15 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
-		1A1A0F351CB3A1B20090F036 /* opengl_example */ = {
+		1A1A0F351CB3A1B20090F036 /* opengl2_example */ = {
 			isa = PBXGroup;
 			children = (
 				1A1A0F371CB3A1B20090F036 /* imgui_impl_glfw.cpp */,
 				1A1A0F381CB3A1B20090F036 /* imgui_impl_glfw.h */,
 				1A1A0F391CB3A1B20090F036 /* main.cpp */,
 			);
-			name = opengl_example;
-			path = ../../opengl_example;
+			name = opengl2_example;
+			path = ../../opengl2_example;
 			sourceTree = "<group>";
 		};
 		6D1E39141B35EEF10017B40F /* usynergy */ = {

--- a/examples/opengl3_example/Makefile
+++ b/examples/opengl3_example/Makefile
@@ -3,9 +3,10 @@
 # Compatible with Ubuntu 14.04.1 and Mac OS X
 #
 #
-# if you using Mac OS X:
-# You'll need glfw
-#    http://www.glfw.org
+# You will need GLFW (http://www.glfw.org)
+#
+#   apt-get install libglfw-dev  # Linux
+#   brew install glfw            # Mac OS X
 #
 
 #CXX = g++
@@ -33,7 +34,7 @@ ifeq ($(UNAME_S), Darwin) #APPLE
 	LIBS += -L/usr/local/lib -lglfw3
 	#LIBS += -L/usr/local/lib -lglfw
 
-	CXXFLAGS = -I../../ -I../libs/gl3w -I/usr/local/Cellar/glew/1.10.0/include -I/usr/local/include
+	CXXFLAGS = -I../../ -I../libs/gl3w -I/usr/local/include
 	CXXFLAGS += -Wall -Wformat
 #	CXXFLAGS += -D__APPLE__
 	CFLAGS = $(CXXFLAGS)


### PR DESCRIPTION
Correctly refer to `opengl2_example` from the Xcode project.