### PR TITLE
ImDrawList: only define GetForegroundDrawList in debug mode

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -3344,11 +3344,13 @@ ImDrawList* ImGui::GetBackgroundDrawList()
     return &GImGui->BackgroundDrawList;
 }
 
+#if IMGUI_DEBUG_NAV_RECTS
 static ImDrawList* GetForegroundDrawList(ImGuiWindow*)
 {
     // This seemingly unnecessary wrapper simplifies compatibility between the 'master' and 'docking' branches.
     return &GImGui->ForegroundDrawList;
 }
+#endif
 
 ImDrawList* ImGui::GetForegroundDrawList()
 {


### PR DESCRIPTION
In release mode, this function is not used, and since it is declared `static`, on strict builds it causes an error about being unused.

This PR wraps it in the same `#if` check to match its only callsite.