### PR TITLE
Fix #2722 - ColorPicker / ColorEdit Widget Wrong Conversion from HSV to RGB

### DIFF
--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -1012,6 +1012,8 @@ struct ImGuiContext
     ImGuiID                 TempInputTextId;                    // Temporary text input when CTRL+clicking on a slider, etc.
     ImGuiColorEditFlags     ColorEditOptions;                   // Store user options for color edit widgets
     ImVec4                  ColorPickerRef;
+    float                   ColorPickerLastHue;
+    float                   ColorPickerLastActiveColor[3];
     bool                    DragCurrentAccumDirty;
     float                   DragCurrentAccum;                   // Accumulator for dragging modification. Always high-precision, not rounded by end-user precision settings
     float                   DragSpeedDefaultRatio;              // If speed == 0.0f, uses (max-min) * DragSpeedDefaultRatio

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -1011,9 +1011,9 @@ struct ImGuiContext
     ImFont                  InputTextPasswordFont;
     ImGuiID                 TempInputTextId;                    // Temporary text input when CTRL+clicking on a slider, etc.
     ImGuiColorEditFlags     ColorEditOptions;                   // Store user options for color edit widgets
+    float                   ColorEditLastHue;
+    float                   ColorEditLastActiveColor[3];
     ImVec4                  ColorPickerRef;
-    float                   ColorPickerLastHue;
-    float                   ColorPickerLastActiveColor[3];
     bool                    DragCurrentAccumDirty;
     float                   DragCurrentAccum;                   // Accumulator for dragging modification. Always high-precision, not rounded by end-user precision settings
     float                   DragSpeedDefaultRatio;              // If speed == 0.0f, uses (max-min) * DragSpeedDefaultRatio

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -4198,10 +4198,10 @@ bool ImGui::ColorEdit4(const char* label, float col[4], ImGuiColorEditFlags flag
         ColorConvertHSVtoRGB(f[0], f[1], f[2], f[0], f[1], f[2]);
     else if ((flags & ImGuiColorEditFlags_InputRGB) && (flags & ImGuiColorEditFlags_DisplayHSV))
     {
-        bool restore_hue = memcmp(g.ColorPickerLastActiveColor, f, sizeof(float) * 3) == 0;
         ColorConvertRGBtoHSV(f[0], f[1], f[2], f[0], f[1], f[2]);
-        if (restore_hue)
-            f[0] = g.ColorPickerLastHue;
+        // Hue is lost when converting from greyscale rgb (saturation=0). Restore it.
+        if (f[1] == 0 && memcmp(g.ColorEditLastActiveColor, col, sizeof(float) * 3) == 0)
+            f[0] = g.ColorEditLastHue;
     }
     int i[4] = { IM_F32_TO_INT8_UNBOUND(f[0]), IM_F32_TO_INT8_UNBOUND(f[1]), IM_F32_TO_INT8_UNBOUND(f[2]), IM_F32_TO_INT8_UNBOUND(f[3]) };
 
@@ -4330,9 +4330,9 @@ bool ImGui::ColorEdit4(const char* label, float col[4], ImGuiColorEditFlags flag
                 f[n] = i[n] / 255.0f;
         if ((flags & ImGuiColorEditFlags_DisplayHSV) && (flags & ImGuiColorEditFlags_InputRGB))
         {
-            g.ColorPickerLastHue = f[0];
+            g.ColorEditLastHue = f[0];
             ColorConvertHSVtoRGB(f[0], f[1], f[2], f[0], f[1], f[2]);
-            memcpy(g.ColorPickerLastActiveColor, f, sizeof(float) * 3);
+            memcpy(g.ColorEditLastActiveColor, f, sizeof(float) * 3);
         }
         if ((flags & ImGuiColorEditFlags_DisplayRGB) && (flags & ImGuiColorEditFlags_InputHSV))
             ColorConvertRGBtoHSV(f[0], f[1], f[2], f[0], f[1], f[2]);
@@ -4512,8 +4512,9 @@ bool ImGui::ColorPicker4(const char* label, float col[4], ImGuiColorEditFlags fl
     if (flags & ImGuiColorEditFlags_InputRGB)
     {
         ColorConvertRGBtoHSV(R, G, B, H, S, V);
-        if (memcmp(g.ColorPickerLastActiveColor, col, sizeof(float) * 3) == 0)
-            H = g.ColorPickerLastHue;
+        // Hue is lost when converting from greyscale rgb (saturation=0). Restore it.
+        if (S == 0 && memcmp(g.ColorEditLastActiveColor, col, sizeof(float) * 3) == 0)
+            H = g.ColorEditLastHue;
     }
     else if (flags & ImGuiColorEditFlags_InputHSV)
         ColorConvertHSVtoRGB(H, S, V, R, G, B);
@@ -4637,9 +4638,9 @@ bool ImGui::ColorPicker4(const char* label, float col[4], ImGuiColorEditFlags fl
     {
         if (flags & ImGuiColorEditFlags_InputRGB)
         {
-            g.ColorPickerLastHue = H;
             ColorConvertHSVtoRGB(H >= 1.0f ? H - 10 * 1e-6f : H, S > 0.0f ? S : 10*1e-6f, V > 0.0f ? V : 1e-6f, col[0], col[1], col[2]);
-            memcpy(g.ColorPickerLastActiveColor, col, sizeof(float) * 3);
+            g.ColorEditLastHue = H;
+            memcpy(g.ColorEditLastActiveColor, col, sizeof(float) * 3);
         }
         else if (flags & ImGuiColorEditFlags_InputHSV)
         {


### PR DESCRIPTION
There already was a fix for hue wrapping around. It depended on `g.ActiveId != 0 && !g.ActiveIdAllowOverlap` condition for detecting changes through `DragInt`/`DragFloat` and it no longer worked. Fix is simply a `bool ColorFixHueWrap` in `ImGuiContext` which is set whenever `DragInt`/`DragFloat` has modified color values, thus 100% reliable now.