### PR TITLE
Fix highdpi screens on SDL examples with viewports

### DIFF
--- a/examples/imgui_impl_opengl2.cpp
+++ b/examples/imgui_impl_opengl2.cpp
@@ -128,6 +128,8 @@ void ImGui_ImplOpenGL2_RenderDrawData(ImDrawData* draw_data)
 
     // Render command lists
     ImVec2 pos = draw_data->DisplayPos;
+    pos.x *= io.DisplayFramebufferScale.x;
+    pos.y *= io.DisplayFramebufferScale.y;
     for (int n = 0; n < draw_data->CmdListsCount; n++)
     {
         const ImDrawList* cmd_list = draw_data->CmdLists[n];

--- a/examples/imgui_impl_opengl3.cpp
+++ b/examples/imgui_impl_opengl3.cpp
@@ -233,6 +233,8 @@ void    ImGui_ImplOpenGL3_RenderDrawData(ImDrawData* draw_data)
 
     // Draw
     ImVec2 pos = draw_data->DisplayPos;
+    pos.x *= io.DisplayFramebufferScale.x;
+    pos.y *= io.DisplayFramebufferScale.y;
     for (int n = 0; n < draw_data->CmdListsCount; n++)
     {
         const ImDrawList* cmd_list = draw_data->CmdLists[n];

--- a/examples/imgui_impl_sdl.cpp
+++ b/examples/imgui_impl_sdl.cpp
@@ -370,7 +370,7 @@ static void ImGui_ImplSDL2_CreateWindow(ImGuiViewport* viewport)
     // We don't enable SDL_WINDOW_RESIZABLE because it enforce windows decorations
     Uint32 sdl_flags = 0;
     sdl_flags |= use_opengl ? SDL_WINDOW_OPENGL : SDL_WINDOW_VULKAN;
-    sdl_flags |= SDL_WINDOW_HIDDEN;
+    sdl_flags |= SDL_WINDOW_HIDDEN | SDL_WINDOW_ALLOW_HIGHDPI;
     sdl_flags |= (viewport->Flags & ImGuiViewportFlags_NoDecoration) ? SDL_WINDOW_BORDERLESS : 0;
     sdl_flags |= (viewport->Flags & ImGuiViewportFlags_NoDecoration) ? 0 : SDL_WINDOW_RESIZABLE;
 #if SDL_HAS_ALWAYS_ON_TOP


### PR DESCRIPTION
NOTE: this patch is meant to be used on top of #2239. When both are merged, the SDL backend correctly works in the viewport branch with highdpi screens.