### PR TITLE
Fix include Example_glfw_vulkan cmake

### DIFF
--- a/examples/example_glfw_vulkan/CMakeLists.txt
+++ b/examples/example_glfw_vulkan/CMakeLists.txt
@@ -20,7 +20,7 @@ include_directories(${GLFW_DIR}/include)
 
 # ImGui
 set(IMGUI_DIR ../../)
-include_directories(${IMGUI_DIR})
+include_directories(${IMGUI_DIR} ..)
 
 # Libraries
 find_library(VULKAN_LIBRARY


### PR DESCRIPTION
Probably got broken because of the refactor.
