### PR TITLE
Added ImGuiInputTextFlags_TabReturnsTrue for commit and navigate behavior for Input widgets

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -704,6 +704,7 @@ enum ImGuiInputTextFlags_
     ImGuiInputTextFlags_NoUndoRedo          = 1 << 16,  // Disable undo/redo. Note that input text owns the text data while active, if you want to provide your own undo/redo stack you need e.g. to call ClearActiveID().
     ImGuiInputTextFlags_CharsScientific     = 1 << 17,  // Allow 0123456789.+-*/eE (Scientific notation input)
     ImGuiInputTextFlags_CallbackResize      = 1 << 18,  // Callback on buffer capacity changes request (beyond 'buf_size' parameter value), allowing the string to grow. Notify when the string wants to be resized (for string types which hold a cache of their Size). You will be provided a new BufSize in the callback and NEED to honor it. (see misc/cpp/imgui_stdlib.h for an example of using this)
+    ImGuiInputTextFlags_TabReturnsTrue      = 1 << 19,  // Return 'true' when Tab is pressed (as opposed to when the value was modified)
     // [Internal]
     ImGuiInputTextFlags_Multiline           = 1 << 20   // For internal use by InputTextMultiline()
 };


### PR DESCRIPTION
Usage Context:
* Some Input*() widgets have values that require commit value behavior instead of on changed input behavior. So when editing multiple Input*() widgets, as an option it is desirable to press tab for committing and navigating.

Notes:
* Behavior desired and implementation is similar to ImGuiInputTextFlags_EnterReturnsTrue where enter commits the value.
* Potential conflict of behavior with other tab behaviors.