### PR TITLE
Column width data is no longer lost when dragged to the right side of the window

### DIFF
--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -202,6 +202,7 @@ enum ImGuiColumnsFlags_
     ImGuiColumnsFlags_NoPreserveWidths      = 1 << 2,   // Disable column width preservation when adjusting columns
     ImGuiColumnsFlags_NoForceWithinWindow   = 1 << 3,   // Disable forcing columns to fit within window
     ImGuiColumnsFlags_GrowParentContentsSize= 1 << 4,   // (WIP) Restore pre-1.51 behavior of extending the parent window contents size but _without affecting the columns width at all_. Will eventually remove.
+    ImGuiColumnsFlags_DraggingColumns       = 1 << 5,   // Returns true if the columns are currently being dragged
 };
 
 enum ImGuiSelectableFlagsPrivate_
@@ -335,6 +336,7 @@ struct ImGuiGroupData
 struct ImGuiColumnData
 {
     float       OffsetNorm; // Column start offset, normalized 0.0 (far left) -> 1.0 (far right)
+    float       OffsetNormDragged; // Column start offset while it is being dragged
     ImRect      ClipRect;
     //float     IndentX;
 };


### PR DESCRIPTION
Fixed an issue where dragging the columns to the edge of the window would collapse the columns (since they are now forced within the window) and their width data would be lost. With this change, the old column widths are remembered until the columns are no longer being dragged. This means columns can be collapsed by dragging them all the way to the right side of the window, and then expanded again by dragging them back to the left, without losing their width data until the columns are actually deselected and no longer being dragged.

I'm not super happy with how the column state is being stored in the StateStorage object, but this was the quickest fix I could put in using the existing tech.

With this change, this is how the column state storage looks:
- StateStorage(ColumnsSetId - 1) The boolean state for whether the columns were dragging last update
- StateStorage(ColumnsSetId + 2 * ColumnIndex) The float for the original column offset norm
- StateStorage(ColumnsSetId + 2 * ColumnIndex + 1) The float for the dragged column offset norm