### PR TITLE
fix uninitialized atlas packing context

### DIFF
--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -1566,7 +1566,7 @@ bool    ImFontAtlasBuildWithStbTruetype(ImFontAtlas* atlas)
 
     // Start packing
     const int max_tex_height = 1024*32;
-    stbtt_pack_context spc;
+    stbtt_pack_context spc = {};
     stbtt_PackBegin(&spc, NULL, atlas->TexWidth, max_tex_height, 0, atlas->TexGlyphPadding, NULL);
     stbtt_PackSetOversampling(&spc, 1, 1);
 


### PR DESCRIPTION
This PR fixes a `maybe-uninitialized` error when building with `-Werror -O3` :)

```
../../imgui_draw.cpp: In function ‘bool ImFontAtlasBuildWithStbTruetype(ImFontAtlas*)’:
../../imgui_draw.cpp:93:54: error: ‘spc.stbtt_pack_context::nodes’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
 #define STBTT_free(x,u)    ((void)(u), ImGui::MemFree(x))
                                                      ^
../../imgui_draw.cpp:1569:24: note: ‘spc.stbtt_pack_context::nodes’ was declared here
     stbtt_pack_context spc;
                        ^
In file included from ../../imgui_draw.cpp:101:0:
../../stb_truetype.h:3629:50: error: ‘spc.stbtt_pack_context::padding’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
             stbrp_coord pad = (stbrp_coord) spc->padding;
                                                  ^
../../imgui_draw.cpp:1569:24: note: ‘spc.stbtt_pack_context::padding’ was declared here
     stbtt_pack_context spc;
                        ^
../../imgui_draw.cpp:1533:42: error: ‘spc.stbtt_pack_context::stride_in_bytes’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
     unsigned char* data = pixels + x + y * stride;
                                          ^
../../imgui_draw.cpp:1569:24: note: ‘spc.stbtt_pack_context::stride_in_bytes’ was declared here
     stbtt_pack_context spc;
                        ^
../../imgui_draw.cpp:93:54: error: ‘spc.stbtt_pack_context::pack_info’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
 #define STBTT_free(x,u)    ((void)(u), ImGui::MemFree(x))
                                                      ^
../../imgui_draw.cpp:1569:24: note: ‘spc.stbtt_pack_context::pack_info’ was declared here
     stbtt_pack_context spc;
                        ^
```