### PR TITLE
Adding scope braces to encapsulate STBTT_assert macro

### DIFF
--- a/imstb_truetype.h
+++ b/imstb_truetype.h
@@ -2949,16 +2949,17 @@ static void stbtt__handle_clipped_edge(float *scanline, int x, stbtt__active_edg
       y1 = e->ey;
    }
 
-   if (x0 == x)
+   if (x0 == x) {
       STBTT_assert(x1 <= x+1);
-   else if (x0 == x+1)
+   } else if (x0 == x+1) {
       STBTT_assert(x1 >= x);
-   else if (x0 <= x)
+   } else if (x0 <= x) {
       STBTT_assert(x1 <= x);
-   else if (x0 >= x+1)
+   } else if (x0 >= x+1) {
       STBTT_assert(x1 >= x+1);
-   else
+   } else {
       STBTT_assert(x1 >= x && x1 <= x+1);
+   }
 
    if (x0 <= x && x1 <= x)
       scanline[x] += e->direction * (y1-y0);

--- a/imstb_truetype.h
+++ b/imstb_truetype.h
@@ -2949,17 +2949,17 @@ static void stbtt__handle_clipped_edge(float *scanline, int x, stbtt__active_edg
       y1 = e->ey;
    }
 
-   if (x0 == x) {
+   if (x0 == x)
       STBTT_assert(x1 <= x+1);
-   } else if (x0 == x+1) {
+   else if (x0 == x+1)
       STBTT_assert(x1 >= x);
-   } else if (x0 <= x) {
+   else if (x0 <= x)
       STBTT_assert(x1 <= x);
-   } else if (x0 >= x+1) {
+   else if (x0 >= x+1)
       STBTT_assert(x1 >= x+1);
-   } else {
+   else
       STBTT_assert(x1 >= x && x1 <= x+1);
-   }
+
    if (x0 <= x && x1 <= x)
       scanline[x] += e->direction * (y1-y0);
    else if (x0 >= x+1 && x1 >= x+1)

--- a/imstb_truetype.h
+++ b/imstb_truetype.h
@@ -2949,17 +2949,17 @@ static void stbtt__handle_clipped_edge(float *scanline, int x, stbtt__active_edg
       y1 = e->ey;
    }
 
-   if (x0 == x)
+   if (x0 == x) {
       STBTT_assert(x1 <= x+1);
-   else if (x0 == x+1)
+   } else if (x0 == x+1) {
       STBTT_assert(x1 >= x);
-   else if (x0 <= x)
+   } else if (x0 <= x) {
       STBTT_assert(x1 <= x);
-   else if (x0 >= x+1)
+   } else if (x0 >= x+1) {
       STBTT_assert(x1 >= x+1);
-   else
+   } else {
       STBTT_assert(x1 >= x && x1 <= x+1);
-
+   }
    if (x0 <= x && x1 <= x)
       scanline[x] += e->direction * (y1-y0);
    else if (x0 >= x+1 && x1 >= x+1)


### PR DESCRIPTION
In my project, I override the IMGUI_ASSERT macro with my own. My macro contains multiple expressions. This was causing a problem with the STBTT_assert macro on these particular lines.