### PR TITLE
Automatically include the available gl loader header

### DIFF
--- a/examples/imgui_impl_opengl3.cpp
+++ b/examples/imgui_impl_opengl3.cpp
@@ -149,6 +149,21 @@ bool    ImGui_ImplOpenGL3_Init(const char* glsl_version)
     strcpy(g_GlslVersionString, glsl_version);
     strcat(g_GlslVersionString, "\n");
 
+    // Dummy constructs to make it easily visible in the IDE and debugger which GL loader has been selected.
+    // if you have multiple GL loaders header files accessible to the compiler, the auto detection block in
+    // imgui_impl_opengl3.h may have chosen the wrong one !! 
+    // Use an explicit '#define IMGUI_IMPL_OPENGL_LOADER_XXX' line in imconfig.h or compiler command-line to enforce a certain GL loader.
+    const char* gl_loader = "Unknown";
+    IM_UNUSED(gl_loader);
+#if defined(IMGUI_IMPL_OPENGL_LOADER_GL3W)
+    gl_loader = "GL3W";
+#elif defined(IMGUI_IMPL_OPENGL_LOADER_GLEW)
+    gl_loader = "GLEW";
+#elif defined(IMGUI_IMPL_OPENGL_LOADER_GLAD)
+    gl_loader = "GLAD";
+#elif defined(IMGUI_IMPL_OPENGL_LOADER_CUSTOM)
+    gl_loader = "Custom";
+#endif
     // Make a dummy GL call (we don't actually need the result)
     // IF YOU GET A CRASH HERE: it probably means that you haven't initialized the OpenGL function loader used by this code.
     // Desktop OpenGL 3/4 need a function loader. See the IMGUI_IMPL_OPENGL_LOADER_xxx explanation above.

--- a/examples/imgui_impl_opengl3.h
+++ b/examples/imgui_impl_opengl3.h
@@ -32,7 +32,19 @@
  && !defined(IMGUI_IMPL_OPENGL_LOADER_GLEW)     \
  && !defined(IMGUI_IMPL_OPENGL_LOADER_GLAD)     \
  && !defined(IMGUI_IMPL_OPENGL_LOADER_CUSTOM)
-#define IMGUI_IMPL_OPENGL_LOADER_GL3W
+    // to avoid problem with non-clang compilers not having this macro.
+    #if defined(__has_include)
+        // check if the header exists, then automatically define the macros ..
+        #if __has_include(<GL/glew.h>)
+            #define IMGUI_IMPL_OPENGL_LOADER_GLEW
+        #elif __has_include(<glad/glad.h>)
+            #define IMGUI_IMPL_OPENGL_LOADER_GLAD
+        #else
+            #define IMGUI_IMPL_OPENGL_LOADER_GL3W
+        #endif
+    #else
+        #define IMGUI_IMPL_OPENGL_LOADER_GL3W
+    #endif
 #endif
 
 IMGUI_IMPL_API bool     ImGui_ImplOpenGL3_Init(const char* glsl_version = NULL);

--- a/examples/imgui_impl_opengl3.h
+++ b/examples/imgui_impl_opengl3.h
@@ -35,15 +35,26 @@
     // to avoid problem with non-clang compilers not having this macro.
     #if defined(__has_include)
         // check if the header exists, then automatically define the macros ..
+        // check if glew gl loader exists, use it
         #if __has_include(<GL/glew.h>)
+            // make sure we don't have another gl loader headers ....
+            // that means that the user might have used one and initialized it
+            // while we use the other ....
+            // so we make sure there is only one gl loader header
+            // in this case, we need to only have glew headers and not glad !
             #if __has_include(<glad/glad.h>)
-                #error you have multiple headers in your system (GLEW + GLAD)
+                #error you have multiple headers in your system (GLEW + GLAD), remove one of them or use '#define IMGUI_IMPL_OPENGL_LOADER_GLEW'
             #else
                 #define IMGUI_IMPL_OPENGL_LOADER_GLEW
             #endif
         #elif __has_include(<glad/glad.h>)
+            // make sure we don't have another gl loader headers ....
+            // that means that the user might have used one and initialized it
+            // while we use the other ....
+            // so we make sure there is only one gl loader header
+            // in this case, we need to only have glad headers and not glew !
             #if __has_include(<GL/glew.h>)
-                 #error you have multiple headers in your system (GLEW + GLAD)
+                 #error you have multiple headers in your system (GLEW + GLAD), remove one of them or use '#define IMGUI_IMPL_OPENGL_LOADER_GLAD'
             #else
                 #define IMGUI_IMPL_OPENGL_LOADER_GLAD
             #endif

--- a/examples/imgui_impl_opengl3.h
+++ b/examples/imgui_impl_opengl3.h
@@ -36,9 +36,17 @@
     #if defined(__has_include)
         // check if the header exists, then automatically define the macros ..
         #if __has_include(<GL/glew.h>)
-            #define IMGUI_IMPL_OPENGL_LOADER_GLEW
+            #if __has_include(<glad/glad.h>)
+                #error you have multiple headers in your system (GLEW + GLAD)
+            #else
+                #define IMGUI_IMPL_OPENGL_LOADER_GLEW
+            #endif
         #elif __has_include(<glad/glad.h>)
-            #define IMGUI_IMPL_OPENGL_LOADER_GLAD
+            #if __has_include(<GL/glew.h>)
+                 #error you have multiple headers in your system (GLEW + GLAD)
+            #else
+                #define IMGUI_IMPL_OPENGL_LOADER_GLAD
+            #endif
         #else
             #define IMGUI_IMPL_OPENGL_LOADER_GL3W
         #endif


### PR DESCRIPTION
This change is additive and doesn't change the existing code.

It handles the case when we don't define any of these macros
{ 
    `IMGUI_IMPL_OPENGL_LOADER_GL3W`,
    `IMGUI_IMPL_OPENGL_LOADER_GLEW`,
   ` IMGUI_IMPL_OPENGL_LOADER_GLAD`,
   ` IMGUI_IMPL_OPENGL_LOADER_CUSTOM`
]

Using the `__has_include` clang extension, we can automatically know which header is available,
then we use it directly without predefined macros or anything, this fits naturally in the code without having to use gl3w or supply any macros ... 
