### PR TITLE
Update imgui_impl_sdl_gl3.cpp

### DIFF
--- a/examples/sdl_opengl3_example/imgui_impl_sdl_gl3.cpp
+++ b/examples/sdl_opengl3_example/imgui_impl_sdl_gl3.cpp
@@ -37,6 +37,9 @@ void ImGui_ImplSdlGL3_RenderDrawLists(ImDrawData* draw_data)
         return;
     draw_data->ScaleClipRects(io.DisplayFramebufferScale);
 
+    //Switch to Texture Unit 0
+    glActiveTexture(GL_TEXTURE0);
+    
     // Backup GL state
     GLint last_program; glGetIntegerv(GL_CURRENT_PROGRAM, &last_program);
     GLint last_texture; glGetIntegerv(GL_TEXTURE_BINDING_2D, &last_texture);
@@ -62,7 +65,6 @@ void ImGui_ImplSdlGL3_RenderDrawLists(ImDrawData* draw_data)
     glDisable(GL_CULL_FACE);
     glDisable(GL_DEPTH_TEST);
     glEnable(GL_SCISSOR_TEST);
-    glActiveTexture(GL_TEXTURE0);
 
     // Setup orthographic projection matrix
     glViewport(0, 0, (GLsizei)fb_width, (GLsizei)fb_height);


### PR DESCRIPTION
ImGui_ImplSdlGL3_RenderDrawLists keeps a pointer to last active texture unit and last active texture, then works on texture unit 0, assuming the last active texture was texture unit 0, which might not be the case. This change makes sure Texture Unit 0 is active before remembering the state.