### PR TITLE
Fix Platform_SetImeInputPos not being called for the main viewport.

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -3790,6 +3790,7 @@ void ImGui::Initialize(ImGuiContext* context)
     ImGuiViewportP* viewport = IM_NEW(ImGuiViewportP)();
     viewport->ID = IMGUI_VIEWPORT_DEFAULT_ID;
     viewport->Idx = 0;
+    viewport->PlatformWindowCreated = true;
     g.Viewports.push_back(viewport);
     g.PlatformIO.MainViewport = g.Viewports[0]; // Make it accessible in public-facing GetPlatformIO() immediately (before the first call to EndFrame)
     g.PlatformIO.Viewports.push_back(g.Viewports[0]);
@@ -10078,7 +10079,7 @@ static void ImGui::UpdateViewportsNewFrame()
     for (int n = 0; n < g.Viewports.Size; n++)
     {
         ImGuiViewportP* viewport = g.Viewports[n];
-        const bool platform_funcs_available = (n == 0 || viewport->PlatformWindowCreated);
+        const bool platform_funcs_available = viewport->PlatformWindowCreated;
         if ((g.ConfigFlagsForFrame & ImGuiConfigFlags_ViewportsEnable))
             if (g.PlatformIO.Platform_GetWindowMinimized && platform_funcs_available)
                 viewport->PlatformWindowMinimized = g.PlatformIO.Platform_GetWindowMinimized(viewport);
@@ -10124,7 +10125,7 @@ static void ImGui::UpdateViewportsNewFrame()
             continue;
         }
 
-        const bool platform_funcs_available = (n == 0 || viewport->PlatformWindowCreated);
+        const bool platform_funcs_available = viewport->PlatformWindowCreated;
         if ((g.ConfigFlagsForFrame & ImGuiConfigFlags_ViewportsEnable))
         {
             // Update Position and Size (from Platform Window to ImGui) if requested. 
@@ -10535,7 +10536,7 @@ void ImGui::UpdatePlatformWindows()
         for (int n = 0; n < g.Viewports.Size && focused_viewport == NULL; n++)
         {
             ImGuiViewportP* viewport = g.Viewports[n];
-            if (n == 0 || viewport->PlatformWindowCreated)
+            if (viewport->PlatformWindowCreated)
                 if (g.PlatformIO.Platform_GetWindowFocus(viewport))
                     focused_viewport = viewport;
         }


### PR DESCRIPTION
Currently the main viewport never has the `PlatformWindowCreated` set to true. This causes `Platform_SetImeInputPos` to never be called for it due to the logic on [imgui.cpp:4081](https://github.com/ocornut/imgui/blob/9afb849e16900d67e0cde7c8754c1f547a349a21/imgui.cpp#L4081).

Right now many places which check `PlatformWindowCreated` use logic to assume the window is created for the main viewport. (Example: [imgui.cpp:10081](https://github.com/ocornut/imgui/blob/9afb849e16900d67e0cde7c8754c1f547a349a21/imgui.cpp#L10081))

To fix this, this PR changes `ImGui::Initialize` function to set `PlatformWindowCreated` to true on the main viewport. I think it's fairly safe to assume that the main viewport will be created by the platform since it wouldn't make much sense for it not to. As such, this PR also removed the `n == 0` checks which were scattered among other places `PlatformWindowCreated` was being used.