### PR TITLE
Fix GLAD error condition

### DIFF
--- a/examples/example_sdl_opengl3/main.cpp
+++ b/examples/example_sdl_opengl3/main.cpp
@@ -64,7 +64,7 @@ int main(int, char**)
 #elif defined(IMGUI_IMPL_OPENGL_LOADER_GLEW)
     bool err = glewInit() != GLEW_OK;
 #elif defined(IMGUI_IMPL_OPENGL_LOADER_GLAD)
-    bool err = gladLoadGL() != 0;
+    bool err = gladLoadGL() == 0;
 #endif
     if (err)
     {


### PR DESCRIPTION
`gladLoadGL` returns 0 on fail, not the other way around.

Excerpt from `glad.c` generated by [the oficial site](https://glad.dav1d.de):

```c++
glGetString = (PFNGLGETSTRINGPROC)load("glGetString");
if(glGetString == NULL) return 0;
if(glGetString(GL_VERSION) == NULL) return 0;
	
// ...

if (!find_extensionsGL()) return 0;
return GLVersion.major != 0 || GLVersion.minor != 0;
```
