### PR TITLE
Render non-antialiased lines with correct thickness and beveled corners

### DIFF
--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -225,7 +225,7 @@ void ImGui::ShowDemoWindow(bool* p_open)
     static bool show_app_constrained_resize = false;
     static bool show_app_simple_overlay = false;
     static bool show_app_window_titles = false;
-    static bool show_app_custom_rendering = false;
+    static bool show_app_custom_rendering = true;
 
     if (show_app_dockspace)           ShowExampleAppDockSpace(&show_app_dockspace);     // Process the Docking app first, as explicit DockSpace() nodes needs to be submitted early (read comments near the DockSpace function)
     if (show_app_documents)           ShowExampleAppDocuments(&show_app_documents);     // Process the Document app next, as it may also use a DockSpace()
@@ -4517,6 +4517,8 @@ static void ShowExampleAppCustomRendering(bool* p_open)
     // In this example we are not using the maths operators!
     ImDrawList* draw_list = ImGui::GetWindowDrawList();
 
+    ImGui::Checkbox("Antialiasing", &ImGui::GetStyle().AntiAliasedLines);
+
     if (ImGui::BeginTabBar("##TabBar"))
     {
         // Primitives
@@ -4567,7 +4569,30 @@ static void ShowExampleAppCustomRendering(bool* p_open)
             draw_list->AddRectFilled(ImVec2(x, y), ImVec2(x + 1, y + 1), col);                          x += sz;            // Pixel (faster than AddLine)
             draw_list->AddRectFilledMultiColor(ImVec2(x, y), ImVec2(x + sz, y + sz), IM_COL32(0, 0, 0, 255), IM_COL32(255, 0, 0, 255), IM_COL32(255, 255, 0, 255), IM_COL32(0, 255, 0, 255));
             ImGui::Dummy(ImVec2((sz + spacing) * 9.8f, (sz + spacing) * 3));
+
+            x = p.x + 4;
+            y += sz + spacing;
+            // (const ImVec2* points, const int points_count, ImU32 col, bool closed, float thickness)
+            // ImVec2 points[4] = {{x, y}, {x+100, y}, {x+100, y+100}, {x+200, y+100}};
+            // draw_list->AddPolyline(points, 4, col, false, 10);
+            ImVec2 points1[3] = {{x, y}, {x+100, y}, {x+100, y+100}};
+            draw_list->AddPolyline(points1, 3, col, true, 10);
+            x += 120;
+            ImVec2 points2[3] = {{x, y}, {x+100, y+100}, {x+100, y}};
+            draw_list->AddPolyline(points2, 3, col, true, 10);
+            x += 120;
+            ImVec2 points3[3] = {{x, y}, {x+100, y+100}, {x+100, y}};
+            draw_list->AddPolyline(points3, 3, col, false, 10);
             ImGui::EndTabItem();
+            x += 60 - 240;
+            y += 100 + 60;
+            static ImVec2 *bench_points = (ImVec2*)malloc(sizeof(ImVec2) * 100000);
+            for (int i = 0; i < 100000; i++) {
+                bench_points[i].x = x + 50*sin(i*0.3);
+                bench_points[i].y = y + 50*cos(i*0.3);
+            }
+            draw_list->AddPolyline(bench_points, 100000, col, false, 10);
+
         }
 
         if (ImGui::BeginTabItem("Canvas"))
@@ -4674,7 +4699,7 @@ void ShowExampleAppDockSpace(bool* p_open)
         window_flags |= ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoNavFocus;
     }
 
-    // When using ImGuiDockNodeFlags_PassthruCentralNode, DockSpace() will render our background 
+    // When using ImGuiDockNodeFlags_PassthruCentralNode, DockSpace() will render our background
     // and handle the pass-thru hole, so we ask Begin() to not render a background.
     if (dockspace_flags & ImGuiDockNodeFlags_PassthruCentralNode)
         window_flags |= ImGuiWindowFlags_NoBackground;


### PR DESCRIPTION
Polyline rendering is currently problematic. Antialiased and non-antialiased lines are handled separately, and each has its unique set of problems.

* Antialiased polylines are rendered with lower thickness around acute angles
* Non-antialiased polylines are rendered as disconnected segments which leads to gaps and overlaps

Antialiased line artifacts:

![Antialiased](https://user-images.githubusercontent.com/4094619/71766031-b82f5480-2efb-11ea-9050-f7545679586f.png)

Non-antialiased line artifacts:

![Screenshot from 2020-01-04 14-08-11](https://user-images.githubusercontent.com/4094619/71766040-d85f1380-2efb-11ea-9b99-a25d5616749b.png)

These problems are discussed in issue #2183, but without arriving at a single solution. 

This PR contains code for non-antialiased rendering with correct line width and bevels around points. I will implement anti-aliased rendering as soon as there is consensus regarding the desired polyline appearance.

It results in this render:

![Screenshot from 2020-01-04 14-19-10](https://user-images.githubusercontent.com/4094619/71766161-350efe00-2efd-11ea-890a-f4a45c01037f.png)

I modified imgui_demo.cpp to better showcase the algorithm (see the images above). These changes should probably be reverted before merging.

The new algorithm does polyline triangulation like this:

![Screenshot from 2020-01-04 13-48-13](https://user-images.githubusercontent.com/4094619/71766134-f2e5bc80-2efc-11ea-8992-c876d0c4d499.png)

This requires 3 verts and 3 faces for each segment. Previously, it was 4 verts and 2 faces. I did not do any rigorous benchmarks, but the code doesn't contain anything heavy.

The main question is: how to bevel the lines? With the algorithm as I implemented it, all angles are bevelled. This changes the appearance of rectangles, checkbox ticks, etc., as right angles were previously not bevelled. It may be better to bevel only acute angles, which complicates the algorithm a bit but should not be a big problem.

Should bevelling be performed only for acute angles, most segments may in practice consist of fewer segments and vertices (namely, 2 and 2). Is it possible to emit variable number of vertices to the draw buffers?
