### PR TITLE
Remove commas after last item in enumeration.

### DIFF
--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -220,7 +220,7 @@ enum ImGuiDataType
 {
     ImGuiDataType_Int,
     ImGuiDataType_Float,
-    ImGuiDataType_Float2,
+    ImGuiDataType_Float2
 };
 
 enum ImGuiDir
@@ -229,7 +229,7 @@ enum ImGuiDir
     ImGuiDir_Left    = 0,
     ImGuiDir_Right   = 1,
     ImGuiDir_Up      = 2,
-    ImGuiDir_Down    = 3,
+    ImGuiDir_Down    = 3
 };
 
 enum ImGuiCorner


### PR DESCRIPTION
This brings these enums to match the rest of the code and fixes
2 warnings under clang about using C++11 extensions.