### PR TITLE
User-defined memory allocations in FreeType

### DIFF
--- a/misc/freetype/README.md
+++ b/misc/freetype/README.md
@@ -121,6 +121,5 @@ struct FreeTypeTest
 ```
 
 ### Known issues
-- FreeType's memory allocator is not overridden.
 - `cfg.OversampleH`, `OversampleV` are ignored (but perhaps not so necessary with this rasterizer).
 

--- a/misc/freetype/imgui_freetype.h
+++ b/misc/freetype/imgui_freetype.h
@@ -28,4 +28,8 @@ namespace ImGuiFreeType
     };
 
     IMGUI_API bool BuildFontAtlas(ImFontAtlas* atlas, unsigned int extra_flags = 0);
+
+    // FreeType does lots of allocations so user might want to provide separate memory heap.
+    // By default ImGuiFreeType will use ImGui::MemAlloc()/MemFree().
+    IMGUI_API void SetAllocatorFunctions(void* (*alloc_func)(size_t sz, void* user_data), void(*free_func)(void* ptr, void* user_data), void* user_data = NULL);
 }


### PR DESCRIPTION
By default `ImGuiFreeType` will use `ImGui::MemAlloc()/MemFree()`.
`ImGuiFreeType::SetAllocatorFunctions()` can be used to specify custom allocator.
