### PR TITLE
Disable IME when not needed

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -9735,7 +9735,7 @@ static void ImeSetInputScreenPosFn_DefaultImpl(int x, int y)
 
 #else
 
-static void ImeSetOpenStatusFn_DefaultImpl(int, int) {}
+static void ImeSetOpenStatusFn_DefaultImpl(bool) {}
 
 static void ImeSetInputScreenPosFn_DefaultImpl(int, int) {}
 

--- a/imgui.h
+++ b/imgui.h
@@ -1376,6 +1376,7 @@ struct ImGuiIO
 
     // Optional: Notify OS Input Method Editor of the screen position of your cursor for text input position (e.g. when using Japanese/Chinese IME on Windows)
     // (default to use native imm32 api on Windows)
+    void        (*ImeSetOpenStatusFn)(bool open);
     void        (*ImeSetInputScreenPosFn)(int x, int y);
     void*       ImeWindowHandle;                // = NULL           // (Windows) Set this to your HWND to get automatic IME cursor positioning.
 

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -999,6 +999,8 @@ struct ImGuiContext
     // Platform support
     ImVec2                  PlatformImePos;                     // Cursor position request & last passed to the OS Input Method Editor
     ImVec2                  PlatformImeLastPos;
+    bool                    PlatformImeStatus;
+    bool                    PlatformImeLastStatus;
 
     // Settings
     bool                           SettingsLoaded;
@@ -1133,6 +1135,7 @@ struct ImGuiContext
         MultiSelectScopeId = 0;
 
         PlatformImePos = PlatformImeLastPos = ImVec2(FLT_MAX, FLT_MAX);
+        PlatformImeStatus = PlatformImeLastStatus = true;
 
         SettingsLoaded = false;
         SettingsDirtyTimer = 0.0f;

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -4040,7 +4040,10 @@ bool ImGui::InputTextEx(const char* label, const char* hint, char* buf, int buf_
 
             // Notify OS of text input position for advanced IME (-1 x offset so that Windows IME can cover our cursor. Bit of an extra nicety.)
             if (!is_readonly)
+            {
                 g.PlatformImePos = ImVec2(cursor_screen_pos.x - 1.0f, cursor_screen_pos.y - g.FontSize);
+                g.PlatformImeStatus = true;
+            }
         }
     }
     else


### PR DESCRIPTION
Now even if the focus is not on the input control, the IME will be activated, like this:

![1](https://user-images.githubusercontent.com/1836844/58543755-a6355700-8232-11e9-8536-aca8696df08b.PNG)



