### PR TITLE
A try, to fix the warning: format not a string literal and no format arguments

### DIFF
--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -1341,7 +1341,7 @@ void ImGui::ShowTestWindow(bool* p_open)
             if (ImGui::Button("Select.."))
                 ImGui::OpenPopup("select");
             ImGui::SameLine();
-            ImGui::Text(selected_fish == -1 ? "<None>" : names[selected_fish]);
+            ImGui::Text("%s", selected_fish == -1 ? "<None>" : names[selected_fish]);
             if (ImGui::BeginPopup("select"))
             {
                 ImGui::Text("Aquarium");


### PR DESCRIPTION
This is the proposed change, to fix #1450 

