### PR TITLE
Improve SetItemDefaultFocus scrolling

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -6973,8 +6973,7 @@ void ImGui::SetItemDefaultFocus()
         g.NavInitResultId = g.NavWindow->DC.LastItemId;
         g.NavInitResultRectRel = ImRect(g.NavWindow->DC.LastItemRect.Min - g.NavWindow->Pos, g.NavWindow->DC.LastItemRect.Max - g.NavWindow->Pos);
         NavUpdateAnyRequestFlag();
-        if (!IsItemVisible())
-            SetScrollHereY();
+        ScrollToBringRectIntoView(window, g.NavWindow->DC.LastItemRect);
     }
 }
 


### PR DESCRIPTION
- An item which is barely visible (1px) was not being visibly focused
- Scrolling to an invisible item was improved to indicate scroll direction instead of simply centering it

Closes #2812