### PR TITLE
Added angle_offset for rotating hexagon like circles.

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -24,7 +24,7 @@
 // Version
 // (Integer encoded as XYYZZ for use in #if preprocessor conditionals. Work in progress versions typically starts at XYY00 then bounced up to XYY01 when release tagging happens)
 #define IMGUI_VERSION               "1.63 WIP"
-#define IMGUI_VERSION_NUM           16300 
+#define IMGUI_VERSION_NUM           16300
 #define IMGUI_CHECKVERSION()        ImGui::DebugCheckVersionAndDataLayout(IMGUI_VERSION, sizeof(ImGuiIO), sizeof(ImGuiStyle), sizeof(ImVec2), sizeof(ImVec4), sizeof(ImDrawVert))
 
 // Define attributes of all API symbols declarations (e.g. for DLL under Windows)
@@ -1675,8 +1675,8 @@ struct ImDrawList
     IMGUI_API void  AddQuadFilled(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& d, ImU32 col);
     IMGUI_API void  AddTriangle(const ImVec2& a, const ImVec2& b, const ImVec2& c, ImU32 col, float thickness = 1.0f);
     IMGUI_API void  AddTriangleFilled(const ImVec2& a, const ImVec2& b, const ImVec2& c, ImU32 col);
-    IMGUI_API void  AddCircle(const ImVec2& centre, float radius, ImU32 col, int num_segments = 12, float thickness = 1.0f);
-    IMGUI_API void  AddCircleFilled(const ImVec2& centre, float radius, ImU32 col, int num_segments = 12);
+    IMGUI_API void  AddCircle(const ImVec2& centre, float radius, ImU32 col, int num_segments = 12, float thickness = 1.0f, float angle_offset=0.0f);
+    IMGUI_API void  AddCircleFilled(const ImVec2& centre, float radius, ImU32 col, int num_segments = 12, float angle_offset=0.0f);
     IMGUI_API void  AddText(const ImVec2& pos, ImU32 col, const char* text_begin, const char* text_end = NULL);
     IMGUI_API void  AddText(const ImFont* font, float font_size, const ImVec2& pos, ImU32 col, const char* text_begin, const char* text_end = NULL, float wrap_width = 0.0f, const ImVec4* cpu_fine_clip_rect = NULL);
     IMGUI_API void  AddImage(ImTextureID user_texture_id, const ImVec2& a, const ImVec2& b, const ImVec2& uv_a = ImVec2(0,0), const ImVec2& uv_b = ImVec2(1,1), ImU32 col = 0xFFFFFFFF);

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -1096,23 +1096,23 @@ void ImDrawList::AddTriangleFilled(const ImVec2& a, const ImVec2& b, const ImVec
     PathFillConvex(col);
 }
 
-void ImDrawList::AddCircle(const ImVec2& centre, float radius, ImU32 col, int num_segments, float thickness)
+void ImDrawList::AddCircle(const ImVec2& centre, float radius, ImU32 col, int num_segments, float thickness, float angle_offset)
 {
     if ((col & IM_COL32_A_MASK) == 0)
         return;
 
     const float a_max = IM_PI*2.0f * ((float)num_segments - 1.0f) / (float)num_segments;
-    PathArcTo(centre, radius-0.5f, 0.0f, a_max, num_segments);
+    PathArcTo(centre, radius-0.5f, angle_offset, a_max + angle_offset, num_segments);
     PathStroke(col, true, thickness);
 }
 
-void ImDrawList::AddCircleFilled(const ImVec2& centre, float radius, ImU32 col, int num_segments)
+void ImDrawList::AddCircleFilled(const ImVec2& centre, float radius, ImU32 col, int num_segments, float angle_offset)
 {
     if ((col & IM_COL32_A_MASK) == 0)
         return;
 
     const float a_max = IM_PI*2.0f * ((float)num_segments - 1.0f) / (float)num_segments;
-    PathArcTo(centre, radius, 0.0f, a_max, num_segments);
+    PathArcTo(centre, radius, angle_offset, a_max + angle_offset, num_segments);
     PathFillConvex(col);
 }
 


### PR DESCRIPTION
For certain rotating widgets, like [knobs](https://github.com/ocornut/imgui/issues/942#issuecomment-268369298), it might be preferable to reduce the line segments in the controlling circle and have the cube/hexagon/not-circle shape rotate along with the value, so in the case of the knob it looks more like a knob being turned than a line being rotated.

From this:
![image](https://user-images.githubusercontent.com/1352934/44604926-c9386380-a7e7-11e8-9ccf-9220046e4427.png)

To this:
![image](https://user-images.githubusercontent.com/1352934/44604960-ea00b900-a7e7-11e8-8291-284ae29e74bc.png)

( the effect is kinda hard to display without a gif but I currently have no good way to capture gifs. sorry)

The pull request adds a angle_offset in radians, defaulted to 0 as a new last argument in to AddCircle and AddCircleFilled.
