### PR TITLE
Examples: Vulkan: Fix missing subpass dependency

### DIFF
--- a/examples/vulkan_example/main.cpp
+++ b/examples/vulkan_example/main.cpp
@@ -142,12 +142,21 @@ static void resize_vulkan(int w, int h)
         subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
         subpass.colorAttachmentCount = 1;
         subpass.pColorAttachments = &color_attachment;
+        VkSubpassDependency dependency = {};
+        dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
+        dependency.dstSubpass = 0;
+        dependency.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+        dependency.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+        dependency.srcAccessMask = 0;
+        dependency.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
         VkRenderPassCreateInfo info = {};
         info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
         info.attachmentCount = 1;
         info.pAttachments = &attachment;
         info.subpassCount = 1;
         info.pSubpasses = &subpass;
+        info.dependencyCount = 1;
+        info.pDependencies = &dependency;
         err = vkCreateRenderPass(g_Device, &info, g_Allocator, &g_RenderPass);
         check_vk_result(err);
     }


### PR DESCRIPTION
Without an appropriate dependency between ``VkSubmitInfo.pWaitDstStageMask`` (here ``COLOR_ATTACHMENT_OUTPUT``) and the render-pass, the ``UNDEFINED`` -> ``COLOR_ATTACHMENT_OPTIMAL`` transition in the render-pass could happen before the swapchain-image is finished being presented (i.e. before ``g_PresentCompleteSemaphore`` is signaled).

This commits adds a ``VK_SUBPASS_EXTERNAL`` subpass-dependency in ``VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT`` to avoid this.