### PR TITLE
ID3D11Factory instead of ID3D11Factory1

### DIFF
--- a/examples/imgui_impl_dx11.cpp
+++ b/examples/imgui_impl_dx11.cpp
@@ -28,14 +28,14 @@
 // DirectX data
 static ID3D11Device*            g_pd3dDevice = NULL;
 static ID3D11DeviceContext*     g_pd3dDeviceContext = NULL;
-static IDXGIFactory1*           g_pFactory = NULL;
+static IDXGIFactory*            g_pFactory = NULL;
 static ID3D11Buffer*            g_pVB = NULL;
 static ID3D11Buffer*            g_pIB = NULL;
-static ID3D10Blob *             g_pVertexShaderBlob = NULL;
+static ID3D10Blob*              g_pVertexShaderBlob = NULL;
 static ID3D11VertexShader*      g_pVertexShader = NULL;
 static ID3D11InputLayout*       g_pInputLayout = NULL;
 static ID3D11Buffer*            g_pVertexConstantBuffer = NULL;
-static ID3D10Blob *             g_pPixelShaderBlob = NULL;
+static ID3D10Blob*              g_pPixelShaderBlob = NULL;
 static ID3D11PixelShader*       g_pPixelShader = NULL;
 static ID3D11SamplerState*      g_pFontSampler = NULL;
 static ID3D11ShaderResourceView*g_pFontTextureView = NULL;
@@ -471,7 +471,7 @@ bool    ImGui_ImplDX11_Init(ID3D11Device* device, ID3D11DeviceContext* device_co
     // Get factory from device
     IDXGIDevice* pDXGIDevice = NULL;
     IDXGIAdapter* pDXGIAdapter = NULL;
-    IDXGIFactory1* pFactory = NULL;
+    IDXGIFactory* pFactory = NULL;
 
     if (device->QueryInterface(IID_PPV_ARGS(&pDXGIDevice)) == S_OK)
         if (pDXGIDevice->GetParent(IID_PPV_ARGS(&pDXGIAdapter)) == S_OK)


### PR DESCRIPTION
While integrating the current version of ImGui, I kept failing the following assert of `ImGui::NewFrame` in my application:

`IM_ASSERT(g.IO.Fonts->Fonts.Size > 0 && "Font Atlas not built. Did you call io.Fonts >GetTexDataAsRGBA32() / GetTexDataAsAlpha8() ?");`

However, the actual cause is not directly related to fonts and font atlases, but rather to ImGui's provided D3D11 bindings. In the code below, the first two `if` conditions are true and the third one is false, resulting in no device, device context and factory bindings. This is the case for my application, but not for the demo application provided with ImGui.

```c++
bool    ImGui_ImplDX11_Init(ID3D11Device* device, ID3D11DeviceContext* device_context)
{
    // Get factory from device
    IDXGIDevice* pDXGIDevice = NULL;
    IDXGIAdapter* pDXGIAdapter = NULL;
    IDXGIFactory1* pFactory = NULL;

    if (device->QueryInterface(IID_PPV_ARGS(&pDXGIDevice)) == S_OK) // true
        if (pDXGIDevice->GetParent(IID_PPV_ARGS(&pDXGIAdapter)) == S_OK) // true
            if (pDXGIAdapter->GetParent(IID_PPV_ARGS(&pFactory)) == S_OK) // false
            {
                g_pd3dDevice = device;
                g_pd3dDeviceContext = device_context;
                g_pFactory = pFactory;
            }
    if (pDXGIDevice) pDXGIDevice->Release();
    if (pDXGIAdapter) pDXGIAdapter->Release();

    return true;
}
```

For obtaining a device and device context in my application, I go the other way around and start with a `IDXGIFactory` (whereas ImGui does use the default `IDXGIAdapter`). 

When I replace both occurrences of `IDXGIFactory1` with `IDXGIFactory` in `imgui_impl_dx11.cpp`, both my application and the provided demo application work correctly. This change is handled by this pull request. (Apparently, ImGui's provided D3D11 bindings do not really use the global variable `g_pFactory` at all. So I am not sure why there is such a variable in the first place and why it needs to be of type `IDXGIFactory1`?)