### PR TITLE
Support for Glbinding loader library in OpenGL3 example.

### DIFF
--- a/examples/example_sdl_opengl3/main.cpp
+++ b/examples/example_sdl_opengl3/main.cpp
@@ -19,6 +19,9 @@
 #include <GL/glew.h>    // Initialize with glewInit()
 #elif defined(IMGUI_IMPL_OPENGL_LOADER_GLAD)
 #include <glad/glad.h>  // Initialize with gladLoadGL()
+#elif defined(IMGUI_IMPL_OPENGL_LOADER_GLBINDING)
+#include <glbinding/gl/gl.h>  // glbinding::Binding::initialize();
+using namespace gl;
 #else
 #include IMGUI_IMPL_OPENGL_LOADER_CUSTOM
 #endif

--- a/examples/imgui_impl_opengl3.cpp
+++ b/examples/imgui_impl_opengl3.cpp
@@ -114,6 +114,9 @@
 #include <GL/glew.h>    // Needs to be initialized with glewInit() in user's code
 #elif defined(IMGUI_IMPL_OPENGL_LOADER_GLAD)
 #include <glad/glad.h>  // Needs to be initialized with gladLoadGL() in user's code
+#elif defined(IMGUI_IMPL_OPENGL_LOADER_GLBINDING)
+#include <glbinding/gl/gl.h> // Needs to be initialized with gladLoadGL() in user's code
+using namespace gl;  // Has to be set to expose OpenGL to the global namespace
 #else
 #include IMGUI_IMPL_OPENGL_LOADER_CUSTOM
 #endif

--- a/examples/imgui_impl_opengl3.h
+++ b/examples/imgui_impl_opengl3.h
@@ -54,6 +54,8 @@ IMGUI_IMPL_API void     ImGui_ImplOpenGL3_DestroyDeviceObjects();
             #define IMGUI_IMPL_OPENGL_LOADER_GLAD
         #elif __has_include(<GL/gl3w.h>)
             #define IMGUI_IMPL_OPENGL_LOADER_GL3W
+        #elif __has_include(<glbinding/gl/gl.h>)
+            #define IMGUI_IMPL_OPENGL_LOADER_GLBINDING
         #else
             #error "Cannot detect OpenGL loader!"
         #endif


### PR DESCRIPTION
Hello!

I think it is a good time to add support for https://github.com/cginternals/glbinding to ImGui.
Since there is already a compile-time check in place for a couple of popular GL bindings libraries such as Glad and Gl3w. 
I think this is a shame that we still don't have out of the box support for Glbinding. This is a modern fancy OpenGL biding library that many (myself included) enjoy using. 
I really like using example OpenGL3 IMGUI rendering implementation in my projects (and I'm pretty sure many others do as well) as a simple and cheap out of the box solution. However, I also don't really like to modify or do some custom things with my modules, such as adding my custom define statements, which is my main motivation for this PR.

Thanks!