### PR TITLE
Added arrow callback function

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -2398,6 +2398,13 @@ void ImGui::RenderFrameBorder(ImVec2 p_min, ImVec2 p_max, float rounding)
     }
 }
 
+// define arrow callback
+void ImGui::SetArrowCallback(ImGuiArrowCallback callback)
+{
+    ImGuiContext& g = *GImGui;
+    g.ArrowCallback = callback;
+}
+
 // Render an arrow aimed to be aligned with text (p_min is a position in the same space text would be positioned). To e.g. denote expanded/collapsed state
 void ImGui::RenderArrow(ImVec2 p_min, ImGuiDir dir, float scale)
 {
@@ -2408,26 +2415,31 @@ void ImGui::RenderArrow(ImVec2 p_min, ImGuiDir dir, float scale)
     ImVec2 center = p_min + ImVec2(h * 0.50f, h * 0.50f * scale);
 
     ImVec2 a, b, c;
-    switch (dir)
-    {
-    case ImGuiDir_Up:
-    case ImGuiDir_Down:
-        if (dir == ImGuiDir_Up) r = -r;
-        a = ImVec2(+0.000f,+0.750f) * r;
-        b = ImVec2(-0.866f,-0.750f) * r;
-        c = ImVec2(+0.866f,-0.750f) * r;
-        break;
-    case ImGuiDir_Left:
-    case ImGuiDir_Right:
-        if (dir == ImGuiDir_Left) r = -r;
-        a = ImVec2(+0.750f,+0.000f) * r;
-        b = ImVec2(-0.750f,+0.866f) * r;
-        c = ImVec2(-0.750f,-0.866f) * r;
-        break;
-    case ImGuiDir_None:
-    case ImGuiDir_COUNT:
-        IM_ASSERT(0);
-        break;
+    if (g.ArrowCallback) {
+        g.ArrowCallback(g.CurrentWindow->DrawList, dir, p_min, h * scale);
+    } else {
+        switch (dir)
+        {
+        case ImGuiDir_Up:
+        case ImGuiDir_Down:
+            if (dir == ImGuiDir_Up) r = -r;
+            a = ImVec2(+0.000f, +0.750f) * r;
+            b = ImVec2(-0.866f, -0.750f) * r;
+            c = ImVec2(+0.866f, -0.750f) * r;
+            break;
+        case ImGuiDir_Left:
+        case ImGuiDir_Right:
+            if (dir == ImGuiDir_Left) r = -r;
+            a = ImVec2(+0.750f, +0.000f) * r;
+            b = ImVec2(-0.750f, +0.866f) * r;
+            c = ImVec2(-0.750f, -0.866f) * r;
+            break;
+        case ImGuiDir_None:
+        case ImGuiDir_COUNT:
+            IM_ASSERT(0);
+            break;
+        }
+        g.CurrentWindow->DrawList->AddTriangleFilled(center + a, center + b, center + c, GetColorU32(ImGuiCol_Text));
     }
 
     g.CurrentWindow->DrawList->AddTriangleFilled(center + a, center + b, center + c, GetColorU32(ImGuiCol_Text));

--- a/imgui.h
+++ b/imgui.h
@@ -113,6 +113,7 @@ struct ImGuiStorage;                // Helper for key->value storage
 struct ImGuiStyle;                  // Runtime data for styling/colors
 struct ImGuiTextBuffer;             // Helper to hold and append into a text buffer (~string builder)
 struct ImGuiTextFilter;             // Helper to parse and apply text filters (e.g. "aaaaa[,bbbb][,ccccc]")
+struct ImVec2;                      // 2D vector (often used to store positions, sizes, etc.)
 
 // Typedefs and Enums/Flags (declared as int for compatibility with old C++, to allow using as flags and to not pollute the top of this file)
 // Use your programming IDE "Go to definition" facility on the names of the center columns to find the actual flags/enum lists.
@@ -148,6 +149,7 @@ typedef int ImGuiTreeNodeFlags;     // -> enum ImGuiTreeNodeFlags_   // Flags: f
 typedef int ImGuiWindowFlags;       // -> enum ImGuiWindowFlags_     // Flags: for Begin*()
 typedef int (*ImGuiInputTextCallback)(ImGuiInputTextCallbackData *data);
 typedef void (*ImGuiSizeCallback)(ImGuiSizeCallbackData* data);
+typedef void(*ImGuiArrowCallback)(ImDrawList* list, ImGuiDir dir, ImVec2 min, float scale);
 
 // Scalar data types
 typedef signed char         ImS8;   // 8-bit signed integer == char

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -979,6 +979,8 @@ struct ImGuiContext
     int                     WantTextInputNextFrame;
     char                    TempBuffer[1024*3+1];               // Temporary text buffer
 
+    ImGuiArrowCallback      ArrowCallback;
+
     ImGuiContext(ImFontAtlas* shared_font_atlas) : BackgroundDrawList(NULL), ForegroundDrawList(NULL)
     {
         Initialized = false;


### PR DESCRIPTION
Hi,

I wanted to be able to customize the elements of the widgets that are currently hard coded and can not be skinned, such as the tree arrows, checkmarks, close button and so on.
All those elements are drawn with RenderArrow/RenderCheckMark/... functions, so it's fairly easy and clean to add a callback to the application to be able to draw anything we want in place of the default.

Until now I've only implemented this for the arrows and tested with combo boxes. I plan to implement the rest of those (especially checkmarks), but before doing so I created this PR hoping to get some feedback/suggestions.

How to use:
Just after having created the context, just add this line:
`ImGui::SetArrowCallback(arrowCallback);`

the arrowCallback can be defined like this, for example:
```
void arrowCallback(ImDrawList* list, ImGuiDir dir, ImVec2 min, float scale)
{
	ImVec2 p[5];
	switch (dir)
	{
	case ImGuiDir_Up:
		p[0] = ImVec2(min.x + 0.5f * scale, min.y + 0.2f * scale);
		p[1] = ImVec2(min.x + 0.2f * scale, min.y + 0.5f * scale);
		p[2] = ImVec2(min.x + 0.2f * scale, min.y + 0.7f * scale);
		p[3] = ImVec2(min.x + 0.8f * scale, min.y + 0.7f * scale);
		p[2] = ImVec2(min.x + 0.8f * scale, min.y + 0.5f * scale);
		break;
	case ImGuiDir_Down:
		p[0] = ImVec2(min.x + 0.5f * scale, min.y + 0.75f * scale);
		p[1] = ImVec2(min.x + 0.25f * scale, min.y + 0.5f * scale);
		p[2] = ImVec2(min.x + 0.25f * scale, min.y + 0.35f * scale);
		p[3] = ImVec2(min.x + 0.75f * scale, min.y + 0.35f * scale);
		p[4] = ImVec2(min.x + 0.75f * scale, min.y + 0.5f * scale);
		break;
	case ImGuiDir_Left:
		p[0] = ImVec2(min.x + 0.2f * scale, min.y + 0.5f * scale);
		p[1] = ImVec2(min.x + 0.5f * scale, min.y + 0.2f * scale);
		p[2] = ImVec2(min.x + 0.7f * scale, min.y + 0.2f * scale);
		p[3] = ImVec2(min.x + 0.7f * scale, min.y + 0.8f * scale);
		p[4] = ImVec2(min.x + 0.5f * scale, min.y + 0.8f * scale);
		break;
	case ImGuiDir_Right:
		p[0] = ImVec2(min.x + 0.8f * scale, min.y + 0.5f * scale);
		p[1] = ImVec2(min.x + 0.5f * scale, min.y + 0.2f * scale);
		p[2] = ImVec2(min.x + 0.3f * scale, min.y + 0.2f * scale);
		p[3] = ImVec2(min.x + 0.3f * scale, min.y + 0.8f * scale);
		p[4] = ImVec2(min.x + 0.5f * scale, min.y + 0.8f * scale);
		break;
	case ImGuiDir_None:
	case ImGuiDir_COUNT:
		throw std::runtime_error("Invalid arrow direction"); // onw might want to use assert instead
		break;
	}
	list->AddConvexPolyFilled(p, 5, ImGui::GetColorU32(ImGuiCol_CheckMark));
}
```

That's it. You can see the difference here: 
![image](https://user-images.githubusercontent.com/11974190/54595311-b46a3880-4a75-11e9-93d4-1cec27c4011b.png)
