### PR TITLE
Fixed selectables rendering outside of bounds.

### DIFF
--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -5299,7 +5299,7 @@ bool ImGui::Selectable(const char* label, bool selected, ImGuiSelectableFlags fl
     ImGuiID id = window->GetID(label);
     ImVec2 label_size = CalcTextSize(label, NULL, true);
     ImVec2 size(size_arg.x != 0.0f ? size_arg.x : label_size.x, size_arg.y != 0.0f ? size_arg.y : label_size.y);
-    ImVec2 pos = window->DC.CursorPos;
+    ImVec2 pos = window->DC.CursorPos + (style.ItemSpacing * 0.5);
     pos.y += window->DC.CurrentLineTextBaseOffset;
     ImRect bb_inner(pos, pos + size);
     ItemSize(size);


### PR DESCRIPTION
Minor fix, selectables were rendering outside of their clip bounds, was apparent when render'd inside a ChildWindow when clipping was enabled.