### PR TITLE
Hit test customization

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -4321,9 +4321,12 @@ bool ImGui::IsMouseHoveringRect(const ImVec2& r_min, const ImVec2& r_max, bool c
 
     // Expand for touch input
     const ImRect rect_for_touch(rect_clipped.Min - g.Style.TouchExtraPadding, rect_clipped.Max + g.Style.TouchExtraPadding);
-    if (!rect_for_touch.Contains(g.IO.MousePos))
-        return false;
-    return true;
+    bool result = rect_for_touch.Contains(g.IO.MousePos);
+
+    if (result && window->DC.HitTest.Callback)
+        return window->DC.HitTest.Callback(g.IO.MousePos, r_min, r_max, window->DC.HitTest.UserData);
+    else
+        return result;
 }
 
 int ImGui::GetKeyIndex(ImGuiKey imgui_key)
@@ -6220,6 +6223,22 @@ void ImGui::PushButtonRepeat(bool repeat)
 void ImGui::PopButtonRepeat()
 {
     PopItemFlag();
+}
+
+void ImGui::PushHitTest(ImGuiHitTestCallback callback, void* user_data)
+{
+    ImGuiHitTestData hitTest = ImGuiHitTestData(callback, user_data);
+
+    ImGuiWindow* window = GetCurrentWindow();
+    window->DC.HitTest = hitTest;
+    window->DC.HitTestStack.push_back(hitTest);
+}
+
+void ImGui::PopHitTest()
+{
+    ImGuiWindow* window = GetCurrentWindow();
+    window->DC.HitTestStack.pop_back();
+    window->DC.HitTest = window->DC.HitTestStack.empty() ? ImGuiHitTestData() : window->DC.HitTestStack.back();
 }
 
 void ImGui::PushTextWrapPos(float wrap_pos_x)

--- a/imgui.h
+++ b/imgui.h
@@ -135,6 +135,7 @@ struct ImGuiStorage;                // Helper for key->value storage
 struct ImGuiStyle;                  // Runtime data for styling/colors
 struct ImGuiTextBuffer;             // Helper to hold and append into a text buffer (~string builder)
 struct ImGuiTextFilter;             // Helper to parse and apply text filters (e.g. "aaaaa[,bbbbb][,ccccc]")
+struct ImVec2;
 
 // Enums/Flags (declared as int for compatibility with old C++, to allow using as flags and to not pollute the top of this file)
 // - Tip: Use your programming IDE navigation facilities on the names in the _central column_ below to find the actual flags/enum lists!
@@ -175,6 +176,7 @@ typedef void* ImTextureID;          // User data for rendering back-end to ident
 typedef unsigned int ImGuiID;       // A unique ID used by widgets, typically hashed from a stack of string.
 typedef int (*ImGuiInputTextCallback)(ImGuiInputTextCallbackData* data);
 typedef void (*ImGuiSizeCallback)(ImGuiSizeCallbackData* data);
+typedef bool (*ImGuiHitTestCallback)(const ImVec2& point, const ImVec2& min, const ImVec2& max, void* user_data);
 
 // Decoded character types
 // (we generally use UTF-8 encoded string in the API. This is storage specifically for a decoded character used for keyboard input and display)
@@ -369,6 +371,8 @@ namespace ImGui
     IMGUI_API void          PopAllowKeyboardFocus();
     IMGUI_API void          PushButtonRepeat(bool repeat);                                  // in 'repeat' mode, Button*() functions return repeated true in a typematic manner (using io.KeyRepeatDelay/io.KeyRepeatRate setting). Note that you can call IsItemActive() after any Button() to tell if the button is held in the current frame.
     IMGUI_API void          PopButtonRepeat();
+    IMGUI_API void          PushHitTest(ImGuiHitTestCallback callback, void* user_data = NULL);
+    IMGUI_API void          PopHitTest();
 
     // Cursor / Layout
     // - By "cursor" we mean the current output position.

--- a/imgui.h
+++ b/imgui.h
@@ -313,6 +313,7 @@ namespace ImGui
     IMGUI_API void          SetNextWindowCollapsed(bool collapsed, ImGuiCond cond = 0);                 // set next window collapsed state. call before Begin()
     IMGUI_API void          SetNextWindowFocus();                                                       // set next window to be focused / top-most. call before Begin()
     IMGUI_API void          SetNextWindowBgAlpha(float alpha);                                          // set next window background color alpha. helper to easily override the Alpha component of ImGuiCol_WindowBg/ChildBg/PopupBg. you may also use ImGuiWindowFlags_NoBackground.
+    IMGUI_API void          SetNextWindowHitTest(ImGuiHitTestCallback callback, void* user_data = NULL);
     IMGUI_API void          SetWindowPos(const ImVec2& pos, ImGuiCond cond = 0);                        // (not recommended) set current window position - call within Begin()/End(). prefer using SetNextWindowPos(), as this may incur tearing and side-effects.
     IMGUI_API void          SetWindowSize(const ImVec2& size, ImGuiCond cond = 0);                      // (not recommended) set current window size - call within Begin()/End(). set to ImVec2(0, 0) to force an auto-fit. prefer using SetNextWindowSize(), as this may incur tearing and minor side-effects.
     IMGUI_API void          SetWindowCollapsed(bool collapsed, ImGuiCond cond = 0);                     // (not recommended) set current window collapsed state. prefer using SetNextWindowCollapsed().
@@ -322,6 +323,7 @@ namespace ImGui
     IMGUI_API void          SetWindowSize(const char* name, const ImVec2& size, ImGuiCond cond = 0);    // set named window size. set axis to 0.0f to force an auto-fit on this axis.
     IMGUI_API void          SetWindowCollapsed(const char* name, bool collapsed, ImGuiCond cond = 0);   // set named window collapsed state
     IMGUI_API void          SetWindowFocus(const char* name);                                           // set named window to be focused / top-most. use NULL to remove focus.
+    IMGUI_API void          SetWindowHitTest(const char* name, ImGuiHitTestCallback callback, void* user_data = NULL);
 
     // Content region
     // - Those functions are bound to be redesigned soon (they are confusing, incomplete and return values in local window coordinates which increases confusion)

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -938,6 +938,7 @@ struct ImGuiNextWindowData
     ImGuiCond                   PosCond;
     ImGuiCond                   SizeCond;
     ImGuiCond                   CollapsedCond;
+    bool                        WindowHitTest;
     ImVec2                      PosVal;
     ImVec2                      PosPivotVal;
     ImVec2                      SizeVal;
@@ -949,6 +950,7 @@ struct ImGuiNextWindowData
     void*                       SizeCallbackUserData;
     float                       BgAlphaVal;             // Override background alpha
     ImVec2                      MenuBarOffsetMinVal;    // *Always on* This is not exposed publicly, so we don't clear it.
+    ImGuiHitTestData            WindowHitTestVal;
 
     ImGuiNextWindowData()       { memset(this, 0, sizeof(*this)); }
     inline void ClearFlags()    { Flags = ImGuiNextWindowDataFlags_None; }
@@ -1617,6 +1619,7 @@ struct IMGUI_API ImGuiWindow
     ImGuiCond               SetWindowCollapsedAllowFlags;       // store acceptable condition flags for SetNextWindowCollapsed() use.
     ImVec2                  SetWindowPosVal;                    // store window position when using a non-zero Pivot (position set needs to be processed when we know the window size)
     ImVec2                  SetWindowPosPivot;                  // store window pivot for positioning. ImVec2(0, 0) when positioning from top-left corner; ImVec2(0.5f, 0.5f) for centering; ImVec2(1, 1) for bottom right.
+    ImGuiHitTestData        WindowHitTest;
 
     ImVector<ImGuiID>       IDStack;                            // ID stack. ID are hashes seeded with the value at the top of the stack. (In theory this should be in the TempData structure)
     ImGuiWindowTempData     DC;                                 // Temporary per-window data, reset at the beginning of the frame. This used to be called ImGuiDrawContext, hence the "DC" variable name.

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -832,6 +832,16 @@ struct ImGuiGroupData
     bool        EmitItem;
 };
 
+// Stacked data for PushHitTest()/PopHitTest()
+struct ImGuiHitTestData
+{
+    ImGuiHitTestCallback Callback;
+    void*                UserData;
+
+    ImGuiHitTestData()                                                      { Callback = NULL; UserData = NULL; }
+    ImGuiHitTestData(ImGuiHitTestCallback callback, void* user_data = NULL) { Callback = callback; UserData = user_data; }
+};
+
 // Simple column measurement, currently used for MenuItem() only.. This is very short-sighted/throw-away code and NOT a generic helper.
 struct IMGUI_API ImGuiMenuColumns
 {
@@ -1511,9 +1521,11 @@ struct IMGUI_API ImGuiWindowTempData
     ImGuiItemFlags          ItemFlags;              // == ItemFlagsStack.back() [empty == ImGuiItemFlags_Default]
     float                   ItemWidth;              // == ItemWidthStack.back(). 0.0: default, >0.0: width in pixels, <0.0: align xx pixels to the right of window
     float                   TextWrapPos;            // == TextWrapPosStack.back() [empty == -1.0f]
+    ImGuiHitTestData        HitTest;
     ImVector<ImGuiItemFlags>ItemFlagsStack;
     ImVector<float>         ItemWidthStack;
     ImVector<float>         TextWrapPosStack;
+    ImVector<ImGuiHitTestData> HitTestStack;
     ImVector<ImGuiGroupData>GroupStack;
     short                   StackSizesBackup[6];    // Store size of various stacks for asserting
 
@@ -1545,6 +1557,9 @@ struct IMGUI_API ImGuiWindowTempData
         CurrentColumns = NULL;
         LayoutType = ParentLayoutType = ImGuiLayoutType_Vertical;
         FocusCounterRegular = FocusCounterTabStop = -1;
+
+        HitTest.Callback = NULL;
+        HitTest.UserData = NULL;
 
         ItemFlags = ImGuiItemFlags_Default_;
         ItemWidth = 0.0f;


### PR DESCRIPTION
### Brief
Add ability to customize hit test for widgets and windows. Former allows to create arbitrary shapes inside of a button rectangle, later to create pass-through areas (holes) in windows. This will make #1503 possible.

I'm opening this PR to open a discussion if such functionality is needed in main branch of ImGui. I would like to hear your opinion on that.

### Usage
To use this ability user must implement custom hit function with signature:
```cpp
typedef bool (*ImGuiHitTestCallback)(const ImVec2& point, const ImVec2& min, const ImVec2& max, void* user_data);
```

Call `PushHitTest`/`PopHitTest` exactly like `PushStyleVar` before drawing widget.
```cpp
IMGUI_API void PushHitTest(ImGuiHitTestCallback callback, void* user_data = NULL);
IMGUI_API void PopHitTest();
```
Example:
```cpp
ImGui::PushHitTest(circleHitTest);
ImGui::Button("I'm ImGui::Button()!", ImVec2(150, 150));
ImGui::PopHitTest();
```

Hit function can be set for windows using these:
```cpp
IMGUI_API void SetNextWindowHitTest(ImGuiHitTestCallback callback, void* user_data = NULL);
IMGUI_API void SetWindowHitTest(const char* name, ImGuiHitTestCallback callback, void* user_data = NULL);
```

![hit_tests](https://user-images.githubusercontent.com/1197433/34173648-74457a66-e4f6-11e7-8ba9-cee9d8273bca.gif)

Circle button example:
```cpp
auto circleHitTest = [](const ImVec2& point, const ImVec2& min, const ImVec2& max, void*)
{
    const auto min_size = ImMin(max.x - min.x, max.y - min.y);
    const auto radius = min_size * 0.5f;
    const auto radius_squared = radius * radius;
    const auto center = (max + min) * 0.5f;
    const auto offset = point - center;
    const auto distance_squared = offset.x * offset.x + offset.y * offset.y;

    return distance_squared < radius_squared;
};

ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 75.0f);
ImGui::PushHitTest(circleHitTest);
bool down = ImGui::Button("I'm ImGui::Button()\n   with rounding\n   and hit test!", ImVec2(150, 150));
ImGui::PopHitTest();
ImGui::PopStyleVar();
static int counter = 0;
if (down)
    ++counter;
ImGui::Text("Clicks: %d", counter);
```

Hole in a window example:
```cpp
static ImVec2 emptyRect;
emptyRect = ImGui::GetCursorScreenPos();
ImGui::SetWindowHitTest("Debug##Default", [](const ImVec2& point, const ImVec2& min, const ImVec2& max, void*)
{
    if (point.x >= emptyRect.x && point.y >= emptyRect.y && point.x <= (emptyRect.x + 150.0f) && point.y <= (emptyRect.y + 150.0f))
        return false;

    return true;
});

ImGui::GetWindowDrawList()->AddRect(
    ImGui::GetCursorScreenPos(), ImGui::GetCursorScreenPos() + ImVec2(150, 150), IM_COL32(255, 0, 0, 255));

ImGui::GetWindowDrawList()->AddText(
    ImGui::GetCursorScreenPos() + ImVec2(0, 150 + ImGui::GetStyle().ItemSpacing.y),
    IM_COL32_WHITE, "This is a hole in window.");
```