### PR TITLE
Internal: Fix signed types warning in pasteboard handler

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -9689,7 +9689,7 @@ static const char* GetClipboardTextFn_DefaultImpl(void*)
 
     ItemCount item_count = 0;
     PasteboardGetItemCount(main_clipboard, &item_count);
-    for (int i = 0; i < item_count; i++)
+    for (ItemCount i = 0; i < item_count; i++)
     {
         PasteboardItemID item_id = 0;
         PasteboardGetItemIdentifier(main_clipboard, i + 1, &item_id);


### PR DESCRIPTION
Fixes a signed type warning in Clang (I use `-Werror` because I'm a masochist). Occurs when `IMGUI_ENABLE_OSX_DEFAULT_CLIPBOARD_FUNCTIONS` is defined.

```console
$ clang --version
Apple LLVM version 10.0.1 (clang-1001.0.46.4)
Target: x86_64-apple-darwin18.6.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```

Technically `ItemCount` probably isn't the _best_ type for `i` but it solves the problem of signedness if/when the typedef changes. Right now, it's ultimately an unsigned type so changing it to `unsigned int i` also works (but would break, again, if `ItemCount` changes back to signed in the future).