### PR TITLE
 Workaround to disable the incomplete UI-less mode IME in SDL(Windows)

### DIFF
--- a/examples/example_sdl_opengl2/main.cpp
+++ b/examples/example_sdl_opengl2/main.cpp
@@ -21,6 +21,7 @@ int main(int, char**)
         printf("Error: %s\n", SDL_GetError());
         return -1;
     }
+    ImGui_ImplSDL2_Init();
 
     // Setup window
     SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
@@ -32,6 +33,7 @@ int main(int, char**)
     SDL_GetCurrentDisplayMode(0, &current);
     SDL_WindowFlags window_flags = (SDL_WindowFlags)(SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
     SDL_Window* window = SDL_CreateWindow("Dear ImGui SDL2+OpenGL example", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 1280, 720, window_flags);
+    ImGui_ImplSDL2_HookIme(window);
     SDL_GLContext gl_context = SDL_GL_CreateContext(window);
     SDL_GL_SetSwapInterval(1); // Enable vsync
 

--- a/examples/example_sdl_opengl3/main.cpp
+++ b/examples/example_sdl_opengl3/main.cpp
@@ -30,6 +30,7 @@ int main(int, char**)
         printf("Error: %s\n", SDL_GetError());
         return -1;
     }
+    ImGui_ImplSDL2_Init();
 
     // Decide GL+GLSL versions
 #if __APPLE__
@@ -56,6 +57,7 @@ int main(int, char**)
     SDL_GetCurrentDisplayMode(0, &current);
     SDL_WindowFlags window_flags = (SDL_WindowFlags)(SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
     SDL_Window* window = SDL_CreateWindow("Dear ImGui SDL2+OpenGL3 example", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 1280, 720, window_flags);
+    ImGui_ImplSDL2_HookIme(window);
     SDL_GLContext gl_context = SDL_GL_CreateContext(window);
     SDL_GL_SetSwapInterval(1); // Enable vsync
 

--- a/examples/example_sdl_vulkan/main.cpp
+++ b/examples/example_sdl_vulkan/main.cpp
@@ -304,12 +304,14 @@ int main(int, char**)
         printf("Error: %s\n", SDL_GetError());
         return 1;
     }
+    ImGui_ImplSDL2_Init();
 
     // Setup window
     SDL_DisplayMode current;
     SDL_GetCurrentDisplayMode(0, &current);
     SDL_WindowFlags window_flags = (SDL_WindowFlags)(SDL_WINDOW_VULKAN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
     SDL_Window* window = SDL_CreateWindow("Dear ImGui SDL2+Vulkan example", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 1280, 720, window_flags);
+    ImGui_ImplSDL2_HookIme(window);
 
     // Setup Vulkan
     uint32_t extensions_count = 0;

--- a/examples/imgui_impl_sdl.cpp
+++ b/examples/imgui_impl_sdl.cpp
@@ -92,7 +92,11 @@ static LRESULT CALLBACK ImGui_ImplSDL2_HookIme_WndProc(HWND hwnd, UINT msg, WPAR
     case WM_SYSKEYUP:
         if (wParam == VK_PROCESSKEY)
         {
-            wndProc = DefWindowProc;
+            ImGuiIO& io = ImGui::GetIO();
+            if (io.WantTextInput)
+            {
+                wndProc = DefWindowProc;
+            }
         }
     }
     return CallWindowProc(wndProc, hwnd, msg, wParam, lParam);

--- a/examples/imgui_impl_sdl.h
+++ b/examples/imgui_impl_sdl.h
@@ -19,6 +19,8 @@
 struct SDL_Window;
 typedef union SDL_Event SDL_Event;
 
+IMGUI_IMPL_API void     ImGui_ImplSDL2_Init();
+IMGUI_IMPL_API void     ImGui_ImplSDL2_HookIme(SDL_Window* window);
 IMGUI_IMPL_API bool     ImGui_ImplSDL2_InitForOpenGL(SDL_Window* window, void* sdl_gl_context);
 IMGUI_IMPL_API bool     ImGui_ImplSDL2_InitForVulkan(SDL_Window* window);
 IMGUI_IMPL_API void     ImGui_ImplSDL2_Shutdown();


### PR DESCRIPTION
1. Set io.ImeSetInputScreenPosFn use SDL_SetTextInputRect
2. SDL try to support UI-less mode IME on Windows, but the implementation is incomplete, that make the default IME window not shown. I made a workaround to disable it.