### PR TITLE
supress potentially unused identifier

### DIFF
--- a/examples/imgui_impl_sdl.cpp
+++ b/examples/imgui_impl_sdl.cpp
@@ -204,6 +204,7 @@ static void ImGui_ImplSDL2_UpdateMousePosAndButtons()
 {
     ImGuiIO& io = ImGui::GetIO();
     const ImVec2 mouse_pos_backup = io.MousePos;
+    (void)mouse_pos_backup; //avoid warning if unused
     io.MousePos = ImVec2(-FLT_MAX, -FLT_MAX);
 
     // Set OS mouse position if requested (rarely used, only when ImGuiConfigFlags_NavEnableSetMousePos is enabled by user)


### PR DESCRIPTION
we pull the lib in as a dep, but our toolchains are configured to error on warning... 
you don't have to accept this.  Just throwing it out there.  Maybe I'll just pragma suppress the warning in a wrapper header around this library or something instead (a wrapper in our own codebase that is)... its just kind of hard to do on my side, because its an explicit bazel rule right into the download library.  Even if I wrapped your lib, it would still error... lol, basically my problem; not yours.  If this lands though, I'll be good.  Otherwise, I'll think of something else.  Let me know if you have any tips.  
