### PR TITLE
include <alloca.h> also on macOS (and osxcross)

### DIFF
--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -32,7 +32,7 @@ Index of this file:
 
 #include <stdio.h>      // vsnprintf, sscanf, printf
 #if !defined(alloca)
-#if defined(__GLIBC__) || defined(__sun) || defined(__CYGWIN__)
+#if defined(__GLIBC__) || defined(__sun) || defined(__CYGWIN__) || defined(__APPLE__)
 #include <alloca.h>     // alloca (glibc uses <alloca.h>. Note that Cygwin may have _WIN32 defined, so the order matters here)
 #elif defined(_WIN32)
 #include <malloc.h>     // alloca


### PR DESCRIPTION
This fixes compilation failure when building with osxcross and MacOS 10.11 SDK:

```
../../libsuperderpy/src/3rdparty/cimgui/imgui/imgui_draw.cpp:667:41: error: use of undeclared identifier 'alloca'; did you mean 'malloc'?
        ImVec2* temp_normals = (ImVec2*)alloca(points_count * (thick_line ? 5 : 3) * sizeof(ImVec2));
                                        ^~~~~~
                                        malloc
/home/dos/git/osxcross/target/SDK/MacOSX10.11.sdk/usr/include/stdlib.h:152:7: note: 'malloc' declared here
void    *malloc(size_t);
         ^
../../libsuperderpy/src/3rdparty/cimgui/imgui/imgui_draw.cpp:849:41: error: use of undeclared identifier 'alloca'; did you mean 'malloc'?
        ImVec2* temp_normals = (ImVec2*)alloca(points_count * sizeof(ImVec2));
                                        ^~~~~~
                                        malloc
/home/dos/git/osxcross/target/SDK/MacOSX10.11.sdk/usr/include/stdlib.h:152:7: note: 'malloc' declared here
void    *malloc(size_t);
         ^
2 errors generated
```