### PR TITLE
Added Support for Changing the Number of BackBuffers Live

### DIFF
--- a/examples/vulkan_example/imgui_impl_glfw_vulkan.h
+++ b/examples/vulkan_example/imgui_impl_glfw_vulkan.h
@@ -12,8 +12,6 @@ struct GLFWwindow;
 
 #include <vulkan/vulkan.h>
 
-#define IMGUI_VK_QUEUED_FRAMES 2
-
 struct ImGui_ImplGlfwVulkan_Init_Data
 {
     VkAllocationCallbacks* allocator;
@@ -22,6 +20,7 @@ struct ImGui_ImplGlfwVulkan_Init_Data
     VkRenderPass           render_pass;
     VkPipelineCache        pipeline_cache;
     VkDescriptorPool       descriptor_pool;
+    int                    vk_queued_frames;
     void (*check_vk_result)(VkResult err);
 };
 
@@ -31,8 +30,13 @@ IMGUI_API void        ImGui_ImplGlfwVulkan_NewFrame();
 IMGUI_API void        ImGui_ImplGlfwVulkan_Render(VkCommandBuffer command_buffer);
 
 // Use if you want to reset your rendering device without losing ImGui state.
+// TODO: Could someone help out with a better name for this function?
+IMGUI_API void        ImGui_ImplGlfwVulkan_InitialiseDevicePointers();
+IMGUI_API void        ImGui_ImplGlfwVulkan_QueuedFramesChanged(int new_queued_frame_count);
 IMGUI_API void        ImGui_ImplGlfwVulkan_InvalidateFontUploadObjects();
+IMGUI_API void        ImGui_ImplGlfwVulkan_InvalidateFrameDeviceObjects();
 IMGUI_API void        ImGui_ImplGlfwVulkan_InvalidateDeviceObjects();
+IMGUI_API void        ImGui_ImplGlfwVulkan_InvalidateAllDeviceObjects();
 IMGUI_API bool        ImGui_ImplGlfwVulkan_CreateFontsTexture(VkCommandBuffer command_buffer);
 IMGUI_API bool        ImGui_ImplGlfwVulkan_CreateDeviceObjects();
 


### PR DESCRIPTION
Previously it relied on a preprocessor macro to define the amount of backbuffers that imgui would use, causing problems when rendering is implemented without any device wait idles in the render loop. This is caused by it trying to free buffers that are still in use causing graphical glitches (and i'd imagine in worst case a crash although I didn't experience one).

Requires some changes to the demo though so it's a compatibility breaking change to the vulkan example implementation.

The new way to initialise the vulkan backend is pretty simple though, you just have to changed the init struct to set the vk_queued_frames value to the amount of backbuffers you are using. When you are rebuilding the swapchain and the amount of backbuffers has changed just call ImGui_ImplGlfwVulkan_QueuedFramesChanged(<new backbuffer count>);

Has some performance deficits of course, but it's all in the initialisation and reinitialisation parts of ImGui so there should be minimal runtime overhead.