### PR TITLE
Add Combo flag to allow left alignment of arrow button

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -799,6 +799,7 @@ enum ImGuiComboFlags_
     ImGuiComboFlags_HeightLargest           = 1 << 4,   // As many fitting items as possible
     ImGuiComboFlags_NoArrowButton           = 1 << 5,   // Display on the preview box without the square arrow button
     ImGuiComboFlags_NoPreview               = 1 << 6,   // Display only a square arrow button
+    ImGuiComboFlags_ArrowAlignLeft          = 1 << 7,   // Align the arrow button on the left
     ImGuiComboFlags_HeightMask_             = ImGuiComboFlags_HeightSmall | ImGuiComboFlags_HeightRegular | ImGuiComboFlags_HeightLarge | ImGuiComboFlags_HeightLargest
 };
 

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -768,6 +768,7 @@ static void ShowDemoWindowWidgets()
             flags &= ~ImGuiComboFlags_NoPreview;     // Clear the other flag, as we cannot combine both
         if (ImGui::CheckboxFlags("ImGuiComboFlags_NoPreview", (unsigned int*)&flags, ImGuiComboFlags_NoPreview))
             flags &= ~ImGuiComboFlags_NoArrowButton; // Clear the other flag, as we cannot combine both
+        ImGui::CheckboxFlags("ImGuiComboFlags_ArrowAlignLeft", (unsigned int*)&flags, ImGuiComboFlags_ArrowAlignLeft);
 
         // General BeginCombo() API, you have full control over your selection data and display type.
         // (your selection data could be an index, a pointer to the object, an id for the object, a flag stored in the object itself, etc.)

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -1303,19 +1303,27 @@ bool ImGui::BeginCombo(const char* label, const char* preview_value, ImGuiComboF
     bool pressed = ButtonBehavior(frame_bb, id, &hovered, &held);
     bool popup_open = IsPopupOpen(id);
 
-    const ImRect value_bb(frame_bb.Min, frame_bb.Max - ImVec2(arrow_size, 0.0f));
+    const float preview_offset = (!(flags & ImGuiComboFlags_NoArrowButton) && (flags & ImGuiComboFlags_ArrowAlignLeft)) ? arrow_size : 0.0f;
+    const ImRect value_bb(frame_bb.Min + ImVec2(preview_offset, 0.0f), frame_bb.Max - ImVec2(arrow_size - preview_offset, 0.0f));
     const ImU32 frame_col = GetColorU32(hovered ? ImGuiCol_FrameBgHovered : ImGuiCol_FrameBg);
     RenderNavHighlight(frame_bb, id);
     if (!(flags & ImGuiComboFlags_NoPreview))
-        window->DrawList->AddRectFilled(frame_bb.Min, ImVec2(frame_bb.Max.x - arrow_size, frame_bb.Max.y), frame_col, style.FrameRounding, ImDrawCornerFlags_Left);
+        window->DrawList->AddRectFilled(value_bb.Min, value_bb.Max, frame_col, style.FrameRounding, ImDrawCornerFlags_Left);
     if (!(flags & ImGuiComboFlags_NoArrowButton))
     {
-        window->DrawList->AddRectFilled(ImVec2(frame_bb.Max.x - arrow_size, frame_bb.Min.y), frame_bb.Max, GetColorU32((popup_open || hovered) ? ImGuiCol_ButtonHovered : ImGuiCol_Button), style.FrameRounding, (w <= arrow_size) ? ImDrawCornerFlags_All : ImDrawCornerFlags_Right);
-        RenderArrow(ImVec2(frame_bb.Max.x - arrow_size + style.FramePadding.y, frame_bb.Min.y + style.FramePadding.y), ImGuiDir_Down);
+        ImVec2 arrow_min(frame_bb.Max.x - arrow_size, frame_bb.Min.y);
+        ImVec2 arrow_max = frame_bb.Max;
+        if (flags & ImGuiComboFlags_ArrowAlignLeft)
+        {
+            arrow_min.x = frame_bb.Min.x;
+            arrow_max.x = frame_bb.Min.x + arrow_size;
+        }
+        window->DrawList->AddRectFilled(arrow_min, arrow_max, GetColorU32((popup_open || hovered) ? ImGuiCol_ButtonHovered : ImGuiCol_Button), style.FrameRounding, (w <= arrow_size) ? ImDrawCornerFlags_All : ImDrawCornerFlags_Right);
+        RenderArrow(ImVec2(arrow_min.x + style.FramePadding.y, arrow_min.y + style.FramePadding.y), ImGuiDir_Down);
     }
     RenderFrameBorder(frame_bb.Min, frame_bb.Max, style.FrameRounding);
     if (preview_value != NULL && !(flags & ImGuiComboFlags_NoPreview))
-        RenderTextClipped(frame_bb.Min + style.FramePadding, value_bb.Max, preview_value, NULL, NULL, ImVec2(0.0f,0.0f));
+        RenderTextClipped(value_bb.Min + style.FramePadding, value_bb.Max, preview_value, NULL, NULL, ImVec2(0.0f,0.0f));
     if (label_size.x > 0)
         RenderText(ImVec2(frame_bb.Max.x + style.ItemInnerSpacing.x, frame_bb.Min.y + style.FramePadding.y), label);
 


### PR DESCRIPTION
This is a minor feature for the ImGui::Combo() widget.

It adds a new ImGuiComboFlag, to control whether the arrow button is aligned to the left or the right side of the widget.

Also updated the demo window.

Attached screenshot from my app, showing it in action.

<img width="954" alt="arrowalignleft" src="https://user-images.githubusercontent.com/687817/52081906-0fb69900-25a4-11e9-889f-78f03e93063e.png">
