### PR TITLE
Added ImGuiTreeNodeFlags_UseFullWidth to allow using the full content  width for the interaction area for unframed tree nodes.

### DIFF
--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -44,6 +44,7 @@ Other Changes:
 - Examples: OpenGL: Added a dummy GL call + comments in ImGui_ImplOpenGL3_Init() to detect uninitialized
   GL function loaders early, and help users understand what they are missing. (#2421)
 - Examples: FreeGLUT: Made io.DeltaTime always > 0. (#2430)
+- Added ImGuiTreeNodeFlags_UseFullWidth to use the full content width for a tree node's interaction area. (#2451)
 
 
 -----------------------------------------------------------------------

--- a/imgui.h
+++ b/imgui.h
@@ -780,6 +780,7 @@ enum ImGuiTreeNodeFlags_
     //ImGuITreeNodeFlags_SpanAllAvailWidth  = 1 << 11,  // FIXME: TODO: Extend hit box horizontally even if not framed
     //ImGuiTreeNodeFlags_NoScrollOnOpen     = 1 << 12,  // FIXME: TODO: Disable automatic scroll on TreePop() if node got just open and contents is not visible
     ImGuiTreeNodeFlags_NavLeftJumpsBackHere = 1 << 13,  // (WIP) Nav: left direction may move to this TreeNode() from any of its child (items submitted between TreeNode and TreePop)
+    ImGuiTreeNodeFlags_UseFullWidth         = 1 << 14,  // The interactable area of the tree node will extend to the full width of the content area rather than being limited to its label. (Implied by ImGuiTreeNodeFlags_Framed)
     ImGuiTreeNodeFlags_CollapsingHeader     = ImGuiTreeNodeFlags_Framed | ImGuiTreeNodeFlags_NoTreePushOnOpen | ImGuiTreeNodeFlags_NoAutoOpenOnLog
 
     // Obsolete names (will be removed)

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -589,7 +589,7 @@ static void ShowDemoWindowWidgets()
             for (int i = 0; i < 6; i++)
             {
                 // Disable the default open on single-click behavior and pass in Selected flag according to our selection state.
-                ImGuiTreeNodeFlags node_flags = ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_OpenOnDoubleClick | ((selection_mask & (1 << i)) ? ImGuiTreeNodeFlags_Selected : 0);
+                ImGuiTreeNodeFlags node_flags = ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_OpenOnDoubleClick | ImGuiTreeNodeFlags_UseFullWidth | ((selection_mask & (1 << i)) ? ImGuiTreeNodeFlags_Selected : 0);
                 if (i < 3)
                 {
                     // Node

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -5001,8 +5001,7 @@ bool ImGui::TreeNodeBehavior(ImGuiID id, ImGuiTreeNodeFlags flags, const char* l
     ItemSize(ImVec2(text_width, frame_height), text_base_offset_y);
 
     // For regular tree nodes, we arbitrary allow to click past 2 worth of ItemSpacing
-    // (Ideally we'd want to add a flag for the user to specify if we want the hit test to be done up to the right side of the content or not)
-    const ImRect interact_bb = display_frame ? frame_bb : ImRect(frame_bb.Min.x, frame_bb.Min.y, frame_bb.Min.x + text_width + style.ItemSpacing.x*2, frame_bb.Max.y);
+    const ImRect interact_bb = (display_frame || (flags & ImGuiTreeNodeFlags_UseFullWidth)) ? frame_bb : ImRect(frame_bb.Min.x, frame_bb.Min.y, frame_bb.Min.x + text_width + style.ItemSpacing.x * 2, frame_bb.Max.y);
     bool is_open = TreeNodeBehaviorIsOpen(id, flags);
     bool is_leaf = (flags & ImGuiTreeNodeFlags_Leaf) != 0;
 


### PR DESCRIPTION
This PR adds a new flag to allow using the full width of the content area for the interaction area of a tree node, resolving [this 3 year old comment](https://github.com/ocornut/imgui/commit/d1b4159b51d944be5258d48ad8dce6fdfe4f4d80#diff-e5e00627776ba59572e7d1d86554aee6R5584).

I opted to retain the behavior of `ImGuiTreeNodeFlags_Framed` similar to `ImGuiTreeNodeFlags_FramePadding`. As such, this does not change current behavior. I also modified the "advanced tree node" demo to use the feature so those learning from the demo will find it easier.

I wasn't 100% sure on protocol for updating the changelog, so I went ahead an updated it.