### PR TITLE
Fix wrong comment in dx implementation headers

### DIFF
--- a/examples/directx10_example/imgui_impl_dx10.h
+++ b/examples/directx10_example/imgui_impl_dx10.h
@@ -20,5 +20,5 @@ IMGUI_API bool        ImGui_ImplDX10_CreateDeviceObjects();
 // You may or not need this for your implementation, but it can serve as reference for handling inputs.
 // Commented out to avoid dragging dependencies on <windows.h> types. You can copy the extern declaration in your code.
 /*
-IMGUI_API LRESULT   ImGui_ImplDX10_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
+IMGUI_API LRESULT   ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
 */

--- a/examples/directx11_example/imgui_impl_dx11.h
+++ b/examples/directx11_example/imgui_impl_dx11.h
@@ -21,5 +21,5 @@ IMGUI_API bool        ImGui_ImplDX11_CreateDeviceObjects();
 // You may or not need this for your implementation, but it can serve as reference for handling inputs.
 // Commented out to avoid dragging dependencies on <windows.h> types. You can copy the extern declaration in your code.
 /*
-IMGUI_API LRESULT   ImGui_ImplDX11_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
+IMGUI_API LRESULT   ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
 */

--- a/examples/directx9_example/imgui_impl_dx9.h
+++ b/examples/directx9_example/imgui_impl_dx9.h
@@ -20,5 +20,5 @@ IMGUI_API bool        ImGui_ImplDX9_CreateDeviceObjects();
 // You may or not need this for your implementation, but it can serve as reference for handling inputs.
 // Commented out to avoid dragging dependencies on <windows.h> types. You can copy the extern declaration in your code.
 /*
-IMGUI_API LRESULT   ImGui_ImplDX9_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
+IMGUI_API LRESULT   ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
 */


### PR DESCRIPTION
The function name was changed in the cpp files, but not in the header comment.