### PR TITLE
Fixed auto-resize collapse bug introduced by d9a84de

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -4557,7 +4557,7 @@ static ImVec2 CalcSizeAfterConstraint(ImGuiWindow* window, ImVec2 new_size)
 
 static ImVec2 CalcSizeContents(ImGuiWindow* window)
 {
-    if (window->Collapsed)
+    if (window->Collapsed && (window->Flags & ImGuiWindowFlags_AlwaysAutoResize) == 0)
         return window->SizeContents;
     if (window->Hidden && window->HiddenFramesForResize == 0 && window->HiddenFramesRegular > 0)
         return window->SizeContents;


### PR DESCRIPTION
Hi,

This PR addresses the re-introduction of the bug described in https://github.com/ocornut/imgui/issues/176 caused by https://github.com/ocornut/imgui/commit/d9a84de9d9c28751bb8ea0ed24e4f3f1cc0e711f.

![capture](https://user-images.githubusercontent.com/1778143/52458539-d71f3e00-2b14-11e9-8366-1b049765384d.PNG)


The fix: Only use the `SizeContents` value if it's collapsed and the auto-resize flag is NOT set. Otherwise, it will not calculate the content size properly.