### PR TITLE
Text input double click selects a word on all systems

### DIFF
--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -3281,14 +3281,14 @@ bool ImGui::InputTextEx(const char* label, char* buf, int buf_size, const ImVec2
         const float mouse_y = (is_multiline ? (io.MousePos.y - draw_window->DC.CursorPos.y - style.FramePadding.y) : (g.FontSize*0.5f));
 
         const bool is_osx = io.ConfigMacOSXBehaviors;
-        if (select_all || (hovered && !is_osx && io.MouseDoubleClicked[0]))
+        if (select_all)
         {
             edit_state.SelectAll();
             edit_state.SelectedAllMouseLock = true;
         }
-        else if (hovered && is_osx && io.MouseDoubleClicked[0])
+        else if (hovered && io.MouseDoubleClicked[0])
         {
-            // Double-click select a word only, OS X style (by simulating keystrokes)
+            // Double-click select a word only (by simulating keystrokes)
             edit_state.OnKeyPressed(STB_TEXTEDIT_K_WORDLEFT);
             edit_state.OnKeyPressed(STB_TEXTEDIT_K_WORDRIGHT | STB_TEXTEDIT_K_SHIFT);
         }


### PR DESCRIPTION
I can see the behavior of "double click to select the whole text on non-osx" was done on purpose, but I have tried various editors and text inputs on windows and they all select a word on double click.