### PR TITLE
Update imgui_impl_glfw_gl3.cpp

### DIFF
--- a/examples/opengl3_example/imgui_impl_glfw_gl3.cpp
+++ b/examples/opengl3_example/imgui_impl_glfw_gl3.cpp
@@ -43,6 +43,9 @@ void ImGui_ImplGlfwGL3_RenderDrawLists(ImDrawData* draw_data)
         return;
     draw_data->ScaleClipRects(io.DisplayFramebufferScale);
 
+    //Activate Texture Unit 0
+    glActiveTexture(GL_TEXTURE0);
+    
     // Backup GL state
     GLint last_program; glGetIntegerv(GL_CURRENT_PROGRAM, &last_program);
     GLint last_texture; glGetIntegerv(GL_TEXTURE_BINDING_2D, &last_texture);
@@ -68,7 +71,6 @@ void ImGui_ImplGlfwGL3_RenderDrawLists(ImDrawData* draw_data)
     glDisable(GL_CULL_FACE);
     glDisable(GL_DEPTH_TEST);
     glEnable(GL_SCISSOR_TEST);
-    glActiveTexture(GL_TEXTURE0);
 
     // Setup viewport, orthographic projection matrix
     glViewport(0, 0, (GLsizei)fb_width, (GLsizei)fb_height);


### PR DESCRIPTION
ImGui_ImplGlfwGL3_RenderDrawLists keeps pointers to the currently active Texture and currently active Texture unit, then works on Texture Unit 0. It assumes the last active texture unit was unit 0. This change makes sure Texture Unit 0 is active before making pointers.