### PR TITLE
Fixed -Wstringop-truncation on GCC8/Linux Manjaro

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -1295,7 +1295,8 @@ int ImStrnicmp(const char* str1, const char* str2, size_t count)
 void ImStrncpy(char* dst, const char* src, size_t count)
 {
     if (count < 1) return;
-    strncpy(dst, src, count);
+    if (count > 1)
+      strncpy(dst, src, count-1);
     dst[count-1] = 0;
 }
 


### PR DESCRIPTION
This PR fixes the warning GCC8 gives about size given to strncpy being equal to the size of the destination buffer (and then assuming you may be lacking space for a '\0'). 

Warning given by GCC8
```
In the function ‘void ImStrncpy(char*, const char*, size_t)’,
    included in line ‘void ImStrncpy(char*, const char*, size_t)’ en imgui/imgui.cpp:1295:6,
    included in line ‘ImGuiTextFilter::ImGuiTextFilter(const char*)’ en imgui/imgui.cpp:2016:18:
imgui/imgui.cpp:1299:14: warning: 'char* strncpy(char*, const char*, size_t)' specified bound 256 equals destination size [-Wstringop-truncation`]
       strncpy(dst, src, count);
       ~~~~~~~^~~~~~~~~~~~~~~~~
```

Tested in
```
Linux 4.19.16-1-MANJARO #1 SMP PREEMPT Fri Jan 18 17:03:05 UTC 2019 x86_64 GNU/Linux
gcc (GCC) 8.2.1 20181127
```
Proposed fix does not change functionality at all. It works exactly the same, but removing the warning. There is no other way that I am aware to remove the warning when using `-Wall`. 