### PR TITLE
using #ifdef GL_SAMPLER_BINDING instead of if (glBindSampler)

### DIFF
--- a/examples/imgui_impl_opengl3.cpp
+++ b/examples/imgui_impl_opengl3.cpp
@@ -163,8 +163,9 @@ void    ImGui_ImplOpenGL3_RenderDrawData(ImDrawData* draw_data)
     glUseProgram(g_ShaderHandle);
     glUniform1i(g_AttribLocationTex, 0);
     glUniformMatrix4fv(g_AttribLocationProjMtx, 1, GL_FALSE, &ortho_projection[0][0]);
-    if (glBindSampler) glBindSampler(0, 0); // We use combined texture/sampler state. Applications using GL 3.3 may set that otherwise.
-
+#ifdef GL_SAMPLER_BINDING
+    glBindSampler(0, 0); // We use combined texture/sampler state. Applications using GL 3.3 may set that otherwise.
+#endif
     // Recreate the VAO every time 
     // (This is to easily allow multiple GL contexts. VAO are not shared among GL contexts, and we don't track creation/deletion of windows so we don't have an obvious key to use to cache them.)
     GLuint vao_handle = 0;
@@ -220,7 +221,9 @@ void    ImGui_ImplOpenGL3_RenderDrawData(ImDrawData* draw_data)
     // Restore modified GL state
     glUseProgram(last_program);
     glBindTexture(GL_TEXTURE_2D, last_texture);
-    if (glBindSampler) glBindSampler(0, last_sampler);
+#ifdef GL_SAMPLER_BINDING
+    glBindSampler(0, last_sampler);
+#endif
     glActiveTexture(last_active_texture);
     glBindVertexArray(last_vertex_array);
     glBindBuffer(GL_ARRAY_BUFFER, last_array_buffer);


### PR DESCRIPTION
OpenGL ES (2.0/3.0) 

This fixes a pedantic compiler error and encapsulates better OpenGL ES API.

`if (glBindSampler) glBindSampler(0, 0);`

Fails on Clang5.0+ (C++17) with warning as errors:

> error: address of function 'glBindSampler' will always evaluate to 'true' [-Werror,-Wpointer-bool-conversion]

And equally the "fix":

`if (&glBindSampler) glBindSampler(0, 0);`

Will fail on GCC 8.1.0+ (and probably earlier)

> error: the address of '__glewBindSampler' will never be NULL [-Werror=address]

Using **#ifdef GL_SAMPLER_BINDING** fixes those errors.
