### PR TITLE
Avoid warning re: unreferenced parameter in ImGui_ImplVulkanH_CreateW…

### DIFF
--- a/examples/imgui_impl_vulkan.cpp
+++ b/examples/imgui_impl_vulkan.cpp
@@ -840,6 +840,7 @@ VkPresentModeKHR ImGui_ImplVulkanH_SelectPresentMode(VkPhysicalDevice physical_d
 void ImGui_ImplVulkanH_CreateWindowDataCommandBuffers(VkPhysicalDevice physical_device, VkDevice device, uint32_t queue_family, ImGui_ImplVulkanH_WindowData* wd, const VkAllocationCallbacks* allocator)
 {
     IM_ASSERT(physical_device != VK_NULL_HANDLE && device != VK_NULL_HANDLE);
+    (void)physical_device;
     (void)allocator;
 
     // Create Command Buffers


### PR DESCRIPTION
Technically, the parameter isn't used outside of the assert that it's not VK_NULL_HANDLE, so it could just be removed entirely if you'd prefer.
