### PR TITLE
Fix potential segmentation fault on `glBindSampler`

### DIFF
--- a/examples/opengl3_example/main.cpp
+++ b/examples/opengl3_example/main.cpp
@@ -21,7 +21,7 @@ int main(int, char**)
     if (!glfwInit())
         return 1;
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
     glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 #if __APPLE__
     glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);


### PR DESCRIPTION
As per [the OpenGL 4 specification](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindSampler.xhtml), `glBindSampler` is available only when the GL version is 3.3 or higher. This fixes a potential segmentation fault when trying to run the OpenGL 3 example with another extension wrangler than the one included in the examples package.