### PR TITLE
Fix binary_to_compressed_c tool to return 0 when successful

### DIFF
--- a/extra_fonts/binary_to_compressed_c.cpp
+++ b/extra_fonts/binary_to_compressed_c.cpp
@@ -53,8 +53,7 @@ int main(int argc, char** argv)
         }
     }
 
-    binary_to_compressed_c(argv[argn], argv[argn+1], use_base85_encoding, use_compression);
-    return 1;
+    return binary_to_compressed_c(argv[argn], argv[argn+1], use_base85_encoding, use_compression) ? 0 : 1;
 }
 
 char Encode85Byte(unsigned int x) 


### PR DESCRIPTION
Returning 1 is seen as an error by many tools, making it tricky to integrate this into build systems as-is.