### PR TITLE
Fixed a possible free(NULL) in ImVector::reserve

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -1197,9 +1197,10 @@ public:
         if (new_capacity <= Capacity) 
             return;
         value_type* new_data = (value_type*)ImGui::MemAlloc((size_t)new_capacity * sizeof(value_type));
-        if (Data)
+        if (Data) {
             memcpy(new_data, Data, (size_t)Size * sizeof(value_type));
-        ImGui::MemFree(Data);
+            ImGui::MemFree(Data);
+        }
         Data = new_data;
         Capacity = new_capacity;
     }


### PR DESCRIPTION
This is not necessary per standard but it gets rid of a needless extra operation since we are already checking for NULL. Also the same defensive technique is employed in ImVector::clear.