### PR TITLE
Add aspect preserving to ShowExampleAppConstrainedResize

### DIFF
--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -3243,11 +3243,14 @@ static void ShowExampleAppConstrainedResize(bool* p_open)
     {
         static void Square(ImGuiSizeCallbackData* data) { data->DesiredSize = ImVec2(IM_MAX(data->DesiredSize.x, data->DesiredSize.y), IM_MAX(data->DesiredSize.x, data->DesiredSize.y)); }
         static void Step(ImGuiSizeCallbackData* data)   { float step = (float)(int)(intptr_t)data->UserData; data->DesiredSize = ImVec2((int)(data->DesiredSize.x / step + 0.5f) * step, (int)(data->DesiredSize.y / step + 0.5f) * step); }
+        static void KeepAspect(ImGuiSizeCallbackData* data) { float ratio = *(float*)data->UserData; data->DesiredSize.y = data->DesiredSize.x / ratio; }
     };
 
     static bool auto_resize = false;
     static int type = 0;
     static int display_lines = 10;
+    const float ratio43 = 4.0f / 3.0f;
+    const float ratio169 = 16.0f / 9.0f;
     if (type == 0) ImGui::SetNextWindowSizeConstraints(ImVec2(-1, 0),    ImVec2(-1, FLT_MAX));      // Vertical only
     if (type == 1) ImGui::SetNextWindowSizeConstraints(ImVec2(0, -1),    ImVec2(FLT_MAX, -1));      // Horizontal only
     if (type == 2) ImGui::SetNextWindowSizeConstraints(ImVec2(100, 100), ImVec2(FLT_MAX, FLT_MAX)); // Width > 100, Height > 100
@@ -3255,6 +3258,8 @@ static void ShowExampleAppConstrainedResize(bool* p_open)
     if (type == 4) ImGui::SetNextWindowSizeConstraints(ImVec2(-1, 400),  ImVec2(-1, 500));          // Height 400-500
     if (type == 5) ImGui::SetNextWindowSizeConstraints(ImVec2(0, 0),     ImVec2(FLT_MAX, FLT_MAX), CustomConstraints::Square);          // Always Square
     if (type == 6) ImGui::SetNextWindowSizeConstraints(ImVec2(0, 0),     ImVec2(FLT_MAX, FLT_MAX), CustomConstraints::Step, (void*)100);// Fixed Step
+    if (type == 7) ImGui::SetNextWindowSizeConstraints(ImVec2(0, 0),     ImVec2(FLT_MAX, FLT_MAX), CustomConstraints::KeepAspect, (void*)&ratio43); // Keep 4:3 aspect
+    if (type == 8) ImGui::SetNextWindowSizeConstraints(ImVec2(0, 0),     ImVec2(FLT_MAX, FLT_MAX), CustomConstraints::KeepAspect, (void*)&ratio169); // Keep 16:9 aspect
 
     ImGuiWindowFlags flags = auto_resize ? ImGuiWindowFlags_AlwaysAutoResize : 0;
     if (ImGui::Begin("Example: Constrained Resize", p_open, flags))
@@ -3268,6 +3273,8 @@ static void ShowExampleAppConstrainedResize(bool* p_open)
             "Height 400-500",
             "Custom: Always Square",
             "Custom: Fixed Steps (100)",
+            "Custom: 4:3 Aspect Ratio",
+            "Custom: 16:9 Aspect Ratio",
         };
         if (ImGui::Button("200x200")) { ImGui::SetWindowSize(ImVec2(200, 200)); } ImGui::SameLine();
         if (ImGui::Button("500x500")) { ImGui::SetWindowSize(ImVec2(500, 500)); } ImGui::SameLine();


### PR DESCRIPTION

![Screenshot](https://i.gyazo.com/29bf26bfd42972977644ffbd96613f9b.png)

This is a fairly minimal version, it's worth noting that there's a few issues when `OptResizeWindowsFromEdges` is enabled:
* You can't resize from the upper or lower edges since this version only recalculates `y` from `x`.
* Resizing from the left or right edges causes the window to drift upwards! No idea what's causing that.
