### PR TITLE
Scoped push/pop

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -123,6 +123,12 @@ struct ImVec4
 #endif
 };
 
+#define CONCAT_(x,y) x##y
+#define CONCAT(x,y) CONCAT_(x,y)
+#define ImGui_ScopePushFont(f) ImGui::ScopePushFont CONCAT(scope_push_font, __LINE__) (f)
+#define ImGui_ScopePushStyleColor(idx, col) ImGui::ScopePushStyleColor CONCAT(scope_push_style_color, __LINE__) (idx, col)
+#define ImGui_ScopePushStyleVar(idx, val) ImGui::ScopePushStyleVar CONCAT(scope_push_style_var, __LINE__) (idx, val)
+
 // ImGui end-user API
 // In a namespace so that user can add extra functions in a separate file (e.g. Value() helpers for your vector or common types)
 namespace ImGui
@@ -194,12 +200,28 @@ namespace ImGui
     // Parameters stacks (shared)
     IMGUI_API void          PushFont(ImFont* font);                                             // use NULL as a shortcut to push default font
     IMGUI_API void          PopFont();
+    struct ScopePushFont
+    {
+        ScopePushFont(ImFont* font) { PushFont(font); }
+        ~ScopePushFont() { PopFont(); }
+    };
     IMGUI_API void          PushStyleColor(ImGuiCol idx, ImU32 col);
     IMGUI_API void          PushStyleColor(ImGuiCol idx, const ImVec4& col);
     IMGUI_API void          PopStyleColor(int count = 1);
+    struct ScopePushStyleColor
+    {
+        ScopePushStyleColor(ImGuiCol idx, const ImVec4& col) { PushStyleColor(idx, col); }
+        ~ScopePushStyleColor() { PopStyleColor(); }
+    };
     IMGUI_API void          PushStyleVar(ImGuiStyleVar idx, float val);
     IMGUI_API void          PushStyleVar(ImGuiStyleVar idx, const ImVec2& val);
     IMGUI_API void          PopStyleVar(int count = 1);
+    struct ScopePushStyleVar
+    {
+        ScopePushStyleVar(ImGuiStyleVar idx, float val) { PushStyleVar(idx, val); }
+        ScopePushStyleVar(ImGuiStyleVar idx, const ImVec2& val) { PushStyleVar(idx, val); }
+        ~ScopePushStyleVar() { PopStyleVar(); }
+    };
     IMGUI_API const ImVec4& GetStyleColorVec4(ImGuiCol idx);                                    // retrieve style color as stored in ImGuiStyle structure. use to feed back into PushStyleColor(), otherwhise use GetColorU32() to get style color + style alpha.
     IMGUI_API ImFont*       GetFont();                                                          // get current font
     IMGUI_API float         GetFontSize();                                                      // get current font size (= height in pixels) of current font with current scale applied

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -289,11 +289,10 @@ void ImGui::ShowDemoWindow(bool* p_open)
             {
                 if (i > 0) ImGui::SameLine();
                 ImGui::PushID(i);
-                ImGui::PushStyleColor(ImGuiCol_Button, (ImVec4)ImColor::HSV(i/7.0f, 0.6f, 0.6f));
-                ImGui::PushStyleColor(ImGuiCol_ButtonHovered, (ImVec4)ImColor::HSV(i/7.0f, 0.7f, 0.7f));
-                ImGui::PushStyleColor(ImGuiCol_ButtonActive, (ImVec4)ImColor::HSV(i/7.0f, 0.8f, 0.8f));
+                ImGui_ScopePushStyleColor(ImGuiCol_Button, (ImVec4)ImColor::HSV(i/7.0f, 0.6f, 0.6f));
+                ImGui_ScopePushStyleColor(ImGuiCol_ButtonHovered, (ImVec4)ImColor::HSV(i/7.0f, 0.7f, 0.7f));
+                ImGui_ScopePushStyleColor(ImGuiCol_ButtonActive, (ImVec4)ImColor::HSV(i/7.0f, 0.8f, 0.8f));
                 ImGui::Button("Click");
-                ImGui::PopStyleColor(3);
                 ImGui::PopID();
             }
 


### PR DESCRIPTION
#### Summary
A suggestion for adding a simple implementation of scoped push/pop.

#### Explanation

When using `ImGui::PushStyleColor()` and  `ImGui::PopStyleColor()`, one must ensure that for each push a pop will be called. Since this is a C++ library, and C++ code can throw exceptions, using the push/pop mechanism is not safe (or at least very uncomfortable to handle).

Consider the following code wrapped with a `try{}catch{}` block and opens a popup with an error in case of exceptions:

```cpp
const char* text() {
    throw std::runtime_error("oops");
}

void drawTextWithBackground(const ImVec4& bgCol) {
    ImGui::PushStyleColor(ImGuiCol_FrameBg, bgCol);
    ImGui::TextUnformatted(text());
    ImGui::PopStyleColor(); //Will not be called
}
```
Running the above will cause an assertion in debug (in the best case), but will just change the background color of some frame, that might be unrelated to the text.

Making the push/pop mechanism use the RAII pattern, by using the c'tor/d'tor to push and pop the style/font/var makes it possible to not worry about exceptions ruining the GUI.


#### Technical stuff

I've chosen to use macros to allow this addition in order for the calls to ImGui to have the same look and feel as they have now (static calls with no state). 
The macro defines a local member with a "random" name (concatenating the type and the line number), with a type being a scope_* of whatever the user wants to push.
```cpp
#define ImGui_ScopePushFont(f) ImGui::ScopePushFont CONCAT(scope_push_font, __LINE__) (f)
```
In addition, this allows search&replace to be used to start using this.

Your review will be appriciated.