### PR TITLE
Fixed backspace handling on MacOS and allow null view parameter to NewFrame

### DIFF
--- a/examples/imgui_impl_osx.h
+++ b/examples/imgui_impl_osx.h
@@ -13,5 +13,5 @@
 
 IMGUI_API bool        ImGui_ImplOSX_Init();
 IMGUI_API void        ImGui_ImplOSX_Shutdown();
-IMGUI_API void        ImGui_ImplOSX_NewFrame(NSView *_Nonnull view);
+IMGUI_API void        ImGui_ImplOSX_NewFrame(NSView *_Nullable view);
 IMGUI_API bool        ImGui_ImplOSX_HandleEvent(NSEvent *_Nonnull event, NSView *_Nullable view);

--- a/examples/imgui_impl_osx.mm
+++ b/examples/imgui_impl_osx.mm
@@ -150,9 +150,12 @@ void ImGui_ImplOSX_NewFrame(NSView* view)
 {
     // Setup display size
     ImGuiIO& io = ImGui::GetIO();
-    const float dpi = [view.window backingScaleFactor];
-    io.DisplaySize = ImVec2((float)view.bounds.size.width, (float)view.bounds.size.height);
-    io.DisplayFramebufferScale = ImVec2(dpi, dpi);
+    if (view)
+    {
+        const float dpi = [view.window backingScaleFactor];
+        io.DisplaySize = ImVec2((float)view.bounds.size.width, (float)view.bounds.size.height);
+        io.DisplayFramebufferScale = ImVec2(dpi, dpi);
+    }
 
     // Setup time step
     if (g_Time == 0.0)
@@ -250,7 +253,7 @@ bool ImGui_ImplOSX_HandleEvent(NSEvent* event, NSView* view)
         for (int i = 0; i < len; i++)
         {
             int c = [str characterAtIndex:i];
-            if (!io.KeyCtrl && !(c >= 0xF700 && c <= 0xFFFF))
+            if (!io.KeyCtrl && !((c >= 0xF700 && c <= 0xFFFF) || c == 127))
                 io.AddInputCharacter((unsigned int)c);
 
             // We must reset in case we're pressing a sequence of special keys while keeping the command pressed


### PR DESCRIPTION
This fixes the issue with backspace handling (https://github.com/ocornut/imgui/issues/2817).

It also allows passing null view to `ImGui_ImplOSX_NewFrame()`. This adds flexibility as the method may be called from thread other than main as methods of NSView can only be accessed from the main thread.
