### PR TITLE
Viewport: Fix setting window size on macos (glfw).

### DIFF
--- a/examples/imgui_impl_glfw.cpp
+++ b/examples/imgui_impl_glfw.cpp
@@ -570,6 +570,16 @@ static ImVec2 ImGui_ImplGlfw_GetWindowSize(ImGuiViewport* viewport)
 static void ImGui_ImplGlfw_SetWindowSize(ImGuiViewport* viewport, ImVec2 size)
 {
     ImGuiViewportDataGlfw* data = (ImGuiViewportDataGlfw*)viewport->PlatformUserData;
+#if __APPLE__
+    // Native OS windows are positioned from the bottom-left corner on macOS, whereas on other platforms they are
+    // positioned from the upper-left corner. GLFW makes an effort to convert macOS style coordinates, however it
+    // doesn't handle it when changing size. We are manually moving the window in order for changes of size to be based
+    // on the upper-left corner.
+    int x, y, width, height;
+    glfwGetWindowPos(data->Window, &x, &y);
+    glfwGetWindowSize(data->Window, &width, &height);
+    glfwSetWindowPos(data->Window, x, y - height + size.y);
+#endif
     glfwSetWindowSize(data->Window, (int)size.x, (int)size.y);
 }
 


### PR DESCRIPTION
MacOS positions windows by their bottom-left corner why the rest of the world (including imgui) position windows by the top-left corner. This created an issue where collapsing imgui window would cause window header to remain at the bottom the full window rect. Likewise resizing window by using sizing handle caused window to grow upwards when we tried to expand window downwards.

This workaround moves window to the opposite direction by the delta of size change creating an illusion that windows are positioned by their top-left corner.