### PR TITLE
Double buffered InputQueueCharacters, MouseWheel and MouseWheelH

### DIFF
--- a/examples/imgui_impl_allegro5.cpp
+++ b/examples/imgui_impl_allegro5.cpp
@@ -309,8 +309,8 @@ bool ImGui_ImplAllegro5_ProcessEvent(ALLEGRO_EVENT *ev)
     case ALLEGRO_EVENT_MOUSE_AXES:
         if (ev->mouse.display == g_Display)
         {
-            io.MouseWheel += ev->mouse.dz;
-            io.MouseWheelH += ev->mouse.dw;
+            io.InputNextFrame->MouseWheel += ev->mouse.dz;
+            io.InputNextFrame->MouseWheelH += ev->mouse.dw;
             io.MousePos = ImVec2(ev->mouse.x, ev->mouse.y);
         }
         return true;

--- a/examples/imgui_impl_freeglut.cpp
+++ b/examples/imgui_impl_freeglut.cpp
@@ -174,9 +174,9 @@ void ImGui_ImplFreeGLUT_MouseWheelFunc(int button, int dir, int x, int y)
     ImGuiIO& io = ImGui::GetIO();
     io.MousePos = ImVec2((float)x, (float)y);
     if (dir > 0)
-        io.MouseWheel += 1.0;
+		io.InputNextFrame->MouseWheel += 1.0;
     else if (dir < 0)
-        io.MouseWheel -= 1.0;
+        io.InputNextFrame->MouseWheel -= 1.0;
     (void)button; // Unused
 }
 

--- a/examples/imgui_impl_glfw.cpp
+++ b/examples/imgui_impl_glfw.cpp
@@ -92,8 +92,8 @@ void ImGui_ImplGlfw_ScrollCallback(GLFWwindow* window, double xoffset, double yo
         g_PrevUserCallbackScroll(window, xoffset, yoffset);
 
     ImGuiIO& io = ImGui::GetIO();
-    io.MouseWheelH += (float)xoffset;
-    io.MouseWheel += (float)yoffset;
+    io.InputNextFrame->MouseWheelH += (float)xoffset;
+    io.InputNextFrame->MouseWheel += (float)yoffset;
 }
 
 void ImGui_ImplGlfw_KeyCallback(GLFWwindow* window, int key, int scancode, int action, int mods)

--- a/examples/imgui_impl_marmalade.cpp
+++ b/examples/imgui_impl_marmalade.cpp
@@ -133,9 +133,9 @@ int32 ImGui_Marmalade_PointerButtonEventCallback(void* system_data, void* user_d
         if (pEvent->m_Button == S3E_POINTER_BUTTON_MIDDLEMOUSE)
             g_MousePressed[2] = true;
         if (pEvent->m_Button == S3E_POINTER_BUTTON_MOUSEWHEELUP)
-            io.MouseWheel += pEvent->m_y;
+            io.InputNextFrame->MouseWheel += pEvent->m_y;
         if (pEvent->m_Button == S3E_POINTER_BUTTON_MOUSEWHEELDOWN)
-            io.MouseWheel += pEvent->m_y;
+            io.InputNextFrame->MouseWheel += pEvent->m_y;
     }
 
     return 0;

--- a/examples/imgui_impl_osx.mm
+++ b/examples/imgui_impl_osx.mm
@@ -175,9 +175,9 @@ bool ImGui_ImplOSX_HandleEvent(NSEvent* event, NSView* view)
         }
 
         if (fabs(wheel_dx) > 0.0)
-            io.MouseWheelH += wheel_dx * 0.1f;
+            io.InputNextFrame->MouseWheelH += wheel_dx * 0.1f;
         if (fabs(wheel_dy) > 0.0)
-            io.MouseWheel += wheel_dy * 0.1f;
+            io.InputNextFrame->MouseWheel += wheel_dy * 0.1f;
         return io.WantCaptureMouse;
     }
 

--- a/examples/imgui_impl_sdl.cpp
+++ b/examples/imgui_impl_sdl.cpp
@@ -87,10 +87,10 @@ bool ImGui_ImplSDL2_ProcessEvent(const SDL_Event* event)
     {
     case SDL_MOUSEWHEEL:
         {
-            if (event->wheel.x > 0) io.MouseWheelH += 1;
-            if (event->wheel.x < 0) io.MouseWheelH -= 1;
-            if (event->wheel.y > 0) io.MouseWheel += 1;
-            if (event->wheel.y < 0) io.MouseWheel -= 1;
+            if (event->wheel.x > 0) io.InputNextFrame->MouseWheelH += 1;
+            if (event->wheel.x < 0) io.InputNextFrame->MouseWheelH -= 1;
+            if (event->wheel.y > 0) io.InputNextFrame->MouseWheel += 1;
+            if (event->wheel.y < 0) io.InputNextFrame->MouseWheel -= 1;
             return true;
         }
     case SDL_MOUSEBUTTONDOWN:

--- a/examples/imgui_impl_win32.cpp
+++ b/examples/imgui_impl_win32.cpp
@@ -217,7 +217,7 @@ void    ImGui_ImplWin32_NewFrame()
     io.KeyShift = (::GetKeyState(VK_SHIFT) & 0x8000) != 0;
     io.KeyAlt = (::GetKeyState(VK_MENU) & 0x8000) != 0;
     io.KeySuper = false;
-    // io.KeysDown[], io.MousePos, io.MouseDown[], io.MouseWheel: filled by the WndProc handler below.
+    // io.KeysDown[], io.MousePos, io.MouseDown[], io.InputNextFrame->MouseWheel: filled by the WndProc handler below.
 
     // Update OS mouse position
     ImGui_ImplWin32_UpdateMousePos();
@@ -288,10 +288,10 @@ IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hwnd, UINT msg, WPARA
         return 0;
     }
     case WM_MOUSEWHEEL:
-        io.MouseWheel += (float)GET_WHEEL_DELTA_WPARAM(wParam) / (float)WHEEL_DELTA;
+        io.InputNextFrame->MouseWheel += (float)GET_WHEEL_DELTA_WPARAM(wParam) / (float)WHEEL_DELTA;
         return 0;
     case WM_MOUSEHWHEEL:
-        io.MouseWheelH += (float)GET_WHEEL_DELTA_WPARAM(wParam) / (float)WHEEL_DELTA;
+        io.InputNextFrame->MouseWheelH += (float)GET_WHEEL_DELTA_WPARAM(wParam) / (float)WHEEL_DELTA;
         return 0;
     case WM_KEYDOWN:
     case WM_SYSKEYDOWN:

--- a/imgui.h
+++ b/imgui.h
@@ -1370,10 +1370,20 @@ struct ImGuiIO
     // Input - Fill before calling NewFrame()
     //------------------------------------------------------------------
 
+    // Any inputs that collect deltas between frame are double buffered to allow for inputs being collected in background threads.
+    struct BufferedInput
+    {
+        ImVector<ImWchar> InputQueueCharacters;     // Queue of _characters_ input (obtained by platform back-end). Fill using AddInputCharacter() helper.
+        float       MouseWheel;                     // Mouse wheel Vertical: 1 unit scrolls about 5 lines text.
+        float       MouseWheelH;                    // Mouse wheel Horizontal. Most users don't have a mouse with an horizontal wheel, may not be filled by all back-ends.
+    };
+
+    BufferedInput InputFrames[2];
+    BufferedInput* InputCurrentFrame;
+    BufferedInput* InputNextFrame;
+
     ImVec2      MousePos;                       // Mouse position, in pixels. Set to ImVec2(-FLT_MAX,-FLT_MAX) if mouse is unavailable (on another screen, etc.)
     bool        MouseDown[5];                   // Mouse buttons: 0=left, 1=right, 2=middle + extras. ImGui itself mostly only uses left button (BeginPopupContext** are using right button). Others buttons allows us to track if the mouse is being used by your application + available to user as a convenience via IsMouse** API.
-    float       MouseWheel;                     // Mouse wheel Vertical: 1 unit scrolls about 5 lines text.
-    float       MouseWheelH;                    // Mouse wheel Horizontal. Most users don't have a mouse with an horizontal wheel, may not be filled by all back-ends.
     bool        KeyCtrl;                        // Keyboard modifier pressed: Control
     bool        KeyShift;                       // Keyboard modifier pressed: Shift
     bool        KeyAlt;                         // Keyboard modifier pressed: Alt
@@ -1424,7 +1434,6 @@ struct ImGuiIO
     float       KeysDownDurationPrev[512];      // Previous duration the key has been down
     float       NavInputsDownDuration[ImGuiNavInput_COUNT];
     float       NavInputsDownDurationPrev[ImGuiNavInput_COUNT];
-    ImVector<ImWchar> InputQueueCharacters;     // Queue of _characters_ input (obtained by platform back-end). Fill using AddInputCharacter() helper.
 
     IMGUI_API   ImGuiIO();
 };

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -2563,7 +2563,7 @@ static void ShowDemoWindowMisc()
             ImGui::Text("Mouse clicked:");  for (int i = 0; i < IM_ARRAYSIZE(io.MouseDown); i++) if (ImGui::IsMouseClicked(i))          { ImGui::SameLine(); ImGui::Text("b%d", i); }
             ImGui::Text("Mouse dbl-clicked:"); for (int i = 0; i < IM_ARRAYSIZE(io.MouseDown); i++) if (ImGui::IsMouseDoubleClicked(i)) { ImGui::SameLine(); ImGui::Text("b%d", i); }
             ImGui::Text("Mouse released:"); for (int i = 0; i < IM_ARRAYSIZE(io.MouseDown); i++) if (ImGui::IsMouseReleased(i))         { ImGui::SameLine(); ImGui::Text("b%d", i); }
-            ImGui::Text("Mouse wheel: %.1f", io.MouseWheel);
+			ImGui::Text("Mouse wheel: %.1f", io.InputCurrentFrame->MouseWheel);
 
             ImGui::Text("Keys down:");      for (int i = 0; i < IM_ARRAYSIZE(io.KeysDown); i++) if (io.KeysDownDuration[i] >= 0.0f)     { ImGui::SameLine(); ImGui::Text("%d (0x%X) (%.02f secs)", i, i, io.KeysDownDuration[i]); }
             ImGui::Text("Keys pressed:");   for (int i = 0; i < IM_ARRAYSIZE(io.KeysDown); i++) if (ImGui::IsKeyPressed(i))             { ImGui::SameLine(); ImGui::Text("%d (0x%X)", i, i); }

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -3435,22 +3435,22 @@ bool ImGui::InputTextEx(const char* label, const char* hint, char* buf, int buf_
         if (state->SelectedAllMouseLock && !io.MouseDown[0])
             state->SelectedAllMouseLock = false;
 
-        if (io.InputQueueCharacters.Size > 0)
+        if (io.InputCurrentFrame->InputQueueCharacters.Size > 0)
         {
             // Process text input (before we check for Return because using some IME will effectively send a Return?)
             // We ignore CTRL inputs, but need to allow ALT+CTRL as some keyboards (e.g. German) use AltGR (which _is_ Alt+Ctrl) to input certain characters.
             bool ignore_inputs = (io.KeyCtrl && !io.KeyAlt) || (is_osx && io.KeySuper);
             if (!ignore_inputs && !is_readonly && !user_nav_input_start)
-                for (int n = 0; n < io.InputQueueCharacters.Size; n++)
+                for (int n = 0; n < io.InputCurrentFrame->InputQueueCharacters.Size; n++)
                 {
                     // Insert character if they pass filtering
-                    unsigned int c = (unsigned int)io.InputQueueCharacters[n];
+                    unsigned int c = (unsigned int)io.InputCurrentFrame->InputQueueCharacters[n];
                     if (InputTextFilterCharacter(&c, flags, callback, callback_user_data))
                         state->OnKeyPressed((int)c);
                 }
 
             // Consume characters
-            io.InputQueueCharacters.resize(0);
+            io.InputCurrentFrame->InputQueueCharacters.resize(0);
         }
     }
 


### PR DESCRIPTION
This change removes the need to ensure all input is handled after EndFrame and before the next NewFrame.

Context:
I integrated ImGui into a mature codebase that used background threads to collect input. I needed to integrated ImGui with very little wake, and without this change mouse scrolling and text input were very behaving erratically inconsistent.

Notes:
* Broke API on purpose so anyone that was setting MouseWheel manually needs to change where they write the update to
* State based inputs are fairly resilient to multithreading so it didn't need a full rewrite
* Updated all example code to use new location
