### PR TITLE
Fix example_win32_directx11 linker settings.

### DIFF
--- a/examples/example_win32_directx11/build_win32.bat
+++ b/examples/example_win32_directx11/build_win32.bat
@@ -1,4 +1,3 @@
 @REM Build for Visual Studio compiler. Run your copy of vcvars32.bat or vcvarsall.bat to setup command-line compiler.
 mkdir Debug
-cl /nologo /Zi /MD /I .. /I ..\.. /I "%WindowsSdkDir%Include\um" /I "%WindowsSdkDir%Include\shared" /I "%DXSDK_DIR%Include" /D UNICODE /D _UNICODE *.cpp ..\imgui_impl_dx11.cpp ..\imgui_impl_win32.cpp ..\..\imgui*.cpp /FeDebug/example_win32_directx11.exe /FoDebug/ /link /LIBPATH:"%DXSDK_DIR%/Lib/x86" d3d11.lib d3dcompiler.lib
-
+cl /nologo /Zi /MD /I .. /I ..\.. /I "%WindowsSdkDir%Include\um" /I "%WindowsSdkDir%Include\shared" /I "%DXSDK_DIR%Include" /D UNICODE /D _UNICODE *.cpp ..\imgui_impl_dx11.cpp ..\imgui_impl_win32.cpp ..\..\imgui*.cpp /FeDebug/example_win32_directx11.exe /FoDebug/ /link /LIBPATH:"%DXSDK_DIR%/Lib/x86" d3d11.lib d3dcompiler.lib gdi32.lib


### PR DESCRIPTION
Got an error building example_win32_directx11 from the repo, using Visual Studio 2017, compiler version `Microsoft (R) C/C++ Optimizing Compiler Version 19.16.27023.1 for x86`.

Running `build_win32.bat` I get this command line:

    cl /nologo /Zi /MD /I .. /I ..\.. /I "C:\Program Files (x86)\Windows Kits\10\Include\um" /I "C:\Program Files (x86)\Windows Kits\10\Include\shared" /I "Include" /D UNICODE /D _UNICODE *.cpp ..\imgui_impl_dx11.cpp ..\imgui_impl_win32.cpp ..\..\imgui*.cpp /FeDebug/example_win32_directx11.exe /FoDebug/ /link /LIBPATH:"/Lib/x86" d3d11.lib d3dcompiler.lib

And this error:

    imgui_impl_win32.obj : error LNK2019: unresolved external symbol __imp__GetDeviceCaps@8 referenced in function "float __cdecl ImGui_ImplWin32_GetDpiScaleForMonitor(void *)" (?ImGui_ImplWin32_GetDpiScaleForMonitor@@YAMPAX@Z)
    Debug/example_win32_directx11.exe : fatal error LNK1120: 1 unresolved externals

The fix for me was to add `gdi32.lib` to the command line explicitly.

Thanks,

--Tom