### PR TITLE
Add flag to ImGuiStyle to hide a collapse button.

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -1142,6 +1142,7 @@ ImGuiStyle::ImGuiStyle()
     WindowMinSize           = ImVec2(32,32);    // Minimum window size
     WindowTitleAlign        = ImVec2(0.0f,0.5f);// Alignment for title bar text
     WindowMenuButtonPosition= ImGuiDir_Left;    // Position of the collapsing/docking button in the title bar (left/right). Defaults to ImGuiDir_Left.
+    WindowHideCollapseButton= false;            // Hide the collapse button in the title bar, while leaving the possibility to collapse the window. Defaults to false.
     ChildRounding           = 0.0f;             // Radius of child window corners rounding. Set to 0.0f to have rectangular child windows
     ChildBorderSize         = 1.0f;             // Thickness of border around child windows. Generally set to 0.0f or 1.0f. Other values not well tested.
     PopupRounding           = 0.0f;             // Radius of popup window corners rounding. Set to 0.0f to have rectangular child windows
@@ -5153,7 +5154,7 @@ void ImGui::RenderWindowTitleBarContents(ImGuiWindow* window, const ImRect& titl
     ImGuiWindowFlags flags = window->Flags;
 
     const bool has_close_button = (p_open != NULL);
-    const bool has_collapse_button = !(flags & ImGuiWindowFlags_NoCollapse);
+    const bool has_collapse_button = !((flags & ImGuiWindowFlags_NoCollapse) || style.WindowHideCollapseButton);
 
     // Close & Collapse button are on the Menu NavLayer and don't default focus (unless there's nothing else on that layer)
     const ImGuiItemFlags item_flags_backup = window->DC.ItemFlags;

--- a/imgui.h
+++ b/imgui.h
@@ -1283,6 +1283,7 @@ struct ImGuiStyle
     ImVec2      WindowMinSize;              // Minimum window size. This is a global setting. If you want to constraint individual windows, use SetNextWindowSizeConstraints().
     ImVec2      WindowTitleAlign;           // Alignment for title bar text. Defaults to (0.0f,0.5f) for left-aligned,vertically centered.
     ImGuiDir    WindowMenuButtonPosition;   // Side of the collapsing/docking button in the title bar (left/right). Defaults to ImGuiDir_Left.
+    bool        WindowHideCollapseButton;   // Hide the collapse button in the title bar, while leaving the possibility to collapse the window. Defaults to false.
     float       ChildRounding;              // Radius of child window corners rounding. Set to 0.0f to have rectangular windows.
     float       ChildBorderSize;            // Thickness of border around child windows. Generally set to 0.0f or 1.0f. (Other values are not well tested and more CPU/GPU costly).
     float       PopupRounding;              // Radius of popup window corners rounding. (Note that tooltip windows use WindowRounding)

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -3071,6 +3071,7 @@ void ImGui::ShowStyleEditor(ImGuiStyle* ref)
     { bool frame_border = (style.FrameBorderSize > 0.0f); if (ImGui::Checkbox("FrameBorder", &frame_border)) style.FrameBorderSize = frame_border ? 1.0f : 0.0f; }
     ImGui::SameLine();
     { bool popup_border = (style.PopupBorderSize > 0.0f); if (ImGui::Checkbox("PopupBorder", &popup_border)) style.PopupBorderSize = popup_border ? 1.0f : 0.0f; }
+    ImGui::Checkbox("Hide collapse buttons", &style.WindowHideCollapseButton);
 
     // Save/Revert button
     if (ImGui::Button("Save Ref"))


### PR DESCRIPTION
PR adds a flag `ImGuiStyle::WindowHideCollapseButton` that allows to hide a collapse button from the title bar when a window is collapsable. 
Setting the flag to true doesn't disable collapsibility of the window. This still can be done by double-clicking on the titlebar.

Related to the issue #2634.

Screenshots:
- Hide collapse button and collapsable window:
![obraz](https://user-images.githubusercontent.com/3495693/60052629-10c4a000-96d6-11e9-8ebb-06b855ae3dbf.png)
![obraz](https://user-images.githubusercontent.com/3495693/60052642-16ba8100-96d6-11e9-80d8-178b5c11b616.png)
- Show collapse button and collapsable window:
![obraz](https://user-images.githubusercontent.com/3495693/60052670-26d26080-96d6-11e9-89de-69d7db4b2ee6.png)
![obraz](https://user-images.githubusercontent.com/3495693/60052680-2d60d800-96d6-11e9-93bc-8cd5b31ea71c.png)

- No collapsable window:
![obraz](https://user-images.githubusercontent.com/3495693/60052703-3ea9e480-96d6-11e9-93ce-edc110a9c9f0.png)
![obraz](https://user-images.githubusercontent.com/3495693/60052708-436e9880-96d6-11e9-9fe0-166260e94984.png)


