### PR TITLE
Fixes a compile issue caused by a missing case.

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -8931,6 +8931,7 @@ void ImGui::LogFinish()
             SetClipboardText(g.LogBuffer.begin());
         break;
     case ImGuiLogType_None:
+        IM_ASSERT(0);
         break;
     }
 

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -8930,6 +8930,8 @@ void ImGui::LogFinish()
         if (!g.LogBuffer.empty())
             SetClipboardText(g.LogBuffer.begin());
         break;
+    case ImGuiLogType_None:
+        break;
     }
 
     g.LogEnabled = false;


### PR DESCRIPTION
imgui.cpp(8933): error C4062: enumerator 'ImGuiLogType_None' in switch of enum 'ImGuiLogType' is not handled

I added an empty case statement for ImGuiLogType_None to match the empty statement for ImGuiLogType_Buffer.  This fixes the compiler warning and should not be a change in behavior.

This is to fix this issue https://github.com/ocornut/imgui/issues/2381
