### PR TITLE
[Vulkan] Fix crash when viewports are disabled and memory leak on shu…

### DIFF
--- a/examples/imgui_impl_vulkan.cpp
+++ b/examples/imgui_impl_vulkan.cpp
@@ -850,8 +850,17 @@ bool    ImGui_ImplVulkan_Init(ImGui_ImplVulkan_InitInfo* info, VkRenderPass rend
 
 void ImGui_ImplVulkan_Shutdown()
 {
-    ImGui_ImplVulkan_ShutdownPlatformInterface();
+    // First destroy objects in all viewports
     ImGui_ImplVulkan_DestroyDeviceObjects();
+
+    // Manually delete main viewport render data in-case we haven't initialized for viewports
+    ImGuiViewport* main_viewport = ImGui::GetMainViewport();
+    if (ImGuiViewportDataVulkan* data = (ImGuiViewportDataVulkan*)main_viewport->RendererUserData)
+        IM_DELETE(data);
+    main_viewport->RendererUserData = NULL;
+
+    // Clean up windows
+    ImGui_ImplVulkan_ShutdownPlatformInterface();
 }
 
 void ImGui_ImplVulkan_NewFrame()


### PR DESCRIPTION
I ran into two issues getting vulkan up and running:
1. When running without viewport enabled the main viewport doesn't get cleaned up properly since the platform hooks haven't been set.
2. Since the ImGui_ImplVulkan_DestroyDeviceObjects() was removed for some reason so some vulkan resources weren't getting cleaned up.