### PR TITLE
Improved ColorPicker hue wheel color interpolation

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -9510,11 +9510,11 @@ static void RenderArrowsForVerticalBar(ImDrawList* draw_list, ImVec2 pos, ImVec2
 static void PaintVertsLinearGradientKeepAlpha(ImDrawVert* vert_start, ImDrawVert* vert_end, ImVec2 gradient_p0, ImVec2 gradient_p1, ImU32 col0, ImU32 col1)
 {
     ImVec2 gradient_extent = gradient_p1 - gradient_p0;
-    float gradient_inv_length = ImInvLength(gradient_extent, 0.0f);
+    float gradient_inv_length2 = 1.0f / ImLengthSqr(gradient_extent);
     for (ImDrawVert* vert = vert_start; vert < vert_end; vert++)
     {
         float d = ImDot(vert->pos - gradient_p0, gradient_extent);
-        float t = ImMin(sqrtf(ImMax(d, 0.0f)) * gradient_inv_length, 1.0f);
+        float t = ImClamp(d * gradient_inv_length2, 0.0f, 1.0f);
         int r = ImLerp((int)(col0 >> IM_COL32_R_SHIFT) & 0xFF, (int)(col1 >> IM_COL32_R_SHIFT) & 0xFF, t);
         int g = ImLerp((int)(col0 >> IM_COL32_G_SHIFT) & 0xFF, (int)(col1 >> IM_COL32_G_SHIFT) & 0xFF, t);
         int b = ImLerp((int)(col0 >> IM_COL32_B_SHIFT) & 0xFF, (int)(col1 >> IM_COL32_B_SHIFT) & 0xFF, t);


### PR DESCRIPTION
Just a very subtle improvement to the hue wheel -> more accurate color interpolation; attached before&after screenshots (hue on the wheel better matches the actual selected hue)

![huewheel_before2](https://user-images.githubusercontent.com/7255954/30066610-b2944eb4-9258-11e7-8d81-2b82667eeb97.png)
![huewheel_after2](https://user-images.githubusercontent.com/7255954/30066614-b58d58cc-9258-11e7-89f3-bd4edd430a3c.png)
