### PR TITLE
Fix snprintf and vsnprintf definition inconsistencies.

### DIFF
--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -100,10 +100,15 @@ Index of this file:
 // Play it nice with Windows users. Notepad in 2017 still doesn't display text data with Unix-style \n.
 #ifdef _WIN32
 #define IM_NEWLINE  "\r\n"
-#define snprintf    _snprintf
-#define vsnprintf   _vsnprintf
 #else
 #define IM_NEWLINE  "\n"
+#endif
+
+#if defined(_MSC_VER) && !defined(snprintf)
+#define snprintf    _snprintf
+#endif
+#if defined(_MSC_VER) && !defined(vsnprintf)
+#define vsnprintf   _vsnprintf
 #endif
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
In `imgui.cpp`, `vsnprintf` is defined inside `#if defined(_MSC_VER) && !defined(vsnprintf)`, whereas in `imgui_demo.cpp` it is defined inside `#if _WIN32`, which is questionable because the compiler/crt have more to do with `_vsnprintf` being present than the platform.

This PR applies the `imgui.cpp` logic to `imgui_demo.cpp` for consistency (and fixes the Cygwin/MSYS2 build).