### PR TITLE
Simplify alloca.h include condition

### DIFF
--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -21,10 +21,10 @@
 #if !defined(alloca)
 #ifdef _WIN32
 #include <malloc.h>     // alloca
-#elif (defined(__FreeBSD__) || defined(FreeBSD_kernel) || defined(__DragonFly__)) && !defined(__GLIBC__)
-#include <stdlib.h>     // alloca. FreeBSD uses stdlib.h unless GLIBC
+#elif !defined(__GLIBC__)
+#include <stdlib.h>     // alloca
 #else
-#include <alloca.h>     // alloca
+#include <alloca.h>     // alloca. glibc has an alloca specific header
 #endif
 #endif
 


### PR DESCRIPTION
And make it _way_ more portable. While `alloca` isn't standardized, glibc is the only place that uses `alloca.h`. This is the only thing keeping imgui from building on NetBSD.
