### PR TITLE
Add macros to set calling conventions for callbacks.

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -712,9 +712,9 @@ static bool             DataTypeApplyOpFromText(const char* buf, const char* ini
 // Platform dependent default implementations
 //-----------------------------------------------------------------------------
 
-static const char*      GetClipboardTextFn_DefaultImpl(void* user_data);
-static void             SetClipboardTextFn_DefaultImpl(void* user_data, const char* text);
-static void             ImeSetInputScreenPosFn_DefaultImpl(int x, int y);
+static const char*      IMGUI_CALLBACK GetClipboardTextFn_DefaultImpl(void* user_data);
+static void             IMGUI_CALLBACK SetClipboardTextFn_DefaultImpl(void* user_data, const char* text);
+static void             IMGUI_CALLBACK ImeSetInputScreenPosFn_DefaultImpl(int x, int y);
 
 //-----------------------------------------------------------------------------
 // Context
@@ -835,6 +835,7 @@ ImGuiIO::ImGuiIO()
 
     // User functions
     RenderDrawListsFn = NULL;
+    UserData = NULL;
     MemAllocFn = malloc;
     MemFreeFn = free;
     GetClipboardTextFn = GetClipboardTextFn_DefaultImpl;   // Platform dependent default implementations
@@ -2047,7 +2048,7 @@ void ImGui::SetCurrentContext(ImGuiContext* ctx)
     GImGui = ctx;
 }
 
-ImGuiContext* ImGui::CreateContext(void* (*malloc_fn)(size_t), void (*free_fn)(void*))
+ImGuiContext* ImGui::CreateContext(void* (IMGUI_CALLBACK *malloc_fn)(size_t), void (IMGUI_CALLBACK *free_fn)(void*))
 {
     if (!malloc_fn) malloc_fn = malloc;
     ImGuiContext* ctx = (ImGuiContext*)malloc_fn(sizeof(ImGuiContext));
@@ -2059,7 +2060,7 @@ ImGuiContext* ImGui::CreateContext(void* (*malloc_fn)(size_t), void (*free_fn)(v
 
 void ImGui::DestroyContext(ImGuiContext* ctx)
 {
-    void (*free_fn)(void*) = ctx->IO.MemFreeFn;
+    void (IMGUI_CALLBACK *free_fn)(void*) = ctx->IO.MemFreeFn;
     ctx->~ImGuiContext();
     free_fn(ctx);
     if (GImGui == ctx)
@@ -2521,7 +2522,7 @@ static void MarkSettingsDirty()
 }
 
 // FIXME: Add a more explicit sort order in the window structure.
-static int ChildWindowComparer(const void* lhs, const void* rhs)
+static int IMGUI_CALLBACK ChildWindowComparer(const void* lhs, const void* rhs)
 {
     const ImGuiWindow* a = *(const ImGuiWindow**)lhs;
     const ImGuiWindow* b = *(const ImGuiWindow**)rhs;
@@ -9588,7 +9589,7 @@ void ImGui::ValueColor(const char* prefix, ImU32 v)
 #pragma comment(lib, "user32")
 #endif
 
-static const char* GetClipboardTextFn_DefaultImpl(void*)
+static const char* IMGUI_CALLBACK GetClipboardTextFn_DefaultImpl(void*)
 {
     static ImVector<char> buf_local;
     buf_local.clear();
@@ -9608,7 +9609,7 @@ static const char* GetClipboardTextFn_DefaultImpl(void*)
     return buf_local.Data;
 }
 
-static void SetClipboardTextFn_DefaultImpl(void*, const char* text)
+static void IMGUI_CALLBACK SetClipboardTextFn_DefaultImpl(void*, const char* text)
 {
     if (!OpenClipboard(NULL))
         return;
@@ -9657,7 +9658,7 @@ static void SetClipboardTextFn_DefaultImpl(void*, const char* text)
 #pragma comment(lib, "imm32")
 #endif
 
-static void ImeSetInputScreenPosFn_DefaultImpl(int x, int y)
+static void IMGUI_CALLBACK ImeSetInputScreenPosFn_DefaultImpl(int x, int y)
 {
     // Notify OS Input Method Editor of text input position
     if (HWND hwnd = (HWND)GImGui->IO.ImeWindowHandle)
@@ -9673,7 +9674,7 @@ static void ImeSetInputScreenPosFn_DefaultImpl(int x, int y)
 
 #else
 
-static void ImeSetInputScreenPosFn_DefaultImpl(int, int) {}
+static void IMGUI_CALLBACK ImeSetInputScreenPosFn_DefaultImpl(int, int) {}
 
 #endif
 

--- a/imgui.h
+++ b/imgui.h
@@ -23,6 +23,13 @@
 #define IMGUI_API
 #endif
 
+// Calling conventions
+#if !defined(IMGUI_CALLBACK) && defined(_WIN32)
+#define IMGUI_CALLBACK __cdecl
+#else
+#define IMGUI_CALLBACK
+#endif
+
 // Define assertion handler.
 #ifndef IM_ASSERT
 #include <assert.h>
@@ -457,7 +464,7 @@ namespace ImGui
     // Internal context access - if you want to use multiple context, share context between modules (e.g. DLL). There is a default context created and active by default.
     // All contexts share a same ImFontAtlas by default. If you want different font atlas, you can new() them and overwrite the GetIO().Fonts variable of an ImGui context.
     IMGUI_API const char*   GetVersion();
-    IMGUI_API ImGuiContext* CreateContext(void* (*malloc_fn)(size_t) = NULL, void (*free_fn)(void*) = NULL);
+    IMGUI_API ImGuiContext* CreateContext(void* (IMGUI_CALLBACK *malloc_fn)(size_t) = NULL, void (IMGUI_CALLBACK *free_fn)(void*) = NULL);
     IMGUI_API void          DestroyContext(ImGuiContext* ctx);
     IMGUI_API ImGuiContext* GetCurrentContext();
     IMGUI_API void          SetCurrentContext(ImGuiContext* ctx);
@@ -754,22 +761,22 @@ struct ImGuiIO
     // Rendering function, will be called in Render().
     // Alternatively you can keep this to NULL and call GetDrawData() after Render() to get the same pointer.
     // See example applications if you are unsure of how to implement this.
-    void        (*RenderDrawListsFn)(ImDrawData* data);
+    void        (IMGUI_CALLBACK *RenderDrawListsFn)(ImDrawData* data);
 
     // Optional: access OS clipboard
     // (default to use native Win32 clipboard on Windows, otherwise uses a private clipboard. Override to access OS clipboard on other architectures)
-    const char* (*GetClipboardTextFn)(void* user_data);
-    void        (*SetClipboardTextFn)(void* user_data, const char* text);
+    const char* (IMGUI_CALLBACK *GetClipboardTextFn)(void* user_data);
+    void        (IMGUI_CALLBACK *SetClipboardTextFn)(void* user_data, const char* text);
     void*       ClipboardUserData;
 
     // Optional: override memory allocations. MemFreeFn() may be called with a NULL pointer.
     // (default to posix malloc/free)
-    void*       (*MemAllocFn)(size_t sz);
-    void        (*MemFreeFn)(void* ptr);
+    void*       (IMGUI_CALLBACK *MemAllocFn)(size_t sz);
+    void        (IMGUI_CALLBACK *MemFreeFn)(void* ptr);
 
     // Optional: notify OS Input Method Editor of the screen position of your cursor for text input position (e.g. when using Japanese/Chinese IME in Windows)
     // (default to use native imm32 api on Windows)
-    void        (*ImeSetInputScreenPosFn)(int x, int y);
+    void        (IMGUI_CALLBACK *ImeSetInputScreenPosFn)(int x, int y);
     void*       ImeWindowHandle;            // (Windows) Set this to your HWND to get automatic IME cursor positioning.
 
     //------------------------------------------------------------------

--- a/stb_rect_pack.h
+++ b/stb_rect_pack.h
@@ -63,6 +63,12 @@
 #define STBRP_DEF extern
 #endif
 
+#if !defined(STBRP_QSORT_CALLBACK) && defined(_WIN32)
+#define STBRP_QSORT_CALLBACK __cdecl
+#else
+#define STBRP_QSORT_CALLBACK
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -509,7 +515,7 @@ static stbrp__findresult stbrp__skyline_pack_rectangle(stbrp_context *context, i
    return res;
 }
 
-static int rect_height_compare(const void *a, const void *b)
+static int STBRP_QSORT_CALLBACK rect_height_compare(const void *a, const void *b)
 {
    const stbrp_rect *p = (const stbrp_rect *) a;
    const stbrp_rect *q = (const stbrp_rect *) b;
@@ -520,7 +526,7 @@ static int rect_height_compare(const void *a, const void *b)
    return (p->w > q->w) ? -1 : (p->w < q->w);
 }
 
-static int rect_width_compare(const void *a, const void *b)
+static int STBRP_QSORT_CALLBACK rect_width_compare(const void *a, const void *b)
 {
    const stbrp_rect *p = (const stbrp_rect *) a;
    const stbrp_rect *q = (const stbrp_rect *) b;
@@ -531,7 +537,7 @@ static int rect_width_compare(const void *a, const void *b)
    return (p->h > q->h) ? -1 : (p->h < q->h);
 }
 
-static int rect_original_order(const void *a, const void *b)
+static int STBRP_QSORT_CALLBACK rect_original_order(const void *a, const void *b)
 {
    const stbrp_rect *p = (const stbrp_rect *) a;
    const stbrp_rect *q = (const stbrp_rect *) b;


### PR DESCRIPTION
Required to successfully link when compiling with non-default calling conventions.

e.g., if the hosting app is compiled with /Gv to use the __vectorcall calling convention by default, which is sometimes a huge performance improvement, they will not be able to call imgui functions. Compiling imgui itself with /Gv does not work since system callbacks also need to be marked.

This change makes a single universal IMGUI_CALLBACK macro for marking up all callbacks, typically to __cdecl. If there is a desire to allow imgui callbacks to have custom calling conventions (if there is ever a high-volume callback, for instance) then there may need to be separate macros for CRT callbacks and imgui callbacks.

This change also modified an stb header that uses `qsort` and hence needs to set calling convention. That change could be pushed back to stb if there is a desire to avoid patches over stb.