### PR TITLE
Add native mac copy/paste support to imgui.cpp

### DIFF
--- a/examples/example_apple_opengl2/example_apple_opengl2.xcodeproj/project.pbxproj
+++ b/examples/example_apple_opengl2/example_apple_opengl2.xcodeproj/project.pbxproj
@@ -38,14 +38,11 @@
 		4080A99F20B034280036BA46 /* imgui_impl_osx.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = imgui_impl_osx.mm; path = ../imgui_impl_osx.mm; sourceTree = "<group>"; };
 		4080A9A020B034280036BA46 /* imgui_impl_opengl2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = imgui_impl_opengl2.h; path = ../imgui_impl_opengl2.h; sourceTree = "<group>"; };
 		4080A9A120B034280036BA46 /* imgui_impl_osx.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = imgui_impl_osx.h; path = ../imgui_impl_osx.h; sourceTree = "<group>"; };
-		4080A9A420B0343C0036BA46 /* stb_truetype.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = stb_truetype.h; path = ../../stb_truetype.h; sourceTree = "<group>"; };
 		4080A9A520B0343C0036BA46 /* imgui_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = imgui_internal.h; path = ../../imgui_internal.h; sourceTree = "<group>"; };
 		4080A9A620B0343C0036BA46 /* imgui_demo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = imgui_demo.cpp; path = ../../imgui_demo.cpp; sourceTree = "<group>"; };
 		4080A9A720B0343C0036BA46 /* imgui.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = imgui.cpp; path = ../../imgui.cpp; sourceTree = "<group>"; };
 		4080A9A820B0343C0036BA46 /* imgui.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = imgui.h; path = ../../imgui.h; sourceTree = "<group>"; };
-		4080A9A920B0343C0036BA46 /* stb_rect_pack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = stb_rect_pack.h; path = ../../stb_rect_pack.h; sourceTree = "<group>"; };
 		4080A9AA20B0343C0036BA46 /* imgui_draw.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = imgui_draw.cpp; path = ../../imgui_draw.cpp; sourceTree = "<group>"; };
-		4080A9AB20B0343C0036BA46 /* stb_textedit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = stb_textedit.h; path = ../../stb_textedit.h; sourceTree = "<group>"; };
 		4080A9AC20B0343C0036BA46 /* imconfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = imconfig.h; path = ../../imconfig.h; sourceTree = "<group>"; };
 		4080A9B220B034E40036BA46 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		4080A9B420B034EA0036BA46 /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = System/Library/Frameworks/OpenGL.framework; sourceTree = SDKROOT; };
@@ -74,9 +71,6 @@
 				4080A9A620B0343C0036BA46 /* imgui_demo.cpp */,
 				4080A9AA20B0343C0036BA46 /* imgui_draw.cpp */,
 				4080A9A520B0343C0036BA46 /* imgui_internal.h */,
-				4080A9A920B0343C0036BA46 /* stb_rect_pack.h */,
-				4080A9AB20B0343C0036BA46 /* stb_textedit.h */,
-				4080A9A420B0343C0036BA46 /* stb_truetype.h */,
 				4080A99E20B034280036BA46 /* imgui_impl_opengl2.cpp */,
 				4080A9A020B034280036BA46 /* imgui_impl_opengl2.h */,
 				4080A9A120B034280036BA46 /* imgui_impl_osx.h */,

--- a/examples/imgui_impl_osx.mm
+++ b/examples/imgui_impl_osx.mm
@@ -54,32 +54,6 @@ bool ImGui_ImplOSX_Init()
     io.KeyMap[ImGuiKey_Y]           = 'Y';
     io.KeyMap[ImGuiKey_Z]           = 'Z';
 
-    io.SetClipboardTextFn = [](void*, const char* str) -> void
-    {
-        NSPasteboard* pasteboard = [NSPasteboard generalPasteboard];
-        [pasteboard declareTypes:[NSArray arrayWithObject:NSPasteboardTypeString] owner:nil];
-        [pasteboard setString:[NSString stringWithUTF8String:str] forType:NSPasteboardTypeString];
-    };
-
-    io.GetClipboardTextFn = [](void*) -> const char*
-    {
-        NSPasteboard* pasteboard = [NSPasteboard generalPasteboard];
-        NSString* available = [pasteboard availableTypeFromArray: [NSArray arrayWithObject:NSPasteboardTypeString]];
-        if (![available isEqualToString:NSPasteboardTypeString])
-            return NULL;
-
-        NSString* string = [pasteboard stringForType:NSPasteboardTypeString];
-        if (string == nil)
-            return NULL;
-
-        const char* string_c = (const char*)[string UTF8String];
-        size_t string_len = strlen(string_c);
-        static ImVector<char> s_clipboard;
-        s_clipboard.resize((int)string_len + 1);
-        strcpy(s_clipboard.Data, string_c);
-        return s_clipboard.Data;
-    };
-
     return true;
 }
 

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -9489,6 +9489,8 @@ static void SettingsHandlerWindow_WriteAll(ImGuiContext* ctx, ImGuiSettingsHandl
 #else
 #include <windows.h>
 #endif
+#elif defined(__APPLE__)
+#include <TargetConditionals.h>
 #endif
 
 // Win32 API clipboard implementation
@@ -9539,6 +9541,58 @@ static void SetClipboardTextFn_DefaultImpl(void*, const char* text)
     if (::SetClipboardData(CF_UNICODETEXT, wbuf_handle) == NULL)
         ::GlobalFree(wbuf_handle);
     ::CloseClipboard();
+}
+
+#elif defined(__APPLE__) && TARGET_OS_OSX && !defined(IMGUI_DISABLE_OSX_FUNCTIONS)
+#include <Carbon/Carbon.h>  // use ye olde worlde API to avoid need for separate .mm file
+static PasteboardRef main_clipboard = 0;
+
+static void SetClipboardTextFn_DefaultImpl(void*, const char* text)
+{
+    if (!main_clipboard)
+        PasteboardCreate(kPasteboardClipboard, &main_clipboard);
+    PasteboardClear(main_clipboard);
+    CFDataRef cf_data = CFDataCreate(kCFAllocatorDefault, (const UInt8*) text, strlen(text));
+    if (cf_data)
+    {
+        PasteboardPutItemFlavor(main_clipboard, (PasteboardItemID) 1, CFSTR("public.utf8-plain-text"), cf_data, 0);
+        CFRelease(cf_data);
+    }
+}
+
+static const char* GetClipboardTextFn_DefaultImpl(void*)
+{
+    if (!main_clipboard)
+        PasteboardCreate(kPasteboardClipboard, &main_clipboard);
+    PasteboardSynchronize(main_clipboard);
+
+    ItemCount item_count = 0;
+    PasteboardGetItemCount(main_clipboard, &item_count);
+
+    for (int i = 0; i < item_count; i++)
+    {
+        PasteboardItemID item_id = 0;
+        PasteboardGetItemIdentifier(main_clipboard, i + 1, &item_id);
+        CFArrayRef flavor_type_array = 0;
+        PasteboardCopyItemFlavors(main_clipboard, item_id, &flavor_type_array);
+        for (CFIndex j = 0, nj = CFArrayGetCount(flavor_type_array); j < nj; j++)
+        {
+            CFDataRef cf_data;
+            if (PasteboardCopyItemFlavorData(main_clipboard, item_id, CFSTR("public.utf8-plain-text"), &cf_data) == noErr)
+            {
+                static ImVector<char> clipboard_text;
+
+                int length = (int) CFDataGetLength(cf_data);
+                clipboard_text.resize(length + 1);
+                CFDataGetBytes(cf_data, CFRangeMake(0, length), (UInt8*) clipboard_text.Data);
+                clipboard_text[length] = 0;
+
+                CFRelease(cf_data);
+                return clipboard_text.Data;
+            }
+        }
+    }
+    return "";
 }
 
 #else


### PR DESCRIPTION
This small addition adds a Mac version of the Win32 "built in" copy/paste support, in roughly the same number of lines of code. It is written using the old CF API to avoid the need for a second .mm file. The added dependencies are from AppKit.framework, which is the base framework necessary for any Mac app. (It is brought in by the umbrella framework "Cocoa" used by the imgui Mac examples, for instance.)

I've removed the additional manual Set/GetClipboardText hooks from imgui_impl_osx.mm now they're no longer necessary, and also some stray file references from the example_apple_opengl2 xcode project.