### PR TITLE
Downgraded Xcode project object version (50->48) to support Xcode 9.2

### DIFF
--- a/examples/example_apple_metal/example_apple_metal.xcodeproj/project.pbxproj
+++ b/examples/example_apple_metal/example_apple_metal.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 48;
 	objects = {
 
 /* Begin PBXBuildFile section */


### PR DESCRIPTION
This allows the project to be opened by the last version of Xcode (9.2) supported on macOS Sierra (10.12).