### PR TITLE
Numeric keypad enter is enabled on glfw

### DIFF
--- a/examples/imgui_impl_glfw.cpp
+++ b/examples/imgui_impl_glfw.cpp
@@ -135,6 +135,7 @@ static bool ImGui_ImplGlfw_Init(GLFWwindow* window, bool install_callbacks, Glfw
     io.KeyMap[ImGuiKey_Backspace] = GLFW_KEY_BACKSPACE;
     io.KeyMap[ImGuiKey_Space] = GLFW_KEY_SPACE;
     io.KeyMap[ImGuiKey_Enter] = GLFW_KEY_ENTER;
+    io.KeyMap[ImGuiKey_NumericEnter] = GLFW_KEY_KP_ENTER;
     io.KeyMap[ImGuiKey_Escape] = GLFW_KEY_ESCAPE;
     io.KeyMap[ImGuiKey_A] = GLFW_KEY_A;
     io.KeyMap[ImGuiKey_C] = GLFW_KEY_C;

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -10917,7 +10917,7 @@ bool ImGui::InputTextEx(const char* label, char* buf, int buf_size, const ImVec2
             }
             edit_state.OnKeyPressed(STB_TEXTEDIT_K_BACKSPACE | k_mask);
         }
-        else if (IsKeyPressedMap(ImGuiKey_Enter))
+        else if (IsKeyPressedMap(ImGuiKey_Enter) || IsKeyPressedMap(ImGuiKey_NumericEnter))
         {
             bool ctrl_enter_for_new_line = (flags & ImGuiInputTextFlags_CtrlEnterForNewLine) != 0;
             if (!is_multiline || (ctrl_enter_for_new_line && !io.KeyCtrl) || (!ctrl_enter_for_new_line && io.KeyCtrl))

--- a/imgui.h
+++ b/imgui.h
@@ -793,6 +793,7 @@ enum ImGuiKey_
     ImGuiKey_Backspace,
     ImGuiKey_Space,
     ImGuiKey_Enter,
+    ImGuiKey_NumericEnter,
     ImGuiKey_Escape,
     ImGuiKey_A,         // for text edit CTRL+A: select all
     ImGuiKey_C,         // for text edit CTRL+C: copy


### PR DESCRIPTION
Numeric keypad enter was disabled on glfw

It is enabled on Win32 + DirectX
It is disabled on glfw + OpenGL
Numeric keypad numbers are enabled on both platforms.

So I make numeric keypad enter enabled.
