### PR TITLE
Viewports: Fix window having incorrect size after it is uncollapsed

### DIFF
--- a/examples/imgui_impl_glfw.cpp
+++ b/examples/imgui_impl_glfw.cpp
@@ -75,9 +75,6 @@ static GLFWscrollfun        g_PrevUserCallbackScroll = NULL;
 static GLFWkeyfun           g_PrevUserCallbackKey = NULL;
 static GLFWcharfun          g_PrevUserCallbackChar = NULL;
 
-// Flags used for GLFW workarounds.
-static bool g_IgnoreSetWindowSizeEvent = false;
-
 // Forward Declarations
 static void ImGui_ImplGlfw_InitPlatformInterface();
 static void ImGui_ImplGlfw_ShutdownPlatformInterface();
@@ -409,8 +406,9 @@ struct ImGuiViewportDataGlfw
 {
     GLFWwindow* Window;
     bool        WindowOwned;
+    bool        IgnoreSetWindowSizeEvent;
 
-    ImGuiViewportDataGlfw() { Window = NULL; WindowOwned = false; }
+    ImGuiViewportDataGlfw() { Window = NULL; WindowOwned = false; IgnoreSetWindowSizeEvent = false; }
     ~ImGuiViewportDataGlfw() { IM_ASSERT(Window == NULL); }
 };
 
@@ -428,18 +426,22 @@ static void ImGui_ImplGlfw_WindowPosCallback(GLFWwindow* window, int, int)
 
 static void ImGui_ImplGlfw_WindowSizeCallback(GLFWwindow* window, int, int)
 {
-    if (g_IgnoreSetWindowSizeEvent)
-    {
-        // GLFW will dispatch window size event. ImGui expects no such event sent when library explicitly requests setting
-        // window size. Depending on the platform this callback may be invoked during glfwSetWindowSize() call or queued
-        // for the next frame and invoked during glfwPollEvents() call. When latter happens - restoring collapsed window
-        // would have incorrect size.
-        g_IgnoreSetWindowSizeEvent = false;
-        return;
-    }
-
     if (ImGuiViewport* viewport = ImGui::FindViewportByPlatformHandle(window))
+    {
+        if (ImGuiViewportDataGlfw* data = (ImGuiViewportDataGlfw*)viewport->PlatformUserData)
+        {
+            if (data->IgnoreSetWindowSizeEvent)
+            {
+                // GLFW will dispatch window size event. ImGui expects no such event sent when library explicitly requests setting
+                // window size. Depending on the platform this callback may be invoked during glfwSetWindowSize() call or queued
+                // for the next frame and invoked during glfwPollEvents() call. When latter happens - restoring collapsed window
+                // would have incorrect size.
+                data->IgnoreSetWindowSizeEvent = false;
+                return;
+            }
+        }
         viewport->PlatformRequestResize = true;
+    }
 }
 
 static void ImGui_ImplGlfw_CreateWindow(ImGuiViewport* viewport)
@@ -582,7 +584,8 @@ static ImVec2 ImGui_ImplGlfw_GetWindowSize(ImGuiViewport* viewport)
 
 static void ImGui_ImplGlfw_SetWindowSize(ImGuiViewport* viewport, ImVec2 size)
 {
-    g_IgnoreSetWindowSizeEvent = true;
+    if (ImGuiViewportDataGlfw* data = (ImGuiViewportDataGlfw*)viewport->PlatformUserData)
+        data->IgnoreSetWindowSizeEvent = true;
     ImGuiViewportDataGlfw* data = (ImGuiViewportDataGlfw*)viewport->PlatformUserData;
     glfwSetWindowSize(data->Window, (int)size.x, (int)size.y);
 }
@@ -634,7 +637,7 @@ static void ImGui_ImplGlfw_RenderWindow(ImGuiViewport* viewport, void*)
 static void ImGui_ImplGlfw_SwapBuffers(ImGuiViewport* viewport, void*)
 {
     ImGuiViewportDataGlfw* data = (ImGuiViewportDataGlfw*)viewport->PlatformUserData;
-    if (g_ClientApi == GlfwClientApi_OpenGL) 
+    if (g_ClientApi == GlfwClientApi_OpenGL)
     {
         glfwMakeContextCurrent(data->Window);
         glfwSwapBuffers(data->Window);


### PR DESCRIPTION
Issue manifests on linux when window is in it's own viewport.

![Video](https://user-images.githubusercontent.com/19151258/63692779-1bf19480-c81b-11e9-9886-b1448badc5f9.gif)

## Why it happened

Event sets `PlatformRequestResize = true` which causes [this line](https://github.com/ocornut/imgui/blob/483534b525063a242d63f4481e55c88cf0c5eba9/imgui.cpp#L6123) to execute and save size of collapsed window as full size.

SDL backend does not send window resize event when `SDL_SetWindowSize()` is called and everything works as expected.

On windows glfw still sends this event, but event is sent during `glfwSetWindowSize()` call which is invoked from [here](https://github.com/ocornut/imgui/blob/483534b525063a242d63f4481e55c88cf0c5eba9/imgui.cpp#L10895). Due to lucky accident `PlatformRequestSize` is [cleared](https://github.com/ocornut/imgui/blob/483534b525063a242d63f4481e55c88cf0c5eba9/imgui.cpp#L10942) soon after imgui requests setting window size. It works on windows by chance.

On linux event is queued and sent to application on next frame during `glfwPollEvents()`. Then imgui gets a chance to react on `PlatformRequestSize` flag and save wrong window size.