### PR TITLE
Don't disable file functions for Emscripten.

### DIFF
--- a/examples/example_emscripten/Makefile
+++ b/examples/example_emscripten/Makefile
@@ -25,7 +25,6 @@ EMS = -s USE_SDL=2 -s WASM=1
 EMS += -s ALLOW_MEMORY_GROWTH=1
 EMS += -s DISABLE_EXCEPTION_CATCHING=1 -s NO_EXIT_RUNTIME=0
 EMS += -s ASSERTIONS=1
-EMS += -s NO_FILESYSTEM=1 -DIMGUI_DISABLE_FILE_FUNCTIONS
 # Uncomment next line to fix possible rendering bugs with emscripten version older then 1.39.0 (https://github.com/ocornut/imgui/issues/2877)
 #EMS += -s BINARYEN_TRAP_MODE=clamp
 #EMS += -s SAFE_HEAP=1    ## Adds overhead
@@ -36,6 +35,7 @@ CPPFLAGS += -Wall -Wformat -Os
 CPPFLAGS += $(EMS)
 LIBS = $(EMS)
 LDFLAGS = --shell-file shell_minimal.html
+LDFLAGS += --no-heap-copy --preload-file ../../misc/fonts@/fonts
 
 ##---------------------------------------------------------------------
 ## BUILD RULES

--- a/examples/example_emscripten/main.cpp
+++ b/examples/example_emscripten/main.cpp
@@ -83,13 +83,14 @@ int main(int, char**)
     // - The fonts will be rasterized at a given size (w/ oversampling) and stored into a texture when calling ImFontAtlas::Build()/GetTexDataAsXXXX(), which ImGui_ImplXXXX_NewFrame below will call.
     // - Read 'docs/FONTS.txt' for more instructions and details.
     // - Remember that in C/C++ if you want to include a backslash \ in a string literal you need to write a double backslash \\ !
+    // - Emscripten allows preloading a file to be used for fopen() and related functions. The Makefile for this project puts the fonts at /fonts.
     //io.Fonts->AddFontDefault();
-    //io.Fonts->AddFontFromFileTTF("../../misc/fonts/Roboto-Medium.ttf", 16.0f);
-    //io.Fonts->AddFontFromFileTTF("../../misc/fonts/Cousine-Regular.ttf", 15.0f);
-    //io.Fonts->AddFontFromFileTTF("../../misc/fonts/DroidSans.ttf", 16.0f);
-    //io.Fonts->AddFontFromFileTTF("../../misc/fonts/ProggyTiny.ttf", 10.0f);
-    //ImFont* font = io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\ArialUni.ttf", 18.0f, NULL, io.Fonts->GetGlyphRangesJapanese());
-    //IM_ASSERT(font != NULL);
+    //io.Fonts->AddFontFromFileTTF("/fonts/Roboto-Medium.ttf", 16.0f);
+    //io.Fonts->AddFontFromFileTTF("/fonts/Cousine-Regular.ttf", 15.0f);
+    //io.Fonts->AddFontFromFileTTF("/fonts/DroidSans.ttf", 16.0f);
+    //io.Fonts->AddFontFromFileTTF("/fonts/ProggyTiny.ttf", 10.0f);
+    ImFont* font = io.Fonts->AddFontFromFileTTF("/fonts/Karla-Regular.ttf", 18.0f, NULL, io.Fonts->GetGlyphRangesJapanese());
+    IM_ASSERT(font != NULL);
 
     // This function call won't return, and will engage in an infinite loop, processing events from the browser, and dispatching them.
     emscripten_set_main_loop_arg(main_loop, NULL, 0, true);

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -269,9 +269,6 @@ static inline ImVec4 operator*(const ImVec4& lhs, const ImVec4& rhs)            
 #endif
 
 // Helpers: File System
-#if defined(__EMSCRIPTEN__) && !defined(IMGUI_DISABLE_FILE_FUNCTIONS)
-#define IMGUI_DISABLE_FILE_FUNCTIONS
-#endif
 #ifdef IMGUI_DISABLE_FILE_FUNCTIONS
 #define IMGUI_DISABLE_DEFAULT_FILE_FUNCTIONS
 typedef void* ImFileHandle;


### PR DESCRIPTION
I updated imgui in [my project](https://github.com/Oipo/IdleBossHunter) today and found that the loading of fonts on emscripten was broken. This PR fixes it and updates the example to show how to get font loading to work.

The result can be seen at https://www.realmofaesir.com/example_emscripten.html
