### PR TITLE
Add Slider hover color just like Drag

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -6856,7 +6856,8 @@ bool ImGui::SliderBehavior(const ImRect& frame_bb, ImGuiID id, float* v, float v
     const ImGuiStyle& style = g.Style;
 
     // Draw frame
-    RenderFrame(frame_bb.Min, frame_bb.Max, GetColorU32(ImGuiCol_FrameBg), true, style.FrameRounding);
+    const ImU32 frame_col = GetColorU32(g.ActiveId == id ? ImGuiCol_FrameBgActive : g.HoveredId == id ? ImGuiCol_FrameBgHovered : ImGuiCol_FrameBg);
+    RenderFrame(frame_bb.Min, frame_bb.Max, frame_col, true, style.FrameRounding);
 
     const bool is_non_linear = (power < 1.0f-0.00001f) || (power > 1.0f+0.00001f);
     const bool is_horizontal = (flags & ImGuiSliderFlags_Vertical) == 0;


### PR DESCRIPTION
I feel like there should be hover color options for each different control instead of the grouped frame color to make it usable for everyone. This also would not reduce performance as all controls already check for hover state as required by the ImGUI::IsHoveredItem() API.