### PR TITLE
Fix docking branch of DX9 sample crash when resize window

### DIFF
--- a/examples/imgui_impl_dx9.cpp
+++ b/examples/imgui_impl_dx9.cpp
@@ -347,8 +347,6 @@ static void ImGui_ImplDX9_SetWindowSize(ImGuiViewport* viewport, ImVec2 size)
 static void ImGui_ImplDX9_RenderWindow(ImGuiViewport* viewport, void*)
 {
     ImGuiViewportDataDx9* data = (ImGuiViewportDataDx9*)viewport->RendererUserData;
-    if (data->SwapChain == NULL)
-        return;
     ImVec4 clear_color = ImVec4(0.0f, 0.0f, 0.0f, 1.0f);
 
     LPDIRECT3DSURFACE9 render_target = NULL;
@@ -374,8 +372,6 @@ static void ImGui_ImplDX9_RenderWindow(ImGuiViewport* viewport, void*)
 static void ImGui_ImplDX9_SwapBuffers(ImGuiViewport* viewport, void*)
 {
     ImGuiViewportDataDx9* data = (ImGuiViewportDataDx9*)viewport->RendererUserData;
-    if (data->SwapChain == NULL)
-        return;
     data->SwapChain->Present(NULL, NULL, data->d3dpp.hDeviceWindow, NULL, NULL);
 }
 

--- a/examples/imgui_impl_dx9.cpp
+++ b/examples/imgui_impl_dx9.cpp
@@ -261,7 +261,7 @@ bool ImGui_ImplDX9_CreateDeviceObjects()
         return false;
     if (!ImGui_ImplDX9_CreateFontsTexture())
         return false;
-	ImGui_ImplDX9_RecreateWindowSwapChain();
+    ImGui_ImplDX9_RecreateWindowSwapChain();
     return true;
 }
 
@@ -272,7 +272,7 @@ void ImGui_ImplDX9_InvalidateDeviceObjects()
     if (g_pVB) { g_pVB->Release(); g_pVB = NULL; }
     if (g_pIB) { g_pIB->Release(); g_pIB = NULL; }
     if (g_FontTexture) { g_FontTexture->Release(); g_FontTexture = NULL; ImGui::GetIO().Fonts->TexID = NULL; } // We copied g_pFontTextureView to io.Fonts->TexID so let's clear that as well.
-	ImGui_ImplDX9_CleanWindowSwapChain();
+    ImGui_ImplDX9_CleanWindowSwapChain();
 }
 
 void ImGui_ImplDX9_NewFrame()
@@ -347,8 +347,8 @@ static void ImGui_ImplDX9_SetWindowSize(ImGuiViewport* viewport, ImVec2 size)
 static void ImGui_ImplDX9_RenderWindow(ImGuiViewport* viewport, void*)
 {
     ImGuiViewportDataDx9* data = (ImGuiViewportDataDx9*)viewport->RendererUserData;
-	if (data->SwapChain == NULL)
-		return;
+    if (data->SwapChain == NULL)
+        return;
     ImVec4 clear_color = ImVec4(0.0f, 0.0f, 0.0f, 1.0f);
 
     LPDIRECT3DSURFACE9 render_target = NULL;
@@ -374,8 +374,8 @@ static void ImGui_ImplDX9_RenderWindow(ImGuiViewport* viewport, void*)
 static void ImGui_ImplDX9_SwapBuffers(ImGuiViewport* viewport, void*)
 {
     ImGuiViewportDataDx9* data = (ImGuiViewportDataDx9*)viewport->RendererUserData;
-	if (data->SwapChain == NULL)
-		return;
+    if (data->SwapChain == NULL)
+        return;
     data->SwapChain->Present(NULL, NULL, data->d3dpp.hDeviceWindow, NULL, NULL);
 }
 
@@ -391,31 +391,31 @@ static void ImGui_ImplDX9_InitPlatformInterface()
 
 static void ImGui_ImplDX9_CleanWindowSwapChain()
 {
-	ImGuiPlatformIO& platform_io = ImGui::GetPlatformIO();
-	for (int i = 1; i < platform_io.Viewports.Size; i++)
-	{
-		ImGuiViewportDataDx9* data = (ImGuiViewportDataDx9*)platform_io.Viewports[i]->RendererUserData;
-		if (data && data->SwapChain)
-		{
-			data->SwapChain->Release();
-			data->SwapChain = NULL;
-		}
-	}
+    ImGuiPlatformIO& platform_io = ImGui::GetPlatformIO();
+    for (int i = 1; i < platform_io.Viewports.Size; i++)
+    {
+        ImGuiViewportDataDx9* data = (ImGuiViewportDataDx9*)platform_io.Viewports[i]->RendererUserData;
+        if (data && data->SwapChain)
+        {
+            data->SwapChain->Release();
+            data->SwapChain = NULL;
+        }
+    }
 }
 
 static void ImGui_ImplDX9_RecreateWindowSwapChain()
 {
-	ImGuiPlatformIO& platform_io = ImGui::GetPlatformIO();
-	for (int i = 1; i < platform_io.Viewports.Size; i++)
-	{
-		ImGuiViewportDataDx9* data = (ImGuiViewportDataDx9*)platform_io.Viewports[i]->RendererUserData;
-		if (data && data->SwapChain)
-		{
-			data->d3dpp.BackBufferWidth = (UINT)platform_io.Viewports[i]->Size.x;
-			data->d3dpp.BackBufferHeight = (UINT)platform_io.Viewports[i]->Size.y;
-			g_pd3dDevice->CreateAdditionalSwapChain(&data->d3dpp, &data->SwapChain);
-		}
-	}
+    ImGuiPlatformIO& platform_io = ImGui::GetPlatformIO();
+    for (int i = 1; i < platform_io.Viewports.Size; i++)
+    {
+        ImGuiViewportDataDx9* data = (ImGuiViewportDataDx9*)platform_io.Viewports[i]->RendererUserData;
+        if (data && data->SwapChain)
+        {
+            data->d3dpp.BackBufferWidth = (UINT)platform_io.Viewports[i]->Size.x;
+            data->d3dpp.BackBufferHeight = (UINT)platform_io.Viewports[i]->Size.y;
+            g_pd3dDevice->CreateAdditionalSwapChain(&data->d3dpp, &data->SwapChain);
+        }
+    }
 }
 
 static void ImGui_ImplDX9_ShutdownPlatformInterface()

--- a/examples/imgui_impl_dx9.cpp
+++ b/examples/imgui_impl_dx9.cpp
@@ -409,7 +409,7 @@ static void ImGui_ImplDX9_RecreateWindowSwapChain()
     for (int i = 1; i < platform_io.Viewports.Size; i++)
     {
         ImGuiViewportDataDx9* data = (ImGuiViewportDataDx9*)platform_io.Viewports[i]->RendererUserData;
-        if (data && data->SwapChain)
+        if (data)
         {
             data->d3dpp.BackBufferWidth = (UINT)platform_io.Viewports[i]->Size.x;
             data->d3dpp.BackBufferHeight = (UINT)platform_io.Viewports[i]->Size.y;


### PR DESCRIPTION
Hi @ocornut. I deal with the problem which I found in [#2502](https://github.com/ocornut/imgui/issues/2502)

The reason is that DX9 device lost. When you create new window through CreateAdditionalSwapChain(). New  resource was created.  So you must release all video memory before device reset.  You can see more detail in Windows DirectX Graphics document and search "lost devices".

I add two function to do this thing. One is clean swap chain. Other is recreate it. 
