### PR TITLE
Cast to ImTextureID instead of void* to enable redefinition of ImText…

### DIFF
--- a/examples/imgui_impl_dx12.cpp
+++ b/examples/imgui_impl_dx12.cpp
@@ -365,7 +365,7 @@ static void ImGui_ImplDX12_CreateFontsTexture()
 
     // Store our identifier
     static_assert(sizeof(ImTextureID) >= sizeof(g_hFontSrvGpuDescHandle.ptr), "Can't pack descriptor handle into TexID, 32-bit not supported yet.");
-    io.Fonts->TexID = (void *)g_hFontSrvGpuDescHandle.ptr;
+    io.Fonts->TexID = (ImTextureID)g_hFontSrvGpuDescHandle.ptr;
 }
 
 bool    ImGui_ImplDX12_CreateDeviceObjects()


### PR DESCRIPTION
imgui.h is set up to enable custom defines of ImTextureID, but imgui_impl_dx12.cpp casts directly to void* instead of whatever ImTextureID has been defined as.  Changing this enables building in 32-bit by defining ImTextureID as UINT64.