### PR TITLE
Don't include memory.h on Arduino

### DIFF
--- a/stb_truetype.h
+++ b/stb_truetype.h
@@ -431,7 +431,9 @@ int main(int arg, char **argv)
    #endif
 
    #ifndef STBTT_memcpy
+   #ifndef ARDUINO
    #include <memory.h>
+   #endif
    #define STBTT_memcpy       memcpy
    #define STBTT_memset       memset
    #endif


### PR DESCRIPTION
`memory.h` is included in Arduino by default, including it will prevent `stb_truetype.h` from being compiled