### PR TITLE
fix undefined behavior

### DIFF
--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -1779,7 +1779,7 @@ static void UnpackBoolVectorToFlatIndexList(const ImBoolVector* in, ImVector<int
     for (const int* it = it_begin; it < it_end; it++)
         if (int entries_32 = *it)
             for (int bit_n = 0; bit_n < 32; bit_n++)
-                if (entries_32 & (1 << bit_n))
+                if (entries_32 & (1u << bit_n))
                     out->push_back((int)((it - it_begin) << 5) + bit_n);
 }
 


### PR DESCRIPTION
We're using imgui for a couple of tools in the Mesa3D project. Mesa
gets free coverity (static analyzer tool) coverage and we got this
warning reported :

   imgui_draw.cpp:1781: error[shiftTooManyBitsSigned]: Shifting signed 32-bit value by 31 bits is undefined behaviour

