### PR TITLE
Reinitiated all static variables when ImGui_ImplOpenGL_Init was called

### DIFF
--- a/examples/imgui_impl_opengl2.cpp
+++ b/examples/imgui_impl_opengl2.cpp
@@ -57,6 +57,8 @@ static GLuint       g_FontTexture = 0;
 // Functions
 bool    ImGui_ImplOpenGL2_Init()
 {
+    g_FontTexture = 0;
+
     // Setup back-end capabilities flags
     ImGuiIO& io = ImGui::GetIO();
     io.BackendRendererName = "imgui_impl_opengl2";

--- a/examples/imgui_impl_opengl3.cpp
+++ b/examples/imgui_impl_opengl3.cpp
@@ -139,6 +139,20 @@ static unsigned int g_VboHandle = 0, g_ElementsHandle = 0;
 // Functions
 bool    ImGui_ImplOpenGL3_Init(const char* glsl_version)
 {
+    g_GlVersion = 0;
+    memset(g_GlslVersionString, 0, sizeof(g_GlslVersionString));
+    g_FontTexture = 0;
+    g_ShaderHandle = 0;
+    g_VertHandle = 0;
+    g_FragHandle = 0;
+    g_AttribLocationTex = 0;
+    g_AttribLocationProjMtx = 0;
+    g_AttribLocationVtxPos = 0;
+    g_AttribLocationVtxUV = 0;
+    g_AttribLocationVtxColor = 0;
+    g_VboHandle = 0;
+    g_ElementsHandle = 0;
+
     // Query for GL version
 #if !defined(IMGUI_IMPL_OPENGL_ES2)
     GLint major, minor;
@@ -157,7 +171,7 @@ bool    ImGui_ImplOpenGL3_Init(const char* glsl_version)
         io.BackendFlags |= ImGuiBackendFlags_RendererHasVtxOffset;  // We can honor the ImDrawCmd::VtxOffset field, allowing for large meshes.
 #endif
 
-    // Store GLSL version string so we can refer to it later in case we recreate shaders. 
+    // Store GLSL version string so we can refer to it later in case we recreate shaders.
     // Note: GLSL version is NOT the same as GL version. Leave this to NULL if unsure.
 #if defined(IMGUI_IMPL_OPENGL_ES2)
     if (glsl_version == NULL)


### PR DESCRIPTION
Hello,

I am creating this PR to allow the reinitialization of static variables from `imgui_impl_opengl3.cpp` and `imgui_impl_opengl2.cpp`.

## Why?

This comes up because of a GLES project I am working on. As the `GLSurfaceView`'s original context has been destroyed and recreated, ImGui's OpenGL implementations kept the original, thus no longer valid programs & shaders, etc., and spilling out lots of GLES errors. Reinitializing the variables whenever `ImGui_ImplOpenGL3_Init` is called solves this issue, and thus making ImGui to go over these things again whenever there's a context creation.
