### PR TITLE
on OSX, ignore text input when CMD key is down

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -10098,7 +10098,7 @@ bool ImGui::InputTextEx(const char* label, char* buf, int buf_size, const ImVec2
         {
             // Process text input (before we check for Return because using some IME will effectively send a Return?)
             // We ignore CTRL inputs, but need to allow ALT+CTRL as some keyboards (e.g. German) use AltGR (which _is_ Alt+Ctrl) to input certain characters.
-            if (!(io.KeyCtrl && !io.KeyAlt) && is_editable && !user_nav_input_start)
+            if (!((io.KeyCtrl && !io.KeyAlt) || (io.OptMacOSXBehaviors && io.KeySuper)) && is_editable && !user_nav_input_start)
                 for (int n = 0; n < IM_ARRAYSIZE(io.InputCharacters) && io.InputCharacters[n]; n++)
                 {
                     // Insert character if they pass filtering


### PR DESCRIPTION
Text edit input characters need to be ignore on OSX when cmd is being pressed, otherwise cut/copy/paste operations add extra characters to the text.