### PR TITLE
Ignore GCC warning (-Wclass-memaccess)

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -52,11 +52,9 @@
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wold-style-cast"
-#elif defined(__GNUC__)
-#if __GNUC__ >= 8
+#elif defined(__GNUC__) and __GNUC__ >= 8
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wclass-memaccess"          // warning: 'memset/memcpy' clearing/writing an object of type 'xxxx' with no trivial copy-assignment; use assignment or value-initialization instead
-#endif
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
 #endif
 
 // Forward declarations
@@ -1927,6 +1925,8 @@ struct ImFont
 
 #if defined(__clang__)
 #pragma clang diagnostic pop
+#elif defined(__GNUC__) and __GNUC__ >= 8
+#pragma GCC diagnostic pop
 #endif
 
 // Include imgui_user.h at the end of imgui.h (convenient for user to only explicitly include vanilla imgui.h)

--- a/imgui.h
+++ b/imgui.h
@@ -36,7 +36,7 @@
 
 // Helpers
 #ifndef IM_ASSERT
-#include <assert.h>                                                             
+#include <assert.h>
 #define IM_ASSERT(_EXPR)            assert(_EXPR)                               // You can override the default assert handler by editing imconfig.h
 #endif
 #if defined(__clang__) || defined(__GNUC__)
@@ -52,6 +52,11 @@
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wold-style-cast"
+#elif defined(__GNUC__)
+#if __GNUC__ >= 8
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclass-memaccess"          // warning: 'memset/memcpy' clearing/writing an object of type 'xxxx' with no trivial copy-assignment; use assignment or value-initialization instead
+#endif
 #endif
 
 // Forward declarations

--- a/imgui.h
+++ b/imgui.h
@@ -52,7 +52,7 @@
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wold-style-cast"
-#elif defined(__GNUC__) and __GNUC__ >= 8
+#elif defined(__GNUC__) && __GNUC__ >= 8
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wclass-memaccess"
 #endif
@@ -1925,7 +1925,7 @@ struct ImFont
 
 #if defined(__clang__)
 #pragma clang diagnostic pop
-#elif defined(__GNUC__) and __GNUC__ >= 8
+#elif defined(__GNUC__) && __GNUC__ >= 8
 #pragma GCC diagnostic pop
 #endif
 


### PR DESCRIPTION
Hello.

"-Wclass-memaccess" was already ignored in imgui.cpp, but it also needs to be ignored in imgui.h ([this](https://github.com/ocornut/imgui/blob/048add5ef20fa06a3ca6062be927b2bee1059feb/imgui.h#L1266) and [this](https://github.com/ocornut/imgui/blob/048add5ef20fa06a3ca6062be927b2bee1059feb/imgui.h#L1274) triggered it) 