### PR TITLE
Fix BeginPopupContextWindow() to behave correctly when bound to a child

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -5117,7 +5117,7 @@ bool ImGui::IsWindowHovered(ImGuiHoveredFlags flags)
     if (!IsWindowContentHoverable(g.HoveredRootWindow, flags))
         return false;
     if (!(flags & ImGuiHoveredFlags_AllowWhenBlockedByActiveItem))
-        if (g.ActiveId != 0 && g.ActiveIdWindow != g.CurrentWindow)
+        if (g.ActiveId != 0 && (g.ActiveIdWindow != g.CurrentWindow) && (g.ActiveIdWindow != g.CurrentWindow->RootWindow))
             return false;
     return true;
 }


### PR DESCRIPTION
I noticed while testing the Console sample in imgui-demo.cpp that the right-click context menu inside the child scroll-frame wouldn't show up sometimes (or most of the time, even).  As best as I can determine, it would only work when *no* imgui window is active.  Once any window is active -- even the parent/root of the child -- the right-click popup would no longer function.