### PR TITLE
Fix a memory leak of ImGuiColumnsSet's Columns vector.  ImVector does…

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -1876,6 +1876,8 @@ ImGuiWindow::~ImGuiWindow()
 {
     IM_DELETE(DrawList);
     IM_DELETE(Name);
+    for (int i = 0; i != ColumnsStorage.Size; i++)
+        ColumnsStorage[i].~ImGuiColumnsSet();
 }
 
 ImGuiID ImGuiWindow::GetID(const char* str, const char* str_end)


### PR DESCRIPTION
…n't call destructors.