### PR TITLE
Fixed FocusPreviousWindowIgnoringOne to not focus on windows that are…

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -5290,7 +5290,7 @@ void ImGui::FocusPreviousWindowIgnoringOne(ImGuiWindow* ignore_window)
     for (int i = g.WindowsFocusOrder.Size - 1; i >= 0; i--)
     {
         ImGuiWindow* window = g.WindowsFocusOrder[i];
-        if (window != ignore_window && window->WasActive && !(window->Flags & ImGuiWindowFlags_ChildWindow))
+        if (window != ignore_window && window->WasActive && !(window->Flags & ImGuiWindowFlags_ChildWindow) && !(window->Flags & ImGuiWindowFlags_NoNavFocus))
         {
             ImGuiWindow* focus_window = NavRestoreLastChildNavWindow(window);
             FocusWindow(focus_window);


### PR DESCRIPTION
Hi @ocornut 

This is the first pull request we are sending your way :)

We first noticed this issue when testing with the gamepad:
1) have a couple of viewports (can focus), menu bar (can focus), and testing UI (with NoNavFocus)
2) close everything except menu bar and testing UI
3) by default the navigation tries to focus on the testing UI, which is undesirable since it should respect the flag.

The fix prevents any NoNavFocus ui from ever being the first active / root window for focusing.