### PR TITLE
Completely clear font when rebuilding atlas.

### DIFF
--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -1540,7 +1540,6 @@ bool    ImFontAtlasBuildWithStbTruetype(ImFontAtlas* atlas)
         const float off_x = cfg.GlyphOffset.x;
         const float off_y = cfg.GlyphOffset.y + (float)(int)(dst_font->Ascent + 0.5f);
 
-        dst_font->FallbackGlyph = NULL; // Always clear fallback so FindGlyph can return NULL. It will be set again in BuildLookupTable()
         for (int i = 0; i < tmp.RangesCount; i++)
         {
             stbtt_pack_range& range = tmp.Ranges[i];
@@ -1582,14 +1581,16 @@ void ImFontAtlasBuildSetupFont(ImFontAtlas* atlas, ImFont* font, ImFontConfig* f
 {
     if (!font_config->MergeMode)
     {
-        font->ContainerAtlas = atlas;
-        font->ConfigData = font_config;
-        font->ConfigDataCount = 0;
+        ImVec2 display_offset = font->DisplayOffset;
+
+        font->Clear();
+
         font->FontSize = font_config->SizePixels;
+        font->DisplayOffset = display_offset;
+        font->ConfigData = font_config;
+        font->ContainerAtlas = atlas;
         font->Ascent = ascent;
         font->Descent = descent;
-        font->Glyphs.resize(0);
-        font->MetricsTotalSurface = 0;
     }
     font->ConfigDataCount++;
 }


### PR DESCRIPTION
Previously, IndexLookup was not cleared on each font, causing FindGlyph to possibly return old glyphs when using MergeMode.

This crept up if a new font was added and built after a config using MergeMode had previously been built. On the second build, IndexLookup would not be cleared, causing FindGlyph to return old glyphs and ultimately not merge the glyphs into the atlas.

I called `ImFont::Clear` and preserved DisplayOffset vs tacking on an explicit clear to IndexLookup, but I'm not sure what's preferred. As an aside, it felt weird that DisplayOffset is reset by Clear, while the other field explicitly set by the user (`Scale`) is not.