### PR TITLE
Fixing Directx 11 window size scaling

### DIFF
--- a/examples/directx11_example/imgui_impl_dx11.cpp
+++ b/examples/directx11_example/imgui_impl_dx11.cpp
@@ -556,7 +556,7 @@ void ImGui_ImplDX11_NewFrame()
 
     // Setup display size (every frame to accommodate for window resizing)
     RECT rect;
-    GetClientRect(g_hWnd, &rect);
+    GetWindowRect (g_hWnd, &rect);
     io.DisplaySize = ImVec2((float)(rect.right - rect.left), (float)(rect.bottom - rect.top));
 
     // Setup time step

--- a/examples/directx11_example/imgui_impl_dx11.cpp
+++ b/examples/directx11_example/imgui_impl_dx11.cpp
@@ -556,7 +556,7 @@ void ImGui_ImplDX11_NewFrame()
 
     // Setup display size (every frame to accommodate for window resizing)
     RECT rect;
-    GetWindowRect (g_hWnd, &rect);
+    GetWindowRect(g_hWnd, &rect);
     io.DisplaySize = ImVec2((float)(rect.right - rect.left), (float)(rect.bottom - rect.top));
 
     // Setup time step


### PR DESCRIPTION
Changing GetClientRect to GetWindowsRect in directx11 to fix issue where the GUI would cut off at the wrong place. This is due to GetWindowsRect returning a rect of the screen coords but GetClientRect returns would only return the client coords which will be not the same size of the window as expected. 
