### PR TITLE
OSX: Treat ctrl-left-click as right click

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -3211,6 +3211,27 @@ static void ImGui::UpdateMouseInputs()
         g.NavDisableMouseHover = false;
 
     g.IO.MousePosPrev = g.IO.MousePos;
+
+    if (g.IO.ConfigMacOSXBehaviors)
+    {
+        if (g.IO.MouseDown[0] && g.IO.MouseDownDuration[0] < 0.0f && g.IO.KeyCtrl)
+        {
+            g.IO.MouseDown[0] = false;
+            g.IO.MouseDown[1] = true;
+            // On the first frame, the control button counts as part of the mouse event, so we eat it
+            g.IO.KeyCtrl = false;
+            g.IO.MacOSXInCtrlRightClick = true;
+        }
+        else if (g.IO.MacOSXInCtrlRightClick && g.IO.MouseDown[0])
+        {
+            // On all frames after the first, we let control go through to allow for ctrl+right click
+            g.IO.MouseDown[0] = false;
+            g.IO.MouseDown[1] = true;
+        }
+        else if (!g.IO.MouseDown[0])
+            g.IO.MacOSXInCtrlRightClick = false;
+    }
+
     for (int i = 0; i < IM_ARRAYSIZE(g.IO.MouseDown); i++)
     {
         g.IO.MouseClicked[i] = g.IO.MouseDown[i] && g.IO.MouseDownDuration[i] < 0.0f;

--- a/imgui.h
+++ b/imgui.h
@@ -1400,6 +1400,7 @@ struct ImGuiIO
     float       NavInputsDownDuration[ImGuiNavInput_COUNT];
     float       NavInputsDownDurationPrev[ImGuiNavInput_COUNT];
     ImVector<ImWchar> InputQueueCharacters;     // Queue of _characters_ input (obtained by platform back-end). Fill using AddInputCharacter() helper.
+    bool        MacOSXInCtrlRightClick;         // Set to true when the current click was a ctrl-click that spawned a simulated right click
 
     IMGUI_API   ImGuiIO();
 };


### PR DESCRIPTION
All native Mac applications treat ctrl + left-click as a right-click event; Apple says in their [user help guide](https://support.apple.com/en-us/HT207700):

> On Mac computers, right click is known as secondary click or Control click. If your mouse, trackpad, or other input device doesn't include a right-click button or other way to perform a right click, just hold down the Control key on your keyboard while you click.

Since ImGui is usually fed input state by directly querying mouse state, it just sees ctrl and left-click without synthesizing them into a right click. This PR integrates the native MacOS behavior of turning ctrl+left-click into right-click when the IO config flag `ConfigMacOSXBehaviors` is set to true.

If this is the wrong place to do this let me know; it occurred to me that this might better belong in the examples code, but there are many frontends that support MacOS, and solving this in a central location makes sense to me.

Related to https://github.com/ocornut/imgui/issues/1765