### PR TITLE
Fix building instruction in a couple of README

### DIFF
--- a/examples/allegro5_example/README.md
+++ b/examples/allegro5_example/README.md
@@ -4,7 +4,7 @@
 - On Ubuntu 14.04+
 
 ```bash
-g++ -I ../imgui main.cpp imgui_impl_a5.cpp ../imgui/imgui*.cpp -lallegro -lallegro_primitives
+g++ -I ../.. main.cpp imgui_impl_a5.cpp ../../imgui*.cpp -lallegro -lallegro_primitives -o allegro5_example
 ```
 
 - On Windows with Visual Studio's CLI

--- a/examples/sdl_opengl2_example/README.md
+++ b/examples/sdl_opengl2_example/README.md
@@ -5,18 +5,18 @@
 
 ```
 set SDL2DIR=path_to_your_sdl2_folder
-cl /Zi /MD /I %SDL2DIR%\include /I ..\.. main.cpp imgui_impl_sdl.cpp ..\..\imgui*.cpp /link /LIBPATH:%SDL2DIR%\lib SDL2.lib SDL2main.lib opengl32.lib /subsystem:console
+cl /Zi /MD /I %SDL2DIR%\include /I ..\.. main.cpp imgui_impl_sdl_gl2.cpp ..\..\imgui*.cpp /link /LIBPATH:%SDL2DIR%\lib SDL2.lib SDL2main.lib opengl32.lib /subsystem:console
 ```
 
 - On Linux and similar Unixes
 
 ```
-c++ `sdl2-config --cflags` -I ../.. main.cpp imgui_impl_sdl.cpp ../../imgui*.cpp `sdl2-config --libs` -lGL -o sdl2example
+c++ `sdl2-config --cflags` -I ../.. main.cpp imgui_impl_sdl_gl2.cpp ../../imgui*.cpp `sdl2-config --libs` -lGL -o sdl2example
 ```
 
 - On Mac OS X
 
 ```
 brew install sdl2
-c++ `sdl2-config --cflags` -I ../.. main.cpp imgui_impl_sdl.cpp ../../imgui*.cpp `sdl2-config --libs` -framework OpenGl -o sdl2example
+c++ `sdl2-config --cflags` -I ../.. main.cpp imgui_impl_sdl_gl2.cpp ../../imgui*.cpp `sdl2-config --libs` -framework OpenGl -o sdl2example
 ```


### PR DESCRIPTION
This fixes some filenames in the g++ command line examples in `sdl_opengl2` and `allegro5` directories.