### PR TITLE
Change font size default if no window

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -5350,7 +5350,7 @@ void ImGui::SetCurrentFont(ImFont* font)
     IM_ASSERT(font->Scale > 0.0f);
     g.Font = font;
     g.FontBaseSize = g.IO.FontGlobalScale * g.Font->FontSize * g.Font->Scale;
-    g.FontSize = g.CurrentWindow ? g.CurrentWindow->CalcFontSize() : 0.0f;
+    g.FontSize = g.CurrentWindow ? g.CurrentWindow->CalcFontSize() : font->FontSize;
 
     ImFontAtlas* atlas = g.Font->ContainerAtlas;
     g.DrawListSharedData.TexUvWhitePixel = atlas->TexUvWhitePixel;


### PR DESCRIPTION
Change:
* If there is no window to calculate font size from, the font size should be the font size the user specified on load, instead of 0.0f.