### PR TITLE
Fix for compilation of Emscripten example (filesystem module is required)

### DIFF
--- a/examples/example_emscripten/Makefile
+++ b/examples/example_emscripten/Makefile
@@ -24,7 +24,8 @@ UNAME_S := $(shell uname -s)
 EMS = -s USE_SDL=2 -s WASM=1
 EMS += -s ALLOW_MEMORY_GROWTH=1 -s BINARYEN_TRAP_MODE=clamp
 EMS += -s DISABLE_EXCEPTION_CATCHING=1 -s NO_EXIT_RUNTIME=0
-EMS += -s ASSERTIONS=1 -s NO_FILESYSTEM=1
+EMS += -s ASSERTIONS=1
+#EMS += -s NO_FILESYSTEM=1 ## Getting "error: undefined symbol: $FS" if filesystem is removed
 #EMS += -s SAFE_HEAP=1    ## Adds overhead
 
 CPPFLAGS = -I../ -I../../


### PR DESCRIPTION
Hi, when playing with ImGUI and the Emscripten example, I got the following error:
`funto@pollux:~/projets_autres/imgui-master/examples/example_emscripten$ make
(...)
error: undefined symbol: $FS
warning: To disable errors for undefined symbols use `-s ERROR_ON_UNDEFINED_SYMBOLS=0`
Error: Aborting compilation due to previous errors
shared:ERROR: '/home/funto/install/emsdk/node/8.9.1_64bit/bin/node /home/funto/install/emsdk/emscripten/1.38.31/src/compiler.js /tmp/tmpa1os4_o1.txt /home/funto/install/emsdk/emscripten/1.38.31/src/library_pthread_stub.js' failed (1)
Makefile:57: recipe for target 'example_emscripten.html' failed
make: *** [example_emscripten.html] Error 1`

It looks like this is due to the removal of the "FILESYSTEM" Emscripten module.
As a result I added it back to the Makefile and it compiled and ran on my second try:

`funto@pollux:~/projets_autres/imgui-master/examples/example_emscripten$ make
em++ -o example_emscripten.html main.o imgui_impl_sdl.o imgui_impl_opengl3.o imgui.o imgui_demo.o imgui_draw.o imgui_widgets.o -s USE_SDL=2 -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s BINARYEN_TRAP_MODE=clamp -s DISABLE_EXCEPTION_CATCHING=1 -s NO_EXIT_RUNTIME=0 -s ASSERTIONS=1 --shell-file shell_minimal.html
Build complete for example_emscripten.html`

Using ImGUI master branch (2019/08/17) and latest Emscripten SDK ( emscripten-1.38.31 sdk-1.38.31-64bit ) on Ubuntu 18.04 LTS.