### PR TITLE
Fixed docked window borders to match undocked window borders

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -10883,7 +10883,7 @@ void ImGui::DestroyPlatformWindows()
 // Docking: Internal Types
 //-----------------------------------------------------------------------------
 
-static float IMGUI_DOCK_SPLITTER_SIZE = 2.0f;
+#define IMGUI_DOCK_SPLITTER_SIZE GetStyle().WindowBorderSize
 
 enum ImGuiDockRequestType
 {

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -1339,7 +1339,7 @@ bool ImGui::SplitterBehavior(const ImRect& bb, ImGuiID id, ImGuiAxis axis, float
     }
 
     // Render
-    const ImU32 col = GetColorU32(held ? ImGuiCol_SeparatorActive : (hovered && g.HoveredIdTimer >= hover_visibility_delay) ? ImGuiCol_SeparatorHovered : ImGuiCol_Separator);
+    const ImU32 col = GetColorU32(held ? ImGuiCol_ResizeGripActive : (hovered && g.HoveredIdTimer >= hover_visibility_delay) ? ImGuiCol_ResizeGripHovered : ImGuiCol_Border);
     window->DrawList->AddRectFilled(bb_render.Min, bb_render.Max, col, g.Style.FrameRounding);
 
     return held;


### PR DESCRIPTION
This PR fixes the borders of docked windows to match the borders of undocked windows.

**Before**: The docked border does not respect the window-border size, and is displayed using the colors assigned to separators. (window borders are set to magenta to highlight the problem)

![before_border](https://user-images.githubusercontent.com/8029835/56918863-fd99a900-6a73-11e9-9122-b884915c3354.png)

**After**: Both borders are now consistent.

![after_border](https://user-images.githubusercontent.com/8029835/56918866-fe323f80-6a73-11e9-84bd-fa6914ff4cbe.png)
