### PR TITLE
Fix spacing in imgui_imp_sdl example

### DIFF
--- a/examples/imgui_impl_sdl.cpp
+++ b/examples/imgui_impl_sdl.cpp
@@ -113,7 +113,7 @@ bool ImGui_ImplSDL2_ProcessEvent(SDL_Event* event)
     return false;
 }
 
-static bool    ImGui_ImplSDL2_Init(SDL_Window* window)
+static bool ImGui_ImplSDL2_Init(SDL_Window* window)
 {
     g_Window = window;
 


### PR DESCRIPTION
Fix spacing to adhere to coding style.
