### PR TITLE
Fix warning

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -794,7 +794,9 @@
 #endif
 
 #include "imgui.h"
+#ifndef IMGUI_DEFINE_MATH_OPERATORS
 #define IMGUI_DEFINE_MATH_OPERATORS
+#endif
 #include "imgui_internal.h"
 
 #include <ctype.h>      // toupper, isprint

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -14,7 +14,9 @@
 #endif
 
 #include "imgui.h"
+#ifndef IMGUI_DEFINE_MATH_OPERATORS
 #define IMGUI_DEFINE_MATH_OPERATORS
+#endif
 #include "imgui_internal.h"
 
 #include <stdio.h>      // vsnprintf, sscanf, printf


### PR DESCRIPTION
Super-big and important PR. Buckle your seatbelts. :trollface:

Fix warning when IMGUI_DEFINE_MATH_OPERATORS is already defined by build system.