### PR TITLE
Added IME support for OSX examples

### DIFF
--- a/examples/example_apple_metal/example_apple_metal.xcodeproj/project.pbxproj
+++ b/examples/example_apple_metal/example_apple_metal.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 /* Begin PBXFileReference section */
 		07A82ED62139413C0078D120 /* imgui_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = imgui_internal.h; path = ../../imgui_internal.h; sourceTree = "<group>"; };
 		07A82ED72139413C0078D120 /* imgui_widgets.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = imgui_widgets.cpp; path = ../../imgui_widgets.cpp; sourceTree = "<group>"; };
+		115BC89222A0C91600C3FF03 /* imgui_impl_osx_ime.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = imgui_impl_osx_ime.h; path = ../../imgui_impl_osx_ime.h; sourceTree = "<group>"; };
 		8307E7BB20E9F9C700473790 /* Renderer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Renderer.h; sourceTree = "<group>"; };
 		8307E7BC20E9F9C700473790 /* Renderer.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = Renderer.mm; sourceTree = "<group>"; };
 		8307E7C420E9F9C900473790 /* example_apple_metal.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = example_apple_metal.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -112,6 +113,7 @@
 		8307E7BA20E9F9C700473790 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				115BC89222A0C91600C3FF03 /* imgui_impl_osx_ime.h */,
 				83BBE9FC20EB54D800295997 /* imgui_impl_metal.h */,
 				83BBE9FD20EB54D800295997 /* imgui_impl_metal.mm */,
 				836D2A2C20EE208D0098E909 /* imgui_impl_osx.h */,

--- a/examples/example_apple_metal/macOS/Base.lproj/Main.storyboard
+++ b/examples/example_apple_metal/macOS/Base.lproj/Main.storyboard
@@ -117,7 +117,7 @@
         <scene sceneID="hIz-AP-VOD">
             <objects>
                 <viewController id="XfG-lQ-9wD" customClass="ViewController" sceneMemberID="viewController">
-                    <view key="view" wantsLayer="YES" id="m2S-Jp-Qdl" customClass="MTKView">
+                    <view key="view" wantsLayer="YES" id="m2S-Jp-Qdl" customClass="ImGuiView">
                         <rect key="frame" x="0.0" y="0.0" width="1280" height="720"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </view>

--- a/examples/imgui_impl_osx.mm
+++ b/examples/imgui_impl_osx.mm
@@ -168,8 +168,6 @@ bool ImGui_ImplOSX_HandleEvent(NSEvent* event, NSView* view)
         for (int i = 0; i < len; i++)
         {
             int c = [str characterAtIndex:i];
-            if (!io.KeyCtrl && !(c >= 0xF700 && c <= 0xFFFF))
-                io.AddInputCharacter((unsigned int)c);
 
             // We must reset in case we're pressing a sequence of special keys while keeping the command pressed
             int key = mapCharacterToKey(c);

--- a/examples/imgui_impl_osx_ime.h
+++ b/examples/imgui_impl_osx_ime.h
@@ -1,0 +1,90 @@
+// dear imgui: Platform Binding for OSX / Cocoa
+// This needs to be used along with a Renderer (e.g. OpenGL2, OpenGL3, Vulkan, Metal..)
+
+static const NSRange kEmptyRange = { NSNotFound, 0 };
+
+@interface ImGuiView : IMGUI_IMPLOSX_BASEVIEW <NSTextInputClient> {
+    int m_x;
+    int m_y;
+}
+- (void)setPosX:(int)x setPosY:(int)y;
+@end
+
+@implementation ImGuiView
+
+- (void)setPosX:(int)x setPosY:(int)y {
+    m_x = x;
+    m_y = y;
+}
+
+- (void)insertText:(id)aString replacementRange:(NSRange)replacementRange {
+    NSString* characters = [aString isKindOfClass: [NSAttributedString class]]
+    ? [aString string]
+    : aString;
+    ImGuiIO& io = ImGui::GetIO();
+    NSUInteger len = [characters length];
+    for (NSUInteger i = 0; i < len; ++i) {
+        const unichar codepoint = [characters characterAtIndex:i];
+        if ((codepoint & 0xff00) == 0xf700)
+            continue;
+        io.AddInputCharacter(codepoint);
+    }
+}
+
+- (BOOL)hasMarkedText {
+    return false;
+}
+
+- (NSRange)markedRange {
+    return kEmptyRange;
+}
+
+- (NSRange)selectedRange {
+    return kEmptyRange;
+}
+
+- (void)setMarkedText:(id)string selectedRange:(NSRange)selectedRange replacementRange:(NSRange)replacementRange {
+}
+
+- (void)unmarkText {
+}
+
+- (NSRect)firstRectForCharacterRange:(NSRange)aRange actualRange:(NSRangePointer)actualRange {
+    if (actualRange) {
+        *actualRange = aRange;
+    }
+    NSWindow* window = [self window];
+    NSRect contentRect = [window contentRectForFrameRect:[window frame]];
+    NSRect rect = NSMakeRect(m_x, contentRect.size.height - m_y, 0, 0);
+    return [window convertRectToScreen:rect];
+}
+
+- (NSAttributedString *)attributedSubstringForProposedRange:(NSRange)aRange actualRange:(NSRangePointer)actualRange {
+    return nil;
+}
+
+- (NSInteger)conversationIdentifier {
+    return (NSInteger) self;
+}
+
+- (NSUInteger)characterIndexForPoint:(NSPoint)thePoint {
+    return 0;
+}
+
+- (NSArray *)validAttributesForMarkedText {
+    return [NSArray array];
+}
+
+@end
+
+static void ImGui_ImplOSX_SetImePos(int x, int y) {
+    if (ImGuiView* view = (__bridge ImGuiView*)ImGui::GetIO().ImeWindowHandle) {
+        [view setPosX: x setPosY:y];
+    }
+}
+
+static void ImGui_ImplOSX_InitIme(ImGuiView* view) {
+    ImGuiIO& io = ImGui::GetIO();
+    io.ImeWindowHandle = (__bridge void*)view;
+    io.ImeSetInputScreenPosFn = ImGui_ImplOSX_SetImePos;
+}


### PR DESCRIPTION
This patch adds IME support for macOS and also fixes some input bugs, such as #2578.

Some TODO:

1. The osx/opengl example has been unusable, I can't test it and add IME support.
2. On macOS, ImGui needs to render `Editing Text` by itself. But this is not very important.
3. Since there is no `Editing Text`, the IME cannot cover the cursor. That is to say, `g.FontSize` cannot be subtracted here.
https://github.com/ocornut/imgui/blob/bff7202ff2ba78dbba59950c85b097c665729e9f/imgui_widgets.cpp#L4043
