### PR TITLE
Fix error in OpenGL3 implementation

### DIFF
--- a/examples/imgui_impl_opengl3.cpp
+++ b/examples/imgui_impl_opengl3.cpp
@@ -384,7 +384,7 @@ static bool CheckShader(GLuint handle, const char* desc)
     glGetShaderiv(handle, GL_INFO_LOG_LENGTH, &log_length);
     if ((GLboolean)status == GL_FALSE)
         fprintf(stderr, "ERROR: ImGui_ImplOpenGL3_CreateDeviceObjects: failed to compile %s!\n", desc);
-    if (log_length > 0)
+    if (log_length > 1)
     {
         ImVector<char> buf;
         buf.resize((int)(log_length + 1));
@@ -402,7 +402,7 @@ static bool CheckProgram(GLuint handle, const char* desc)
     glGetProgramiv(handle, GL_INFO_LOG_LENGTH, &log_length);
     if ((GLboolean)status == GL_FALSE)
         fprintf(stderr, "ERROR: ImGui_ImplOpenGL3_CreateDeviceObjects: failed to link %s! (with GLSL '%s')\n", desc, g_GlslVersionString);
-    if (log_length > 0)
+    if (log_length > 1)
     {
         ImVector<char> buf;
         buf.resize((int)(log_length + 1));


### PR DESCRIPTION
Fixed minor bug in CheckShader and CheckProgram of OpenGL3 implementation.

The log_length reported by 
glGetProgramiv(handle, GL_INFO_LOG_LENGTH, &log_length)
in these two functions will always return at least 1, since the string delimiter is also counted to the log length.

The old version therefore always prints (an empty string) to stderr. This is annoying in the emscripten port, since it prints a red error message to the Javascript console. The new version fixes this behavior.
