### PR TITLE
Assert that fmt != NULL before calling vsnprintf

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -1250,6 +1250,7 @@ static const char* ImAtoi(const char* src, TYPE* output)
 #ifndef IMGUI_DISABLE_FORMAT_STRING_FUNCTIONS
 int ImFormatString(char* buf, size_t buf_size, const char* fmt, ...)
 {
+    IM_ASSERT(fmt != NULL);
     va_list args;
     va_start(args, fmt);
     int w = vsnprintf(buf, buf_size, fmt, args);
@@ -1264,6 +1265,7 @@ int ImFormatString(char* buf, size_t buf_size, const char* fmt, ...)
 
 int ImFormatStringV(char* buf, size_t buf_size, const char* fmt, va_list args)
 {
+    IM_ASSERT(fmt != NULL);
     int w = vsnprintf(buf, buf_size, fmt, args);
     if (buf == NULL)
         return w;


### PR DESCRIPTION
vsnprintf(buf, buf_size, NULL, args) results in undefined behavior. In the case of Visual Studio 15.6 and Windows 10.0.17134, it appeared to corrupt the stack rather than provide a clear exception. Therefore, Dear ImGui should check beforehand whether fmt is NULL.

Sorry this is on my master branch.