### PR TITLE
Don't set the cursor when ImGui doesn't draw it

### DIFF
--- a/examples/directx11_example/imgui_impl_dx11.cpp
+++ b/examples/directx11_example/imgui_impl_dx11.cpp
@@ -576,7 +576,8 @@ void ImGui_ImplDX11_NewFrame()
     // io.MouseWheel : filled by WM_MOUSEWHEEL events
 
     // Hide OS mouse cursor if ImGui is drawing it
-    SetCursor(io.MouseDrawCursor ? NULL : LoadCursor(NULL, IDC_ARROW));
+    if(io.MouseDrawCursor)
+        SetCursor(NULL);
 
     // Start the frame
     ImGui::NewFrame();


### PR DESCRIPTION
If the cursor is set by another piece of code this will create a flickering cursor