### PR TITLE
Fix for mouse event forwarding in MacOS example

### DIFF
--- a/examples/example_apple_opengl2/main.mm
+++ b/examples/example_apple_opengl2/main.mm
@@ -133,7 +133,6 @@
     return (YES);
 }
 
-// Flip coordinate system upside down on Y
 -(BOOL)isFlipped
 {
     return (NO);

--- a/examples/example_apple_opengl2/main.mm
+++ b/examples/example_apple_opengl2/main.mm
@@ -235,7 +235,7 @@
 #endif // MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
     [self.window setContentView:view];
 	
-	[self.window setAcceptsMouseMovedEvents:YES];
+    [self.window setAcceptsMouseMovedEvents:YES];
 
     if ([view openGLContext] == nil)
         NSLog(@"No OpenGL Context!");

--- a/examples/example_apple_opengl2/main.mm
+++ b/examples/example_apple_opengl2/main.mm
@@ -150,7 +150,7 @@
 -(void)mouseDown:(NSEvent *)event       { ImGui_ImplOSX_HandleEvent(event, self); }
 -(void)mouseUp:(NSEvent *)event         { ImGui_ImplOSX_HandleEvent(event, self); }
 -(void)mouseMoved:(NSEvent *)event      { ImGui_ImplOSX_HandleEvent(event, self); }
--(void)mouseDragged:(NSEvent *)event	{ ImGui_ImplOSX_HandleEvent(event, self); }
+-(void)mouseDragged:(NSEvent *)event    { ImGui_ImplOSX_HandleEvent(event, self); }
 -(void)scrollWheel:(NSEvent *)event     { ImGui_ImplOSX_HandleEvent(event, self); }
 
 @end
@@ -234,7 +234,7 @@
         [view setWantsBestResolutionOpenGLSurface:YES];
 #endif // MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
     [self.window setContentView:view];
-	
+    
     [self.window setAcceptsMouseMovedEvents:YES];
 
     if ([view openGLContext] == nil)

--- a/examples/example_apple_opengl2/main.mm
+++ b/examples/example_apple_opengl2/main.mm
@@ -175,6 +175,7 @@
 
     _window = [[NSWindow alloc] initWithContentRect:viewRect styleMask:NSWindowStyleMaskTitled|NSWindowStyleMaskMiniaturizable|NSWindowStyleMaskResizable|NSWindowStyleMaskClosable backing:NSBackingStoreBuffered defer:YES];
     [_window setTitle:@"Dear ImGui OSX+OpenGL2 Example"];
+    [_window setAcceptsMouseMovedEvents:YES];
     [_window setOpaque:YES];
     [_window makeKeyAndOrderFront:NSApp];
 
@@ -230,8 +231,6 @@
 #endif // MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
     [self.window setContentView:view];
     
-    [self.window setAcceptsMouseMovedEvents:YES];
-
     if ([view openGLContext] == nil)
         NSLog(@"No OpenGL Context!");
 

--- a/examples/example_apple_opengl2/main.mm
+++ b/examples/example_apple_opengl2/main.mm
@@ -136,7 +136,7 @@
 // Flip coordinate system upside down on Y
 -(BOOL)isFlipped
 {
-    return (YES);
+    return (NO);
 }
 
 -(void)dealloc
@@ -150,6 +150,8 @@
 -(void)flagsChanged:(NSEvent *)event    { ImGui_ImplOSX_HandleEvent(event, self); }
 -(void)mouseDown:(NSEvent *)event       { ImGui_ImplOSX_HandleEvent(event, self); }
 -(void)mouseUp:(NSEvent *)event         { ImGui_ImplOSX_HandleEvent(event, self); }
+-(void)mouseMoved:(NSEvent *)event      { ImGui_ImplOSX_HandleEvent(event, self); }
+-(void)mouseDragged:(NSEvent *)event	{ ImGui_ImplOSX_HandleEvent(event, self); }
 -(void)scrollWheel:(NSEvent *)event     { ImGui_ImplOSX_HandleEvent(event, self); }
 
 @end
@@ -233,6 +235,8 @@
         [view setWantsBestResolutionOpenGLSurface:YES];
 #endif // MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
     [self.window setContentView:view];
+	
+	[self.window setAcceptsMouseMovedEvents:YES];
 
     if ([view openGLContext] == nil)
         NSLog(@"No OpenGL Context!");

--- a/examples/example_apple_opengl2/main.mm
+++ b/examples/example_apple_opengl2/main.mm
@@ -133,11 +133,6 @@
     return (YES);
 }
 
--(BOOL)isFlipped
-{
-    return (NO);
-}
-
 -(void)dealloc
 {
     animationTimer = nil;


### PR DESCRIPTION
Fix for the issue https://github.com/ocornut/imgui/issues/2664

Changes:
- Added forwarding of mouse move and drag events from the main application to `imgui_impl_osx` event handlers
- Changed coordinate flipping
- Tested on MacOS 10.14.4 Mojave, Xcode 10.1

