### PR TITLE
Fixed clipboard paste memory leak in SDL examples

### DIFF
--- a/examples/sdl_opengl2_example/imgui_impl_sdl_gl2.cpp
+++ b/examples/sdl_opengl2_example/imgui_impl_sdl_gl2.cpp
@@ -48,6 +48,7 @@ static Uint64       g_Time = 0;
 static bool         g_MousePressed[3] = { false, false, false };
 static GLuint       g_FontTexture = 0;
 static SDL_Cursor*  g_MouseCursors[ImGuiMouseCursor_COUNT] = { 0 };
+static char*        g_ClipboardTextData = NULL;
 
 // OpenGL2 Render function.
 // (this used to be set in io.RenderDrawListsFn and called by ImGui::Render(), but you can now call this directly from your main loop)
@@ -135,7 +136,10 @@ void ImGui_ImplSdlGL2_RenderDrawData(ImDrawData* draw_data)
 
 static const char* ImGui_ImplSdlGL2_GetClipboardText(void*)
 {
-    return SDL_GetClipboardText();
+    if (g_ClipboardTextData) SDL_free(g_ClipboardTextData);
+    g_ClipboardTextData = SDL_GetClipboardText();
+
+    return g_ClipboardTextData;
 }
 
 static void ImGui_ImplSdlGL2_SetClipboardText(void*, const char* text)
@@ -284,6 +288,9 @@ void ImGui_ImplSdlGL2_Shutdown()
     for (ImGuiMouseCursor cursor_n = 0; cursor_n < ImGuiMouseCursor_COUNT; cursor_n++)
         SDL_FreeCursor(g_MouseCursors[cursor_n]);
     memset(g_MouseCursors, 0, sizeof(g_MouseCursors));
+
+    // Remove previously allocated clipboard text data
+    if (g_ClipboardTextData) SDL_free(g_ClipboardTextData);
 
     // Destroy OpenGL objects
     ImGui_ImplSdlGL2_InvalidateDeviceObjects();

--- a/examples/sdl_opengl3_example/imgui_impl_sdl_gl3.cpp
+++ b/examples/sdl_opengl3_example/imgui_impl_sdl_gl3.cpp
@@ -51,6 +51,7 @@
 static Uint64       g_Time = 0;
 static bool         g_MousePressed[3] = { false, false, false };
 static SDL_Cursor*  g_MouseCursors[ImGuiMouseCursor_COUNT] = { 0 };
+static char*        g_ClipboardTextData = NULL;
 
 // OpenGL data
 static char         g_GlslVersion[32] = "#version 150";
@@ -183,7 +184,10 @@ void ImGui_ImplSdlGL3_RenderDrawData(ImDrawData* draw_data)
 
 static const char* ImGui_ImplSdlGL3_GetClipboardText(void*)
 {
-    return SDL_GetClipboardText();
+    if (g_ClipboardTextData) SDL_free(g_ClipboardTextData);
+    g_ClipboardTextData = SDL_GetClipboardText();
+
+    return g_ClipboardTextData;
 }
 
 static void ImGui_ImplSdlGL3_SetClipboardText(void*, const char* text)
@@ -417,6 +421,9 @@ void ImGui_ImplSdlGL3_Shutdown()
     for (ImGuiMouseCursor cursor_n = 0; cursor_n < ImGuiMouseCursor_COUNT; cursor_n++)
         SDL_FreeCursor(g_MouseCursors[cursor_n]);
     memset(g_MouseCursors, 0, sizeof(g_MouseCursors));
+
+    // Remove previously allocated clipboard text data
+    if (g_ClipboardTextData) SDL_free(g_ClipboardTextData);
 
     // Destroy OpenGL objects
     ImGui_ImplSdlGL3_InvalidateDeviceObjects();


### PR DESCRIPTION
[SDL_GetClipboardText's wiki page](https://wiki.libsdl.org/SDL_GetClipboardText) says that the clipboard text must be cleaned by the user manually with `SDL_free`. ImGui didn't do that in SDL examples, which caused a memory leak, which was confirmed with Valgrind and pasting lots of text into text widget.

This simple fix causes the problem, which was confirmed by Valgrind too. Let me know if you want some additional changes / style fixes. :)