### PR TITLE
Fix highdpi screens on SDL examples with viewports

### DIFF
--- a/examples/example_sdl_opengl2/main.cpp
+++ b/examples/example_sdl_opengl2/main.cpp
@@ -30,7 +30,7 @@ int main(int, char**)
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
     SDL_DisplayMode current;
     SDL_GetCurrentDisplayMode(0, &current);
-    SDL_Window* window = SDL_CreateWindow("Dear ImGui SDL2+OpenGL example", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 1280, 720, SDL_WINDOW_OPENGL|SDL_WINDOW_RESIZABLE);
+    SDL_Window* window = SDL_CreateWindow("Dear ImGui SDL2+OpenGL example", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 1280, 720, SDL_WINDOW_OPENGL|SDL_WINDOW_RESIZABLE|SDL_WINDOW_ALLOW_HIGHDPI);
     SDL_GLContext gl_context = SDL_GL_CreateContext(window);
     SDL_GL_MakeCurrent(window, gl_context);
     SDL_GL_SetSwapInterval(1); // Enable vsync

--- a/examples/example_sdl_opengl3/main.cpp
+++ b/examples/example_sdl_opengl3/main.cpp
@@ -54,7 +54,7 @@ int main(int, char**)
     SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
     SDL_DisplayMode current;
     SDL_GetCurrentDisplayMode(0, &current);
-    SDL_Window* window = SDL_CreateWindow("Dear ImGui SDL2+OpenGL3 example", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 1280, 720, SDL_WINDOW_OPENGL|SDL_WINDOW_RESIZABLE);
+    SDL_Window* window = SDL_CreateWindow("Dear ImGui SDL2+OpenGL3 example", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 1280, 720, SDL_WINDOW_OPENGL|SDL_WINDOW_RESIZABLE|SDL_WINDOW_ALLOW_HIGHDPI);
     SDL_GLContext gl_context = SDL_GL_CreateContext(window);
     SDL_GL_MakeCurrent(window, gl_context);
     SDL_GL_SetSwapInterval(1); // Enable vsync

--- a/examples/imgui_impl_opengl2.cpp
+++ b/examples/imgui_impl_opengl2.cpp
@@ -128,6 +128,8 @@ void ImGui_ImplOpenGL2_RenderDrawData(ImDrawData* draw_data)
 
     // Render command lists
     ImVec2 pos = draw_data->DisplayPos;
+    pos.x *= io.DisplayFramebufferScale.x;
+    pos.y *= io.DisplayFramebufferScale.y;
     for (int n = 0; n < draw_data->CmdListsCount; n++)
     {
         const ImDrawList* cmd_list = draw_data->CmdLists[n];

--- a/examples/imgui_impl_opengl3.cpp
+++ b/examples/imgui_impl_opengl3.cpp
@@ -233,6 +233,8 @@ void    ImGui_ImplOpenGL3_RenderDrawData(ImDrawData* draw_data)
 
     // Draw
     ImVec2 pos = draw_data->DisplayPos;
+    pos.x *= io.DisplayFramebufferScale.x;
+    pos.y *= io.DisplayFramebufferScale.y;
     for (int n = 0; n < draw_data->CmdListsCount; n++)
     {
         const ImDrawList* cmd_list = draw_data->CmdLists[n];

--- a/examples/imgui_impl_sdl.cpp
+++ b/examples/imgui_impl_sdl.cpp
@@ -387,7 +387,7 @@ static void ImGui_ImplSDL2_CreateWindow(ImGuiViewport* viewport)
     // We don't enable SDL_WINDOW_RESIZABLE because it enforce windows decorations
     Uint32 sdl_flags = 0;
     sdl_flags |= use_opengl ? SDL_WINDOW_OPENGL : SDL_WINDOW_VULKAN;
-    sdl_flags |= SDL_WINDOW_HIDDEN;
+    sdl_flags |= SDL_WINDOW_HIDDEN | SDL_WINDOW_ALLOW_HIGHDPI;
     sdl_flags |= (viewport->Flags & ImGuiViewportFlags_NoDecoration) ? SDL_WINDOW_BORDERLESS : 0;
     sdl_flags |= (viewport->Flags & ImGuiViewportFlags_NoDecoration) ? 0 : SDL_WINDOW_RESIZABLE;
 #if SDL_HAS_ALWAYS_ON_TOP


### PR DESCRIPTION
`imgui_impl_opengl3.cpp` and `imgui_impl_opengl2.cpp` currently have a bug in the `viewport` branch when used with a HighDPI configuration. I discovered this bug while testing ImGui in an application that turns on HighDPI (not to improve rendering of imgui itself, but rather the application itself over which ImGui is drawn).

To reproduce this bug, you can use any OpenGL-based example. I personally use SDL so it's possible to trigger this by modifying `example_sdl_opengl3/main.cpp` to add `SDL_WINDOW_ALLOWHIGHDPI` when calling `SDL_CreateWindow()`. After having added this flag, running the example immediately produces a broken output like this:

<img width="1392" alt="screenshot 2019-01-15 19 18 41" src="https://user-images.githubusercontent.com/1014109/51200857-e4bd1b80-18fa-11e9-91d5-f4445acfa158.png">

The bug is in `ImGui_ImplOpenGL3_RenderDrawData`: the `draw_data->DisplayPos` variable is not scaled by the current framebuffer scale.

This PR fixes this bug for both OpenGL2 and OpenGL3 implementation. Moreover, it activates HighDPI rendering on SDL examples. This is not strictly required to fix any bug, but I think it's a good idea to keep it active because it increases the amount of code being tested by running the examples, and is thus easier to uncover hidden bugs with highdpi scaling.