### PR TITLE
Examples: add Gtk3/OpenGL3 example

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -33,6 +33,7 @@ example_glfw_opengl2/example_glfw_opengl2
 example_glfw_opengl3/example_glfw_opengl3
 example_sdl_opengl2/example_sdl_opengl2
 example_sdl_opengl3/example_sdl_opengl3
+example_gtk3_opengl3/example_gtk3_opengl3
 
 ## Dear ImGui Ini files
 imgui.ini

--- a/examples/example_gtk3_opengl3/Makefile
+++ b/examples/example_gtk3_opengl3/Makefile
@@ -1,0 +1,48 @@
+#
+# You will need GTK+ 3.0 :
+# Linux:
+#   apt-get install libgtk-3-dev
+#
+
+#CXX = g++
+#CXX = clang++
+
+EXE = example_gtk3_opengl3
+SOURCES = main.cpp
+SOURCES += ../imgui_impl_gtk3.cpp ../imgui_impl_opengl3.cpp
+SOURCES += ../../imgui.cpp ../../imgui_demo.cpp ../../imgui_draw.cpp ../../imgui_widgets.cpp
+SOURCES += ../libs/gl3w/GL/gl3w.c
+OBJS = $(addsuffix .o, $(basename $(notdir $(SOURCES))))
+
+UNAME_S := $(shell uname -s)
+
+
+ifeq ($(UNAME_S), Linux) #LINUX
+	ECHO_MESSAGE = "Linux"
+	LIBS = -lGL `pkg-config --libs gtk+-3.0 epoxy` -ldl
+
+	CXXFLAGS = -I../ -I../../ -I../libs/gl3w `pkg-config --cflags gtk+-3.0`
+	CXXFLAGS += -Wall -Wformat -Wno-deprecated-declarations -Wno-parentheses
+	CFLAGS = $(CXXFLAGS)
+endif
+
+%.o:%.cpp
+	$(CXX) $(CXXFLAGS) -c -o $@ $<
+
+%.o:../%.cpp
+	$(CXX) $(CXXFLAGS) -c -o $@ $<
+
+%.o:../../%.cpp
+	$(CXX) $(CXXFLAGS) -c -o $@ $<
+
+%.o:../libs/gl3w/GL/%.c
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+all: $(EXE)
+	@echo Build complete for $(ECHO_MESSAGE)
+
+$(EXE): $(OBJS)
+	$(CXX) -o $@ $^ $(CXXFLAGS) $(LIBS)
+
+clean:
+	rm -f $(EXE) $(OBJS)

--- a/examples/example_gtk3_opengl3/main.cpp
+++ b/examples/example_gtk3_opengl3/main.cpp
@@ -1,0 +1,167 @@
+// ImGui - standalone example application for GLFW + OpenGL 3, using programmable pipeline
+// If you are new to ImGui, see examples/README.txt and documentation at the top of imgui.cpp.
+// (GLFW is a cross-platform general purpose library for handling windows, inputs, OpenGL/Vulkan graphics context creation, etc.)
+// (GL3W is a helper library to access OpenGL functions since there is no standard header to access modern OpenGL functions easily. Alternatives are GLEW, Glad, etc.)
+
+#include "imgui.h"
+#include "imgui_impl_gtk3.h"
+#include "imgui_impl_opengl3.h"
+#include <stdio.h>
+
+// About OpenGL function loaders: modern OpenGL doesn't have a standard header file and requires individual function pointers to be loaded manually.
+// Helper libraries are often used for this purpose! Here we are supporting a few common ones: gl3w, glew, glad.
+// You may use another loader/header of your choice (glext, glLoadGen, etc.), or chose to manually implement your own.
+#if defined(IMGUI_IMPL_OPENGL_LOADER_GL3W)
+#include <GL/gl3w.h>    // Initialize with gl3wInit()
+#elif defined(IMGUI_IMPL_OPENGL_LOADER_GLEW)
+#include <GL/glew.h>    // Initialize with glewInit()
+#elif defined(IMGUI_IMPL_OPENGL_LOADER_GLAD)
+#include <glad/glad.h>  // Initialize with gladLoadGL()
+#else
+#include IMGUI_IMPL_OPENGL_LOADER_CUSTOM
+#endif
+
+#include <gtk/gtk.h>
+
+static gboolean render_area(GtkGLArea* area, GdkGLContext* context)
+{
+    static bool show_demo_window = true;
+    static bool show_another_window = false;
+    static ImVec4 clear_color = ImVec4(0.45f, 0.55f, 0.60f, 1.00f);
+
+    // Start the Dear ImGui frame
+    ImGui_ImplOpenGL3_NewFrame();
+    ImGui_ImplGtk3_NewFrame();
+    ImGui::NewFrame();
+
+    // 1. Show the big demo window (Most of the sample code is in ImGui::ShowDemoWindow()! You can browse its code to learn more about Dear ImGui!).
+    if (show_demo_window)
+        ImGui::ShowDemoWindow(&show_demo_window);
+
+    // 2. Show a simple window that we create ourselves. We use a Begin/End pair to created a named window.
+    {
+        static float f = 0.0f;
+        static int counter = 0;
+
+        ImGui::Begin("Hello, world!");                          // Create a window called "Hello, world!" and append into it.
+
+        ImGui::Text("This is some useful text.");               // Display some text (you can use a format strings too)
+        ImGui::Checkbox("Demo Window", &show_demo_window);      // Edit bools storing our window open/close state
+        ImGui::Checkbox("Another Window", &show_another_window);
+
+        ImGui::SliderFloat("float", &f, 0.0f, 1.0f);            // Edit 1 float using a slider from 0.0f to 1.0f
+        ImGui::ColorEdit3("clear color", (float*)&clear_color); // Edit 3 floats representing a color
+
+        if (ImGui::Button("Button"))                            // Buttons return true when clicked (most widgets return true when edited/activated)
+            counter++;
+        ImGui::SameLine();
+        ImGui::Text("counter = %d", counter);
+
+        ImGui::Text("Application average %.3f ms/frame (%.1f FPS)", 1000.0f / ImGui::GetIO().Framerate, ImGui::GetIO().Framerate);
+        ImGui::End();
+    }
+
+    // 3. Show another simple window.
+    if (show_another_window)
+    {
+        ImGui::Begin("Another Window", &show_another_window);   // Pass a pointer to our bool variable (the window will have a closing button that will clear the bool when clicked)
+        ImGui::Text("Hello from another window!");
+        if (ImGui::Button("Close Me"))
+            show_another_window = false;
+        ImGui::End();
+    }
+
+    // Rendering
+    ImGui::Render();
+    glClearColor(clear_color.x, clear_color.y, clear_color.z, clear_color.w);
+    glClear(GL_COLOR_BUFFER_BIT);
+    ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+
+    // Queue another rendering request.
+    gtk_gl_area_queue_render(area);
+
+    return TRUE;
+}
+
+static void realize_area(GtkGLArea* area)
+{
+    // Setup Dear ImGui binding
+    IMGUI_CHECKVERSION();
+    ImGui::CreateContext();
+    ImGuiIO& io = ImGui::GetIO(); (void)io;
+    //io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;  // Enable Keyboard Controls
+    //io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;   // Enable Gamepad Controls
+
+    ImGui_ImplGtk3_Init(GTK_WIDGET(area), true);
+    ImGui_ImplOpenGL3_Init("#version 130");
+
+    // Setup style
+    ImGui::StyleColorsDark();
+    //ImGui::StyleColorsClassic();
+
+    // Load Fonts
+    // - If no fonts are loaded, dear imgui will use the default font. You can also load multiple fonts and use ImGui::PushFont()/PopFont() to select them.
+    // - AddFontFromFileTTF() will return the ImFont* so you can store it if you need to select the font among multiple.
+    // - If the file cannot be loaded, the function will return NULL. Please handle those errors in your application (e.g. use an assertion, or display an error and quit).
+    // - The fonts will be rasterized at a given size (w/ oversampling) and stored into a texture when calling ImFontAtlas::Build()/GetTexDataAsXXXX(), which ImGui_ImplXXXX_NewFrame below will call.
+    // - Read 'misc/fonts/README.txt' for more instructions and details.
+    // - Remember that in C/C++ if you want to include a backslash \ in a string literal you need to write a double backslash \\ !
+    //io.Fonts->AddFontDefault();
+    //io.Fonts->AddFontFromFileTTF("../../misc/fonts/Roboto-Medium.ttf", 16.0f);
+    //io.Fonts->AddFontFromFileTTF("../../misc/fonts/Cousine-Regular.ttf", 15.0f);
+    //io.Fonts->AddFontFromFileTTF("../../misc/fonts/DroidSans.ttf", 16.0f);
+    //io.Fonts->AddFontFromFileTTF("../../misc/fonts/ProggyTiny.ttf", 10.0f);
+    //ImFont* font = io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\ArialUni.ttf", 18.0f, NULL, io.Fonts->GetGlyphRangesJapanese());
+    //IM_ASSERT(font != NULL);
+}
+
+static void unrealize_area(GtkGLArea* area)
+{
+    gtk_gl_area_make_current(area);
+
+    // Cleanup
+    ImGui_ImplOpenGL3_Shutdown();
+    ImGui_ImplGtk3_Shutdown();
+    ImGui::DestroyContext();
+}
+
+int main(int argc, char** argv)
+{
+    gtk_init(&argc, &argv);
+
+    // Create window with graphics context
+    GtkWidget* window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+    gtk_window_set_title(GTK_WINDOW(window), "Dear ImGui GTK+3 & OpenGL3 example");
+    g_signal_connect(window, "delete-event", G_CALLBACK(gtk_main_quit), NULL);
+    gtk_window_resize(GTK_WINDOW(window), 1280, 720);
+
+    GtkWidget* gl_area = gtk_gl_area_new();
+    gtk_gl_area_set_auto_render(GTK_GL_AREA(gl_area), TRUE);
+    g_signal_connect(gl_area, "realize", G_CALLBACK(realize_area), NULL);
+    g_signal_connect(gl_area, "unrealize", G_CALLBACK(unrealize_area), NULL);
+    g_signal_connect(gl_area, "render", G_CALLBACK(render_area), NULL);
+    gtk_container_add(GTK_CONTAINER(window), gl_area);
+
+    gtk_widget_show_all(window);
+
+    gtk_gl_area_make_current(GTK_GL_AREA(gl_area));
+
+    // Initialize OpenGL loader
+#if defined(IMGUI_IMPL_OPENGL_LOADER_GL3W)
+    bool err = gl3wInit() != 0;
+#elif defined(IMGUI_IMPL_OPENGL_LOADER_GLEW)
+    bool err = glewInit() != GLEW_OK;
+#elif defined(IMGUI_IMPL_OPENGL_LOADER_GLAD)
+    bool err = gladLoadGL() != 0;
+#endif
+    if (err)
+    {
+        fprintf(stderr, "Failed to initialize OpenGL loader!\n");
+        return 1;
+    }
+
+    // Main loop
+    gtk_main();
+
+    return 0;
+}

--- a/examples/imgui_impl_gtk3.cpp
+++ b/examples/imgui_impl_gtk3.cpp
@@ -1,0 +1,279 @@
+// ImGui Platform Binding for: Gtk+ 3.x
+// This needs to be used along with the OpenGL3 Renderer
+
+// Implemented features:
+//  [X] Platform: Clipboard support.
+//  [X] Platform: Mouse cursor shape and visibility. Disable with 'io.ConfigFlags |= ImGuiConfigFlags_NoMouseCursorChange'.
+//  [X] Platform: Keyboard arrays indexed using GDK_KEY_* codes, e.g. ImGui::IsKeyPressed(GDK_KEY_space).
+
+// You can copy and use unmodified imgui_impl_* files in your project. See main.cpp for an example of using this.
+// If you are new to dear imgui, read examples/README.txt and read the documentation at the top of imgui.cpp.
+// https://github.com/ocornut/imgui
+
+#include <imgui.h>
+#include "imgui_impl_gtk3.h"
+
+#include <gtk/gtk.h>
+
+#define EVENT_MASK                              \
+    ((GdkEventMask)                             \
+     (GDK_STRUCTURE_MASK |                      \
+      GDK_FOCUS_CHANGE_MASK |                   \
+      GDK_EXPOSURE_MASK |                       \
+      GDK_PROPERTY_CHANGE_MASK |                \
+      GDK_ENTER_NOTIFY_MASK |                   \
+      GDK_LEAVE_NOTIFY_MASK |                   \
+      GDK_KEY_PRESS_MASK |                      \
+      GDK_KEY_RELEASE_MASK |                    \
+      GDK_BUTTON_PRESS_MASK |                   \
+      GDK_BUTTON_RELEASE_MASK |                 \
+      GDK_POINTER_MOTION_MASK |                 \
+      GDK_SMOOTH_SCROLL_MASK |                  \
+      GDK_SCROLL_MASK))
+
+// Data
+static GtkWidget*       g_GtkGlArea = NULL;
+static guint64          g_Time = 0;
+static bool             g_MousePressed[5] = { false, false, false, false, false };
+static ImVec2           g_MousePosition = ImVec2(-FLT_MAX, -FLT_MAX);
+static float            g_MouseWheel = 0.0f;
+static const char*      g_MouseCursors[ImGuiMouseCursor_COUNT] = { NULL };
+
+static const char* ImGui_ImplGtk3_GetClipboardText(void* user_data)
+{
+    static char* last_clipboard = NULL;
+
+    g_clear_pointer(&last_clipboard, g_free);
+    last_clipboard = gtk_clipboard_wait_for_text(GTK_CLIPBOARD(user_data));
+    return last_clipboard;
+}
+
+static void ImGui_ImplGtk3_SetClipboardText(void* user_data, const char* text)
+{
+    gtk_clipboard_set_text(GTK_CLIPBOARD(user_data), text, -1);
+}
+
+void   ImGui_ImplGtk3_HandleEvent(GdkEvent* event)
+{
+    ImGuiIO& io = ImGui::GetIO();
+
+    GdkEventType type = gdk_event_get_event_type(event);
+    switch (type)
+    {
+    case GDK_MOTION_NOTIFY:
+    {
+        gdouble x = 0.0f, y = 0.0f;
+        if (gdk_event_get_coords(event, &x, &y))
+            g_MousePosition = ImVec2(x, y);
+        break;
+    }
+    case GDK_BUTTON_PRESS:
+    case GDK_BUTTON_RELEASE:
+    {
+        guint button = 0;
+        if (gdk_event_get_button(event, &button) && button > 0 && button <= 5)
+        {
+            if (type == GDK_BUTTON_PRESS)
+                g_MousePressed[button - 1] = true;
+        }
+        break;
+    }
+    case GDK_SCROLL:
+    {
+        gdouble x, y;
+        if (gdk_event_get_scroll_deltas(event, &x, &y))
+            g_MouseWheel = -y;
+        break;
+    }
+    case GDK_KEY_PRESS:
+    case GDK_KEY_RELEASE:
+    {
+        GdkEventKey* e = (GdkEventKey* ) event;
+
+        static const struct
+        {
+            enum ImGuiKey_ imgui;
+            guint gdk;
+        } gdk_key_to_imgui_key[] =
+              {
+                  { ImGuiKey_Tab, GDK_KEY_Tab },
+                  { ImGuiKey_Tab, GDK_KEY_ISO_Left_Tab },
+                  { ImGuiKey_LeftArrow, GDK_KEY_Left },
+                  { ImGuiKey_RightArrow, GDK_KEY_Right },
+                  { ImGuiKey_UpArrow, GDK_KEY_Up },
+                  { ImGuiKey_DownArrow, GDK_KEY_Down },
+                  { ImGuiKey_PageUp, GDK_KEY_Page_Up },
+                  { ImGuiKey_PageDown, GDK_KEY_Page_Down },
+                  { ImGuiKey_Home, GDK_KEY_Home },
+                  { ImGuiKey_End, GDK_KEY_End },
+                  { ImGuiKey_Delete, GDK_KEY_Delete },
+                  { ImGuiKey_Backspace, GDK_KEY_BackSpace },
+                  { ImGuiKey_Enter, GDK_KEY_Return },
+                  { ImGuiKey_Escape, GDK_KEY_Escape },
+                  { ImGuiKey_A, GDK_KEY_a },
+                  { ImGuiKey_C, GDK_KEY_c },
+                  { ImGuiKey_V, GDK_KEY_v },
+                  { ImGuiKey_X, GDK_KEY_x },
+                  { ImGuiKey_Y, GDK_KEY_y },
+                  { ImGuiKey_Z, GDK_KEY_z },
+              };
+        for (unsigned i = 0; i < G_N_ELEMENTS(gdk_key_to_imgui_key); i++)
+        {
+            if (e->keyval == gdk_key_to_imgui_key[i].gdk)
+                io.KeysDown[gdk_key_to_imgui_key[i].imgui] = type == GDK_KEY_PRESS;
+        }
+        if (e->keyval >= ImGuiKey_COUNT && e->keyval < G_N_ELEMENTS(io.KeysDown))
+            io.KeysDown[e->keyval] = type == GDK_KEY_PRESS;
+
+        if (type == GDK_KEY_PRESS && e->string)
+            io.AddInputCharactersUTF8(e->string);
+
+        struct {
+            bool* var;
+            GdkModifierType modifier;
+            guint keyvals[3];
+        } mods[] = {
+            { &io.KeyCtrl, GDK_CONTROL_MASK,
+              { GDK_KEY_Control_L, GDK_KEY_Control_R, 0 }, },
+            { &io.KeyShift, GDK_SHIFT_MASK,
+              { GDK_KEY_Shift_L, GDK_KEY_Shift_R, 0 }, },
+            { &io.KeyAlt, GDK_MOD1_MASK,
+              { GDK_KEY_Alt_L, GDK_KEY_Alt_R, 0 }, },
+            { &io.KeySuper, GDK_SUPER_MASK,
+              { GDK_KEY_Super_L, GDK_KEY_Super_R, 0 }, }
+        };
+        for (unsigned i = 0; i < G_N_ELEMENTS(mods); i++)
+        {
+            *mods[i].var = (mods[i].modifier & e->state);
+
+            bool match = false;
+            for (int j = 0; mods[i].keyvals[j] != 0; j++)
+                if (e->keyval == mods[i].keyvals[j])
+                    match = true;
+
+            if (match)
+                *mods[i].var = type == GDK_KEY_PRESS;
+        }
+        break;
+    }
+    default:
+        break;
+    }
+
+    gtk_gl_area_queue_render(GTK_GL_AREA(g_GtkGlArea));
+    //gtk_widget_queue_draw(g_GtkGlArea);
+}
+
+static gboolean handle_gdk_event(GtkWidget* widget, GdkEvent* event, void* data)
+{
+    ImGui_ImplGtk3_HandleEvent(event);
+    return TRUE;
+}
+
+bool ImGui_ImplGtk3_Init(GtkWidget* gl_area, bool install_callbacks)
+{
+    g_clear_pointer(&g_GtkGlArea, g_object_unref);
+
+    g_GtkGlArea = GTK_WIDGET(g_object_ref(gl_area));
+    gtk_widget_realize(g_GtkGlArea);
+    gtk_widget_set_can_focus(g_GtkGlArea, TRUE);
+    gtk_widget_grab_focus(g_GtkGlArea);
+
+    if (install_callbacks) {
+        gtk_widget_add_events(g_GtkGlArea, EVENT_MASK);
+        g_signal_connect(g_GtkGlArea, "event", G_CALLBACK(handle_gdk_event), NULL);
+    }
+
+    ImGuiIO& io = ImGui::GetIO();
+    for (int i = 0; i < ImGuiKey_COUNT; i++)
+    {
+        io.KeyMap[i] = i;
+    }
+
+    io.SetClipboardTextFn = ImGui_ImplGtk3_SetClipboardText;
+    io.GetClipboardTextFn = ImGui_ImplGtk3_GetClipboardText;
+    io.ClipboardUserData = gtk_widget_get_clipboard(g_GtkGlArea,
+                                                    GDK_SELECTION_CLIPBOARD);
+
+    g_MouseCursors[ImGuiMouseCursor_Arrow] = "default";
+    g_MouseCursors[ImGuiMouseCursor_TextInput] = "text";
+    g_MouseCursors[ImGuiMouseCursor_ResizeAll] = "all-scroll"; // TODO?: Looks good enough
+    g_MouseCursors[ImGuiMouseCursor_ResizeNS] = "ns-resize";
+    g_MouseCursors[ImGuiMouseCursor_ResizeEW] = "ew-resize";
+    g_MouseCursors[ImGuiMouseCursor_ResizeNESW] = "nesw-resize";
+    g_MouseCursors[ImGuiMouseCursor_ResizeNWSE] = "nwse-resize";
+    g_MouseCursors[ImGuiMouseCursor_Hand] = "grab";
+
+    return true;
+}
+
+void ImGui_ImplGtk3_Shutdown()
+{
+    g_clear_pointer(&g_GtkGlArea, g_object_unref);
+}
+
+static void ImGui_ImplGtk3_UpdateMouseCursor(GdkWindow* window)
+{
+    ImGuiIO& io = ImGui::GetIO();
+    if (io.ConfigFlags & ImGuiConfigFlags_NoMouseCursorChange)
+        return;
+
+    GdkDisplay* display = gdk_window_get_display(window);
+    const char *cursor_name;
+
+    ImGuiMouseCursor imgui_cursor = ImGui::GetMouseCursor();
+    if (imgui_cursor == ImGuiMouseCursor_None || io.MouseDrawCursor)
+    {
+        cursor_name = "none";
+    }
+    else
+    {
+        cursor_name = g_MouseCursors[imgui_cursor] ? g_MouseCursors[imgui_cursor] : g_MouseCursors[ImGuiMouseCursor_Arrow];
+    }
+
+    GdkCursor* cursor = gdk_cursor_new_from_name(display, cursor_name);
+    gdk_window_set_cursor(window, cursor);
+    g_object_unref(cursor);
+}
+
+void ImGui_ImplGtk3_NewFrame()
+{
+    ImGuiIO& io = ImGui::GetIO();
+
+    // Setup display size (every frame to accommodate for window resizing)
+    io.DisplaySize = ImVec2((float)gtk_widget_get_allocated_width(g_GtkGlArea),
+                            (float)gtk_widget_get_allocated_height(g_GtkGlArea));
+    int scale_factor = gtk_widget_get_scale_factor(g_GtkGlArea);
+    io.DisplayFramebufferScale = ImVec2(scale_factor, scale_factor);
+
+    // Setup time step
+    guint64 current_time =  g_get_monotonic_time();
+    io.DeltaTime = g_Time > 0 ? ((float)(current_time - g_Time) / 1000000) : (float)(1.0f/60.0f);
+    g_Time = current_time;
+
+    // Setup inputs
+    if (gtk_widget_has_focus(g_GtkGlArea))
+    {
+        io.MousePos = g_MousePosition;   // Mouse position in screen coordinates (set to -1,-1 if no mouse / on another screen, etc.)
+    }
+    else
+    {
+        io.MousePos = ImVec2(-FLT_MAX, -FLT_MAX);
+    }
+
+    GdkWindow* window = gtk_widget_get_window(g_GtkGlArea);
+    GdkDevice* pointer = gdk_device_manager_get_client_pointer(gdk_display_get_device_manager(gdk_display_get_default()));
+    GdkModifierType modifiers;
+    gdk_device_get_state(pointer, window, NULL, &modifiers);
+
+    for (int i = 0; i < 3; i++)
+    {
+        io.MouseDown[i] = g_MousePressed[i] || (modifiers & (GDK_BUTTON1_MASK << i)) != 0;
+        g_MousePressed[i] = false;
+    }
+
+    io.MouseWheel = g_MouseWheel;
+    g_MouseWheel = 0.0f;
+
+    ImGui_ImplGtk3_UpdateMouseCursor(window);
+}

--- a/examples/imgui_impl_gtk3.h
+++ b/examples/imgui_impl_gtk3.h
@@ -1,0 +1,20 @@
+// ImGui Platform Binding for: Gtk+ 3.x
+// This needs to be used along with the OpenGL3 Renderer
+
+// Implemented features:
+//  [X] Platform: Clipboard support.
+//  [X] Platform: Mouse cursor shape and visibility. Disable with 'io.ConfigFlags |= ImGuiConfigFlags_NoMouseCursorChange'.
+//  [X] Platform: Keyboard arrays indexed using GDK_KEY_* codes, e.g. ImGui::IsKeyPressed(GDK_KEY_space).
+
+// You can copy and use unmodified imgui_impl_* files in your project. See main.cpp for an example of using this.
+// If you are new to dear imgui, read examples/README.txt and read the documentation at the top of imgui.cpp.
+// https://github.com/ocornut/imgui
+
+typedef struct _GtkWidget GtkWidget;
+typedef union  _GdkEvent  GdkEvent;
+
+IMGUI_API bool          ImGui_ImplGtk3_Init(GtkWidget* gl_area, bool install_callbacks);
+IMGUI_API void          ImGui_ImplGtk3_HandleEvent(GdkEvent* event);
+
+IMGUI_API void          ImGui_ImplGtk3_Shutdown();
+IMGUI_API void          ImGui_ImplGtk3_NewFrame();


### PR DESCRIPTION
I've been using different flavors of Gtk3 bindings on Desktop/Linux so that I can have some level of integration with the window manager (i.e client side decoration on Wayland, retina displays, etc...).
I figured somebody might want to reuse that, so here is a PR that reuses the existing OpenGL3 rendering implementation and just sets up the window system through GTK+.

The makefile only supports Linux but I'm pretty sure someone could add support for MacOS/Windows in a few lines (unfortunately I don't have such systems).