### PR TITLE
Add vcpkg install instructions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,17 @@ Dear ImGui is self-contained within a few files that you can easily copy and com
 
 No specific build process is required. You can add the .cpp files to your project or #include them from an existing file.
 
+If you are using the [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager you can download and install Dear ImGui with a single command:
+- Mac and Linux
+```
+./vcpkg install imgui
+```
+- Windows
+```
+.\vcpkg.exe install imgui
+```
+This command will also provide usage instructions for your CMake-based projects.
+
 ### Usage
 
 Your code passes mouse/keyboard/gamepad inputs and settings to Dear ImGui (see example applications for more details). After Dear ImGui is setup, you can use it from \_anywhere\_ in your program loop:


### PR DESCRIPTION
Hey @ocornut. Imgui is available as a port in vcpkg, which offers users a simplified build and install process for imgui along with their other project dependencies. Documenting the install process here will help to lower the barrier to entry for both imgui and vcpkg.

Thanks!

