### PR TITLE
Added Support for Changing the Number of BackBuffers Live Update

### DIFF
--- a/examples/example_glfw_vulkan/example_glfw_vulkan.vcxproj
+++ b/examples/example_glfw_vulkan/example_glfw_vulkan.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -153,6 +153,7 @@
     <ClCompile Include="..\..\imgui.cpp" />
     <ClCompile Include="..\..\imgui_demo.cpp" />
     <ClCompile Include="..\..\imgui_draw.cpp" />
+    <ClCompile Include="..\..\imgui_widgets.cpp" />
     <ClCompile Include="..\imgui_impl_glfw.cpp" />
     <ClCompile Include="..\imgui_impl_vulkan.cpp" />
     <ClCompile Include="main.cpp" />

--- a/examples/example_glfw_vulkan/example_glfw_vulkan.vcxproj.filters
+++ b/examples/example_glfw_vulkan/example_glfw_vulkan.vcxproj.filters
@@ -28,6 +28,9 @@
     <ClCompile Include="..\imgui_impl_vulkan.cpp">
       <Filter>sources</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\imgui_widgets.cpp">
+      <Filter>imgui</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\imconfig.h">

--- a/examples/example_glfw_vulkan/main.cpp
+++ b/examples/example_glfw_vulkan/main.cpp
@@ -16,6 +16,7 @@
 #define IMGUI_VULKAN_DEBUG_REPORT
 #endif
 
+static uint32_t						g_MinImageCount = 2;
 static VkAllocationCallbacks*       g_Allocator = NULL;
 static VkInstance                   g_Instance = VK_NULL_HANDLE;
 static VkPhysicalDevice             g_PhysicalDevice = VK_NULL_HANDLE;
@@ -204,8 +205,8 @@ static void SetupVulkanWindowData(ImGui_ImplVulkanH_WindowData* wd, VkSurfaceKHR
     //printf("[vulkan] Selected PresentMode = %d\n", wd->PresentMode);
 
     // Create SwapChain, RenderPass, Framebuffer, etc.
-    ImGui_ImplVulkanH_CreateWindowDataCommandBuffers(g_PhysicalDevice, g_Device, g_QueueFamily, wd, g_Allocator);
-    ImGui_ImplVulkanH_CreateWindowDataSwapChainAndFramebuffer(g_PhysicalDevice, g_Device, wd, g_Allocator, width, height);
+    ImGui_ImplVulkanH_CreateWindowDataSwapChainAndFramebuffer(g_PhysicalDevice, g_Device, wd, g_Allocator, width, height, g_MinImageCount);
+	ImGui_ImplVulkanH_CreateWindowDataCommandBuffers(g_PhysicalDevice, g_Device, g_QueueFamily, wd, g_Allocator);
 }
 
 static void CleanupVulkan()
@@ -364,6 +365,7 @@ int main(int, char**)
     init_info.DescriptorPool = g_DescriptorPool;
     init_info.Allocator = g_Allocator;
     init_info.CheckVkResultFn = check_vk_result;
+	init_info.QueuedFrames = wd->BackBufferCount;
     ImGui_ImplVulkan_Init(&init_info, wd->RenderPass);
 
     // Setup style
@@ -430,7 +432,10 @@ int main(int, char**)
         glfwPollEvents();
 		if (g_ResizeWanted)
 		{
-			ImGui_ImplVulkanH_CreateWindowDataSwapChainAndFramebuffer(g_PhysicalDevice, g_Device, &g_WindowData, g_Allocator, g_ResizeWidth, g_ResizeHeight);
+			ImGui_ImplVulkanH_CreateWindowDataSwapChainAndFramebuffer(g_PhysicalDevice, g_Device, &g_WindowData, g_Allocator, g_ResizeWidth, g_ResizeHeight, g_MinImageCount);
+			ImGui_ImplVulkanH_CreateWindowDataCommandBuffers(g_PhysicalDevice, g_Device, g_QueueFamily, &g_WindowData, g_Allocator);
+			ImGui_ImplVulkan_SetQueuedFramesCount(g_WindowData.BackBufferCount);
+			g_WindowData.FrameIndex = 0;
 			g_ResizeWanted = false;
 		}
 
@@ -473,6 +478,28 @@ int main(int, char**)
             ImGui::Text("Hello from another window!");
             if (ImGui::Button("Close Me"))
                 show_another_window = false;
+
+			if (ImGui::Button("Increase"))
+			{
+				g_MinImageCount++;
+				g_ResizeWanted = true;
+			}
+
+			ImGui::SameLine();
+			if (ImGui::Button("Decrease"))
+			{
+				if (g_MinImageCount != 2)
+				{
+					g_MinImageCount--;
+					g_ResizeWanted = true;
+				}
+			}
+
+			ImGui::SameLine();
+			ImGui::Text("Back Buffers: %i", g_MinImageCount);
+
+			ImGui::Text("Frame Index %i", wd->FrameIndex);
+
             ImGui::End();
         }
 

--- a/examples/example_sdl_vulkan/main.cpp
+++ b/examples/example_sdl_vulkan/main.cpp
@@ -15,6 +15,8 @@
 #define IMGUI_VULKAN_DEBUG_REPORT
 #endif
 
+static uint32_t						g_MinImageCount = 2;
+static bool							g_PendingSwapchainRebuild = false;
 static VkAllocationCallbacks*       g_Allocator = NULL;
 static VkInstance                   g_Instance = VK_NULL_HANDLE;
 static VkPhysicalDevice             g_PhysicalDevice = VK_NULL_HANDLE;
@@ -200,8 +202,8 @@ static void SetupVulkanWindowData(ImGui_ImplVulkanH_WindowData* wd, VkSurfaceKHR
     wd->PresentMode = ImGui_ImplVulkanH_SelectPresentMode(g_PhysicalDevice, wd->Surface, &present_mode, 1);
 
     // Create SwapChain, RenderPass, Framebuffer, etc.
-    ImGui_ImplVulkanH_CreateWindowDataCommandBuffers(g_PhysicalDevice, g_Device, g_QueueFamily, wd, g_Allocator);
-    ImGui_ImplVulkanH_CreateWindowDataSwapChainAndFramebuffer(g_PhysicalDevice, g_Device, wd, g_Allocator, width, height);
+    ImGui_ImplVulkanH_CreateWindowDataSwapChainAndFramebuffer(g_PhysicalDevice, g_Device, wd, g_Allocator, width, height, g_MinImageCount);
+	ImGui_ImplVulkanH_CreateWindowDataCommandBuffers(g_PhysicalDevice, g_Device, g_QueueFamily, wd, g_Allocator);
 }
 
 static void CleanupVulkan()
@@ -295,6 +297,21 @@ static void FramePresent(ImGui_ImplVulkanH_WindowData* wd)
     check_vk_result(err);
 }
 
+static void RebuildSwapChain(int width, int height)
+{
+
+	ImGui_ImplVulkanH_CreateWindowDataSwapChainAndFramebuffer(g_PhysicalDevice, g_Device, &g_WindowData, g_Allocator, width, height, g_MinImageCount);
+	ImGui_ImplVulkanH_CreateWindowDataCommandBuffers(g_PhysicalDevice, g_Device, g_QueueFamily, &g_WindowData, g_Allocator);
+	ImGui_ImplVulkan_SetQueuedFramesCount(g_WindowData.BackBufferCount);
+	g_WindowData.FrameIndex = 0;
+	g_PendingSwapchainRebuild = false;
+}
+
+static void RebuildSwapChain()
+{
+	RebuildSwapChain(g_WindowData.Width, g_WindowData.Height);
+}
+
 int main(int, char**)
 {
     // Setup SDL
@@ -350,6 +367,7 @@ int main(int, char**)
     init_info.PipelineCache = g_PipelineCache;
     init_info.DescriptorPool = g_DescriptorPool;
     init_info.Allocator = g_Allocator;
+	init_info.QueuedFrames = wd->BackBufferCount;
     init_info.CheckVkResultFn = check_vk_result;
     ImGui_ImplVulkan_Init(&init_info, wd->RenderPass);
 
@@ -421,9 +439,16 @@ int main(int, char**)
             ImGui_ImplSDL2_ProcessEvent(&event);
             if (event.type == SDL_QUIT)
                 done = true;
-            if (event.type == SDL_WINDOWEVENT && event.window.event == SDL_WINDOWEVENT_RESIZED && event.window.windowID == SDL_GetWindowID(window)) 
-                ImGui_ImplVulkanH_CreateWindowDataSwapChainAndFramebuffer(g_PhysicalDevice, g_Device, &g_WindowData, g_Allocator, (int)event.window.data1, (int)event.window.data2);
+            if (event.type == SDL_WINDOWEVENT && event.window.event == SDL_WINDOWEVENT_RESIZED && event.window.windowID == SDL_GetWindowID(window))
+            {
+				RebuildSwapChain((int)event.window.data1, (int)event.window.data2);
+            }
         }
+
+		if (g_PendingSwapchainRebuild)
+		{
+			RebuildSwapChain();
+		}
 
         // Start the Dear ImGui frame
         ImGui_ImplVulkan_NewFrame();
@@ -464,6 +489,28 @@ int main(int, char**)
             ImGui::Text("Hello from another window!");
             if (ImGui::Button("Close Me"))
                 show_another_window = false;
+
+			if (ImGui::Button("Increase"))
+			{
+				g_MinImageCount++;
+				g_PendingSwapchainRebuild = true;
+			}
+
+			ImGui::SameLine();
+			if (ImGui::Button("Decrease"))
+			{
+				if (g_MinImageCount != 2)
+				{
+					g_MinImageCount--;
+					g_PendingSwapchainRebuild = true;
+				}
+			}
+
+			ImGui::SameLine();
+			ImGui::Text("Back Buffers: %i", g_MinImageCount);
+
+			ImGui::Text("Frame Index %i", wd->FrameIndex);
+
             ImGui::End();
         }
 

--- a/examples/imgui_impl_vulkan.cpp
+++ b/examples/imgui_impl_vulkan.cpp
@@ -60,8 +60,8 @@ struct FrameDataForRender
     VkBuffer        VertexBuffer;
     VkBuffer        IndexBuffer;
 };
-static int                    g_FrameIndex = 0;
-static FrameDataForRender     g_FramesDataBuffers[IMGUI_VK_QUEUED_FRAMES] = {};
+static int                              g_FrameIndex = 0;
+static ImVector<FrameDataForRender>     g_FramesDataBuffers = {};
 
 // Font data
 static VkSampler              g_FontSampler = VK_NULL_HANDLE;
@@ -206,7 +206,7 @@ void ImGui_ImplVulkan_RenderDrawData(ImDrawData* draw_data, VkCommandBuffer comm
         return;
 
     FrameDataForRender* fd = &g_FramesDataBuffers[g_FrameIndex];
-    g_FrameIndex = (g_FrameIndex + 1) % IMGUI_VK_QUEUED_FRAMES;
+    g_FrameIndex = (g_FrameIndex + 1) % g_FramesDataBuffers.size();
 
     // Create the Vertex and Index buffers:
     size_t vertex_size = draw_data->TotalVtxCount * sizeof(ImDrawVert);
@@ -674,16 +674,6 @@ void    ImGui_ImplVulkan_InvalidateFontUploadObjects()
 void    ImGui_ImplVulkan_InvalidateDeviceObjects()
 {
     ImGui_ImplVulkan_InvalidateFontUploadObjects();
-
-    for (int i = 0; i < IMGUI_VK_QUEUED_FRAMES; i++)
-    {
-        FrameDataForRender* fd = &g_FramesDataBuffers[i];
-        if (fd->VertexBuffer)       { vkDestroyBuffer   (g_Device, fd->VertexBuffer,        g_Allocator); fd->VertexBuffer = VK_NULL_HANDLE; }
-        if (fd->VertexBufferMemory) { vkFreeMemory      (g_Device, fd->VertexBufferMemory,  g_Allocator); fd->VertexBufferMemory = VK_NULL_HANDLE; }
-        if (fd->IndexBuffer)        { vkDestroyBuffer   (g_Device, fd->IndexBuffer,         g_Allocator); fd->IndexBuffer = VK_NULL_HANDLE; }
-        if (fd->IndexBufferMemory)  { vkFreeMemory      (g_Device, fd->IndexBufferMemory,   g_Allocator); fd->IndexBufferMemory = VK_NULL_HANDLE; }
-    }
-
     if (g_FontView)             { vkDestroyImageView(g_Device, g_FontView, g_Allocator); g_FontView = VK_NULL_HANDLE; }
     if (g_FontImage)            { vkDestroyImage(g_Device, g_FontImage, g_Allocator); g_FontImage = VK_NULL_HANDLE; }
     if (g_FontMemory)           { vkFreeMemory(g_Device, g_FontMemory, g_Allocator); g_FontMemory = VK_NULL_HANDLE; }
@@ -691,6 +681,18 @@ void    ImGui_ImplVulkan_InvalidateDeviceObjects()
     if (g_DescriptorSetLayout)  { vkDestroyDescriptorSetLayout(g_Device, g_DescriptorSetLayout, g_Allocator); g_DescriptorSetLayout = VK_NULL_HANDLE; }
     if (g_PipelineLayout)       { vkDestroyPipelineLayout(g_Device, g_PipelineLayout, g_Allocator); g_PipelineLayout = VK_NULL_HANDLE; }
     if (g_Pipeline)             { vkDestroyPipeline(g_Device, g_Pipeline, g_Allocator); g_Pipeline = VK_NULL_HANDLE; }
+}
+
+void ImGui_ImplVulkan_InvalidateFrameDeviceObjects()
+{
+	for (int i = 0; i < g_FramesDataBuffers.size(); i++)
+	{
+		FrameDataForRender* fd = &g_FramesDataBuffers[i];
+		if (fd->VertexBuffer) { vkDestroyBuffer(g_Device, fd->VertexBuffer, g_Allocator); fd->VertexBuffer = VK_NULL_HANDLE; }
+		if (fd->VertexBufferMemory) { vkFreeMemory(g_Device, fd->VertexBufferMemory, g_Allocator); fd->VertexBufferMemory = VK_NULL_HANDLE; }
+		if (fd->IndexBuffer) { vkDestroyBuffer(g_Device, fd->IndexBuffer, g_Allocator); fd->IndexBuffer = VK_NULL_HANDLE; }
+		if (fd->IndexBufferMemory) { vkFreeMemory(g_Device, fd->IndexBufferMemory, g_Allocator); fd->IndexBufferMemory = VK_NULL_HANDLE; }
+	}
 }
 
 bool    ImGui_ImplVulkan_Init(ImGui_ImplVulkan_InitInfo* info, VkRenderPass render_pass)
@@ -712,6 +714,11 @@ bool    ImGui_ImplVulkan_Init(ImGui_ImplVulkan_InitInfo* info, VkRenderPass rend
     g_DescriptorPool = info->DescriptorPool;
     g_Allocator = info->Allocator;
     g_CheckVkResultFn = info->CheckVkResultFn;
+	g_FramesDataBuffers.resize(info->QueuedFrames);
+	for (int i = 0; i < g_FramesDataBuffers.size(); i++)
+	{
+		g_FramesDataBuffers[i] = FrameDataForRender();
+	}
 
     ImGui_ImplVulkan_CreateDeviceObjects();
 
@@ -720,11 +727,30 @@ bool    ImGui_ImplVulkan_Init(ImGui_ImplVulkan_InitInfo* info, VkRenderPass rend
 
 void ImGui_ImplVulkan_Shutdown()
 {
+	ImGui_ImplVulkan_InvalidateFrameDeviceObjects();
     ImGui_ImplVulkan_InvalidateDeviceObjects();
 }
 
 void ImGui_ImplVulkan_NewFrame()
 {
+}
+
+void ImGui_ImplVulkan_SetQueuedFramesCount(uint32_t count)
+{
+	if (count == g_FramesDataBuffers.size())
+	{
+		return;
+	}
+	ImGui_ImplVulkan_InvalidateFrameDeviceObjects();
+
+	uint32_t old_size = g_FramesDataBuffers.size();
+	g_FramesDataBuffers.resize(count);
+	for (uint32_t i = old_size; i < count; i++)
+	{
+		
+		g_FramesDataBuffers[i] = FrameDataForRender();
+	}
+	g_FrameIndex = 0;
 }
 
 
@@ -844,7 +870,7 @@ void ImGui_ImplVulkanH_CreateWindowDataCommandBuffers(VkPhysicalDevice physical_
 
     // Create Command Buffers
     VkResult err;
-    for (int i = 0; i < IMGUI_VK_QUEUED_FRAMES; i++)
+    for (int i = 0; i < wd->Frames.size(); i++)
     {
         ImGui_ImplVulkanH_FrameData* fd = &wd->Frames[i];
         {
@@ -894,9 +920,8 @@ int ImGui_ImplVulkanH_GetMinImageCountFromPresentMode(VkPresentModeKHR present_m
     return 1;
 }
 
-void ImGui_ImplVulkanH_CreateWindowDataSwapChainAndFramebuffer(VkPhysicalDevice physical_device, VkDevice device, ImGui_ImplVulkanH_WindowData* wd, const VkAllocationCallbacks* allocator, int w, int h)
+void ImGui_ImplVulkanH_CreateWindowDataSwapChainAndFramebuffer(VkPhysicalDevice physical_device, VkDevice device, ImGui_ImplVulkanH_WindowData* wd, const VkAllocationCallbacks* allocator, int w, int h, uint32_t min_image_count)
 {
-    uint32_t min_image_count = 2;	// FIXME: this should become a function parameter
 
     VkResult err;
     VkSwapchainKHR old_swapchain = wd->Swapchain;
@@ -958,7 +983,18 @@ void ImGui_ImplVulkanH_CreateWindowDataSwapChainAndFramebuffer(VkPhysicalDevice 
         err = vkGetSwapchainImagesKHR(device, wd->Swapchain, &wd->BackBufferCount, NULL);
         check_vk_result(err);
         err = vkGetSwapchainImagesKHR(device, wd->Swapchain, &wd->BackBufferCount, wd->BackBuffer);
-        check_vk_result(err);
+		check_vk_result(err);
+
+		for (uint32_t i = 0; i < wd->Frames.size(); i++)
+		{
+			ImGui_ImplVulkanH_DestroyFrameData(g_Instance, device, &wd->Frames[i], allocator);
+		}
+		uint32_t old_size = wd->Frames.size();
+		wd->Frames.resize(wd->BackBufferCount);
+		for (uint32_t i = 0; i < wd->Frames.size(); i++)
+		{
+			wd->Frames[i] = ImGui_ImplVulkanH_FrameData();
+		}
     }
     if (old_swapchain)
         vkDestroySwapchainKHR(device, old_swapchain, allocator);
@@ -1045,14 +1081,10 @@ void ImGui_ImplVulkanH_DestroyWindowData(VkInstance instance, VkDevice device, I
     vkDeviceWaitIdle(device); // FIXME: We could wait on the Queue if we had the queue in wd-> (otherwise VulkanH functions can't use globals)
     //vkQueueWaitIdle(g_Queue);
 
-    for (int i = 0; i < IMGUI_VK_QUEUED_FRAMES; i++)
+    for (int i = 0; i < wd->Frames.size(); i++)
     {
         ImGui_ImplVulkanH_FrameData* fd = &wd->Frames[i];
-        vkDestroyFence(device, fd->Fence, allocator);
-        vkFreeCommandBuffers(device, fd->CommandPool, 1, &fd->CommandBuffer);
-        vkDestroyCommandPool(device, fd->CommandPool, allocator);
-        vkDestroySemaphore(device, fd->ImageAcquiredSemaphore, allocator);
-        vkDestroySemaphore(device, fd->RenderCompleteSemaphore, allocator);
+		ImGui_ImplVulkanH_DestroyFrameData(instance, device, fd, allocator);
     }
     for (uint32_t i = 0; i < wd->BackBufferCount; i++)
     {
@@ -1063,4 +1095,13 @@ void ImGui_ImplVulkanH_DestroyWindowData(VkInstance instance, VkDevice device, I
     vkDestroySwapchainKHR(device, wd->Swapchain, allocator);
     vkDestroySurfaceKHR(instance, wd->Surface, allocator);
     *wd = ImGui_ImplVulkanH_WindowData();
+}
+
+void ImGui_ImplVulkanH_DestroyFrameData(VkInstance instance, VkDevice device, ImGui_ImplVulkanH_FrameData* fd, const VkAllocationCallbacks* allocator)
+{
+	vkDestroyFence(device, fd->Fence, allocator);
+	vkFreeCommandBuffers(device, fd->CommandPool, 1, &fd->CommandBuffer);
+	vkDestroyCommandPool(device, fd->CommandPool, allocator);
+	vkDestroySemaphore(device, fd->ImageAcquiredSemaphore, allocator);
+	vkDestroySemaphore(device, fd->RenderCompleteSemaphore, allocator);
 }

--- a/examples/imgui_impl_vulkan.h
+++ b/examples/imgui_impl_vulkan.h
@@ -13,7 +13,7 @@
 
 #include <vulkan/vulkan.h>
 
-#define IMGUI_VK_QUEUED_FRAMES      2
+//#define IMGUI_VK_QUEUED_FRAMES      2
 
 // Please zero-clear before use.
 struct ImGui_ImplVulkan_InitInfo
@@ -25,6 +25,7 @@ struct ImGui_ImplVulkan_InitInfo
     VkQueue                         Queue;
     VkPipelineCache                 PipelineCache;
     VkDescriptorPool                DescriptorPool;
+	int								QueuedFrames;
     const VkAllocationCallbacks*    Allocator;
     void                            (*CheckVkResultFn)(VkResult err);
 };
@@ -33,6 +34,7 @@ struct ImGui_ImplVulkan_InitInfo
 IMGUI_IMPL_API bool     ImGui_ImplVulkan_Init(ImGui_ImplVulkan_InitInfo* info, VkRenderPass render_pass);
 IMGUI_IMPL_API void     ImGui_ImplVulkan_Shutdown();
 IMGUI_IMPL_API void     ImGui_ImplVulkan_NewFrame();
+IMGUI_IMPL_API void     ImGui_ImplVulkan_SetQueuedFramesCount(uint32_t count);
 IMGUI_IMPL_API void     ImGui_ImplVulkan_RenderDrawData(ImDrawData* draw_data, VkCommandBuffer command_buffer);
 IMGUI_IMPL_API bool     ImGui_ImplVulkan_CreateFontsTexture(VkCommandBuffer command_buffer);
 IMGUI_IMPL_API void     ImGui_ImplVulkan_InvalidateFontUploadObjects();
@@ -40,6 +42,7 @@ IMGUI_IMPL_API void     ImGui_ImplVulkan_InvalidateFontUploadObjects();
 // Called by ImGui_ImplVulkan_Init() might be useful elsewhere.
 IMGUI_IMPL_API bool     ImGui_ImplVulkan_CreateDeviceObjects();
 IMGUI_IMPL_API void     ImGui_ImplVulkan_InvalidateDeviceObjects();
+IMGUI_IMPL_API void     ImGui_ImplVulkan_InvalidateFrameDeviceObjects();
 
 
 //-------------------------------------------------------------------------
@@ -60,8 +63,9 @@ struct ImGui_ImplVulkanH_FrameData;
 struct ImGui_ImplVulkanH_WindowData;
 
 IMGUI_IMPL_API void                 ImGui_ImplVulkanH_CreateWindowDataCommandBuffers(VkPhysicalDevice physical_device, VkDevice device, uint32_t queue_family, ImGui_ImplVulkanH_WindowData* wd, const VkAllocationCallbacks* allocator);
-IMGUI_IMPL_API void                 ImGui_ImplVulkanH_CreateWindowDataSwapChainAndFramebuffer(VkPhysicalDevice physical_device, VkDevice device, ImGui_ImplVulkanH_WindowData* wd, const VkAllocationCallbacks* allocator, int w, int h);
+IMGUI_IMPL_API void                 ImGui_ImplVulkanH_CreateWindowDataSwapChainAndFramebuffer(VkPhysicalDevice physical_device, VkDevice device, ImGui_ImplVulkanH_WindowData* wd, const VkAllocationCallbacks* allocator, int w, int h, uint32_t min_image_count);
 IMGUI_IMPL_API void                 ImGui_ImplVulkanH_DestroyWindowData(VkInstance instance, VkDevice device, ImGui_ImplVulkanH_WindowData* wd, const VkAllocationCallbacks* allocator);
+IMGUI_IMPL_API void                 ImGui_ImplVulkanH_DestroyFrameData(VkInstance instance, VkDevice device, ImGui_ImplVulkanH_FrameData* fd, const VkAllocationCallbacks* allocator);
 IMGUI_IMPL_API VkSurfaceFormatKHR   ImGui_ImplVulkanH_SelectSurfaceFormat(VkPhysicalDevice physical_device, VkSurfaceKHR surface, const VkFormat* request_formats, int request_formats_count, VkColorSpaceKHR request_color_space);
 IMGUI_IMPL_API VkPresentModeKHR     ImGui_ImplVulkanH_SelectPresentMode(VkPhysicalDevice physical_device, VkSurfaceKHR surface, const VkPresentModeKHR* request_modes, int request_modes_count);
 IMGUI_IMPL_API int                  ImGui_ImplVulkanH_GetMinImageCountFromPresentMode(VkPresentModeKHR present_mode);
@@ -96,7 +100,7 @@ struct ImGui_ImplVulkanH_WindowData
     VkImageView         BackBufferView[16];
     VkFramebuffer       Framebuffer[16];
     uint32_t            FrameIndex;
-    ImGui_ImplVulkanH_FrameData Frames[IMGUI_VK_QUEUED_FRAMES];
+    ImVector<ImGui_ImplVulkanH_FrameData> Frames;
 
     IMGUI_IMPL_API ImGui_ImplVulkanH_WindowData();
 };


### PR DESCRIPTION
Follow on From #1677 

> Previously it relied on a preprocessor macro to define the amount of backbuffers that imgui would use, causing problems when rendering is implemented without any device wait idles in the render loop. This is caused by it trying to free buffers that are still in use causing graphical glitches (and i'd imagine in worst case a crash although I didn't experience one).
> 
> Requires some changes to the demo though so it's a compatibility breaking change to the vulkan example implementation.
> 
> The new way to initialise the vulkan backend is pretty simple though, you just have to changed the init struct to set the vk_queued_frames value to the amount of backbuffers you are using. When you are rebuilding the swapchain and the amount of backbuffers has changed just call ImGui_ImplGlfwVulkan_QueuedFramesChanged();
> 
> Has some performance deficits of course, but it's all in the initialisation and reinitialisation parts of ImGui so there should be minimal runtime overhead.

WARNING: This is an API breaking change to the reference vulkan implementation.

Changes include: 
- ImGui_ImplVulkan_InitInfo now has an additional QueuedFrames member that MUST BE SET at setup time. It sets the minimum number of queued frames (should be the same as the number of backbuffers. See example_sdl_vulkan/main.cpp:370 for reference.
- When rebuilding the swapchain a call to ImGui_ImpleVulkan_SetQueuedFramesCount must occur to update various buffers and recreate resources internally. See example_sdl_vulkan/main.cpp:300 for reference
- Both ImGui_ImplVulkanH_CreateWindowDataSwapChainAndFramebuffer and ImGui_ImplVulkanH_CreateWindowDataCommandBuffers need to be called to recreate the swapchain and some of it's associated resources when rebuilding the swapchain. See example_sdl_vulkan/main.cpp:300 for info.
- In example_sdl_vulkan/main.cpp when recreating the swapchain we reset the frame index to be < the new number of backbuffers. Something similar must be done when integrating these changes in your own integration as if the number of backbuffers increases there is a chance to read outside of an array's bounds.
