### PR TITLE
Add a callback for customizing how textures are set during rendering

### DIFF
--- a/examples/imgui_impl_dx12.h
+++ b/examples/imgui_impl_dx12.h
@@ -18,14 +18,19 @@ struct ID3D12GraphicsCommandList;
 struct D3D12_CPU_DESCRIPTOR_HANDLE;
 struct D3D12_GPU_DESCRIPTOR_HANDLE;
 
-// cmd_list is the command list that the implementation will use to render imgui draw lists.
-// Before calling the render function, caller must prepare cmd_list by resetting it and setting the appropriate
-// render target and descriptor heap that contains font_srv_cpu_desc_handle/font_srv_gpu_desc_handle.
-// font_srv_cpu_desc_handle and font_srv_gpu_desc_handle are handles to a single SRV descriptor to use for the internal font texture.
+// Required: Device, number of frames to allocate space for, format of render target
+// If managing font texture on your own make sure that it's set before rendering the first frame, and you
+// will probably also want to make sure that ImGui::GetIO().SetTextureFn is set to work with your textures.
+IMGUI_IMPL_API bool     ImGui_ImplDX12_Init(ID3D12Device* device, int num_frames_in_flight, DXGI_FORMAT rtv_format);
+
+// Optional: font_srv_cpu_desc_handle and font_srv_gpu_desc_handle are handles to a single SRV descriptor to use for the internal font texture.
 IMGUI_IMPL_API bool     ImGui_ImplDX12_Init(ID3D12Device* device, int num_frames_in_flight, DXGI_FORMAT rtv_format,
                                             D3D12_CPU_DESCRIPTOR_HANDLE font_srv_cpu_desc_handle, D3D12_GPU_DESCRIPTOR_HANDLE font_srv_gpu_desc_handle);
+
 IMGUI_IMPL_API void     ImGui_ImplDX12_Shutdown();
 IMGUI_IMPL_API void     ImGui_ImplDX12_NewFrame();
+
+// graphics_command_list is the command list that the implementation will use to render imgui draw lists.
 IMGUI_IMPL_API void     ImGui_ImplDX12_RenderDrawData(ImDrawData* draw_data, ID3D12GraphicsCommandList* graphics_command_list);
 
 // Use if you want to reset your rendering device without losing ImGui state.

--- a/imgui.h
+++ b/imgui.h
@@ -1347,6 +1347,10 @@ struct ImGuiIO
     ImFont*     FontDefault;                    // = NULL           // Font to use on NewFrame(). Use NULL to uses Fonts->Fonts[0].
     ImVec2      DisplayFramebufferScale;        // = (1, 1)         // For retina display or other situations where window coordinates are different from framebuffer coordinates. This generally ends up in ImDrawData::FramebufferScale.
 
+    // Optional: Custom handler for setting textures during rendering.
+    // If you set this you will likely need to set Font texture to your own implementation (io.Fonts->SetTexID())
+    void        (*SetTextureFn)(ImTextureID texture);
+
     // Miscellaneous options
     bool        MouseDrawCursor;                // = false          // Request ImGui to draw a mouse cursor for you (if you are on a platform without a mouse cursor). Cannot be easily renamed to 'io.ConfigXXX' because this is frequently used by back-end implementations.
     bool        ConfigMacOSXBehaviors;          // = defined(__APPLE__) // OS X style: Text editing cursor movement using Alt instead of Ctrl, Shortcuts using Cmd/Super instead of Ctrl, Line/Text Start and End using Cmd+Arrows instead of Home/End, Double click selects by word instead of selecting whole text, Multi-selection in lists uses Cmd/Super instead of Ctrl (was called io.OptMacOSXBehaviors prior to 1.63)


### PR DESCRIPTION
**Context**:
DX12 (and I think Vulkan) have a much more complicated resource management system. This change enabled better integration with existing render systems. For DX12 it can help prevent having multiple calls to SetDescriptorHeaps in a frame which can be a costly operation.

**Changes**:
* The only change to imgui core is just adding a function pointer to ImGuiIO. It's up to the user + render backend to support it.
* Only implemented for DX12 since it's the only backend I can test. Updated to only try to set texture if it changed (and after a reset state request). Prevent creating font texture if it's already set.

