### PR TITLE
Add configurable color for button text in hovered and active states

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -766,6 +766,8 @@ ImGuiStyle::ImGuiStyle()
 
     Colors[ImGuiCol_Text]                   = ImVec4(0.90f, 0.90f, 0.90f, 1.00f);
     Colors[ImGuiCol_TextDisabled]           = ImVec4(0.60f, 0.60f, 0.60f, 1.00f);
+    Colors[ImGuiCol_TextButtonHover]        = ImVec4(0.90f, 0.90f, 0.90f, 1.00f);
+    Colors[ImGuiCol_TextButtonActive]       = ImVec4(0.90f, 0.90f, 0.90f, 1.00f);
     Colors[ImGuiCol_WindowBg]               = ImVec4(0.00f, 0.00f, 0.00f, 0.70f);
     Colors[ImGuiCol_ChildWindowBg]          = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
     Colors[ImGuiCol_PopupBg]                = ImVec4(0.05f, 0.05f, 0.10f, 0.90f);
@@ -4800,6 +4802,8 @@ const char* ImGui::GetStyleColName(ImGuiCol idx)
     {
     case ImGuiCol_Text: return "Text";
     case ImGuiCol_TextDisabled: return "TextDisabled";
+    case ImGuiCol_TextButtonHover: return "TextButtonHover";
+    case ImGuiCol_TextButtonActive: return "TextButtonActive";
     case ImGuiCol_WindowBg: return "WindowBg";
     case ImGuiCol_ChildWindowBg: return "ChildWindowBg";
     case ImGuiCol_PopupBg: return "PopupBg";
@@ -5640,7 +5644,14 @@ bool ImGui::ButtonEx(const char* label, const ImVec2& size_arg, ImGuiButtonFlags
     // Render
     const ImU32 col = GetColorU32((hovered && held) ? ImGuiCol_ButtonActive : hovered ? ImGuiCol_ButtonHovered : ImGuiCol_Button);
     RenderFrame(bb.Min, bb.Max, col, true, style.FrameRounding);
+
+    if (hovered)
+        ImGui::PushStyleColor(ImGuiCol_Text, g.Style.Colors[held ? ImGuiCol_TextButtonActive : ImGuiCol_TextButtonHover]);
+
     RenderTextClipped(bb.Min + style.FramePadding, bb.Max - style.FramePadding, label, NULL, &label_size, style.ButtonTextAlign, &bb);
+
+    if (hovered)
+        ImGui::PopStyleColor();
 
     // Automatically close popups
     //if (pressed && !(flags & ImGuiButtonFlags_DontClosePopups) && (window->Flags & ImGuiWindowFlags_Popup))

--- a/imgui.h
+++ b/imgui.h
@@ -587,6 +587,8 @@ enum ImGuiCol_
 {
     ImGuiCol_Text,
     ImGuiCol_TextDisabled,
+    ImGuiCol_TextButtonHover,
+    ImGuiCol_TextButtonActive,
     ImGuiCol_WindowBg,              // Background of normal windows
     ImGuiCol_ChildWindowBg,         // Background of child windows
     ImGuiCol_PopupBg,               // Background of popups, menus, tooltips windows


### PR DESCRIPTION
Allows for more flexible configuration of button colors, specifically useful for creating buttons that have an inverted background when hovered.

Would a better approach be to add an argument to `RenderTextClipped` that selects the color class?

r: @ocornut 