### PR TITLE
FindRenderedTextEnd: fixed null text issue

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -3074,6 +3074,9 @@ void ImGui::Render()
 
 const char* ImGui::FindRenderedTextEnd(const char* text, const char* text_end)
 {
+    if (!text)
+        return NULL;
+ 
     const char* text_display_end = text;
     if (!text_end)
         text_end = (const char*)-1;


### PR DESCRIPTION
If we don't check for null the code will try to access protected memory.
For example, widgets with null labels might cause a runtime error.