### PR TITLE
GL context wasn't set when using multiple windows.

### DIFF
--- a/examples/imgui_impl_glfw.cpp
+++ b/examples/imgui_impl_glfw.cpp
@@ -602,8 +602,10 @@ static void ImGui_ImplGlfw_RenderWindow(ImGuiViewport* viewport, void*)
 static void ImGui_ImplGlfw_SwapBuffers(ImGuiViewport* viewport, void*)
 {
     ImGuiViewportDataGlfw* data = (ImGuiViewportDataGlfw*)viewport->PlatformUserData;
-    if (g_ClientApi == GlfwClientApi_OpenGL)
+    if (g_ClientApi == GlfwClientApi_OpenGL) {
+        glfwMakeContextCurrent(data->Window);
         glfwSwapBuffers(data->Window);
+    }
 }
 
 //--------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
In the docking branch, there is a bug when 3 or more floating windows are open. The GLFW backend was not correctly selecting the appropriate context for each window. This simple patch fixes the issue.