### PR TITLE
Examples: OpenGL3: Change polygone mode storage variable's type to the correct OpenGL3 API type.

### DIFF
--- a/examples/opengl3_example/imgui_impl_glfw_gl3.cpp
+++ b/examples/opengl3_example/imgui_impl_glfw_gl3.cpp
@@ -153,7 +153,7 @@ void ImGui_ImplGlfwGL3_RenderDrawData(ImDrawData* draw_data)
     if (last_enable_cull_face) glEnable(GL_CULL_FACE); else glDisable(GL_CULL_FACE);
     if (last_enable_depth_test) glEnable(GL_DEPTH_TEST); else glDisable(GL_DEPTH_TEST);
     if (last_enable_scissor_test) glEnable(GL_SCISSOR_TEST); else glDisable(GL_SCISSOR_TEST);
-    glPolygonMode(GL_FRONT_AND_BACK, last_polygon_mode[0]);
+    glPolygonMode(GL_FRONT_AND_BACK, static_cast<GLenum>(last_polygon_mode[0]));
     glViewport(last_viewport[0], last_viewport[1], (GLsizei)last_viewport[2], (GLsizei)last_viewport[3]);
     glScissor(last_scissor_box[0], last_scissor_box[1], (GLsizei)last_scissor_box[2], (GLsizei)last_scissor_box[3]);
 }


### PR DESCRIPTION
According to the Khronos reference 
https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glPolygonMode.xhtml.

`glPolygonMode` must have this signature:
```cpp
void glPolygonMode( GLenum,  GLenum);
```

Which means that if I were to use something like https://github.com/cginternals/glbinding that has enum classes with the current example, I would not be able to build it.



