### PR TITLE
Fix incorrect header name on Linux MinGW systems

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -11524,7 +11524,11 @@ void ImGui::EndDragDropTarget()
 #if defined(_WIN32) && !defined(_WINDOWS_) && (!defined(IMGUI_DISABLE_WIN32_DEFAULT_CLIPBOARD_FUNCTIONS) || !defined(IMGUI_DISABLE_WIN32_DEFAULT_IME_FUNCTIONS))
 #undef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#ifndef __MINGW32__
 #include <Windows.h>
+#else
+#include <windows.h>
+#endif
 #endif
 
 // Win32 API clipboard implementation


### PR DESCRIPTION
Using a setup where a Linux slave builds for Windows, the header file `Windows.h` is unable to be found due to the default MinGW package providing lowercase `windows.h`.

```
imgui/imgui.cpp:11527:21: fatal error: Windows.h: No such file or directory
 #include <Windows.h>
                     ^
compilation terminated.
```

This was working before the recent commit 1f26652 which changed the include. This is a simple fix to check if the current compiler is MinGW, and if so, use the correct name.