### PR TITLE
Fix MSVC's C4312 warning about casting user texture type to void* in ImageButton

### DIFF
--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -838,7 +838,7 @@ bool ImGui::ImageButton(ImTextureID user_texture_id, const ImVec2& size, const I
 
     // Default to using texture ID as ID. User can still push string/integer prefixes.
     // We could hash the size/uv to create a unique ID but that would prevent the user from animating UV.
-    PushID((void*)user_texture_id);
+    PushID((void*)(intptr_t)user_texture_id);
     const ImGuiID id = window->GetID("#image");
     PopID();
 


### PR DESCRIPTION
Here's the warning:

``` warning C4312: 'type cast': conversion from 'unsigned int' to 'void *' of greater size```

It happens when ImTextureID is redefined to unsigned int (e.g. if defining ImTextureId to be GLuint).