### PR TITLE
SDL Example: SDL_GetDisplayDPI

### DIFF
--- a/examples/imgui_impl_sdl.cpp
+++ b/examples/imgui_impl_sdl.cpp
@@ -523,7 +523,7 @@ static void ImGui_ImplSDL2_UpdateMonitors()
 #endif
 #if SDL_HAS_PER_MONITOR_DPI
         float dpi = 0.0f;
-        if (SDL_GetDisplayDPI(n, &dpi, NULL, NULL))
+        if (!SDL_GetDisplayDPI(n, &dpi, NULL, NULL))
             monitor.DpiScale = dpi / 96.0f;
 #endif
         platform_io.Monitors.push_back(monitor);


### PR DESCRIPTION
SDL_GetDisplayDPI returns 0 on success

https://wiki.libsdl.org/SDL_GetDisplayDPI
New PR to replace the errant one made in docking
