### PR TITLE
fix mingw c++11 compilation

### DIFF
--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -24,7 +24,7 @@
 
 #include "imgui.h"
 #include <ctype.h>          // toupper, isprint
-#include <limits.h>         // INT_MIN, INT_MAX
+#include <climits>         // INT_MIN, INT_MAX
 #include <math.h>           // sqrtf, powf, cosf, sinf, floorf, ceilf
 #include <stdio.h>          // vsnprintf, sscanf, printf
 #include <stdlib.h>         // NULL, malloc, free, atoi


### PR DESCRIPTION
fix mingw "LLONG_MIN, ULLONG_MAX not declarated in scope" when compiling with c++11