### PR TITLE
Fix Docking branch of DX9 sample crash when exit program in x64 mode

### DIFF
--- a/examples/imgui_impl_dx9.cpp
+++ b/examples/imgui_impl_dx9.cpp
@@ -225,7 +225,7 @@ void ImGui_ImplDX9_Shutdown()
 {
     ImGui_ImplDX9_ShutdownPlatformInterface();
     ImGui_ImplDX9_InvalidateDeviceObjects();
-    if (g_pd3dDevice) { g_pd3dDevice->Release(); g_pd3dDevice = NULL; }
+    g_pd3dDevice = NULL;
 }
 
 static bool ImGui_ImplDX9_CreateFontsTexture()


### PR DESCRIPTION
Hi @ocornut . I'm come again. 
This PR is fix the crash problem when you exit the program. But the interesting thing is that the crash will only appear in the x64 mode besides I use the debug tool of gflag in win32 mode.

The reason is that dx9 device is release twice.  One in ImGui_ImplDX9_Shutdown(). Other in CleanupDeviceD3D().


