### PR TITLE
Assert when using empty string as id

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -1841,6 +1841,7 @@ ImGuiID ImGuiWindow::GetID(const char* str, const char* str_end)
 {
     ImGuiID seed = IDStack.back();
     ImGuiID id = ImHash(str, str_end ? (int)(str_end - str) : 0, seed);
+    IM_ASSERT(id != seed);
     ImGui::KeepAliveID(id);
     return id;
 }


### PR DESCRIPTION
Using empty label can cause problems, e.g. in combo does not work in following example:
```cpp
	if (!ImGui::CollapsingHeader(label)) return;
	ImGui::PushID(label);
	ImGui::Combo("", &current, getter, this, editor.getEventTypesCount());
```