### PR TITLE
Added Collapse & Close for NavInput

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -5066,7 +5066,7 @@ bool ImGui::Begin(const char* name, bool* p_open, ImGuiWindowFlags flags)
 
             // Collapse button
             if (!(flags & ImGuiWindowFlags_NoCollapse))
-                if (CollapseButton(window->GetID("#COLLAPSE"), window->Pos))
+                if (CollapseButton(window->GetID("#COLLAPSE"), window->Pos) || (g.NavWindowingTarget == window && IsNavInputPressed(ImGuiNavInput_Activate, ImGuiInputReadMode_Pressed)))
                     window->WantCollapseToggle = true; // Defer collapsing to next frame as we are too far in the Begin() function
 
             // Close button
@@ -5074,7 +5074,7 @@ bool ImGui::Begin(const char* name, bool* p_open, ImGuiWindowFlags flags)
             {
                 const float pad = style.FramePadding.y;
                 const float rad = g.FontSize * 0.5f;
-                if (CloseButton(window->GetID("#CLOSE"), window->Rect().GetTR() + ImVec2(-pad - rad, pad + rad), rad + 1))
+                if (CloseButton(window->GetID("#CLOSE"), window->Rect().GetTR() + ImVec2(-pad - rad, pad + rad), rad + 1) || (g.NavWindowingTarget == window && IsNavInputPressed(ImGuiNavInput_Input, ImGuiInputReadMode_Pressed)))
                     *p_open = false;
             }
 


### PR DESCRIPTION
Usage Context:
* Instead of having to navigate to the respective buttons, this is useful and faster for collapsing and closing when using a gamepad.

Notes:
* Actual NavInput key does not matter, but would be nice to custom bind these for user.

Changes:
* Handle IsNavInputPressed for ImGuiNavInput_Activate if the window is the NavWindowingTarget to collapse the window.
* Handle IsNavInputPressed for ImGuiNavInput_Input if the window is the NavWindowingTarget to close the window.
