### PR TITLE
Add GlyphExtraSpacing.y to ascent

### DIFF
--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -1412,7 +1412,7 @@ bool    ImFontAtlas::Build()
         int unscaled_ascent, unscaled_descent, unscaled_line_gap;
         stbtt_GetFontVMetrics(&tmp.FontInfo, &unscaled_ascent, &unscaled_descent, &unscaled_line_gap);
 
-        float ascent = unscaled_ascent * font_scale;
+        float ascent = unscaled_ascent * font_scale + cfg.GlyphExtraSpacing.y;
         float descent = unscaled_descent * font_scale;
         if (!cfg.MergeMode)
         {


### PR DESCRIPTION
Certain fonts, such as Source Sans Pro, have an ascent value so high that glyphs don't appear vertically centered. I tried setting ImFontConfig.GlyphExtraSpacing.y to a negative value to compensate, only to discover that it's an unused value. This patch provides the behavior I expected.

Before:
<img width="886" alt="screenshot 2017-06-18 15 37 42" src="https://user-images.githubusercontent.com/603802/27263729-4331c05a-543d-11e7-9a02-fa95191b54bd.png">

After: (with extra y spacing of -2)
<img width="878" alt="screenshot 2017-06-18 15 37 14" src="https://user-images.githubusercontent.com/603802/27263730-4c33d2b0-543d-11e7-93d3-e0b2a94d14e3.png">
