### PR TITLE
Make subsequent window creation possible

### DIFF
--- a/examples/opengl2_example/imgui_impl_glfw_gl2.cpp
+++ b/examples/opengl2_example/imgui_impl_glfw_gl2.cpp
@@ -233,6 +233,7 @@ static void ImGui_ImplGlfw_InstallCallbacks(GLFWwindow* window)
 bool    ImGui_ImplGlfwGL2_Init(GLFWwindow* window, bool install_callbacks)
 {
     g_Window = window;
+    g_Time = 0;
 
     // Setup back-end capabilities flags
     ImGuiIO& io = ImGui::GetIO();

--- a/examples/opengl2_example/imgui_impl_glfw_gl2.h
+++ b/examples/opengl2_example/imgui_impl_glfw_gl2.h
@@ -13,6 +13,9 @@
 // If you are new to ImGui, see examples/README.txt and documentation at the top of imgui.cpp.
 // https://github.com/ocornut/imgui
 
+#ifndef __IMGUI_IMPL_GLFW_GL2__
+#define __IMGUI_IMPL_GLFW_GL2__
+
 struct GLFWwindow;
 
 IMGUI_API bool        ImGui_ImplGlfwGL2_Init(GLFWwindow* window, bool install_callbacks);
@@ -30,3 +33,5 @@ IMGUI_API void        ImGui_ImplGlfw_MouseButtonCallback(GLFWwindow* window, int
 IMGUI_API void        ImGui_ImplGlfw_ScrollCallback(GLFWwindow* window, double xoffset, double yoffset);
 IMGUI_API void        ImGui_ImplGlfw_KeyCallback(GLFWwindow* window, int key, int scancode, int action, int mods);
 IMGUI_API void        ImGui_ImplGlfw_CharCallback(GLFWwindow* window, unsigned int c);
+
+#endif // __IMGUI_IMPL_GLFW_GL2__

--- a/examples/opengl3_example/imgui_impl_glfw_gl3.cpp
+++ b/examples/opengl3_example/imgui_impl_glfw_gl3.cpp
@@ -358,6 +358,7 @@ static void ImGui_ImplGlfw_InstallCallbacks(GLFWwindow* window)
 bool    ImGui_ImplGlfwGL3_Init(GLFWwindow* window, bool install_callbacks, const char* glsl_version)
 {
     g_Window = window;
+    g_Time = 0;
 
     // Store GL version string so we can refer to it later in case we recreate shaders.
     if (glsl_version == NULL)

--- a/examples/opengl3_example/imgui_impl_glfw_gl3.h
+++ b/examples/opengl3_example/imgui_impl_glfw_gl3.h
@@ -11,6 +11,9 @@
 // If you are new to ImGui, see examples/README.txt and documentation at the top of imgui.cpp.
 // https://github.com/ocornut/imgui
 
+#ifndef __IMGUI_IMPL_GLFW_GL3__
+#define __IMGUI_IMPL_GLFW_GL3__
+
 struct GLFWwindow;
 
 IMGUI_API bool        ImGui_ImplGlfwGL3_Init(GLFWwindow* window, bool install_callbacks, const char* glsl_version = NULL);
@@ -29,3 +32,5 @@ IMGUI_API void        ImGui_ImplGlfw_MouseButtonCallback(GLFWwindow* window, int
 IMGUI_API void        ImGui_ImplGlfw_ScrollCallback(GLFWwindow* window, double xoffset, double yoffset);
 IMGUI_API void        ImGui_ImplGlfw_KeyCallback(GLFWwindow* window, int key, int scancode, int action, int mods);
 IMGUI_API void        ImGui_ImplGlfw_CharCallback(GLFWwindow* window, unsigned int c);
+
+#endif // __IMGUI_IMPL_GLFW_GL3__


### PR DESCRIPTION
## Context

I'm the author of the [Java binding](https://github.com/ice1000/jimgui) of dear-imgui, and I want to do GUI tests (say, running some GUI windows on a non-headless machine and automatically stop after a few seconds).
But when I was running the second window, I saw:

```
java: /home/ice1000/git-repos/jimgui/core/jni/imgui/imgui.cpp:3484：void ImGui::NewFrame():
假设 ‘g.IO.DeltaTime >= 0.0f && "Need a positive DeltaTime (zero is tolerated but will cause some timing issues)"’ 失败。
```

(假设 == assume, 失败 == failed)

After some debugging I found that when I initialize glfw the second time, `glfwGetTime` is reset to 0 (or, very close to 0) but `g_Time` (a static global variable) isn't. And `DeltaTime` is set to `current_time - g_Time` which is negative under this circumstance.

```cpp
io.DeltaTime = g_Time > 0.0 ? (float)(current_time - g_Time) : (float)(1.0f/60.0f)
```

## Modifications

+ Added `ifndef`/`define`/`endif` to gl2/gl3 example header files
+ Re-initialize `g_Time` in `ImGui_ImplGlfwGLX_Init`
