### PR TITLE
ImFont: add RenderGlyph() to allow rendering of individual glyphs

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -1376,6 +1376,7 @@ struct ImFont
     // 'wrap_width' enable automatic word-wrapping across multiple lines to fit into given width. 0.0f to disable.
     IMGUI_API ImVec2            CalcTextSizeA(float size, float max_width, float wrap_width, const char* text_begin, const char* text_end = NULL, const char** remaining = NULL) const; // utf8
     IMGUI_API const char*       CalcWordWrapPositionA(float scale, const char* text, const char* text_end, float wrap_width) const;
+    IMGUI_API void              RenderGlyph(ImDrawList* draw_list, ImVec2 pos, ImU32 col, const ImFont::Glyph* glyph) const;
     IMGUI_API void              RenderChar(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col, unsigned short c) const;
     IMGUI_API void              RenderText(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col, const ImVec4& clip_rect, const char* text_begin, const char* text_end, float wrap_width = 0.0f, bool cpu_fine_clip = false) const;
 

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -1979,6 +1979,15 @@ ImVec2 ImFont::CalcTextSizeA(float size, float max_width, float wrap_width, cons
     return text_size;
 }
 
+void ImFont::RenderGlyph(ImDrawList* draw_list, ImVec2 pos, ImU32 col, const ImFont::Glyph* glyph) const {
+    pos.x = (float)(int)pos.x + DisplayOffset.x;
+    pos.y = (float)(int)pos.y + DisplayOffset.y;
+    ImVec2 pos_tl(pos.x + glyph->X0, pos.y + glyph->Y0);
+    ImVec2 pos_br(pos.x + glyph->X1, pos.y + glyph->Y1);
+    draw_list->PrimReserve(6, 4);
+    draw_list->PrimRectUV(pos_tl, pos_br, ImVec2(glyph->U0, glyph->V0), ImVec2(glyph->U1, glyph->V1), col);
+}
+
 void ImFont::RenderChar(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col, unsigned short c) const
 {
     if (c == ' ' || c == '\t' || c == '\n' || c == '\r') // Match behavior of RenderText(), those 4 codepoints are hard-coded.


### PR DESCRIPTION
I'm loading a symbol font and using it to draw icons on a trace visualizer, possibly many thousands.  It seemed useful to have a path to draw glyphs without text processing, lookup, scaling, etc.  This way I can ImFont::FindGlyph() on my icons once and draw them all over the place with minimal extra overhead.

Submitted for your consideration.
