### PR TITLE
A tiny optimization to ImLineClosestPoint. Removed unnecessary sqrtf call.

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -950,14 +950,13 @@ ImVec2 ImLineClosestPoint(const ImVec2& a, const ImVec2& b, const ImVec2& p)
 {
     ImVec2 ap = p - a;
     ImVec2 ab_dir = b - a;
-    float ab_len = sqrtf(ab_dir.x * ab_dir.x + ab_dir.y * ab_dir.y);
-    ab_dir *= 1.0f / ab_len;
     float dot = ap.x * ab_dir.x + ap.y * ab_dir.y;
     if (dot < 0.0f)
         return a;
-    if (dot > ab_len)
+    float ab_len_sqr = ab_dir.x * ab_dir.x + ab_dir.y * ab_dir.y;
+    if (dot > ab_len_sqr)
         return b;
-    return a + ab_dir * dot;
+    return a + ab_dir * dot / ab_len_sqr;
 }
 
 bool ImTriangleContainsPoint(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& p)


### PR DESCRIPTION
This might be useful if some widget makes a lot of calls to *ImLineClosestPoint*. The call to *sqrtf* was eliminated while keeping the behavior of the functions precisely the same. 

According to the google benchmark, it is roughly x2.4 faster now.

    Benchmark                             Time           CPU Iterations
    -------------------------------------------------------------------
    ImLineClosestPoint_original        4867 ns       5000 ns     100000
    ImLineClosestPoint_optimized       1981 ns       1950 ns     344615
