### PR TITLE
Add missing IMGUI_API macros to ImVec2/4 functions

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -120,9 +120,9 @@ typedef unsigned long long  ImU64;  // 64-bit unsigned integer
 struct ImVec2
 {
     float     x, y;
-    ImVec2()  { x = y = 0.0f; }
-    ImVec2(float _x, float _y) { x = _x; y = _y; }
-    float operator[] (size_t i) const { IM_ASSERT(i <= 1); return (&x)[i]; }    // We very rarely use this [] operator, the assert overhead is fine.
+    IMGUI_API ImVec2()  { x = y = 0.0f; }
+    IMGUI_API ImVec2(float _x, float _y) { x = _x; y = _y; }
+    IMGUI_API float operator[] (size_t i) const { IM_ASSERT(i <= 1); return (&x)[i]; }    // We very rarely use this [] operator, the assert overhead is fine.
 #ifdef IM_VEC2_CLASS_EXTRA
     IM_VEC2_CLASS_EXTRA     // Define additional constructors and implicit cast operators in imconfig.h to convert back and forth between your math types and ImVec2.
 #endif
@@ -132,8 +132,8 @@ struct ImVec2
 struct ImVec4
 {
     float     x, y, z, w;
-    ImVec4()  { x = y = z = w = 0.0f; }
-    ImVec4(float _x, float _y, float _z, float _w) { x = _x; y = _y; z = _z; w = _w; }
+    IMGUI_API ImVec4()  { x = y = z = w = 0.0f; }
+    IMGUI_API ImVec4(float _x, float _y, float _z, float _w) { x = _x; y = _y; z = _z; w = _w; }
 #ifdef IM_VEC4_CLASS_EXTRA
     IM_VEC4_CLASS_EXTRA     // Define additional constructors and implicit cast operators in imconfig.h to convert back and forth between your math types and ImVec4.
 #endif


### PR DESCRIPTION
Adds missing IMGUI_API  macros to members of ImVec2/4 structs, most notably the constructors.

Needed for cppsharp wrapper generation.