### PR TITLE
Disable Win32 clipboard and IME functions when build target UWP (#2892)

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -9483,6 +9483,10 @@ static void WindowSettingsHandler_WriteAll(ImGuiContext* ctx, ImGuiSettingsHandl
 #else
 #include <windows.h>
 #endif
+#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)
+#define IMGUI_DISABLE_WIN32_DEFAULT_CLIPBOARD_FUNCTIONS
+#define IMGUI_DISABLE_WIN32_DEFAULT_IME_FUNCTIONS
+#endif
 #elif defined(__APPLE__)
 #include <TargetConditionals.h>
 #endif


### PR DESCRIPTION
Fix #2892 
Maybe more job to do to make clipboard and IME work on UWP platform.
