### PR TITLE
Fix SetItemDefaultFocus() consistency

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -6973,8 +6973,7 @@ void ImGui::SetItemDefaultFocus()
         g.NavInitResultId = g.NavWindow->DC.LastItemId;
         g.NavInitResultRectRel = ImRect(g.NavWindow->DC.LastItemRect.Min - g.NavWindow->Pos, g.NavWindow->DC.LastItemRect.Max - g.NavWindow->Pos);
         NavUpdateAnyRequestFlag();
-        if (!IsItemVisible())
-            SetScrollHereY();
+        SetScrollHereY();
     }
 }
 


### PR DESCRIPTION
Fixes the issue that an item which was barely visible (1px) was not being visibly focused. Also always focusing the default item in the center of the surrounding area makes it behave consistently independent of initial visibility. Both of which are being resolved with this change.

Additional suggestion: Introduce optional `center_y_ratio` parameter to forward to SetScrollHereY() for more control.

Dear ImGui 1.73
