### PR TITLE
 Add flags to skip window rendering for subsequent access to drawLists.

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -5928,10 +5928,11 @@ bool ImGui::Begin(const char* name, bool* p_open, ImGuiWindowFlags flags)
             RenderFrame(title_bar_rect.Min, title_bar_rect.Max, title_bar_col, true, window_rounding);
             g.Style.FrameBorderSize = backup_border_size;
         }
-        else
+        else if((window->Flags & ImGuiWindowFlags_NoWindow) != ImGuiWindowFlags_NoWindow)
         {
             // Window background
             ImU32 bg_col = GetColorU32(GetWindowBgColorIdxFromFlags(flags));
+
             if (g.NextWindowData.BgAlphaCond != 0)
             {
                 bg_col = (bg_col & ~IM_COL32_A_MASK) | (IM_F32_TO_INT8_SAT(g.NextWindowData.BgAlphaVal) << IM_COL32_A_SHIFT);

--- a/imgui.h
+++ b/imgui.h
@@ -563,7 +563,9 @@ enum ImGuiWindowFlags_
     ImGuiWindowFlags_ResizeFromAnySide      = 1 << 17,  // (WIP) Enable resize from any corners and borders. Your back-end needs to honor the different values of io.MouseCursor set by imgui.
     ImGuiWindowFlags_NoNavInputs            = 1 << 18,  // No gamepad/keyboard navigation within the window
     ImGuiWindowFlags_NoNavFocus             = 1 << 19,  // No focusing toward this window with gamepad/keyboard navigation (e.g. skipped by CTRL+TAB)
+    ImGuiWindowFlags_NoBackground           = 1 << 20,  // Do not draw background for this window
     ImGuiWindowFlags_NoNav                  = ImGuiWindowFlags_NoNavInputs | ImGuiWindowFlags_NoNavFocus,
+    ImGuiWindowFlags_NoWindow               = ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoInputs,
 
     // [Internal]
     ImGuiWindowFlags_NavFlattened           = 1 << 23,  // (WIP) Allow gamepad/keyboard navigation to cross over parent border to this child (only use on child that have no scrolling!)


### PR DESCRIPTION
The flags are `ImGuiWindowFlags_NoBackground/NoWindow`. They make it easier to create an invisible window for drawing texts outside of imgui via raw access to the draw lists as suggested in #628. The window drawing is skipped when ImGuiWindowFlags_NoWindow is set, so this saves us from setting alpha on the window for this purpose.