### PR TITLE
Add support for custom key list

### DIFF
--- a/imconfig.h
+++ b/imconfig.h
@@ -63,6 +63,17 @@
 //---- Use 32-bit vertex indices (default is 16-bit) to allow meshes with more than 64K vertices. Render function needs to support it.
 //#define ImDrawIdx unsigned int
 
+//---- Allow custom keymap for expanded key access (for widget hotkeys or other custom code)
+//#define IM_CUSTOM_KEYLIST
+//
+// enum ImGuiKey_
+// {
+// 	    ImGuiKey_Tab,
+//		ImGuiKey_G,
+//		...
+//		ImGuiKey_COUNT
+// }
+
 //---- Tip: You can add extra functions within the ImGui:: namespace, here or in your own headers files.
 /*
 namespace ImGui
@@ -70,3 +81,5 @@ namespace ImGui
     void MyFunction(const char* name, const MyMatrix44& v);
 }
 */
+
+

--- a/imgui.h
+++ b/imgui.h
@@ -765,6 +765,7 @@ enum ImGuiDir_
 };
 
 // User fill ImGuiIO.KeyMap[] array with indices into the ImGuiIO.KeysDown[512] array
+#ifndef IM_CUSTOM_KEYLIST
 enum ImGuiKey_
 {
     ImGuiKey_Tab,
@@ -790,6 +791,7 @@ enum ImGuiKey_
     ImGuiKey_Z,         // for text edit CTRL+Z: undo
     ImGuiKey_COUNT
 };
+#endif
 
 // [BETA] Gamepad/Keyboard directional navigation
 // Keyboard: Set io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard to enable. NewFrame() will automatically fill io.NavInputs[] based on your io.KeysDown[] + io.KeyMap[] arrays.


### PR DESCRIPTION
This is a small change added to allow users to implement a custom key list without having to replace or modify the list in imgui.h.

Instead, they can use imconfig.h or use the preprocessor to do disable the default list and implement their own. 