### PR TITLE
Examples: Metal: Restore state after UserCallback

### DIFF
--- a/examples/imgui_impl_metal.mm
+++ b/examples/imgui_impl_metal.mm
@@ -473,6 +473,10 @@ void ImGui_ImplMetal_DestroyDeviceObjects()
             {
                 // User callback (registered via ImDrawList::AddCallback)
                 pcmd->UserCallback(cmd_list, pcmd);
+                
+                [commandEncoder setRenderPipelineState:renderPipelineState];
+                [commandEncoder setVertexBuffer:vertexBuffer.buffer offset:0 atIndex:0];
+                [commandEncoder setVertexBufferOffset:vertexBufferOffset atIndex:0];
             }
             else
             {


### PR DESCRIPTION
In other backends it is possible for the UserCallback to read the current state, do whatever state changes it needs, and then restore the imgui state before returning. In Metal there doesn't seem to be a way for a UserCallback to save the existing state before changing it so we should restore our state after the UserCallback is complete.