### PR TITLE
avoid floating point exception when _EM_OVERFLOW is enabled

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -3729,7 +3729,7 @@ void ImGui::EndFrame()
     IM_ASSERT(g.FrameScopeActive && "Forgot to call ImGui::NewFrame()?");
 
     // Notify OS when our Input Method Editor cursor has moved (e.g. CJK inputs using Microsoft IME)
-    if (g.IO.ImeSetInputScreenPosFn && ImLengthSqr(g.PlatformImeLastPos - g.PlatformImePos) > 0.0001f)
+    if (g.IO.ImeSetInputScreenPosFn && (g.PlatformImeLastPos.x == FLT_MAX || ImLengthSqr(g.PlatformImeLastPos - g.PlatformImePos) > 0.0001f))
     {
         g.IO.ImeSetInputScreenPosFn((int)g.PlatformImePos.x, (int)g.PlatformImePos.y);
         g.PlatformImeLastPos = g.PlatformImePos;


### PR DESCRIPTION
To avoid avoid a floating point exception when _EM_OVERFLOW is enabled there is an additional check needed in ImGui::EndFrame() to detected if g.PlatformImeLastPos.x is on its initial value FLT_MAX.
I think an check of g.PlatformImeLastPos.y not needed because both vars get updated together.