### PR TITLE
Allegro: Added build instructions for macOS

### DIFF
--- a/examples/example_allegro5/README.md
+++ b/examples/example_allegro5/README.md
@@ -31,3 +31,14 @@ Build:
 set ALLEGRODIR=path_to_your_allegro5_folder
 cl /Zi /MD /I %ALLEGRODIR%\include /DIMGUI_USER_CONFIG=\"examples/example_allegro5/imconfig_allegro5.h\" /I .. /I ..\.. main.cpp ..\imgui_impl_allegro5.cpp ..\..\imgui*.cpp /link /LIBPATH:%ALLEGRODIR%\lib allegro-5.0.10-monolith-md.lib user32.lib
 ```
+
+### On macOS
+
+Install Allegro with homebrew:
+
+`brew install allegro`
+
+Build:
+```bash
+g++ -DIMGUI_USER_CONFIG=\"examples/example_allegro5/imconfig_allegro5.h\" -I .. -I ../.. main.cpp ../imgui_impl_allegro5.cpp ../../imgui*.cpp -lallegro -lallegro_main -lallegro_primitives -o allegro5_example
+```

--- a/examples/example_allegro5/README.md
+++ b/examples/example_allegro5/README.md
@@ -9,10 +9,10 @@ Note that the back-end supports _BOTH_ 16-bit and 32-bit indices, but 32-bit ind
 
 # How to Build
 
-### On Ubuntu 14.04+
+### On Ubuntu 14.04+ and macOS
 
 ```bash
-g++ -DIMGUI_USER_CONFIG=\"examples/example_allegro5/imconfig_allegro5.h\" -I .. -I ../.. main.cpp ../imgui_impl_allegro5.cpp ../../imgui*.cpp -lallegro -lallegro_primitives -o allegro5_example
+g++ -DIMGUI_USER_CONFIG=\"examples/example_allegro5/imconfig_allegro5.h\" -I .. -I ../.. main.cpp ../imgui_impl_allegro5.cpp ../../imgui*.cpp -lallegro -lallegro_main -lallegro_primitives -o allegro5_example
 ```
 
 ### On Windows with Visual Studio's CLI
@@ -32,13 +32,4 @@ set ALLEGRODIR=path_to_your_allegro5_folder
 cl /Zi /MD /I %ALLEGRODIR%\include /DIMGUI_USER_CONFIG=\"examples/example_allegro5/imconfig_allegro5.h\" /I .. /I ..\.. main.cpp ..\imgui_impl_allegro5.cpp ..\..\imgui*.cpp /link /LIBPATH:%ALLEGRODIR%\lib allegro-5.0.10-monolith-md.lib user32.lib
 ```
 
-### On macOS
-
-Install Allegro with homebrew:
-
-`brew install allegro`
-
-Build:
-```bash
-g++ -DIMGUI_USER_CONFIG=\"examples/example_allegro5/imconfig_allegro5.h\" -I .. -I ../.. main.cpp ../imgui_impl_allegro5.cpp ../../imgui*.cpp -lallegro -lallegro_main -lallegro_primitives -o allegro5_example
-```
+On macOS, install Allegro with homebrew: `brew install allegro`


### PR DESCRIPTION
Hi,

I've tried to compile Allegro variant under macOS Mojave 10.14.6 but was running into this error:

```shell
Undefined symbols for architecture x86_64:
  "_main", referenced from:
     implicit entry/start for main executable
     (maybe you meant: __al_mangled_main)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

My build commands were based on the Ubuntu build example from README.md.

After some googling I found out that under macOS one has to link to *allegro_main* library as well. Not sure why Ubuntu doesn't need it, but macOS must have it. 

I've added a build example for macOS to README.md. Maybe it'll be of some use to other macOS newbies like me. 

Cheers,