### PR TITLE
Allow imgui to render into a multisampled Vulkan framebuffer

### DIFF
--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -33,6 +33,9 @@ HOW TO UPDATE?
  VERSION 1.73 (In Progress)
 -----------------------------------------------------------------------
 
+Other Changes:
+- Backends: Vulkan: Added support for specifying multisample count. Set ImGui_ImplVulkan_InitInfo::MSAASamples to one of the VkSampleCountFlagBits values to use, default is non-multisampled as before.
+
 
 -----------------------------------------------------------------------
  VERSION 1.72 (Released 2019-07-27)

--- a/examples/imgui_impl_vulkan.cpp
+++ b/examples/imgui_impl_vulkan.cpp
@@ -22,6 +22,7 @@
 
 // CHANGELOG
 // (minor and older changes stripped away, please see git history for details)
+//  2019-07-31: Vulkan: Added support for specifying multisample count. Set ImGui_ImplVulkan_InitInfo::MSAASamples to one of the VkSampleCountFlagBits values to use, default is non-multisampled as before.
 //  2019-05-29: Vulkan: Added support for large mesh (64K+ vertices), enable ImGuiBackendFlags_RendererHasVtxOffset flag.
 //  2019-04-30: Vulkan: Added support for special ImDrawCallback_ResetRenderState callback to reset render state.
 //  2019-04-04: *BREAKING CHANGE*: Vulkan: Added ImageCount/MinImageCount fields in ImGui_ImplVulkan_InitInfo, required for initialization (was previously a hard #define IMGUI_VK_QUEUED_FRAMES 2). Added ImGui_ImplVulkan_SetMinImageCount().
@@ -721,12 +722,10 @@ bool ImGui_ImplVulkan_CreateDeviceObjects()
 
     VkPipelineMultisampleStateCreateInfo ms_info = {};
     ms_info.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
-    if (v->MSAASamples != 0) {
+    if (v->MSAASamples != 0)
         ms_info.rasterizationSamples = v->MSAASamples;
-    }
-    else {
+    else
         ms_info.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
-    }
 
     VkPipelineColorBlendAttachmentState color_attachment[1] = {};
     color_attachment[0].blendEnable = VK_TRUE;

--- a/examples/imgui_impl_vulkan.cpp
+++ b/examples/imgui_impl_vulkan.cpp
@@ -721,7 +721,12 @@ bool ImGui_ImplVulkan_CreateDeviceObjects()
 
     VkPipelineMultisampleStateCreateInfo ms_info = {};
     ms_info.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
-    ms_info.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+    if (v->MSAASamples != 0) {
+      ms_info.rasterizationSamples = v->MSAASamples;
+    }
+    else {
+      ms_info.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+    }
 
     VkPipelineColorBlendAttachmentState color_attachment[1] = {};
     color_attachment[0].blendEnable = VK_TRUE;

--- a/examples/imgui_impl_vulkan.cpp
+++ b/examples/imgui_impl_vulkan.cpp
@@ -722,10 +722,10 @@ bool ImGui_ImplVulkan_CreateDeviceObjects()
     VkPipelineMultisampleStateCreateInfo ms_info = {};
     ms_info.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
     if (v->MSAASamples != 0) {
-      ms_info.rasterizationSamples = v->MSAASamples;
+        ms_info.rasterizationSamples = v->MSAASamples;
     }
     else {
-      ms_info.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+        ms_info.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
     }
 
     VkPipelineColorBlendAttachmentState color_attachment[1] = {};

--- a/examples/imgui_impl_vulkan.h
+++ b/examples/imgui_impl_vulkan.h
@@ -37,6 +37,7 @@ struct ImGui_ImplVulkan_InitInfo
     VkDescriptorPool    DescriptorPool;
     uint32_t            MinImageCount;          // >= 2
     uint32_t            ImageCount;             // >= MinImageCount
+    VkSampleCountFlagBits  MSAASamples;         // >= VK_SAMPLE_COUNT_1_BIT
     const VkAllocationCallbacks* Allocator;
     void                (*CheckVkResultFn)(VkResult err);
 };


### PR DESCRIPTION
ImGui always sets the MSAA level to 1 sample, disabling it. This means you get errors if you try to render with ImGui's into a multisampled framebuffer in Vulkan, because  Vulkan requires you to specify the correct multisampling level at pipeline creation time.

This change adds a new member to the `ImGui_ImplVulkan_InitInfo` struct which users of ImGui can set to the correct multisample level for their target frame buffer. The zero value (which you'll get by default if the struct has been zero-initialised) is not a valid MSAA level in Vulkan, so we detect that case and use `VK_SAMPLE_COUNT_1_BIT` instead at setup time. Unless you've explicitly set the MSAASamples to something, the default behaviour should be exactly as it was previously, i.e. multisampling will be disabled.

This fixes issue #2705 

Feedback very much appreciated!