### PR TITLE
Capture/release window in DX9 implementation

### DIFF
--- a/examples/directx9_example/imgui_impl_dx9.cpp
+++ b/examples/directx9_example/imgui_impl_dx9.cpp
@@ -177,21 +177,27 @@ IMGUI_API LRESULT ImGui_ImplDX9_WndProcHandler(HWND, UINT msg, WPARAM wParam, LP
     switch (msg)
     {
     case WM_LBUTTONDOWN:
+        SetCapture( hWnd );
         io.MouseDown[0] = true;
         return true;
     case WM_LBUTTONUP:
+        ReleaseCapture();
         io.MouseDown[0] = false;
         return true;
     case WM_RBUTTONDOWN:
+        SetCapture( hWnd );
         io.MouseDown[1] = true;
         return true;
     case WM_RBUTTONUP:
+        ReleaseCapture();
         io.MouseDown[1] = false;
         return true;
     case WM_MBUTTONDOWN:
+        SetCapture( hWnd );
         io.MouseDown[2] = true;
         return true;
     case WM_MBUTTONUP:
+        ReleaseCapture();
         io.MouseDown[2] = false;
         return true;
     case WM_MOUSEWHEEL:


### PR DESCRIPTION
This helps a lot when the user drags a slider but carries the cursor offscreen before releasing the button - without the capturing, the slider will "stick" to the mouse cursor even after the button has been released. (This should generally be added to all Windows implementations - I won't mind doing it if you think it's a good idea.)