### PR TITLE
Added actual logarithmic sliders

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -6550,7 +6550,13 @@ static inline float SliderBehaviorCalcRatioFromValue(float v, float v_min, float
 
     const bool is_non_linear = (power < 1.0f-0.00001f) || (power > 1.0f+0.00001f);
     const float v_clamped = (v_min < v_max) ? ImClamp(v, v_min, v_max) : ImClamp(v, v_max, v_min);
-    if (is_non_linear)
+
+    if (power == 0.0f)
+    {
+        // Logarithmic
+        return logf(v_clamped / v_min) / logf(v_max / v_min);
+    }
+    else if (is_non_linear)
     {
         if (v_clamped < 0.0f)
         {
@@ -6628,7 +6634,12 @@ bool ImGui::SliderBehavior(const ImRect& frame_bb, ImGuiID id, float* v, float v
         if (set_new_value)
         {
             float new_value;
-            if (is_non_linear)
+            if (power == 0.0f)
+            {
+                // Logarithmic
+                new_value = v_min * powf(v_max / v_min, clicked_t);
+            }
+            else if (is_non_linear)
             {
                 // Account for logarithmic scale on both sides of the zero
                 if (clicked_t < linear_zero_pos)

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -358,9 +358,9 @@ void ImGui::ShowTestWindow(bool* p_open)
                 ImGui::SliderInt("slider int", &i1, -1, 3);
                 ImGui::SameLine(); ShowHelpMarker("CTRL+click to input value.");
 
-                static float f1=0.123f, f2=0.0f;
+                static float f1=0.123f, f2=1.0f;
                 ImGui::SliderFloat("slider float", &f1, 0.0f, 1.0f, "ratio = %.3f");
-                ImGui::SliderFloat("slider log float", &f2, -10.0f, 10.0f, "%.4f", 3.0f);
+                ImGui::SliderFloat("slider log float", &f2, 0.01f, 100.0f, "%.4f", 0.0f);
                 static float angle = 0.0f;
                 ImGui::SliderAngle("slider angle", &angle);
             }


### PR DESCRIPTION
The slider behavior previously called "logarithmic" is actually polynomial. This is true logarithmic and can be triggered by passing a `power` argument of `0.0f` in `SliderFloat`.

I left the previous behavior for backwards compatibility, but in my opinion it should be removed and the `float power` argument should be changed to `bool logarithmic`.

Also updated demo for "slider log float".

Solves #642 