### PR TITLE
Don't redefine WIN32_LEAN_AND_MEAN if already defined

### DIFF
--- a/examples/imgui_impl_win32.cpp
+++ b/examples/imgui_impl_win32.cpp
@@ -8,7 +8,9 @@
 
 #include "imgui.h"
 #include "imgui_impl_win32.h"
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 #include <tchar.h>
 


### PR DESCRIPTION
It is difficult to consume imgui_impl_win32.cpp directly if WIN32_LEAN_AND_MEAN is already defined in the project.  This adds a simple check to see if it is already defined before defining it.