### PR TITLE
Fix division by 0 in ImGui::PlotLines when values_count = 1

### DIFF
--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -5343,7 +5343,7 @@ void ImGui::PlotEx(ImGuiPlotType plot_type, const char* label, float (*values_ge
 
     RenderFrame(frame_bb.Min, frame_bb.Max, GetColorU32(ImGuiCol_FrameBg), true, style.FrameRounding);
 
-    if (values_count > 0)
+    if (values_count > int(plot_type == ImGuiPlotType_Lines) ) // ImGuiPlotType_Lines requires at least 2 values
     {
         int res_w = ImMin((int)frame_size.x, values_count) + ((plot_type == ImGuiPlotType_Lines) ? -1 : 0);
         int item_count = values_count + ((plot_type == ImGuiPlotType_Lines) ? -1 : 0);


### PR DESCRIPTION
If `values_count == 1`, then there is a division by zero in `const float t_step = 1.0f / (float)res_w;` as res_w can be 0 ( `ImMin((int)graph_size.x, values_count) + ((plot_type == ImGuiPlotType_Lines) ? -1 : 0) == 1 - 1 == 0` )

This can be reproduced with the following snippet:
```cpp
float values[1] = {0.f};
ImGui::PlotLines("Boom", values, 1);
```