### PR TITLE
Fixed an issue getting input when input thread doesn't have a window …

### DIFF
--- a/examples/imgui_impl_win32.cpp
+++ b/examples/imgui_impl_win32.cpp
@@ -132,7 +132,7 @@ static void ImGui_ImplWin32_UpdateMousePos()
     // Set mouse position
     io.MousePos = ImVec2(-FLT_MAX, -FLT_MAX);
     POINT pos;
-    if (::GetActiveWindow() == g_hWnd && ::GetCursorPos(&pos))
+    if (::GetForegroundWindow() == g_hWnd && ::GetCursorPos(&pos))
         if (::ScreenToClient(g_hWnd, &pos))
             io.MousePos = ImVec2((float)pos.x, (float)pos.y);
 }


### PR DESCRIPTION
…attached

>The active window (the result of GetActiveWindow()) is the window attached to the calling thread that gets input. The foreground window (the result of of GetForegroundWindow()) is the window that's currently getting input regardless of its relationship to the calling thread. The active window is essentially localized to your application; the foreground window is global to the system.

In some games, the thread that handles input is not always the thread that has the window attached. For example, in some games, the thread might have the window attached while being in the menu of the game but not while playing the game. Using GetForegroundWindow instead of GetActiveWindow fixes this issue.
