### PR TITLE
Remove bad looking Separator @ Color Edit widget

### DIFF
--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -3918,11 +3918,10 @@ bool ImGui::ColorEdit4(const char* label, float col[4], ImGuiColorEditFlags flag
         if (BeginPopup("picker"))
         {
             picker_active_window = g.CurrentWindow;
+
             if (label != label_display_end)
-            {
                 TextUnformatted(label, label_display_end);
-                Separator();
-            }
+
             ImGuiColorEditFlags picker_flags_to_forward = ImGuiColorEditFlags__DataTypeMask | ImGuiColorEditFlags__PickerMask | ImGuiColorEditFlags_HDR | ImGuiColorEditFlags_NoAlpha | ImGuiColorEditFlags_AlphaBar;
             ImGuiColorEditFlags picker_flags = (flags_untouched & picker_flags_to_forward) | ImGuiColorEditFlags__InputsMask | ImGuiColorEditFlags_NoLabel | ImGuiColorEditFlags_AlphaPreviewHalf;
             PushItemWidth(square_sz * 12.0f); // Use 256 + bar sizes?


### PR DESCRIPTION
This **Separator** looks bad and it's useless in my opinion.
It would look much better without it, what do you think?

**1.** With Separator

![1](https://user-images.githubusercontent.com/9334579/45253081-c3a35780-b369-11e8-9024-9b325a311f54.png)

**2.** Without Separator

![2](https://user-images.githubusercontent.com/9334579/45253082-c3a35780-b369-11e8-9cfb-cc7842c0fd14.png)
