### PR TITLE
Add editor config for 4 spaces instead of tab.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Default settings:
+# Use 4 spaces as indentation
+[*]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
Allow automatic enforcement of spacing rule for supported editors. I use tabs in my code and this makes it so I don't have to think about it.