### PR TITLE
Fix OSX mouse clicks and drags

### DIFF
--- a/examples/example_apple_opengl2/main.mm
+++ b/examples/example_apple_opengl2/main.mm
@@ -136,7 +136,7 @@
 // Flip coordinate system upside down on Y
 -(BOOL)isFlipped
 {
-    return (YES);
+    return (NO);
 }
 
 -(void)dealloc
@@ -150,6 +150,20 @@
 -(void)flagsChanged:(NSEvent *)event    { ImGui_ImplOSX_HandleEvent(event, self); }
 -(void)mouseDown:(NSEvent *)event       { ImGui_ImplOSX_HandleEvent(event, self); }
 -(void)mouseUp:(NSEvent *)event         { ImGui_ImplOSX_HandleEvent(event, self); }
+-(void)mouseMoved:(NSEvent *)event
+{
+	ImGui_ImplOSX_HandleEvent(event, self);
+	[super mouseMoved: event];
+
+}
+
+-(void)mouseDragged:(NSEvent *)event
+{
+	ImGui_ImplOSX_HandleEvent(event, self);
+	[super mouseMoved: event];
+
+}
+
 -(void)scrollWheel:(NSEvent *)event     { ImGui_ImplOSX_HandleEvent(event, self); }
 
 @end
@@ -182,6 +196,8 @@
     [_window setOpaque:YES];
     [_window makeKeyAndOrderFront:NSApp];
 	
+	[_window setAcceptsMouseMovedEvents:YES];
+
     return (_window);
 }
 

--- a/examples/example_apple_opengl2/main.mm
+++ b/examples/example_apple_opengl2/main.mm
@@ -150,20 +150,8 @@
 -(void)flagsChanged:(NSEvent *)event    { ImGui_ImplOSX_HandleEvent(event, self); }
 -(void)mouseDown:(NSEvent *)event       { ImGui_ImplOSX_HandleEvent(event, self); }
 -(void)mouseUp:(NSEvent *)event         { ImGui_ImplOSX_HandleEvent(event, self); }
--(void)mouseMoved:(NSEvent *)event
-{
-	ImGui_ImplOSX_HandleEvent(event, self);
-	[super mouseMoved: event];
-
-}
-
--(void)mouseDragged:(NSEvent *)event
-{
-	ImGui_ImplOSX_HandleEvent(event, self);
-	[super mouseMoved: event];
-
-}
-
+-(void)mouseMoved:(NSEvent *)event      { ImGui_ImplOSX_HandleEvent(event, self); }
+-(void)mouseDragged:(NSEvent *)event      { ImGui_ImplOSX_HandleEvent(event, self); }
 -(void)scrollWheel:(NSEvent *)event     { ImGui_ImplOSX_HandleEvent(event, self); }
 
 @end
@@ -195,8 +183,7 @@
     [_window setTitle:@"ImGui OSX+OpenGL2 Example"];
     [_window setOpaque:YES];
     [_window makeKeyAndOrderFront:NSApp];
-	
-	[_window setAcceptsMouseMovedEvents:YES];
+    [_window setAcceptsMouseMovedEvents:YES];
 
     return (_window);
 }


### PR DESCRIPTION
Use an un-flipped coordinate system in the window (Y increasing from top to bottom).
Tell OSX we want mouseMoved and mouseDragged events.
Pass mouseMoved and mouseDragged events to imgui handler.
