### PR TITLE
add right-aligned text for column, add colored text for menuitem

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -7832,12 +7832,33 @@ void ImGui::TextV(const char* fmt, va_list args)
     TextUnformatted(g.TempBuffer, text_end);
 }
 
+void ImGui::TextV2(const char* fmt, va_list args)
+{
+	ImGuiWindow* window = GetCurrentWindow();
+	if (window->SkipItems)
+		return;
+
+	ImGuiContext& g = *GImGui;
+	const char* text_end = g.TempBuffer + ImFormatStringV(g.TempBuffer, IM_ARRAYSIZE(g.TempBuffer), fmt, args);
+	TextUnformatted2(g.TempBuffer, text_end);
+}
+
 void ImGui::Text(const char* fmt, ...)
 {
     va_list args;
     va_start(args, fmt);
     TextV(fmt, args);
     va_end(args);
+}
+
+void ImGui::Text2(const ImVec4& col, const char* fmt, ...)
+{
+	PushStyleColor(ImGuiCol_Text, col);
+	va_list args;
+	va_start(args, fmt);	
+	TextV2(fmt, args);	
+	va_end(args);
+	PopStyleColor();
 }
 
 void ImGui::TextColoredV(const ImVec4& col, const char* fmt, va_list args)
@@ -7990,6 +8011,30 @@ void ImGui::TextUnformatted(const char* text, const char* text_end)
         // Render (we don't hide text after ## in this end-user function)
         RenderTextWrapped(bb.Min, text_begin, text_end, wrap_width);
     }
+}
+
+void ImGui::TextUnformatted2(const char* text, const char* text_end)
+{
+	ImGuiWindow* window = GetCurrentWindow();
+	if (window->SkipItems)
+		return;
+
+	ImGuiContext& g = *GImGui;
+	IM_ASSERT(text != NULL);
+	const char* text_begin = text;
+	if (text_end == NULL)
+		text_end = text + strlen(text); // FIXME-OPT
+										
+	const ImRect clip_rect = window->ClipRect;
+	const float wrap_width = 0.0f;
+	const ImVec2 text_size = CalcTextSize(text_begin, text_end, false, wrap_width);
+
+	const ImVec2 text_pos(window->DC.CursorPos.x + clip_rect.GetWidth() - text_size.x - g.FontSize, window->DC.CursorPosPrevLine.y); 
+	const float wrap_pos_x = window->DC.TextWrapPos;
+	const bool wrap_enabled = wrap_pos_x >= 0.0f;
+	ImRect bb(text_pos, text_pos + text_size);
+
+	RenderTextWrapped(bb.Min, text_begin, text_end, wrap_width);
 }
 
 void ImGui::AlignTextToFramePadding()
@@ -11841,6 +11886,50 @@ bool ImGui::MenuItem(const char* label, const char* shortcut, bool selected, boo
             RenderCheckMark(pos + ImVec2(window->MenuColumns.Pos[2] + extra_w + g.FontSize * 0.40f, g.FontSize * 0.134f * 0.5f), GetColorU32(enabled ? ImGuiCol_Text : ImGuiCol_TextDisabled), g.FontSize  * 0.866f);
     }
     return pressed;
+}
+
+bool ImGui::MenuItem2(const char* label, const char* rightText, bool selected, bool enabled, ImVec4 color)
+{
+	ImGui::PushItemFlag(ImGuiItemFlags_SelectableDontClosePopup, true);
+	ImGuiWindow* window = GetCurrentWindow();
+	if (window->SkipItems)
+		return false;
+
+	ImGuiContext& g = *GImGui;
+	ImGuiStyle& style = g.Style;
+	ImVec2 pos = window->DC.CursorPos;
+	ImVec2 label_size = CalcTextSize(label, NULL, true);
+
+	ImGuiSelectableFlags flags = ImGuiSelectableFlags_PressedOnRelease | (enabled ? 0 : ImGuiSelectableFlags_Disabled);
+	bool pressed;
+	if (window->DC.LayoutType == ImGuiLayoutType_Horizontal)
+	{
+		// Mimic the exact layout spacing of BeginMenu() to allow MenuItem() inside a menu bar, which is a little misleading but may be useful
+		// Note that in this situation we render neither the shortcut neither the selected tick mark
+		float w = label_size.x;
+		window->DC.CursorPos.x += (float)(int)(style.ItemSpacing.x * 0.5f);
+		PushStyleVar(ImGuiStyleVar_ItemSpacing, style.ItemSpacing * 2.0f);
+		pressed = Selectable(label, false, flags, ImVec2(w, 0.0f));
+		PopStyleVar();
+		window->DC.CursorPos.x += (float)(int)(style.ItemSpacing.x * (-1.0f + 0.5f)); // -1 spacing to compensate the spacing added when Selectable() did a SameLine(). It would also work to call SameLine() ourselves after the PopStyleVar().
+	}
+	else
+	{
+		ImVec2 shortcut_size = rightText ? CalcTextSize(rightText, NULL) : ImVec2(0.0f, 0.0f);
+		float w = window->MenuColumns.DeclColumns(label_size.x, shortcut_size.x, (float)(int)(g.FontSize * 1.20f)); // Feedback for next frame
+		float extra_w = ImMax(0.0f, GetContentRegionAvail().x - w);
+		pressed = Selectable(label, false, flags | ImGuiSelectableFlags_DrawFillAvailWidth, ImVec2(w, 0.0f));
+		if (shortcut_size.x > 0.0f)
+		{
+			PushStyleColor(ImGuiCol_Text, color);
+			RenderText(pos + ImVec2(window->MenuColumns.Pos[1] + extra_w, 0.0f), rightText, NULL, false);
+			PopStyleColor();
+		}
+		if (selected)
+			RenderCheckMark(pos + ImVec2(window->MenuColumns.Pos[2] + extra_w + g.FontSize * 0.40f, g.FontSize * 0.134f * 0.5f), GetColorU32(enabled ? ImGuiCol_Text : ImGuiCol_TextDisabled), g.FontSize  * 0.866f);
+	}
+	ImGui::PopItemFlag();
+	return pressed;
 }
 
 bool ImGui::MenuItem(const char* label, const char* shortcut, bool* p_selected, bool enabled)

--- a/imgui.h
+++ b/imgui.h
@@ -310,9 +310,9 @@ namespace ImGui
     IMGUI_API void          TextUnformatted(const char* text, const char* text_end = NULL);                // raw text without formatting. Roughly equivalent to Text("%s", text) but: A) doesn't require null terminated string if 'text_end' is specified, B) it's faster, no memory copy is done, no buffer size limits, recommended for long chunks of text.
 	IMGUI_API void          TextUnformatted2(const char* text, const char* text_end = NULL);
     IMGUI_API void          Text(const char* fmt, ...)                                      IM_FMTARGS(1); // simple formatted text
-	IMGUI_API void          Text2(const ImVec4& col, const char* fmt, ...)                  IM_FMTARGS(1); // simple formatted text
+	IMGUI_API void          Text2(const ImVec4& col, const char* fmt, ...)                  IM_FMTARGS(2); // right aligned text with color
     IMGUI_API void          TextV(const char* fmt, va_list args)                            IM_FMTLIST(1);
-	IMGUI_API void          TextV2(const char* fmt, va_list args)                           IM_FMTLIST(1);
+	IMGUI_API void          TextV2(const char* fmt, va_list args)                           IM_FMTLIST(2);
     IMGUI_API void          TextColored(const ImVec4& col, const char* fmt, ...)            IM_FMTARGS(2); // shortcut for PushStyleColor(ImGuiCol_Text, col); Text(fmt, ...); PopStyleColor();
     IMGUI_API void          TextColoredV(const ImVec4& col, const char* fmt, va_list args)  IM_FMTLIST(2);
     IMGUI_API void          TextDisabled(const char* fmt, ...)                              IM_FMTARGS(1); // shortcut for PushStyleColor(ImGuiCol_Text, style.Colors[ImGuiCol_TextDisabled]); Text(fmt, ...); PopStyleColor();

--- a/imgui.h
+++ b/imgui.h
@@ -308,8 +308,11 @@ namespace ImGui
 
     // Widgets: Text
     IMGUI_API void          TextUnformatted(const char* text, const char* text_end = NULL);                // raw text without formatting. Roughly equivalent to Text("%s", text) but: A) doesn't require null terminated string if 'text_end' is specified, B) it's faster, no memory copy is done, no buffer size limits, recommended for long chunks of text.
+	IMGUI_API void          TextUnformatted2(const char* text, const char* text_end = NULL);
     IMGUI_API void          Text(const char* fmt, ...)                                      IM_FMTARGS(1); // simple formatted text
+	IMGUI_API void          Text2(const ImVec4& col, const char* fmt, ...)                  IM_FMTARGS(1); // simple formatted text
     IMGUI_API void          TextV(const char* fmt, va_list args)                            IM_FMTLIST(1);
+	IMGUI_API void          TextV2(const char* fmt, va_list args)                           IM_FMTLIST(1);
     IMGUI_API void          TextColored(const ImVec4& col, const char* fmt, ...)            IM_FMTARGS(2); // shortcut for PushStyleColor(ImGuiCol_Text, col); Text(fmt, ...); PopStyleColor();
     IMGUI_API void          TextColoredV(const ImVec4& col, const char* fmt, va_list args)  IM_FMTLIST(2);
     IMGUI_API void          TextDisabled(const char* fmt, ...)                              IM_FMTARGS(1); // shortcut for PushStyleColor(ImGuiCol_Text, style.Colors[ImGuiCol_TextDisabled]); Text(fmt, ...); PopStyleColor();
@@ -458,6 +461,7 @@ namespace ImGui
     IMGUI_API void          EndMenu();                                                          // only call EndMenu() if BeginMenu() returns true!
     IMGUI_API bool          MenuItem(const char* label, const char* shortcut = NULL, bool selected = false, bool enabled = true);  // return true when activated. shortcuts are displayed for convenience but not processed by ImGui at the moment
     IMGUI_API bool          MenuItem(const char* label, const char* shortcut, bool* p_selected, bool enabled = true);              // return true when activated + toggle (*p_selected) if p_selected != NULL
+	IMGUI_API bool          MenuItem2(const char* label, const char* rightText= NULL, bool selected = false, bool enabled = true, ImVec4 color = ImVec4());  // return true when activated. shortcuts are displayed for convenience but not processed by ImGui at the moment
 
     // Popups
     IMGUI_API void          OpenPopup(const char* str_id);                                      // call to mark popup as open (don't call every frame!). popups are closed when user click outside, or if CloseCurrentPopup() is called within a BeginPopup()/EndPopup() block. By default, Selectable()/MenuItem() are calling CloseCurrentPopup(). Popup identifiers are relative to the current ID-stack (so OpenPopup and BeginPopup needs to be at the same level).

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -233,6 +233,14 @@ void ImGui::ShowDemoWindow(bool* p_open)
             ImGui::MenuItem("Custom rendering", NULL, &show_app_custom_rendering);
             ImGui::EndMenu();
         }
+		if (ImGui::BeginMenu("MultiTextColored"))
+		{
+			ImGui::MenuItem2("Primary Text", "Secondary Text in Red", false, true, ImVec4(1.0, 0.0, 0.0, 1.0));
+			ImGui::MenuItem2("Primary Long Text", "Green Text checked", true, true, ImVec4(0.0, 1.0, 0.0, 1.0));
+			ImGui::MenuItem2("Short", "Blue Text", false, true, ImVec4(0.0, 0.0, 1.0, 1.0));
+			ImGui::EndMenu();
+		}
+
         if (ImGui::BeginMenu("Help"))
         {
             ImGui::MenuItem("Metrics", NULL, &show_app_metrics);
@@ -2101,6 +2109,25 @@ void ImGui::ShowDemoWindow(bool* p_open)
             ImGui::Separator();
             ImGui::TreePop();
         }
+
+		if (ImGui::TreeNode("Multi-Text Right-Aligned"))
+		{
+			ImGui::Columns(3, NULL, true);
+			for (int i = 0; i < 3 * 3; i++)
+			{
+				if (ImGui::GetColumnIndex() == 0)
+					ImGui::Separator();
+				
+				ImGui::Text("Width");
+				ImGui::Text2(ImVec4(0.0, 1.0, 0.0, 1.0), "%.2f", ImGui::GetColumnWidth());
+				ImGui::NextColumn();
+			}
+			ImGui::Columns(1);
+			ImGui::Separator();
+			ImGui::TreePop();
+		}
+
+
         ImGui::PopID();
     }
 


### PR DESCRIPTION
- Adding right-aligned text for column, with colored text support
  This is useful for displaying statistic data when the number on the right side on the table

- Adding secondary colored text for the menu item.
  basically it similar text for the shortcut in the menu, but with additional text color argument

- update the demo app

![imgui-pr-1](https://user-images.githubusercontent.com/10397816/43247806-07ac1dce-90e0-11e8-9173-1ffab8563efd.png)
