### PR TITLE
Include <alloca.h> also when __SWITCH__ is defined

### DIFF
--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -33,7 +33,7 @@ Index of this file:
 
 #include <stdio.h>      // vsnprintf, sscanf, printf
 #if !defined(alloca)
-#if defined(__GLIBC__) || defined(__sun) || defined(__CYGWIN__) || defined(__APPLE__)
+#if defined(__GLIBC__) || defined(__sun) || defined(__CYGWIN__) || defined(__APPLE__) || defined(__SWITCH__)
 #include <alloca.h>     // alloca (glibc uses <alloca.h>. Note that Cygwin may have _WIN32 defined, so the order matters here)
 #elif defined(_WIN32)
 #include <malloc.h>     // alloca


### PR DESCRIPTION
Fixes compilation with devkitPro for Nintendo Switch