### PR TITLE
Fix -Wconversion warning when ImTextureID is not a pointer type

### DIFF
--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -407,7 +407,7 @@ ImDrawList* ImDrawList::CloneOutput() const
 
 // Using macros because C++ is a terrible language, we want guaranteed inline, no code in header, and no overhead in Debug builds
 #define GetCurrentClipRect()    (_ClipRectStack.Size ? _ClipRectStack.Data[_ClipRectStack.Size-1]  : _Data->ClipRectFullscreen)
-#define GetCurrentTextureId()   (_TextureIdStack.Size ? _TextureIdStack.Data[_TextureIdStack.Size-1] : NULL)
+#define GetCurrentTextureId()   (_TextureIdStack.Size ? _TextureIdStack.Data[_TextureIdStack.Size-1] : (ImTextureID)NULL)
 
 void ImDrawList::AddDrawCmd()
 {


### PR DESCRIPTION
The warning was caused by implicit conversion from pointer type which NULL has to non-pointer type, e.g. if ImTextureID is long int. Example of a warning:

```
imgui_draw.cpp:416:26: warning: converting to non-pointer type ‘long int’ from NULL [-Wconversion-null]
     draw_cmd.TextureId = GetCurrentTextureId();
```
