### PR TITLE
Added SetScrollXHere, SetScrollFromPosX

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -6020,6 +6020,31 @@ void ImGui::SetScrollHere(float center_y_ratio)
     SetScrollFromPosY(target_y, center_y_ratio);
 }
 
+void ImGui::SetScrollFromPosX(float pos_x, float center_x_ratio)
+{
+    // We store a target position so centering can occur on the next frame when we are guaranteed to have a known window size
+    ImGuiWindow* window = GetCurrentWindow();
+    IM_ASSERT(center_x_ratio >= 0.0f && center_x_ratio <= 1.0f);
+    window->ScrollTarget.x = (float)(int)(pos_x + window->Scroll.x);
+    window->ScrollTargetCenterRatio.x = center_x_ratio;
+
+    // Minor hack to to make scrolling to left/right of window take account of WindowPadding, it looks more right to the user this way
+    if (center_x_ratio <= 0.0f && window->ScrollTarget.x <= window->WindowPadding.x)
+        window->ScrollTarget.x = 0.0f;
+    else if (center_x_ratio >= 1.0f && window->ScrollTarget.x >= window->SizeContents.x - window->WindowPadding.x + GImGui->Style.ItemSpacing.x)
+        window->ScrollTarget.x = window->SizeContents.x;
+}
+
+// center_x_ratio: 0.0f left of last item, 0.5f horizontal center of last item, 1.0f right of last item.
+void ImGui::SetScrollXHere(float center_x_ratio)
+{
+    ImGuiWindow* window = GetCurrentWindow();
+    float target_x = window->DC.LastItemRect.GetTL().x - window->Pos.x; // left of last item, in window space
+    float last_item_width = window->DC.LastItemRect.GetWidth();
+    target_x += (last_item_width * center_x_ratio) + (GImGui->Style.ItemSpacing.x * (center_x_ratio - 0.5f) * 2.0f); // Precisely aim before, in the middle or after the last item.
+    SetScrollFromPosX(target_x, center_x_ratio);
+}
+
 // FIXME-NAV: This function is a placeholder for the upcoming Navigation branch + Focusing features.
 // In the current branch this function will only set the scrolling, in the navigation branch it will also set your navigation cursor.
 // Prefer using "SetItemDefaultFocus()" over "if (IsWindowAppearing()) SetScrollHere()" when applicable.

--- a/imgui.h
+++ b/imgui.h
@@ -194,6 +194,8 @@ namespace ImGui
     IMGUI_API void          SetScrollY(float scroll_y);                                         // set scrolling amount [0..GetScrollMaxY()]
     IMGUI_API void          SetScrollHere(float center_y_ratio = 0.5f);                         // adjust scrolling amount to make current cursor position visible. center_y_ratio=0.0: top, 0.5: center, 1.0: bottom. When using to make a "default/current item" visible, consider using SetItemDefaultFocus() instead.
     IMGUI_API void          SetScrollFromPosY(float pos_y, float center_y_ratio = 0.5f);        // adjust scrolling amount to make given position valid. use GetCursorPos() or GetCursorStartPos()+offset to get valid positions.
+    IMGUI_API void          SetScrollXHere(float center_x_ratio = 0.5f);                        // adjust scrolling amount to make current cursor position visible. center_x_ratio=0.0: left, 0.5: center, 1.0: right. When using to make a "default/current item" visible, consider using SetItemDefaultFocus() instead.
+    IMGUI_API void          SetScrollFromPosX(float pos_x, float center_x_ratio = 0.5f);        // adjust scrolling amount to make given position valid. use GetCursorPos() or GetCursorStartPos()+offset to get valid positions.
     IMGUI_API void          SetStateStorage(ImGuiStorage* tree);                                // replace tree state storage with our own (if you want to manipulate it yourself, typically clear subsection of it)
     IMGUI_API ImGuiStorage* GetStateStorage();
 


### PR DESCRIPTION
I had to scroll horizontally to a precise item of a list.

While there is some function to do that in a vertical scrolling (y), there two function were missing to do it horizontally.

I created them in my repo, but I think it may help some other people as well, so here is a pull request.

I'm aware that the changing of "SetScrollHere" to "SetScrollYHere" is a break, but I think it is reasonable and the name is more clear. Anyway fill free to accept it, reject it, rename these functions etc.