### PR TITLE
OpenGL 3 Example: Use GLboolean for compile/link status

### DIFF
--- a/examples/imgui_impl_opengl3.cpp
+++ b/examples/imgui_impl_opengl3.cpp
@@ -312,7 +312,7 @@ static bool CheckShader(GLuint handle, const char* desc)
     GLint status = 0, log_length = 0;
     glGetShaderiv(handle, GL_COMPILE_STATUS, &status);
     glGetShaderiv(handle, GL_INFO_LOG_LENGTH, &log_length);
-    if (status == GL_FALSE)
+    if ((GLboolean)status == GL_FALSE)
         fprintf(stderr, "ERROR: ImGui_ImplOpenGL3_CreateDeviceObjects: failed to compile %s!\n", desc);
     if (log_length > 0)
     {
@@ -321,7 +321,7 @@ static bool CheckShader(GLuint handle, const char* desc)
         glGetShaderInfoLog(handle, log_length, NULL, (GLchar*)buf.begin());
         fprintf(stderr, "%s\n", buf.begin());
     }
-    return status == GL_TRUE;
+    return (GLboolean)status == GL_TRUE;
 }
 
 // If you get an error please report on github. You may try different GL context version or GLSL version.
@@ -330,7 +330,7 @@ static bool CheckProgram(GLuint handle, const char* desc)
     GLint status = 0, log_length = 0;
     glGetProgramiv(handle, GL_LINK_STATUS, &status);
     glGetProgramiv(handle, GL_INFO_LOG_LENGTH, &log_length);
-    if (status == GL_FALSE)
+    if ((GLboolean)status == GL_FALSE)
         fprintf(stderr, "ERROR: ImGui_ImplOpenGL3_CreateDeviceObjects: failed to link %s!\n", desc);
     if (log_length > 0)
     {
@@ -339,7 +339,7 @@ static bool CheckProgram(GLuint handle, const char* desc)
         glGetProgramInfoLog(handle, log_length, NULL, (GLchar*)buf.begin());
         fprintf(stderr, "%s\n", buf.begin());
     }
-    return status == GL_TRUE;
+    return (GLboolean)status == GL_TRUE;
 }
 
 bool    ImGui_ImplOpenGL3_CreateDeviceObjects()


### PR DESCRIPTION
I'm using an OpenGL binding that is quite strict about type safety ([glbinding](https://github.com/cginternals/glbinding)) and does not allow comparisons between `GLint`s and `GLboolean`s. The OpenGL 3 example wouldn't compile before changing the status variable (in `CheckShader`/``CheckProgram`) to a `GLboolean`.
Since this is a trivial fix I'm not including the error log for now, however if you have any doubts or would like more detailed information I can provide a full log.