### PR TITLE
Add text alignment to SliderFloat just like Button

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -7439,7 +7439,7 @@ bool ImGui::SliderFloat(const char* label, float* v, float v_min, float v_max, c
     // Display value using user-provided display format so user can add prefix/suffix/decorations to the value.
     char value_buf[64];
     const char* value_buf_end = value_buf + ImFormatString(value_buf, IM_ARRAYSIZE(value_buf), display_format, *v);
-    RenderTextClipped(frame_bb.Min, frame_bb.Max, value_buf, value_buf_end, NULL, ImVec2(0.5f,0.5f));
+    RenderTextClipped(frame_bb.Min + style.FramePadding, frame_bb.Max - style.FramePadding, value_buf, value_buf_end, NULL, style.ButtonTextAlign);
 
     if (label_size.x > 0.0f)
         RenderText(ImVec2(frame_bb.Max.x + style.ItemInnerSpacing.x, frame_bb.Min.y + style.FramePadding.y), label);


### PR DESCRIPTION
To make this generic I would suggest renaming `ButtonTextAlign` to `TextAlign` and using it for many other controls as well. Alternatively adding multiple text align styles for each control type would be possible too although not necessary since this style can be edited before drawing each control by the user. This would have no performance impact as `RenderTextClipped` already processes alignment anyway.