### PR TITLE
ImGUI with SDL and Vulkan

### DIFF
--- a/examples/sdl_vulkan_example/Makefile
+++ b/examples/sdl_vulkan_example/Makefile
@@ -1,0 +1,60 @@
+#
+# Cross Platform Makefile
+# Compatible with MSYS2/MINGW, Ubuntu 14.04.1 and Mac OS X
+#
+#
+# You will need SDL2 (http://www.libsdl.org)
+#
+#   apt-get install libsdl2-dev  # Linux
+#   brew install sdl2            # Mac OS X
+#   pacman -S mingw-w64-i686-SDL # MSYS2
+#
+
+#CXX = g++
+
+EXE = sdl_vulkan_example
+OBJS = main.o imgui_impl_sdl_vulkan.o
+OBJS += ../../imgui.o ../../imgui_demo.o ../../imgui_draw.o
+
+UNAME_S := $(shell uname -s)
+
+
+ifeq ($(UNAME_S), Linux) #LINUX
+	ECHO_MESSAGE = "Linux"
+	LIBS = -lvulkan -ldl `sdl2-config --libs`
+
+	CXXFLAGS = -I../../ -I../libs/gl3w `sdl2-config --cflags`
+	CXXFLAGS += -Wall -Wformat
+	CFLAGS = $(CXXFLAGS)
+endif
+
+ifeq ($(UNAME_S), Darwin) #APPLE
+	ECHO_MESSAGE = "Mac OS X"
+	LIBS = -framework OpenGL -framework Cocoa -framework IOKit -framework CoreVideo `sdl2-config --libs`
+
+	CXXFLAGS = -I../../ -I../libs/gl3w -I/usr/local/include `sdl2-config --cflags`
+	CXXFLAGS += -Wall -Wformat
+	CFLAGS = $(CXXFLAGS)
+endif
+
+ifeq ($(findstring MINGW,$(UNAME_S)),MINGW)
+   ECHO_MESSAGE = "Windows"
+   LIBS = -lgdi32 -lvulkan -limm32 `pkg-config --static --libs sdl2`
+
+   CXXFLAGS = `pkg-config --cflags sdl2`
+   CXXFLAGS += -Wall -Wformat
+   CFLAGS = $(CXXFLAGS)
+endif
+
+
+.cpp.o:
+	$(CXX) $(CXXFLAGS) -c -o $@ $<
+
+all: $(EXE)
+	@echo Build complete for $(ECHO_MESSAGE)
+
+$(EXE): $(OBJS)
+	$(CXX) -o $(EXE) $(OBJS) $(CXXFLAGS) $(LIBS)
+
+clean:
+	rm $(EXE) $(OBJS)

--- a/examples/sdl_vulkan_example/gen_spv.sh
+++ b/examples/sdl_vulkan_example/gen_spv.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+glslangValidator -V -x -o glsl_shader.frag.u32 glsl_shader.frag
+glslangValidator -V -x -o glsl_shader.vert.u32 glsl_shader.vert

--- a/examples/sdl_vulkan_example/glsl_shader.frag
+++ b/examples/sdl_vulkan_example/glsl_shader.frag
@@ -1,0 +1,14 @@
+#version 450 core
+layout(location = 0) out vec4 fColor;
+
+layout(set=0, binding=0) uniform sampler2D sTexture;
+
+layout(location = 0) in struct{
+    vec4 Color;
+    vec2 UV;
+} In;
+
+void main()
+{
+    fColor = In.Color * texture(sTexture, In.UV.st);
+}

--- a/examples/sdl_vulkan_example/glsl_shader.vert
+++ b/examples/sdl_vulkan_example/glsl_shader.vert
@@ -1,0 +1,25 @@
+#version 450 core
+layout(location = 0) in vec2 aPos;
+layout(location = 1) in vec2 aUV;
+layout(location = 2) in vec4 aColor;
+
+layout(push_constant) uniform uPushConstant{
+    vec2 uScale;
+    vec2 uTranslate;
+} pc;
+
+out gl_PerVertex{
+    vec4 gl_Position;
+};
+
+layout(location = 0) out struct{
+    vec4 Color;
+    vec2 UV;
+} Out;
+
+void main()
+{
+    Out.Color = aColor;
+    Out.UV = aUV;
+    gl_Position = vec4(aPos*pc.uScale+pc.uTranslate, 0, 1);
+}

--- a/examples/sdl_vulkan_example/imgui_impl_sdl_vulkan.cpp
+++ b/examples/sdl_vulkan_example/imgui_impl_sdl_vulkan.cpp
@@ -1,0 +1,838 @@
+// ImGui GLFW binding with Vulkan + shaders
+// FIXME: Changes of ImTextureID aren't supported by this binding! Please, someone add it!
+
+// You can copy and use unmodified imgui_impl_* files in your project. See main.cpp for an example of using this.
+// If you use this binding you'll need to call 5 functions: ImGui_ImplXXXX_Init(), ImGui_ImplXXX_CreateFontsTexture(), ImGui_ImplXXXX_NewFrame(), ImGui_ImplXXXX_Render() and ImGui_ImplXXXX_Shutdown().
+// If you are new to ImGui, see examples/README.txt and documentation at the top of imgui.cpp.
+// https://github.com/ocornut/imgui
+
+#include <imgui.h>
+
+// SDL
+#include <SDL.h>
+#include <SDL_syswm.h>
+#include <SDL_vulkan.h>
+
+#include "vulkan/vulkan.h"
+
+#include "imgui_impl_sdl_vulkan.h"
+
+// GLFW Data
+static SDL_Window*  g_Window = NULL;
+static double       g_Time = 0.0f;
+static bool         g_MousePressed[3] = { false, false, false };
+static float        g_MouseWheel = 0.0f;
+
+// Vulkan Data
+static VkAllocationCallbacks* g_Allocator = NULL;
+static VkPhysicalDevice       g_Gpu = VK_NULL_HANDLE;
+static VkDevice               g_Device = VK_NULL_HANDLE;
+static VkRenderPass           g_RenderPass = VK_NULL_HANDLE;
+static VkPipelineCache        g_PipelineCache = VK_NULL_HANDLE;
+static VkDescriptorPool       g_DescriptorPool = VK_NULL_HANDLE;
+static void (*g_CheckVkResult)(VkResult err) = NULL;
+
+static VkCommandBuffer        g_CommandBuffer = VK_NULL_HANDLE;
+static size_t                 g_BufferMemoryAlignment = 256;
+static VkPipelineCreateFlags  g_PipelineCreateFlags = 0;
+static int                    g_FrameIndex = 0;
+
+static VkDescriptorSetLayout  g_DescriptorSetLayout = VK_NULL_HANDLE;
+static VkPipelineLayout       g_PipelineLayout = VK_NULL_HANDLE;
+static VkDescriptorSet        g_DescriptorSet = VK_NULL_HANDLE;
+static VkPipeline             g_Pipeline = VK_NULL_HANDLE;
+
+static VkSampler              g_FontSampler = VK_NULL_HANDLE;
+static VkDeviceMemory         g_FontMemory = VK_NULL_HANDLE;
+static VkImage                g_FontImage = VK_NULL_HANDLE;
+static VkImageView            g_FontView = VK_NULL_HANDLE;
+
+static VkDeviceMemory         g_VertexBufferMemory[IMGUI_VK_QUEUED_FRAMES] = {};
+static VkDeviceMemory         g_IndexBufferMemory[IMGUI_VK_QUEUED_FRAMES] = {};
+static size_t                 g_VertexBufferSize[IMGUI_VK_QUEUED_FRAMES] = {};
+static size_t                 g_IndexBufferSize[IMGUI_VK_QUEUED_FRAMES] = {};
+static VkBuffer               g_VertexBuffer[IMGUI_VK_QUEUED_FRAMES] = {};
+static VkBuffer               g_IndexBuffer[IMGUI_VK_QUEUED_FRAMES] = {};
+
+static VkDeviceMemory         g_UploadBufferMemory = VK_NULL_HANDLE;
+static VkBuffer               g_UploadBuffer = VK_NULL_HANDLE;
+
+static uint32_t __glsl_shader_vert_spv[] =
+{
+    0x07230203,0x00010000,0x00080001,0x0000002e,0x00000000,0x00020011,0x00000001,0x0006000b,
+    0x00000001,0x4c534c47,0x6474732e,0x3035342e,0x00000000,0x0003000e,0x00000000,0x00000001,
+    0x000a000f,0x00000000,0x00000004,0x6e69616d,0x00000000,0x0000000b,0x0000000f,0x00000015,
+    0x0000001b,0x0000001c,0x00030003,0x00000002,0x000001c2,0x00040005,0x00000004,0x6e69616d,
+    0x00000000,0x00030005,0x00000009,0x00000000,0x00050006,0x00000009,0x00000000,0x6f6c6f43,
+    0x00000072,0x00040006,0x00000009,0x00000001,0x00005655,0x00030005,0x0000000b,0x0074754f,
+    0x00040005,0x0000000f,0x6c6f4361,0x0000726f,0x00030005,0x00000015,0x00565561,0x00060005,
+    0x00000019,0x505f6c67,0x65567265,0x78657472,0x00000000,0x00060006,0x00000019,0x00000000,
+    0x505f6c67,0x7469736f,0x006e6f69,0x00030005,0x0000001b,0x00000000,0x00040005,0x0000001c,
+    0x736f5061,0x00000000,0x00060005,0x0000001e,0x73755075,0x6e6f4368,0x6e617473,0x00000074,
+    0x00050006,0x0000001e,0x00000000,0x61635375,0x0000656c,0x00060006,0x0000001e,0x00000001,
+    0x61725475,0x616c736e,0x00006574,0x00030005,0x00000020,0x00006370,0x00040047,0x0000000b,
+    0x0000001e,0x00000000,0x00040047,0x0000000f,0x0000001e,0x00000002,0x00040047,0x00000015,
+    0x0000001e,0x00000001,0x00050048,0x00000019,0x00000000,0x0000000b,0x00000000,0x00030047,
+    0x00000019,0x00000002,0x00040047,0x0000001c,0x0000001e,0x00000000,0x00050048,0x0000001e,
+    0x00000000,0x00000023,0x00000000,0x00050048,0x0000001e,0x00000001,0x00000023,0x00000008,
+    0x00030047,0x0000001e,0x00000002,0x00020013,0x00000002,0x00030021,0x00000003,0x00000002,
+    0x00030016,0x00000006,0x00000020,0x00040017,0x00000007,0x00000006,0x00000004,0x00040017,
+    0x00000008,0x00000006,0x00000002,0x0004001e,0x00000009,0x00000007,0x00000008,0x00040020,
+    0x0000000a,0x00000003,0x00000009,0x0004003b,0x0000000a,0x0000000b,0x00000003,0x00040015,
+    0x0000000c,0x00000020,0x00000001,0x0004002b,0x0000000c,0x0000000d,0x00000000,0x00040020,
+    0x0000000e,0x00000001,0x00000007,0x0004003b,0x0000000e,0x0000000f,0x00000001,0x00040020,
+    0x00000011,0x00000003,0x00000007,0x0004002b,0x0000000c,0x00000013,0x00000001,0x00040020,
+    0x00000014,0x00000001,0x00000008,0x0004003b,0x00000014,0x00000015,0x00000001,0x00040020,
+    0x00000017,0x00000003,0x00000008,0x0003001e,0x00000019,0x00000007,0x00040020,0x0000001a,
+    0x00000003,0x00000019,0x0004003b,0x0000001a,0x0000001b,0x00000003,0x0004003b,0x00000014,
+    0x0000001c,0x00000001,0x0004001e,0x0000001e,0x00000008,0x00000008,0x00040020,0x0000001f,
+    0x00000009,0x0000001e,0x0004003b,0x0000001f,0x00000020,0x00000009,0x00040020,0x00000021,
+    0x00000009,0x00000008,0x0004002b,0x00000006,0x00000028,0x00000000,0x0004002b,0x00000006,
+    0x00000029,0x3f800000,0x00050036,0x00000002,0x00000004,0x00000000,0x00000003,0x000200f8,
+    0x00000005,0x0004003d,0x00000007,0x00000010,0x0000000f,0x00050041,0x00000011,0x00000012,
+    0x0000000b,0x0000000d,0x0003003e,0x00000012,0x00000010,0x0004003d,0x00000008,0x00000016,
+    0x00000015,0x00050041,0x00000017,0x00000018,0x0000000b,0x00000013,0x0003003e,0x00000018,
+    0x00000016,0x0004003d,0x00000008,0x0000001d,0x0000001c,0x00050041,0x00000021,0x00000022,
+    0x00000020,0x0000000d,0x0004003d,0x00000008,0x00000023,0x00000022,0x00050085,0x00000008,
+    0x00000024,0x0000001d,0x00000023,0x00050041,0x00000021,0x00000025,0x00000020,0x00000013,
+    0x0004003d,0x00000008,0x00000026,0x00000025,0x00050081,0x00000008,0x00000027,0x00000024,
+    0x00000026,0x00050051,0x00000006,0x0000002a,0x00000027,0x00000000,0x00050051,0x00000006,
+    0x0000002b,0x00000027,0x00000001,0x00070050,0x00000007,0x0000002c,0x0000002a,0x0000002b,
+    0x00000028,0x00000029,0x00050041,0x00000011,0x0000002d,0x0000001b,0x0000000d,0x0003003e,
+    0x0000002d,0x0000002c,0x000100fd,0x00010038
+};
+
+static uint32_t __glsl_shader_frag_spv[] =
+{
+    0x07230203,0x00010000,0x00080001,0x0000001e,0x00000000,0x00020011,0x00000001,0x0006000b,
+    0x00000001,0x4c534c47,0x6474732e,0x3035342e,0x00000000,0x0003000e,0x00000000,0x00000001,
+    0x0007000f,0x00000004,0x00000004,0x6e69616d,0x00000000,0x00000009,0x0000000d,0x00030010,
+    0x00000004,0x00000007,0x00030003,0x00000002,0x000001c2,0x00040005,0x00000004,0x6e69616d,
+    0x00000000,0x00040005,0x00000009,0x6c6f4366,0x0000726f,0x00030005,0x0000000b,0x00000000,
+    0x00050006,0x0000000b,0x00000000,0x6f6c6f43,0x00000072,0x00040006,0x0000000b,0x00000001,
+    0x00005655,0x00030005,0x0000000d,0x00006e49,0x00050005,0x00000016,0x78655473,0x65727574,
+    0x00000000,0x00040047,0x00000009,0x0000001e,0x00000000,0x00040047,0x0000000d,0x0000001e,
+    0x00000000,0x00040047,0x00000016,0x00000022,0x00000000,0x00040047,0x00000016,0x00000021,
+    0x00000000,0x00020013,0x00000002,0x00030021,0x00000003,0x00000002,0x00030016,0x00000006,
+    0x00000020,0x00040017,0x00000007,0x00000006,0x00000004,0x00040020,0x00000008,0x00000003,
+    0x00000007,0x0004003b,0x00000008,0x00000009,0x00000003,0x00040017,0x0000000a,0x00000006,
+    0x00000002,0x0004001e,0x0000000b,0x00000007,0x0000000a,0x00040020,0x0000000c,0x00000001,
+    0x0000000b,0x0004003b,0x0000000c,0x0000000d,0x00000001,0x00040015,0x0000000e,0x00000020,
+    0x00000001,0x0004002b,0x0000000e,0x0000000f,0x00000000,0x00040020,0x00000010,0x00000001,
+    0x00000007,0x00090019,0x00000013,0x00000006,0x00000001,0x00000000,0x00000000,0x00000000,
+    0x00000001,0x00000000,0x0003001b,0x00000014,0x00000013,0x00040020,0x00000015,0x00000000,
+    0x00000014,0x0004003b,0x00000015,0x00000016,0x00000000,0x0004002b,0x0000000e,0x00000018,
+    0x00000001,0x00040020,0x00000019,0x00000001,0x0000000a,0x00050036,0x00000002,0x00000004,
+    0x00000000,0x00000003,0x000200f8,0x00000005,0x00050041,0x00000010,0x00000011,0x0000000d,
+    0x0000000f,0x0004003d,0x00000007,0x00000012,0x00000011,0x0004003d,0x00000014,0x00000017,
+    0x00000016,0x00050041,0x00000019,0x0000001a,0x0000000d,0x00000018,0x0004003d,0x0000000a,
+    0x0000001b,0x0000001a,0x00050057,0x00000007,0x0000001c,0x00000017,0x0000001b,0x00050085,
+    0x00000007,0x0000001d,0x00000012,0x0000001c,0x0003003e,0x00000009,0x0000001d,0x000100fd,
+    0x00010038
+};
+
+static uint32_t ImGui_ImplSdlVulkan_MemoryType(VkMemoryPropertyFlags properties, uint32_t type_bits)
+{
+    VkPhysicalDeviceMemoryProperties prop;
+    vkGetPhysicalDeviceMemoryProperties(g_Gpu, &prop);
+    for (uint32_t i = 0; i < prop.memoryTypeCount; i++)
+        if ((prop.memoryTypes[i].propertyFlags & properties) == properties && type_bits & (1<<i))
+            return i;
+    return 0xffffffff; // Unable to find memoryType
+}
+
+static void ImGui_ImplSdlVulkan_VkResult(VkResult err)
+{
+    if (g_CheckVkResult)
+        g_CheckVkResult(err);
+}
+
+// This is the main rendering function that you have to implement and provide to ImGui (via setting up 'RenderDrawListsFn' in the ImGuiIO structure)
+void ImGui_ImplSdlVulkan_RenderDrawLists(ImDrawData* draw_data)
+{
+    VkResult err;
+    ImGuiIO& io = ImGui::GetIO();
+
+    // Create the Vertex Buffer:
+    size_t vertex_size = draw_data->TotalVtxCount * sizeof(ImDrawVert);
+    if (!g_VertexBuffer[g_FrameIndex] || g_VertexBufferSize[g_FrameIndex] < vertex_size)
+    {
+        if (g_VertexBuffer[g_FrameIndex])
+            vkDestroyBuffer(g_Device, g_VertexBuffer[g_FrameIndex], g_Allocator);
+        if (g_VertexBufferMemory[g_FrameIndex])
+            vkFreeMemory(g_Device, g_VertexBufferMemory[g_FrameIndex], g_Allocator);
+        size_t vertex_buffer_size = ((vertex_size-1) / g_BufferMemoryAlignment+1) * g_BufferMemoryAlignment;
+        VkBufferCreateInfo buffer_info = {};
+        buffer_info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+        buffer_info.size = vertex_buffer_size;
+        buffer_info.usage = VK_BUFFER_USAGE_VERTEX_BUFFER_BIT;
+        buffer_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+        err = vkCreateBuffer(g_Device, &buffer_info, g_Allocator, &g_VertexBuffer[g_FrameIndex]);
+        ImGui_ImplSdlVulkan_VkResult(err);
+        VkMemoryRequirements req;
+        vkGetBufferMemoryRequirements(g_Device, g_VertexBuffer[g_FrameIndex], &req);
+        g_BufferMemoryAlignment = (g_BufferMemoryAlignment > req.alignment) ? g_BufferMemoryAlignment : req.alignment;
+        VkMemoryAllocateInfo alloc_info = {};
+        alloc_info.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+        alloc_info.allocationSize = req.size;
+        alloc_info.memoryTypeIndex = ImGui_ImplSdlVulkan_MemoryType(VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, req.memoryTypeBits);
+        err = vkAllocateMemory(g_Device, &alloc_info, g_Allocator, &g_VertexBufferMemory[g_FrameIndex]);
+        ImGui_ImplSdlVulkan_VkResult(err);
+        err = vkBindBufferMemory(g_Device, g_VertexBuffer[g_FrameIndex], g_VertexBufferMemory[g_FrameIndex], 0);
+        ImGui_ImplSdlVulkan_VkResult(err);
+        g_VertexBufferSize[g_FrameIndex] = vertex_buffer_size;
+    }
+
+    // Create the Index Buffer:
+    size_t index_size = draw_data->TotalIdxCount * sizeof(ImDrawIdx);
+    if (!g_IndexBuffer[g_FrameIndex] || g_IndexBufferSize[g_FrameIndex] < index_size)
+    {
+        if (g_IndexBuffer[g_FrameIndex])
+            vkDestroyBuffer(g_Device, g_IndexBuffer[g_FrameIndex], g_Allocator);
+        if (g_IndexBufferMemory[g_FrameIndex])
+            vkFreeMemory(g_Device, g_IndexBufferMemory[g_FrameIndex], g_Allocator);
+        size_t index_buffer_size = ((index_size-1) / g_BufferMemoryAlignment+1) * g_BufferMemoryAlignment;
+        VkBufferCreateInfo buffer_info = {};
+        buffer_info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+        buffer_info.size = index_buffer_size;
+        buffer_info.usage = VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
+        buffer_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+        err = vkCreateBuffer(g_Device, &buffer_info, g_Allocator, &g_IndexBuffer[g_FrameIndex]);
+        ImGui_ImplSdlVulkan_VkResult(err);
+        VkMemoryRequirements req;
+        vkGetBufferMemoryRequirements(g_Device, g_IndexBuffer[g_FrameIndex], &req);
+        g_BufferMemoryAlignment = (g_BufferMemoryAlignment > req.alignment) ? g_BufferMemoryAlignment : req.alignment;
+        VkMemoryAllocateInfo alloc_info = {};
+        alloc_info.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+        alloc_info.allocationSize = req.size;
+        alloc_info.memoryTypeIndex = ImGui_ImplSdlVulkan_MemoryType(VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, req.memoryTypeBits);
+        err = vkAllocateMemory(g_Device, &alloc_info, g_Allocator, &g_IndexBufferMemory[g_FrameIndex]);
+        ImGui_ImplSdlVulkan_VkResult(err);
+        err = vkBindBufferMemory(g_Device, g_IndexBuffer[g_FrameIndex], g_IndexBufferMemory[g_FrameIndex], 0);
+        ImGui_ImplSdlVulkan_VkResult(err);
+        g_IndexBufferSize[g_FrameIndex] = index_buffer_size;
+    }
+
+    // Upload Vertex and index Data:
+    {
+        ImDrawVert* vtx_dst;
+        ImDrawIdx* idx_dst;
+        err = vkMapMemory(g_Device, g_VertexBufferMemory[g_FrameIndex], 0, vertex_size, 0, (void**)(&vtx_dst));
+        ImGui_ImplSdlVulkan_VkResult(err);
+        err = vkMapMemory(g_Device, g_IndexBufferMemory[g_FrameIndex], 0, index_size, 0, (void**)(&idx_dst));
+        ImGui_ImplSdlVulkan_VkResult(err);
+        for (int n = 0; n < draw_data->CmdListsCount; n++)
+        {
+            const ImDrawList* cmd_list = draw_data->CmdLists[n];
+            memcpy(vtx_dst, cmd_list->VtxBuffer.Data, cmd_list->VtxBuffer.Size * sizeof(ImDrawVert));
+            memcpy(idx_dst, cmd_list->IdxBuffer.Data, cmd_list->IdxBuffer.Size * sizeof(ImDrawIdx));
+            vtx_dst += cmd_list->VtxBuffer.Size;
+            idx_dst += cmd_list->IdxBuffer.Size;
+        }
+        VkMappedMemoryRange range[2] = {};
+        range[0].sType = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;
+        range[0].memory = g_VertexBufferMemory[g_FrameIndex];
+        range[0].size = VK_WHOLE_SIZE;
+        range[1].sType = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;
+        range[1].memory = g_IndexBufferMemory[g_FrameIndex];
+        range[1].size = VK_WHOLE_SIZE;
+        err = vkFlushMappedMemoryRanges(g_Device, 2, range);
+        ImGui_ImplSdlVulkan_VkResult(err);
+        vkUnmapMemory(g_Device, g_VertexBufferMemory[g_FrameIndex]);
+        vkUnmapMemory(g_Device, g_IndexBufferMemory[g_FrameIndex]);
+    }
+
+    // Bind pipeline and descriptor sets:
+    {
+        vkCmdBindPipeline(g_CommandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, g_Pipeline);
+        VkDescriptorSet desc_set[1] = {g_DescriptorSet};
+        vkCmdBindDescriptorSets(g_CommandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, g_PipelineLayout, 0, 1, desc_set, 0, NULL);
+    }
+
+    // Bind Vertex And Index Buffer:
+    {
+        VkBuffer vertex_buffers[1] = {g_VertexBuffer[g_FrameIndex]};
+        VkDeviceSize vertex_offset[1] = {0};
+        vkCmdBindVertexBuffers(g_CommandBuffer, 0, 1, vertex_buffers, vertex_offset);
+        vkCmdBindIndexBuffer(g_CommandBuffer, g_IndexBuffer[g_FrameIndex], 0, VK_INDEX_TYPE_UINT16);
+    }
+
+    // Setup viewport:
+    {
+        VkViewport viewport;
+        viewport.x = 0;
+        viewport.y = 0;
+        viewport.width = ImGui::GetIO().DisplaySize.x;
+        viewport.height = ImGui::GetIO().DisplaySize.y;
+        viewport.minDepth = 0.0f;
+        viewport.maxDepth = 1.0f;
+        vkCmdSetViewport(g_CommandBuffer, 0, 1, &viewport);
+    }
+
+    // Setup scale and translation:
+    {
+        float scale[2];
+        scale[0] = 2.0f/io.DisplaySize.x;
+        scale[1] = 2.0f/io.DisplaySize.y;
+        float translate[2];
+        translate[0] = -1.0f;
+        translate[1] = -1.0f;
+        vkCmdPushConstants(g_CommandBuffer, g_PipelineLayout, VK_SHADER_STAGE_VERTEX_BIT, sizeof(float) * 0, sizeof(float) * 2, scale);
+        vkCmdPushConstants(g_CommandBuffer, g_PipelineLayout, VK_SHADER_STAGE_VERTEX_BIT, sizeof(float) * 2, sizeof(float) * 2, translate);
+    }
+
+    // Render the command lists:
+    int vtx_offset = 0;
+    int idx_offset = 0;
+    for (int n = 0; n < draw_data->CmdListsCount; n++)
+    {
+        const ImDrawList* cmd_list = draw_data->CmdLists[n];
+        for (int cmd_i = 0; cmd_i < cmd_list->CmdBuffer.Size; cmd_i++)
+        {
+            const ImDrawCmd* pcmd = &cmd_list->CmdBuffer[cmd_i];
+            if (pcmd->UserCallback)
+            {
+                pcmd->UserCallback(cmd_list, pcmd);
+            }
+            else
+            {
+                VkRect2D scissor;
+                scissor.offset.x = (int32_t)(pcmd->ClipRect.x) > 0 ? (int32_t)(pcmd->ClipRect.x) : 0;
+                scissor.offset.y = (int32_t)(pcmd->ClipRect.y) > 0 ? (int32_t)(pcmd->ClipRect.y) : 0;
+                scissor.extent.width = (uint32_t)(pcmd->ClipRect.z - pcmd->ClipRect.x);
+                scissor.extent.height = (uint32_t)(pcmd->ClipRect.w - pcmd->ClipRect.y + 1); // FIXME: Why +1 here?
+                vkCmdSetScissor(g_CommandBuffer, 0, 1, &scissor);
+                vkCmdDrawIndexed(g_CommandBuffer, pcmd->ElemCount, 1, idx_offset, vtx_offset, 0);
+            }
+            idx_offset += pcmd->ElemCount;
+        }
+        vtx_offset += cmd_list->VtxBuffer.Size;
+    }
+}
+
+static const char* ImGui_ImplSdlVulkan_GetClipboardText(void* user_data)
+{
+    return SDL_GetClipboardText();
+}
+
+static void ImGui_ImplSdlVulkan_SetClipboardText(void* user_data, const char* text)
+{
+    SDL_SetClipboardText(text);
+}
+
+bool ImGui_ImplSdlVulkan_ProcessEvent(SDL_Event* event)
+{
+    ImGuiIO& io = ImGui::GetIO();
+    switch (event->type)
+    {
+    case SDL_MOUSEWHEEL:
+        {
+            if (event->wheel.y > 0)
+                g_MouseWheel = 1;
+            if (event->wheel.y < 0)
+                g_MouseWheel = -1;
+            return true;
+        }
+    case SDL_MOUSEBUTTONDOWN:
+        {
+            if (event->button.button == SDL_BUTTON_LEFT) g_MousePressed[0] = true;
+            if (event->button.button == SDL_BUTTON_RIGHT) g_MousePressed[1] = true;
+            if (event->button.button == SDL_BUTTON_MIDDLE) g_MousePressed[2] = true;
+            return true;
+        }
+    case SDL_TEXTINPUT:
+        {
+            io.AddInputCharactersUTF8(event->text.text);
+            return true;
+        }
+    case SDL_KEYDOWN:
+    case SDL_KEYUP:
+        {
+            int key = event->key.keysym.sym & ~SDLK_SCANCODE_MASK;
+            io.KeysDown[key] = (event->type == SDL_KEYDOWN);
+            io.KeyShift = ((SDL_GetModState() & KMOD_SHIFT) != 0);
+            io.KeyCtrl = ((SDL_GetModState() & KMOD_CTRL) != 0);
+            io.KeyAlt = ((SDL_GetModState() & KMOD_ALT) != 0);
+            io.KeySuper = ((SDL_GetModState() & KMOD_GUI) != 0);
+            return true;
+        }
+    }
+    return false;
+}
+
+bool ImGui_ImplSdlVulkan_CreateFontsTexture(VkCommandBuffer command_buffer)
+{
+    ImGuiIO& io = ImGui::GetIO();
+
+    unsigned char* pixels;
+    int width, height;
+    io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);
+    size_t upload_size = width*height*4*sizeof(char);
+
+    VkResult err;
+
+    // Create the Image:
+    {
+        VkImageCreateInfo info = {};
+        info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+        info.imageType = VK_IMAGE_TYPE_2D;
+        info.format = VK_FORMAT_R8G8B8A8_UNORM;
+        info.extent.width = width;
+        info.extent.height = height;
+        info.extent.depth = 1;
+        info.mipLevels = 1;
+        info.arrayLayers = 1;
+        info.samples = VK_SAMPLE_COUNT_1_BIT;
+        info.tiling = VK_IMAGE_TILING_OPTIMAL;
+        info.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+        info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+        info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        err = vkCreateImage(g_Device, &info, g_Allocator, &g_FontImage);
+        ImGui_ImplSdlVulkan_VkResult(err);
+        VkMemoryRequirements req;
+        vkGetImageMemoryRequirements(g_Device, g_FontImage, &req);
+        VkMemoryAllocateInfo alloc_info = {};
+        alloc_info.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+        alloc_info.allocationSize = req.size;
+        alloc_info.memoryTypeIndex = ImGui_ImplSdlVulkan_MemoryType(VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, req.memoryTypeBits);
+        err = vkAllocateMemory(g_Device, &alloc_info, g_Allocator, &g_FontMemory);
+        ImGui_ImplSdlVulkan_VkResult(err);
+        err = vkBindImageMemory(g_Device, g_FontImage, g_FontMemory, 0);
+        ImGui_ImplSdlVulkan_VkResult(err);
+    }
+
+    // Create the Image View:
+    {
+        VkImageViewCreateInfo info = {};
+        info.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+        info.image = g_FontImage;
+        info.viewType = VK_IMAGE_VIEW_TYPE_2D;
+        info.format = VK_FORMAT_R8G8B8A8_UNORM;
+        info.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        info.subresourceRange.levelCount = 1;
+        info.subresourceRange.layerCount = 1;
+        err = vkCreateImageView(g_Device, &info, g_Allocator, &g_FontView);
+        ImGui_ImplSdlVulkan_VkResult(err);
+    }
+
+    // Update the Descriptor Set:
+    {
+        VkDescriptorImageInfo desc_image[1] = {};
+        desc_image[0].sampler = g_FontSampler;
+        desc_image[0].imageView = g_FontView;
+        desc_image[0].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        VkWriteDescriptorSet write_desc[1] = {};
+        write_desc[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        write_desc[0].dstSet = g_DescriptorSet;
+        write_desc[0].descriptorCount = 1;
+        write_desc[0].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+        write_desc[0].pImageInfo = desc_image;
+        vkUpdateDescriptorSets(g_Device, 1, write_desc, 0, NULL);
+    }
+
+    // Create the Upload Buffer:
+    {
+        VkBufferCreateInfo buffer_info = {};
+        buffer_info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+        buffer_info.size = upload_size;
+        buffer_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+        buffer_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+        err = vkCreateBuffer(g_Device, &buffer_info, g_Allocator, &g_UploadBuffer);
+        ImGui_ImplSdlVulkan_VkResult(err);
+        VkMemoryRequirements req;
+        vkGetBufferMemoryRequirements(g_Device, g_UploadBuffer, &req);
+        g_BufferMemoryAlignment = (g_BufferMemoryAlignment > req.alignment) ? g_BufferMemoryAlignment : req.alignment;
+        VkMemoryAllocateInfo alloc_info = {};
+        alloc_info.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+        alloc_info.allocationSize = req.size;
+        alloc_info.memoryTypeIndex = ImGui_ImplSdlVulkan_MemoryType(VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, req.memoryTypeBits);
+        err = vkAllocateMemory(g_Device, &alloc_info, g_Allocator, &g_UploadBufferMemory);
+        ImGui_ImplSdlVulkan_VkResult(err);
+        err = vkBindBufferMemory(g_Device, g_UploadBuffer, g_UploadBufferMemory, 0);
+        ImGui_ImplSdlVulkan_VkResult(err);
+    }
+
+    // Upload to Buffer:
+    {
+        char* map = NULL;
+        err = vkMapMemory(g_Device, g_UploadBufferMemory, 0, upload_size, 0, (void**)(&map));
+        ImGui_ImplSdlVulkan_VkResult(err);
+        memcpy(map, pixels, upload_size);
+        VkMappedMemoryRange range[1] = {};
+        range[0].sType = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;
+        range[0].memory = g_UploadBufferMemory;
+        range[0].size = upload_size;
+        err = vkFlushMappedMemoryRanges(g_Device, 1, range);
+        ImGui_ImplSdlVulkan_VkResult(err);
+        vkUnmapMemory(g_Device, g_UploadBufferMemory);
+    }
+    // Copy to Image:
+    {
+        VkImageMemoryBarrier copy_barrier[1] = {};
+        copy_barrier[0].sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+        copy_barrier[0].dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        copy_barrier[0].oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        copy_barrier[0].newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+        copy_barrier[0].srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        copy_barrier[0].dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        copy_barrier[0].image = g_FontImage;
+        copy_barrier[0].subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        copy_barrier[0].subresourceRange.levelCount = 1;
+        copy_barrier[0].subresourceRange.layerCount = 1;
+        vkCmdPipelineBarrier(command_buffer, VK_PIPELINE_STAGE_HOST_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, NULL, 0, NULL, 1, copy_barrier);
+
+        VkBufferImageCopy region = {};
+        region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        region.imageSubresource.layerCount = 1;
+        region.imageExtent.width = width;
+        region.imageExtent.height = height;
+        region.imageExtent.depth = 1;
+        vkCmdCopyBufferToImage(command_buffer, g_UploadBuffer, g_FontImage, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
+
+        VkImageMemoryBarrier use_barrier[1] = {};
+        use_barrier[0].sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+        use_barrier[0].srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        use_barrier[0].dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+        use_barrier[0].oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+        use_barrier[0].newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        use_barrier[0].srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        use_barrier[0].dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        use_barrier[0].image = g_FontImage;
+        use_barrier[0].subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        use_barrier[0].subresourceRange.levelCount = 1;
+        use_barrier[0].subresourceRange.layerCount = 1;
+        vkCmdPipelineBarrier(command_buffer, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0, NULL, 0, NULL, 1, use_barrier);
+    }
+
+    // Store our identifier
+    io.Fonts->TexID = (void *)(intptr_t)g_FontImage;
+
+    return true;
+}
+
+bool ImGui_ImplSdlVulkan_CreateDeviceObjects()
+{
+    VkResult err;
+    VkShaderModule vert_module;
+    VkShaderModule frag_module;
+
+    // Create The Shader Modules:
+    {
+        VkShaderModuleCreateInfo vert_info = {};
+        vert_info.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+        vert_info.codeSize = sizeof(__glsl_shader_vert_spv);
+        vert_info.pCode = (uint32_t*)__glsl_shader_vert_spv;
+        err = vkCreateShaderModule(g_Device, &vert_info, g_Allocator, &vert_module);
+        ImGui_ImplSdlVulkan_VkResult(err);
+        VkShaderModuleCreateInfo frag_info = {};
+        frag_info.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+        frag_info.codeSize = sizeof(__glsl_shader_frag_spv);
+        frag_info.pCode = (uint32_t*)__glsl_shader_frag_spv;
+        err = vkCreateShaderModule(g_Device, &frag_info, g_Allocator, &frag_module);
+        ImGui_ImplSdlVulkan_VkResult(err);
+    }
+
+    if (!g_FontSampler)
+    {
+        VkSamplerCreateInfo info = {};
+        info.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+        info.magFilter = VK_FILTER_LINEAR;
+        info.minFilter = VK_FILTER_LINEAR;
+        info.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
+        info.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+        info.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+        info.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+        info.minLod = -1000;
+        info.maxLod = 1000;
+        info.maxAnisotropy = 1.0f;
+        err = vkCreateSampler(g_Device, &info, g_Allocator, &g_FontSampler);
+        ImGui_ImplSdlVulkan_VkResult(err);
+    }
+
+    if (!g_DescriptorSetLayout)
+    {
+        VkSampler sampler[1] = {g_FontSampler};
+        VkDescriptorSetLayoutBinding binding[1] = {};
+        binding[0].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+        binding[0].descriptorCount = 1;
+        binding[0].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+        binding[0].pImmutableSamplers = sampler;
+        VkDescriptorSetLayoutCreateInfo info = {};
+        info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+        info.bindingCount = 1;
+        info.pBindings = binding;
+        err = vkCreateDescriptorSetLayout(g_Device, &info, g_Allocator, &g_DescriptorSetLayout);
+        ImGui_ImplSdlVulkan_VkResult(err);
+    }
+
+    // Create Descriptor Set:
+    {
+        VkDescriptorSetAllocateInfo alloc_info = {};
+        alloc_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+        alloc_info.descriptorPool = g_DescriptorPool;
+        alloc_info.descriptorSetCount = 1;
+        alloc_info.pSetLayouts = &g_DescriptorSetLayout;
+        err = vkAllocateDescriptorSets(g_Device, &alloc_info, &g_DescriptorSet);
+        ImGui_ImplSdlVulkan_VkResult(err);
+    }
+
+    if (!g_PipelineLayout)
+    {
+        VkPushConstantRange push_constants[1] = {};
+        push_constants[0].stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
+        push_constants[0].offset = sizeof(float) * 0;
+        push_constants[0].size = sizeof(float) * 4;
+        VkDescriptorSetLayout set_layout[1] = {g_DescriptorSetLayout};
+        VkPipelineLayoutCreateInfo layout_info = {};
+        layout_info.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+        layout_info.setLayoutCount = 1;
+        layout_info.pSetLayouts = set_layout;
+        layout_info.pushConstantRangeCount = 1;
+        layout_info.pPushConstantRanges = push_constants;
+        err = vkCreatePipelineLayout(g_Device, &layout_info, g_Allocator, &g_PipelineLayout);
+        ImGui_ImplSdlVulkan_VkResult(err);
+    }
+
+    VkPipelineShaderStageCreateInfo stage[2] = {};
+    stage[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    stage[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
+    stage[0].module = vert_module;
+    stage[0].pName = "main";
+    stage[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    stage[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
+    stage[1].module = frag_module;
+    stage[1].pName = "main";
+
+    VkVertexInputBindingDescription binding_desc[1] = {};
+    binding_desc[0].stride = sizeof(ImDrawVert);
+    binding_desc[0].inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+
+    VkVertexInputAttributeDescription attribute_desc[3] = {};
+    attribute_desc[0].location = 0;
+    attribute_desc[0].binding = binding_desc[0].binding;
+    attribute_desc[0].format = VK_FORMAT_R32G32_SFLOAT;
+    attribute_desc[0].offset = (size_t)(&((ImDrawVert*)0)->pos);
+    attribute_desc[1].location = 1;
+    attribute_desc[1].binding = binding_desc[0].binding;
+    attribute_desc[1].format = VK_FORMAT_R32G32_SFLOAT;
+    attribute_desc[1].offset = (size_t)(&((ImDrawVert*)0)->uv);
+    attribute_desc[2].location = 2;
+    attribute_desc[2].binding = binding_desc[0].binding;
+    attribute_desc[2].format = VK_FORMAT_R8G8B8A8_UNORM;
+    attribute_desc[2].offset = (size_t)(&((ImDrawVert*)0)->col);
+
+    VkPipelineVertexInputStateCreateInfo vertex_info = {};
+    vertex_info.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
+    vertex_info.vertexBindingDescriptionCount = 1;
+    vertex_info.pVertexBindingDescriptions = binding_desc;
+    vertex_info.vertexAttributeDescriptionCount = 3;
+    vertex_info.pVertexAttributeDescriptions = attribute_desc;
+
+    VkPipelineInputAssemblyStateCreateInfo ia_info = {};
+    ia_info.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
+    ia_info.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+
+    VkPipelineViewportStateCreateInfo viewport_info = {};
+    viewport_info.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
+    viewport_info.viewportCount = 1;
+    viewport_info.scissorCount = 1;
+
+    VkPipelineRasterizationStateCreateInfo raster_info = {};
+    raster_info.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
+    raster_info.polygonMode = VK_POLYGON_MODE_FILL;
+    raster_info.cullMode = VK_CULL_MODE_NONE;
+    raster_info.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+    raster_info.lineWidth = 1.0f;
+
+    VkPipelineMultisampleStateCreateInfo ms_info = {};
+    ms_info.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
+    ms_info.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+
+    VkPipelineColorBlendAttachmentState color_attachment[1] = {};
+    color_attachment[0].blendEnable = VK_TRUE;
+    color_attachment[0].srcColorBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA;
+    color_attachment[0].dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+    color_attachment[0].colorBlendOp = VK_BLEND_OP_ADD;
+    color_attachment[0].srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+    color_attachment[0].dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO;
+    color_attachment[0].alphaBlendOp = VK_BLEND_OP_ADD;
+    color_attachment[0].colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+
+    VkPipelineDepthStencilStateCreateInfo depth_info = {};
+    depth_info.sType = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
+
+    VkPipelineColorBlendStateCreateInfo blend_info = {};
+    blend_info.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
+    blend_info.attachmentCount = 1;
+    blend_info.pAttachments = color_attachment;
+
+    VkDynamicState dynamic_states[2] = { VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR };
+    VkPipelineDynamicStateCreateInfo dynamic_state = {};
+    dynamic_state.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
+    dynamic_state.dynamicStateCount = 2;
+    dynamic_state.pDynamicStates = dynamic_states;
+
+    VkGraphicsPipelineCreateInfo info = {};
+    info.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
+    info.flags = g_PipelineCreateFlags;
+    info.stageCount = 2;
+    info.pStages = stage;
+    info.pVertexInputState = &vertex_info;
+    info.pInputAssemblyState = &ia_info;
+    info.pViewportState = &viewport_info;
+    info.pRasterizationState = &raster_info;
+    info.pMultisampleState = &ms_info;
+    info.pDepthStencilState = &depth_info;
+    info.pColorBlendState = &blend_info;
+    info.pDynamicState = &dynamic_state;
+    info.layout = g_PipelineLayout;
+    info.renderPass = g_RenderPass;
+    err = vkCreateGraphicsPipelines(g_Device, g_PipelineCache, 1, &info, g_Allocator, &g_Pipeline);
+    ImGui_ImplSdlVulkan_VkResult(err);
+
+    vkDestroyShaderModule(g_Device, vert_module, g_Allocator);
+    vkDestroyShaderModule(g_Device, frag_module, g_Allocator);
+
+    return true;
+}
+
+void    ImGui_ImplSdlVulkan_InvalidateFontUploadObjects()
+{
+    if (g_UploadBuffer)
+    {
+        vkDestroyBuffer(g_Device, g_UploadBuffer, g_Allocator);
+        g_UploadBuffer = VK_NULL_HANDLE;
+    }
+    if (g_UploadBufferMemory)
+    {
+        vkFreeMemory(g_Device, g_UploadBufferMemory, g_Allocator);
+        g_UploadBufferMemory = VK_NULL_HANDLE;
+    }
+}
+
+void    ImGui_ImplSdlVulkan_InvalidateDeviceObjects()
+{
+    ImGui_ImplSdlVulkan_InvalidateFontUploadObjects();
+
+    for (int i = 0; i < IMGUI_VK_QUEUED_FRAMES; i++)
+    {
+        if (g_VertexBuffer[i])          { vkDestroyBuffer(g_Device, g_VertexBuffer[i], g_Allocator); g_VertexBuffer[i] = VK_NULL_HANDLE; }
+        if (g_VertexBufferMemory[i])    { vkFreeMemory(g_Device, g_VertexBufferMemory[i], g_Allocator); g_VertexBufferMemory[i] = VK_NULL_HANDLE; }
+        if (g_IndexBuffer[i])           { vkDestroyBuffer(g_Device, g_IndexBuffer[i], g_Allocator); g_IndexBuffer[i] = VK_NULL_HANDLE; }
+        if (g_IndexBufferMemory[i])     { vkFreeMemory(g_Device, g_IndexBufferMemory[i], g_Allocator); g_IndexBufferMemory[i] = VK_NULL_HANDLE; }
+    }
+
+    if (g_FontView)             { vkDestroyImageView(g_Device, g_FontView, g_Allocator); g_FontView = VK_NULL_HANDLE; }
+    if (g_FontImage)            { vkDestroyImage(g_Device, g_FontImage, g_Allocator); g_FontImage = VK_NULL_HANDLE; }
+    if (g_FontMemory)           { vkFreeMemory(g_Device, g_FontMemory, g_Allocator); g_FontMemory = VK_NULL_HANDLE; }
+    if (g_FontSampler)          { vkDestroySampler(g_Device, g_FontSampler, g_Allocator); g_FontSampler = VK_NULL_HANDLE; }
+    if (g_DescriptorSetLayout)  { vkDestroyDescriptorSetLayout(g_Device, g_DescriptorSetLayout, g_Allocator); g_DescriptorSetLayout = VK_NULL_HANDLE; }
+    if (g_PipelineLayout)       { vkDestroyPipelineLayout(g_Device, g_PipelineLayout, g_Allocator); g_PipelineLayout = VK_NULL_HANDLE; }
+    if (g_Pipeline)             { vkDestroyPipeline(g_Device, g_Pipeline, g_Allocator); g_Pipeline = VK_NULL_HANDLE; }
+}
+
+bool    ImGui_ImplSdlVulkan_Init(SDL_Window* window, bool install_callbacks, ImGui_ImplSdlVulkan_Init_Data *init_data)
+{
+    g_Allocator = init_data->allocator;
+    g_Gpu = init_data->gpu;
+    g_Device = init_data->device;
+    g_RenderPass = init_data->render_pass;
+    g_PipelineCache = init_data->pipeline_cache;
+    g_DescriptorPool = init_data->descriptor_pool;
+    g_CheckVkResult = init_data->check_vk_result;
+
+    g_Window = window;
+
+    ImGuiIO& io = ImGui::GetIO();
+    io.KeyMap[ImGuiKey_Tab] = SDLK_TAB;                     // Keyboard mapping. ImGui will use those indices to peek into the io.KeyDown[] array.
+    io.KeyMap[ImGuiKey_LeftArrow] = SDL_SCANCODE_LEFT;
+    io.KeyMap[ImGuiKey_RightArrow] = SDL_SCANCODE_RIGHT;
+    io.KeyMap[ImGuiKey_UpArrow] = SDL_SCANCODE_UP;
+    io.KeyMap[ImGuiKey_DownArrow] = SDL_SCANCODE_DOWN;
+    io.KeyMap[ImGuiKey_PageUp] = SDL_SCANCODE_PAGEUP;
+    io.KeyMap[ImGuiKey_PageDown] = SDL_SCANCODE_PAGEDOWN;
+    io.KeyMap[ImGuiKey_Home] = SDL_SCANCODE_HOME;
+    io.KeyMap[ImGuiKey_End] = SDL_SCANCODE_END;
+    io.KeyMap[ImGuiKey_Delete] = SDLK_DELETE;
+    io.KeyMap[ImGuiKey_Backspace] = SDLK_BACKSPACE;
+    io.KeyMap[ImGuiKey_Enter] = SDLK_RETURN;
+    io.KeyMap[ImGuiKey_Escape] = SDLK_ESCAPE;
+    io.KeyMap[ImGuiKey_A] = SDLK_a;
+    io.KeyMap[ImGuiKey_C] = SDLK_c;
+    io.KeyMap[ImGuiKey_V] = SDLK_v;
+    io.KeyMap[ImGuiKey_X] = SDLK_x;
+    io.KeyMap[ImGuiKey_Y] = SDLK_y;
+    io.KeyMap[ImGuiKey_Z] = SDLK_z;
+
+    io.RenderDrawListsFn = ImGui_ImplSdlVulkan_RenderDrawLists;       // Alternatively you can set this to NULL and call ImGui::GetDrawData() after ImGui::Render() to get the same ImDrawData pointer.
+    io.SetClipboardTextFn = ImGui_ImplSdlVulkan_SetClipboardText;
+    io.GetClipboardTextFn = ImGui_ImplSdlVulkan_GetClipboardText;
+    io.ClipboardUserData = g_Window;
+#ifdef _WIN32
+    SDL_SysWMinfo wmInfo;
+    SDL_VERSION(&wmInfo.version);
+    SDL_GetWindowWMInfo(window, &wmInfo);
+    io.ImeWindowHandle = wmInfo.info.win.window;
+#else
+    (void)window;
+#endif
+
+    ImGui_ImplSdlVulkan_CreateDeviceObjects();
+
+    return true;
+}
+
+void ImGui_ImplSdlVulkan_Shutdown()
+{
+    ImGui_ImplSdlVulkan_InvalidateDeviceObjects();
+    ImGui::Shutdown();
+}
+
+void ImGui_ImplSdlVulkan_NewFrame(SDL_Window* window)
+{
+    ImGuiIO& io = ImGui::GetIO();
+
+    // Setup display size (every frame to accommodate for window resizing)
+    int w, h;
+    int display_w, display_h;
+    SDL_GetWindowSize(window, &w, &h);
+    SDL_Vulkan_GetDrawableSize(window, &display_w, &display_h);
+    io.DisplaySize = ImVec2((float)w, (float)h);
+    io.DisplayFramebufferScale = ImVec2(w > 0 ? ((float)display_w / w) : 0, h > 0 ? ((float)display_h / h) : 0);
+
+    // Setup time step
+    double current_time = SDL_GetPerformanceCounter() / (double)SDL_GetPerformanceFrequency();
+    io.DeltaTime = g_Time > 0.0 ? (float)(current_time - g_Time) : (float)(1.0f / 60.0f);
+    g_Time = current_time;
+
+    // Setup inputs
+    // (we already got mouse wheel, keyboard keys & characters from SDL_PollEvent())
+    int mx, my;
+    Uint32 mouseMask = SDL_GetMouseState(&mx, &my);
+    if (SDL_GetWindowFlags(window) & SDL_WINDOW_MOUSE_FOCUS)
+        io.MousePos = ImVec2((float)mx, (float)my);   // Mouse position, in pixels (set to -1,-1 if no mouse / on another screen, etc.)
+    else
+        io.MousePos = ImVec2(-FLT_MAX, -FLT_MAX);
+
+    io.MouseDown[0] = g_MousePressed[0] || (mouseMask & SDL_BUTTON(SDL_BUTTON_LEFT)) != 0;		// If a mouse press event came, always pass it as "mouse held this frame", so we don't miss click-release events that are shorter than 1 frame.
+    io.MouseDown[1] = g_MousePressed[1] || (mouseMask & SDL_BUTTON(SDL_BUTTON_RIGHT)) != 0;
+    io.MouseDown[2] = g_MousePressed[2] || (mouseMask & SDL_BUTTON(SDL_BUTTON_MIDDLE)) != 0;
+    g_MousePressed[0] = g_MousePressed[1] = g_MousePressed[2] = false;
+
+    io.MouseWheel = g_MouseWheel;
+    g_MouseWheel = 0.0f;
+
+    // Hide OS mouse cursor if ImGui is drawing it
+    SDL_ShowCursor(io.MouseDrawCursor ? 0 : 1);
+
+    // Start the frame
+    ImGui::NewFrame();
+}
+
+void ImGui_ImplSdlVulkan_Render(VkCommandBuffer command_buffer)
+{
+    g_CommandBuffer = command_buffer;
+    ImGui::Render();
+    g_CommandBuffer = VK_NULL_HANDLE;
+    g_FrameIndex = (g_FrameIndex + 1) % IMGUI_VK_QUEUED_FRAMES;
+}

--- a/examples/sdl_vulkan_example/imgui_impl_sdl_vulkan.h
+++ b/examples/sdl_vulkan_example/imgui_impl_sdl_vulkan.h
@@ -1,0 +1,35 @@
+// ImGui SDL binding with Vulkan + shaders
+// FIXME: Changes of ImTextureID aren't supported by this binding! Please, someone add it!
+
+// You can copy and use unmodified imgui_impl_* files in your project. See main.cpp for an example of using this.
+// If you use this binding you'll need to call 5 functions: ImGui_ImplXXXX_Init(), ImGui_ImplXXX_CreateFontsTexture(), ImGui_ImplXXXX_NewFrame(), ImGui_ImplXXXX_Render() and ImGui_ImplXXXX_Shutdown().
+// If you are new to ImGui, see examples/README.txt and documentation at the top of imgui.cpp.
+// https://github.com/ocornut/imgui
+
+struct SDL_Window;
+
+#define IMGUI_VK_QUEUED_FRAMES 2
+
+struct ImGui_ImplSdlVulkan_Init_Data
+{
+    VkAllocationCallbacks* allocator;
+    VkPhysicalDevice       gpu;
+    VkDevice               device;
+    VkRenderPass           render_pass;
+    VkPipelineCache        pipeline_cache;
+    VkDescriptorPool       descriptor_pool;
+    void (*check_vk_result)(VkResult err);
+};
+
+IMGUI_API bool        ImGui_ImplSdlVulkan_Init(SDL_Window* window, bool install_callbacks, ImGui_ImplSdlVulkan_Init_Data *init_data);
+IMGUI_API void        ImGui_ImplSdlVulkan_Shutdown();
+IMGUI_API void        ImGui_ImplSdlVulkan_NewFrame(SDL_Window* window);
+IMGUI_API bool        ImGui_ImplSdlVulkan_ProcessEvent(SDL_Event* event);
+IMGUI_API void        ImGui_ImplSdlVulkan_Render(VkCommandBuffer command_buffer);
+
+// Use if you want to reset your rendering device without losing ImGui state.
+IMGUI_API void        ImGui_ImplSdlVulkan_InvalidateFontUploadObjects();
+IMGUI_API void        ImGui_ImplSdlVulkan_InvalidateDeviceObjects();
+IMGUI_API bool        ImGui_ImplSdlVulkan_CreateFontsTexture(VkCommandBuffer command_buffer);
+IMGUI_API bool        ImGui_ImplSdlVulkan_CreateDeviceObjects();
+

--- a/examples/sdl_vulkan_example/main.cpp
+++ b/examples/sdl_vulkan_example/main.cpp
@@ -1,0 +1,746 @@
+// ImGui - standalone example application for Glfw + Vulkan, using programmable pipeline
+// If you are new to ImGui, see examples/README.txt and documentation at the top of imgui.cpp.
+
+#include <imgui.h>
+
+#include <stdio.h>          // printf, fprintf
+#include <stdlib.h>         // abort
+
+#include <SDL.h>
+#include <SDL_syswm.h>
+#include <SDL_vulkan.h>
+
+#include "vulkan/vulkan.h"
+
+#include "imgui_impl_sdl_vulkan.h"
+
+#define IMGUI_MAX_POSSIBLE_BACK_BUFFERS 16
+#define IMGUI_UNLIMITED_FRAME_RATE
+//#ifdef _DEBUG
+//#define IMGUI_VULKAN_DEBUG_REPORT
+//#endif
+
+static VkAllocationCallbacks*   g_Allocator = NULL;
+static VkInstance               g_Instance = VK_NULL_HANDLE;
+static VkSurfaceKHR             g_Surface = VK_NULL_HANDLE;
+static VkPhysicalDevice         g_Gpu = VK_NULL_HANDLE;
+static VkDevice                 g_Device = VK_NULL_HANDLE;
+static VkSwapchainKHR           g_Swapchain = VK_NULL_HANDLE;
+static VkRenderPass             g_RenderPass = VK_NULL_HANDLE;
+static uint32_t                 g_QueueFamily = 0;
+static VkQueue                  g_Queue = VK_NULL_HANDLE;
+static VkDebugReportCallbackEXT g_Debug_Report = VK_NULL_HANDLE;
+
+static VkSurfaceFormatKHR       g_SurfaceFormat;
+static VkImageSubresourceRange  g_ImageRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+static VkPresentModeKHR         g_PresentMode;
+
+static VkPipelineCache          g_PipelineCache = VK_NULL_HANDLE;
+static VkDescriptorPool         g_DescriptorPool = VK_NULL_HANDLE;
+
+static int                      fb_width, fb_height;
+static uint32_t                 g_BackbufferIndices[IMGUI_VK_QUEUED_FRAMES];    // keep track of recently rendered swapchain frame indices
+static uint32_t                 g_BackBufferCount = 0;
+static VkImage                  g_BackBuffer[IMGUI_MAX_POSSIBLE_BACK_BUFFERS] = {};
+static VkImageView              g_BackBufferView[IMGUI_MAX_POSSIBLE_BACK_BUFFERS] = {};
+static VkFramebuffer            g_Framebuffer[IMGUI_MAX_POSSIBLE_BACK_BUFFERS] = {};
+
+static uint32_t                 g_FrameIndex = 0;
+static VkCommandPool            g_CommandPool[IMGUI_VK_QUEUED_FRAMES];
+static VkCommandBuffer          g_CommandBuffer[IMGUI_VK_QUEUED_FRAMES];
+static VkFence                  g_Fence[IMGUI_VK_QUEUED_FRAMES];
+static VkSemaphore              g_PresentCompleteSemaphore[IMGUI_VK_QUEUED_FRAMES];
+static VkSemaphore              g_RenderCompleteSemaphore[IMGUI_VK_QUEUED_FRAMES];
+
+static VkClearValue             g_ClearValue = {};
+
+static void check_vk_result(VkResult err)
+{
+    if (err == 0) return;
+    printf("VkResult %d\n", err);
+    if (err < 0)
+        abort();
+}
+
+static void resize_vulkan(SDL_Window* /*window*/, int w, int h)
+{
+    VkResult err;
+    VkSwapchainKHR old_swapchain = g_Swapchain;
+    err = vkDeviceWaitIdle(g_Device);
+    check_vk_result(err);
+
+    // Destroy old Framebuffer:
+    for (uint32_t i = 0; i < g_BackBufferCount; i++)
+        if (g_BackBufferView[i])
+            vkDestroyImageView(g_Device, g_BackBufferView[i], g_Allocator);
+    for (uint32_t i = 0; i < g_BackBufferCount; i++)
+        if (g_Framebuffer[i])
+            vkDestroyFramebuffer(g_Device, g_Framebuffer[i], g_Allocator);
+    if (g_RenderPass)
+        vkDestroyRenderPass(g_Device, g_RenderPass, g_Allocator);
+
+    // Create Swapchain:
+    {
+        VkSwapchainCreateInfoKHR info = {};
+        info.sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
+        info.surface = g_Surface;
+        info.imageFormat = g_SurfaceFormat.format;
+        info.imageColorSpace = g_SurfaceFormat.colorSpace;
+        info.imageArrayLayers = 1;
+        info.imageUsage |= VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+        info.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
+        info.preTransform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
+        info.compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
+        info.presentMode = g_PresentMode;
+        info.clipped = VK_TRUE;
+        info.oldSwapchain = old_swapchain;
+        VkSurfaceCapabilitiesKHR cap;
+        err = vkGetPhysicalDeviceSurfaceCapabilitiesKHR(g_Gpu, g_Surface, &cap);
+        check_vk_result(err);
+        if (cap.maxImageCount > 0)
+            info.minImageCount = (cap.minImageCount + 2 < cap.maxImageCount) ? (cap.minImageCount + 2) : cap.maxImageCount;
+        else
+            info.minImageCount = cap.minImageCount + 2;
+
+        if (cap.currentExtent.width == 0xffffffff)
+        {
+            fb_width = w;
+            fb_height = h;
+            info.imageExtent.width = fb_width;
+            info.imageExtent.height = fb_height;
+        }
+        else
+        {
+            fb_width = cap.currentExtent.width;
+            fb_height = cap.currentExtent.height;
+            info.imageExtent.width = fb_width;
+            info.imageExtent.height = fb_height;
+        }
+        err = vkCreateSwapchainKHR(g_Device, &info, g_Allocator, &g_Swapchain);
+        check_vk_result(err);
+        err = vkGetSwapchainImagesKHR(g_Device, g_Swapchain, &g_BackBufferCount, NULL);
+        check_vk_result(err);
+        err = vkGetSwapchainImagesKHR(g_Device, g_Swapchain, &g_BackBufferCount, g_BackBuffer);
+        check_vk_result(err);
+    }
+    if (old_swapchain)
+        vkDestroySwapchainKHR(g_Device, old_swapchain, g_Allocator);
+
+    // Create the Render Pass:
+    {
+        VkAttachmentDescription attachment = {};
+        attachment.format = g_SurfaceFormat.format;
+        attachment.samples = VK_SAMPLE_COUNT_1_BIT;
+        attachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+        attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+        attachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment.finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+        VkAttachmentReference color_attachment = {};
+        color_attachment.attachment = 0;
+        color_attachment.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        VkSubpassDescription subpass = {};
+        subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+        subpass.colorAttachmentCount = 1;
+        subpass.pColorAttachments = &color_attachment;
+        VkRenderPassCreateInfo info = {};
+        info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+        info.attachmentCount = 1;
+        info.pAttachments = &attachment;
+        info.subpassCount = 1;
+        info.pSubpasses = &subpass;
+        err = vkCreateRenderPass(g_Device, &info, g_Allocator, &g_RenderPass);
+        check_vk_result(err);
+    }
+
+    // Create The Image Views
+    {
+        VkImageViewCreateInfo info = {};
+        info.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+        info.viewType = VK_IMAGE_VIEW_TYPE_2D;
+        info.format = g_SurfaceFormat.format;
+        info.components.r = VK_COMPONENT_SWIZZLE_R;
+        info.components.g = VK_COMPONENT_SWIZZLE_G;
+        info.components.b = VK_COMPONENT_SWIZZLE_B;
+        info.components.a = VK_COMPONENT_SWIZZLE_A;
+        info.subresourceRange = g_ImageRange;
+        for (uint32_t i = 0; i < g_BackBufferCount; i++)
+        {
+            info.image = g_BackBuffer[i];
+            err = vkCreateImageView(g_Device, &info, g_Allocator, &g_BackBufferView[i]);
+            check_vk_result(err);
+        }
+    }
+
+    // Create Framebuffer:
+    {
+        VkImageView attachment[1];
+        VkFramebufferCreateInfo info = {};
+        info.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+        info.renderPass = g_RenderPass;
+        info.attachmentCount = 1;
+        info.pAttachments = attachment;
+        info.width = fb_width;
+        info.height = fb_height;
+        info.layers = 1;
+        for (uint32_t i = 0; i < g_BackBufferCount; i++)
+        {
+            attachment[0] = g_BackBufferView[i];
+            err = vkCreateFramebuffer(g_Device, &info, g_Allocator, &g_Framebuffer[i]);
+            check_vk_result(err);
+        }
+    }
+}
+
+#ifdef IMGUI_VULKAN_DEBUG_REPORT
+static VKAPI_ATTR VkBool32 VKAPI_CALL debug_report(
+    VkDebugReportFlagsEXT flags, VkDebugReportObjectTypeEXT objectType, uint64_t object, size_t location, int32_t messageCode, const char* pLayerPrefix, const char* pMessage, void* pUserData)
+{
+    printf("[vulkan] ObjectType: %i\nMessage: %s\n\n", objectType, pMessage );
+    return VK_FALSE;
+}
+#endif // IMGUI_VULKAN_DEBUG_REPORT
+
+static void setup_vulkan(SDL_Window* window)
+{
+    VkResult err;
+
+    // Create Vulkan Instance
+    {
+        uint32_t extensions_count;
+	SDL_Vulkan_GetInstanceExtensions(window, &extensions_count, nullptr);
+
+	const char **sdl_extensions = new const char*[extensions_count];
+	SDL_Vulkan_GetInstanceExtensions(window, &extensions_count, sdl_extensions);
+
+        VkInstanceCreateInfo create_info = {};
+        create_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+        create_info.enabledExtensionCount = extensions_count;
+        create_info.ppEnabledExtensionNames = sdl_extensions;
+
+#ifdef IMGUI_VULKAN_DEBUG_REPORT
+        // enabling multiple validation layers grouped as lunarg standard validation
+        const char* layers[] = {"VK_LAYER_LUNARG_standard_validation"};
+        create_info.enabledLayerCount = 1;
+        create_info.ppEnabledLayerNames = layers;
+
+        // need additional storage for char pointer to debug report extension
+        const char** extensions = (const char**)malloc(sizeof(const char*) * (extensions_count + 1));
+        for (size_t i = 0; i < extensions_count; i++)
+            extensions[i] = sdl_extensions[i];
+        extensions[ extensions_count ] = "VK_EXT_debug_report";
+        create_info.enabledExtensionCount = extensions_count+1;
+        create_info.ppEnabledExtensionNames = extensions;
+#endif // IMGUI_VULKAN_DEBUG_REPORT
+
+        err = vkCreateInstance(&create_info, g_Allocator, &g_Instance);
+        check_vk_result(err);
+
+#ifdef IMGUI_VULKAN_DEBUG_REPORT
+        free(extensions);
+
+        // create the debug report callback
+        VkDebugReportCallbackCreateInfoEXT debug_report_ci ={};
+        debug_report_ci.sType = VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT;
+        debug_report_ci.flags = VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT | VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT;
+        debug_report_ci.pfnCallback = debug_report;
+        debug_report_ci.pUserData = NULL;
+        
+        // get the proc address of the function pointer, required for used extensions
+        PFN_vkCreateDebugReportCallbackEXT vkCreateDebugReportCallbackEXT = 
+            (PFN_vkCreateDebugReportCallbackEXT)vkGetInstanceProcAddr(g_Instance, "vkCreateDebugReportCallbackEXT");
+
+        err = vkCreateDebugReportCallbackEXT( g_Instance, &debug_report_ci, g_Allocator, &g_Debug_Report );
+        check_vk_result(err);
+#endif // IMGUI_VULKAN_DEBUG_REPORT
+    }
+
+    // Create Window Surface
+    {
+        SDL_bool result = SDL_Vulkan_CreateSurface(window, g_Instance, &g_Surface);
+        if(result == 0) {
+            printf("failed to create Vulkan surface\n");
+            abort();
+        }
+    }
+
+    // Get GPU
+    {
+        uint32_t gpu_count;
+        err = vkEnumeratePhysicalDevices(g_Instance, &gpu_count, NULL);
+        check_vk_result(err);
+
+        VkPhysicalDevice* gpus = (VkPhysicalDevice*)malloc(sizeof(VkPhysicalDevice) * gpu_count);
+        err = vkEnumeratePhysicalDevices(g_Instance, &gpu_count, gpus);
+        check_vk_result(err);
+
+        // If a number >1 of GPUs got reported, you should find the best fit GPU for your purpose
+        // e.g. VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU if available, or with the greatest memory available, etc.
+        // for sake of simplicity we'll just take the first one, assuming it has a graphics queue family.
+        g_Gpu = gpus[0];
+        free(gpus);
+    }
+
+    // Get queue
+    {
+        uint32_t count;
+        vkGetPhysicalDeviceQueueFamilyProperties(g_Gpu, &count, NULL);
+        VkQueueFamilyProperties* queues = (VkQueueFamilyProperties*)malloc(sizeof(VkQueueFamilyProperties) * count);
+        vkGetPhysicalDeviceQueueFamilyProperties(g_Gpu, &count, queues);
+        for (uint32_t i = 0; i < count; i++)
+        {
+            if (queues[i].queueFlags & VK_QUEUE_GRAPHICS_BIT)
+            {
+                g_QueueFamily = i;
+                break;
+            }
+        }
+        free(queues);
+    }
+
+    // Check for WSI support
+    {
+        VkBool32 res;
+        vkGetPhysicalDeviceSurfaceSupportKHR(g_Gpu, g_QueueFamily, g_Surface, &res);
+        if (res != VK_TRUE)
+        {
+            fprintf(stderr, "Error no WSI support on physical device 0\n");
+            exit(-1);
+        }
+    }
+
+    // Get Surface Format
+    {
+        // Per Spec Format and View Format are expected to be the same unless VK_IMAGE_CREATE_MUTABLE_BIT was set at image creation
+        // Assuming that the default behavior is without setting this bit, there is no need for separate Spawchain image and image view format
+        // additionally several new color spaces were introduced with Vulkan Spec v1.0.40
+        // hence we must make sure that a format with the mostly available color space, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR, is found and used
+        uint32_t count;
+        vkGetPhysicalDeviceSurfaceFormatsKHR(g_Gpu, g_Surface, &count, NULL);
+        VkSurfaceFormatKHR *formats = (VkSurfaceFormatKHR*)malloc(sizeof(VkSurfaceFormatKHR) * count);
+        vkGetPhysicalDeviceSurfaceFormatsKHR(g_Gpu, g_Surface, &count, formats);
+
+        // first check if only one format, VK_FORMAT_UNDEFINED, is available, which would imply that any format is available
+        if (count == 1)
+        {
+            if( formats[0].format == VK_FORMAT_UNDEFINED )
+            {
+                g_SurfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
+                g_SurfaceFormat.colorSpace = VK_COLORSPACE_SRGB_NONLINEAR_KHR;
+            }
+            else
+            {   // no point in searching another format
+                g_SurfaceFormat = formats[0];
+            }
+        }
+        else
+        {
+            // request several formats, the first found will be used 
+            VkFormat requestSurfaceImageFormat[] = {VK_FORMAT_B8G8R8A8_UNORM, VK_FORMAT_R8G8B8A8_UNORM, VK_FORMAT_B8G8R8_UNORM, VK_FORMAT_R8G8B8_UNORM};
+            VkColorSpaceKHR requestSurfaceColorSpace = VK_COLORSPACE_SRGB_NONLINEAR_KHR;
+            bool requestedFound = false;
+            for (size_t i = 0; i < sizeof(requestSurfaceImageFormat) / sizeof(requestSurfaceImageFormat[0]); i++)
+            {
+                if( requestedFound ) {
+                    break;
+                }
+                for (uint32_t j = 0; j < count; j++)
+                {
+                    if (formats[j].format == requestSurfaceImageFormat[i] && formats[j].colorSpace == requestSurfaceColorSpace)
+                    {
+                        g_SurfaceFormat = formats[j];
+                        requestedFound = true;
+                    }
+                }
+            }
+
+            // if none of the requested image formats could be found, use the first available
+            if (!requestedFound)
+                g_SurfaceFormat = formats[0];
+        }
+        free(formats);
+    }
+
+
+    // Get Present Mode
+    {
+        // Requst a certain mode and confirm that it is available. If not use VK_PRESENT_MODE_FIFO_KHR which is mandatory
+#ifdef IMGUI_UNLIMITED_FRAME_RATE
+        g_PresentMode = VK_PRESENT_MODE_IMMEDIATE_KHR;
+#else
+        g_PresentMode = VK_PRESENT_MODE_FIFO_KHR;
+#endif
+        uint32_t count = 0;
+        vkGetPhysicalDeviceSurfacePresentModesKHR(g_Gpu, g_Surface, &count, nullptr);
+        VkPresentModeKHR* presentModes = (VkPresentModeKHR*)malloc(sizeof(VkQueueFamilyProperties) * count);
+        vkGetPhysicalDeviceSurfacePresentModesKHR(g_Gpu, g_Surface, &count, presentModes);
+        bool presentModeAvailable = false;
+        for (size_t i = 0; i < count; i++) 
+        {
+            if (presentModes[i] == g_PresentMode)
+            {
+                presentModeAvailable = true;
+                break;
+            }
+        }
+        if( !presentModeAvailable )
+            g_PresentMode = VK_PRESENT_MODE_FIFO_KHR;   // always available
+    }
+
+
+    // Create Logical Device
+    {
+        int device_extension_count = 1;
+        const char* device_extensions[] = {"VK_KHR_swapchain"};
+        const uint32_t queue_index = 0;
+        const uint32_t queue_count = 1;
+        const float queue_priority[] = {1.0f};
+        VkDeviceQueueCreateInfo queue_info[1] = {};
+        queue_info[0].sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+        queue_info[0].queueFamilyIndex = g_QueueFamily;
+        queue_info[0].queueCount = queue_count;
+        queue_info[0].pQueuePriorities = queue_priority;
+        VkDeviceCreateInfo create_info = {};
+        create_info.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+        create_info.queueCreateInfoCount = sizeof(queue_info)/sizeof(queue_info[0]);
+        create_info.pQueueCreateInfos = queue_info;
+        create_info.enabledExtensionCount = device_extension_count;
+        create_info.ppEnabledExtensionNames = device_extensions;
+        err = vkCreateDevice(g_Gpu, &create_info, g_Allocator, &g_Device);
+        check_vk_result(err);
+        vkGetDeviceQueue(g_Device, g_QueueFamily, queue_index, &g_Queue);
+    }
+
+    // Create Framebuffers
+    {
+        int w, h;
+        SDL_GetWindowSize(window, &w, &h);
+        resize_vulkan(window, w, h);
+    }
+
+    // Create Command Buffers
+    for (int i = 0; i < IMGUI_VK_QUEUED_FRAMES; i++)
+    {
+        {
+            VkCommandPoolCreateInfo info = {};
+            info.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+            info.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+            info.queueFamilyIndex = g_QueueFamily;
+            err = vkCreateCommandPool(g_Device, &info, g_Allocator, &g_CommandPool[i]);
+            check_vk_result(err);
+        }
+        {
+            VkCommandBufferAllocateInfo info = {};
+            info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+            info.commandPool = g_CommandPool[i];
+            info.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+            info.commandBufferCount = 1;
+            err = vkAllocateCommandBuffers(g_Device, &info, &g_CommandBuffer[i]);
+            check_vk_result(err);
+        }
+        {
+            VkFenceCreateInfo info = {};
+            info.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+            info.flags = VK_FENCE_CREATE_SIGNALED_BIT;
+            err = vkCreateFence(g_Device, &info, g_Allocator, &g_Fence[i]);
+            check_vk_result(err);
+        }
+        {
+            VkSemaphoreCreateInfo info = {};
+            info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+            err = vkCreateSemaphore(g_Device, &info, g_Allocator, &g_PresentCompleteSemaphore[i]);
+            check_vk_result(err);
+            err = vkCreateSemaphore(g_Device, &info, g_Allocator, &g_RenderCompleteSemaphore[i]);
+            check_vk_result(err);
+        }
+    }
+
+    // Create Descriptor Pool
+    {
+        VkDescriptorPoolSize pool_size[11] =
+        {
+            { VK_DESCRIPTOR_TYPE_SAMPLER, 1000 },
+            { VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1000 },
+            { VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1000 },
+            { VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1000 },
+            { VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, 1000 },
+            { VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, 1000 },
+            { VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1000 },
+            { VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1000 },
+            { VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, 1000 },
+            { VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC, 1000 },
+            { VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 1000 }
+        };
+        VkDescriptorPoolCreateInfo pool_info = {};
+        pool_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+        pool_info.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
+        pool_info.maxSets = 1000 * 11;
+        pool_info.poolSizeCount = 11;
+        pool_info.pPoolSizes = pool_size;
+        err = vkCreateDescriptorPool(g_Device, &pool_info, g_Allocator, &g_DescriptorPool);
+        check_vk_result(err);
+    }
+}
+
+static void cleanup_vulkan()
+{
+    vkDestroyDescriptorPool(g_Device, g_DescriptorPool, g_Allocator);
+    for (int i = 0; i < IMGUI_VK_QUEUED_FRAMES; i++)
+    {
+        vkDestroyFence(g_Device, g_Fence[i], g_Allocator);
+        vkFreeCommandBuffers(g_Device, g_CommandPool[i], 1, &g_CommandBuffer[i]);
+        vkDestroyCommandPool(g_Device, g_CommandPool[i], g_Allocator);
+        vkDestroySemaphore(g_Device, g_PresentCompleteSemaphore[i], g_Allocator);
+        vkDestroySemaphore(g_Device, g_RenderCompleteSemaphore[i], g_Allocator);
+    }
+    for (uint32_t i = 0; i < g_BackBufferCount; i++)
+    {
+        vkDestroyImageView(g_Device, g_BackBufferView[i], g_Allocator);
+        vkDestroyFramebuffer(g_Device, g_Framebuffer[i], g_Allocator);
+    }
+    vkDestroyRenderPass(g_Device, g_RenderPass, g_Allocator);
+    vkDestroySwapchainKHR(g_Device, g_Swapchain, g_Allocator);
+    vkDestroySurfaceKHR(g_Instance, g_Surface, g_Allocator);
+
+#ifdef IMGUI_VULKAN_DEBUG_REPORT
+    // get the proc address of the function pointer, required for used extensions
+    auto vkDestroyDebugReportCallbackEXT = (PFN_vkDestroyDebugReportCallbackEXT)vkGetInstanceProcAddr(g_Instance, "vkDestroyDebugReportCallbackEXT");
+    vkDestroyDebugReportCallbackEXT(g_Instance, g_Debug_Report, g_Allocator);
+#endif // IMGUI_VULKAN_DEBUG_REPORT
+
+    vkDestroyDevice(g_Device, g_Allocator);
+    vkDestroyInstance(g_Instance, g_Allocator);
+}
+
+static void frame_begin()
+{
+    VkResult err;
+    while (true)
+    {
+        err = vkWaitForFences(g_Device, 1, &g_Fence[g_FrameIndex], VK_TRUE, 100);
+        if (err == VK_SUCCESS) break;
+        if (err == VK_TIMEOUT) continue;
+        check_vk_result(err);
+    }
+    {
+        err = vkAcquireNextImageKHR(g_Device, g_Swapchain, UINT64_MAX, g_PresentCompleteSemaphore[g_FrameIndex], VK_NULL_HANDLE, &g_BackbufferIndices[g_FrameIndex]);
+        check_vk_result(err);
+    }
+    {
+        err = vkResetCommandPool(g_Device, g_CommandPool[g_FrameIndex], 0);
+        check_vk_result(err);
+        VkCommandBufferBeginInfo info = {};
+        info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+        info.flags |= VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+        err = vkBeginCommandBuffer(g_CommandBuffer[g_FrameIndex], &info);
+        check_vk_result(err);
+    }
+    {
+        VkRenderPassBeginInfo info = {};
+        info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+        info.renderPass = g_RenderPass;
+        info.framebuffer = g_Framebuffer[g_BackbufferIndices[g_FrameIndex]];
+        info.renderArea.extent.width = fb_width;
+        info.renderArea.extent.height = fb_height;
+        info.clearValueCount = 1;
+        info.pClearValues = &g_ClearValue;
+        vkCmdBeginRenderPass(g_CommandBuffer[g_FrameIndex], &info, VK_SUBPASS_CONTENTS_INLINE);
+    }
+}
+
+static void frame_end()
+{
+    VkResult err;
+    vkCmdEndRenderPass(g_CommandBuffer[g_FrameIndex]);
+    {
+        VkPipelineStageFlags wait_stage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+        VkSubmitInfo info = {};
+        info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+        info.waitSemaphoreCount = 1;
+        info.pWaitSemaphores = &g_PresentCompleteSemaphore[g_FrameIndex];
+        info.pWaitDstStageMask = &wait_stage;
+        info.commandBufferCount = 1;
+        info.pCommandBuffers = &g_CommandBuffer[g_FrameIndex];
+        info.signalSemaphoreCount = 1;
+        info.pSignalSemaphores = &g_RenderCompleteSemaphore[g_FrameIndex];
+
+        err = vkEndCommandBuffer(g_CommandBuffer[g_FrameIndex]);
+        check_vk_result(err);
+        err = vkResetFences(g_Device, 1, &g_Fence[g_FrameIndex]);
+        check_vk_result(err);
+        err = vkQueueSubmit(g_Queue, 1, &info, g_Fence[g_FrameIndex]);
+        check_vk_result(err);
+    }
+}
+
+static void frame_present()
+{
+    VkResult err;
+    // If IMGUI_UNLIMITED_FRAME_RATE is defined we present the latest but one frame. Otherwise we present the latest rendered frame
+#ifdef IMGUI_UNLIMITED_FRAME_RATE
+    uint32_t PresentIndex = (g_FrameIndex + IMGUI_VK_QUEUED_FRAMES - 1) % IMGUI_VK_QUEUED_FRAMES;
+#else
+    uint32_t PresentIndex = g_FrameIndex;
+#endif // IMGUI_UNLIMITED_FRAME_RATE
+
+    VkSwapchainKHR swapchains[1] = {g_Swapchain};
+    uint32_t indices[1] = {g_BackbufferIndices[PresentIndex]};
+    VkPresentInfoKHR info = {};
+    info.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
+    info.waitSemaphoreCount = 1;
+    info.pWaitSemaphores = &g_RenderCompleteSemaphore[PresentIndex];
+    info.swapchainCount = 1;
+    info.pSwapchains = swapchains;
+    info.pImageIndices = indices;
+    err = vkQueuePresentKHR(g_Queue, &info);
+    check_vk_result(err);
+
+    g_FrameIndex = (g_FrameIndex + 1) % IMGUI_VK_QUEUED_FRAMES;
+}
+
+int main(int, char**)
+{
+    // Setup SDL
+    if (SDL_Init(SDL_INIT_VIDEO|SDL_INIT_TIMER) != 0)
+    {
+        printf("Error: %s\n", SDL_GetError());
+        return -1;
+    }
+
+    // Setup window
+    SDL_DisplayMode current;
+    SDL_GetCurrentDisplayMode(0, &current);
+    SDL_Window *window = SDL_CreateWindow("ImGui SDL2+Vulkan example", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 1280, 720, SDL_WINDOW_VULKAN|SDL_WINDOW_RESIZABLE);
+
+    // Setup Vulkan
+    setup_vulkan(window);
+
+    // Setup ImGui binding
+    ImGui_ImplSdlVulkan_Init_Data init_data = {};
+    init_data.allocator = g_Allocator;
+    init_data.gpu = g_Gpu;
+    init_data.device = g_Device;
+    init_data.render_pass = g_RenderPass;
+    init_data.pipeline_cache = g_PipelineCache;
+    init_data.descriptor_pool = g_DescriptorPool;
+    init_data.check_vk_result = check_vk_result;
+    ImGui_ImplSdlVulkan_Init(window, true, &init_data);
+
+    // Load Fonts
+    // (there is a default font, this is only if you want to change it. see extra_fonts/README.txt for more details)
+    //ImGuiIO& io = ImGui::GetIO();
+    //io.Fonts->AddFontDefault();
+    //io.Fonts->AddFontFromFileTTF("../../extra_fonts/Cousine-Regular.ttf", 15.0f);
+    //io.Fonts->AddFontFromFileTTF("../../extra_fonts/DroidSans.ttf", 16.0f);
+    //io.Fonts->AddFontFromFileTTF("../../extra_fonts/Roboto-Medium.ttf", 16.0f);
+    //io.Fonts->AddFontFromFileTTF("../../extra_fonts/ProggyTiny.ttf", 10.0f);
+    //io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\ArialUni.ttf", 18.0f, NULL, io.Fonts->GetGlyphRangesJapanese());
+
+    // Upload Fonts
+    {
+        VkResult err;
+        err = vkResetCommandPool(g_Device, g_CommandPool[g_FrameIndex], 0);
+        check_vk_result(err);
+        VkCommandBufferBeginInfo begin_info = {};
+        begin_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+        begin_info.flags |= VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+        err = vkBeginCommandBuffer(g_CommandBuffer[g_FrameIndex], &begin_info);
+        check_vk_result(err);
+
+        ImGui_ImplSdlVulkan_CreateFontsTexture(g_CommandBuffer[g_FrameIndex]);
+
+        VkSubmitInfo end_info = {};
+        end_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+        end_info.commandBufferCount = 1;
+        end_info.pCommandBuffers = &g_CommandBuffer[g_FrameIndex];
+        err = vkEndCommandBuffer(g_CommandBuffer[g_FrameIndex]);
+        check_vk_result(err);
+        err = vkQueueSubmit(g_Queue, 1, &end_info, VK_NULL_HANDLE);
+        check_vk_result(err);
+
+        err = vkDeviceWaitIdle(g_Device);
+        check_vk_result(err);
+        ImGui_ImplSdlVulkan_InvalidateFontUploadObjects();
+    }
+
+    bool show_test_window = true;
+    bool show_another_window = false;
+    ImVec4 clear_color = ImVec4(0.45f, 0.55f, 0.60f, 1.00f);
+
+    // When IMGUI_UNLIMITED_FRAME_RATE is defined we render into latest image acquired from the swapchain but we display the image which was rendered before.
+    // Hence we must render once and increase the g_FrameIndex without presenting, which we do before entering the render loop.
+    // This is also the reason why frame_end() is split into frame_end() and frame_present(), the later one not being called here.
+#ifdef IMGUI_UNLIMITED_FRAME_RATE
+    ImGui_ImplSdlVulkan_NewFrame(window);
+    frame_begin();
+    ImGui_ImplSdlVulkan_Render(g_CommandBuffer[g_FrameIndex]);
+    frame_end();
+    g_FrameIndex = (g_FrameIndex + 1) % IMGUI_VK_QUEUED_FRAMES;
+#endif // IMGUI_UNLIMITED_FRAME_RATE
+
+    // Main loop
+    bool done = false;
+    while (!done)
+    {
+        SDL_Event event;
+        while (SDL_PollEvent(&event))
+        {
+            ImGui_ImplSdlVulkan_ProcessEvent(&event);
+            if(event.type == SDL_WINDOWEVENT && event.window.event == SDL_WINDOWEVENT_RESIZED)  {
+                int w = event.window.data1, h = event.window.data2;
+                resize_vulkan(window, w, h);
+            }
+            if (event.type == SDL_QUIT)
+                done = true;
+        }
+        ImGui_ImplSdlVulkan_NewFrame(window);
+
+        // 1. Show a simple window
+        // Tip: if we don't call ImGui::Begin()/ImGui::End() the widgets appears in a window automatically called "Debug"
+        {
+            static float f = 0.0f;
+            ImGui::Text("Hello, world!");
+            ImGui::SliderFloat("float", &f, 0.0f, 1.0f);
+            ImGui::ColorEdit3("clear color", (float*)&clear_color);
+            if (ImGui::Button("Test Window")) show_test_window ^= 1;
+            if (ImGui::Button("Another Window")) show_another_window ^= 1;
+            ImGui::Text("Application average %.3f ms/frame (%.1f FPS)", 1000.0f / ImGui::GetIO()    .Framerate, ImGui::GetIO().Framerate);
+        }
+
+        // 2. Show another simple window, this time using an explicit Begin/End pair
+        if (show_another_window)
+        {
+            ImGui::Begin("Another Window", &show_another_window);
+            ImGui::Text("Hello from another window!");
+            ImGui::End();
+        }
+
+        // 3. Show the ImGui test window. Most of the sample code is in ImGui::ShowTestWindow()
+        if (show_test_window)
+        {
+            ImGui::SetNextWindowPos(ImVec2(650, 20), ImGuiCond_FirstUseEver);
+            ImGui::ShowTestWindow(&show_test_window);
+        }
+
+        g_ClearValue.color.float32[0] = clear_color.x;
+        g_ClearValue.color.float32[1] = clear_color.y;
+        g_ClearValue.color.float32[2] = clear_color.z;
+        g_ClearValue.color.float32[3] = clear_color.w;
+
+        frame_begin();
+        ImGui_ImplSdlVulkan_Render(g_CommandBuffer[g_FrameIndex]);
+        frame_end();
+        frame_present();
+    }
+
+    // Cleanup
+    VkResult err = vkDeviceWaitIdle(g_Device);
+    check_vk_result(err);
+    ImGui_ImplSdlVulkan_Shutdown();
+    cleanup_vulkan();
+    SDL_DestroyWindow(window);
+    SDL_Quit();
+
+    return 0;
+}


### PR DESCRIPTION
I took the recently released Vulkan support in SDL 2.0.6 and ported the ImGUI Vulkan example over to use SDL instead of glfw. Keep in mind that I only performed some cursory testing on Linux.