### PR TITLE
Add 0.15f to height_in_items in ListBoxHeader when height_in_items > items_count

### DIFF
--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -5117,10 +5117,11 @@ bool ImGui::ListBoxHeader(const char* label, int items_count, int height_in_item
 {
     // Size default to hold ~7 items. Fractional number of items helps seeing that we can scroll down/up without looking at scrollbar.
     // We don't add +0.40f if items_count <= height_in_items. It is slightly dodgy, because it means a dynamic list of items will make the widget resize occasionally when it crosses that size.
+    // We are also adding +0.15f so that a single item listbox with height_in_items set to 1 won't be drawing unnecessary scrollbar.
     // I am expecting that someone will come and complain about this behavior in a remote future, then we can advise on a better solution.
     if (height_in_items < 0)
         height_in_items = ImMin(items_count, 7);
-    float height_in_items_f = height_in_items < items_count ? (height_in_items + 0.40f) : (height_in_items + 0.00f);
+    float height_in_items_f = height_in_items < items_count ? (height_in_items + 0.40f) : (height_in_items + 0.15f);
 
     // We include ItemSpacing.y so that a list sized for the exact number of items doesn't make a scrollbar appears. We could also enforce that by passing a flag to BeginChild().
     ImVec2 size;


### PR DESCRIPTION
* This fixes an issue where scrollbar is being drawn for single
  item list with height_in_items set to 1.

* Example code:
  const char* listbox_items[] = { "AaAaAaAa" };
  static int listbox_item_current = 1;
  ImGui::ListBox("", &listbox_item_current, listbox_items, IM_ARRAYSIZE(listbox_items), 1);