### PR TITLE
Add shadow offset support

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -2173,6 +2173,7 @@ struct ImFontAtlas
     ImTextureID                 TexID;              // User data to refer to the texture once it has been uploaded to user's graphic systems. It is passed back to you during rendering via the ImDrawCmd structure.
     int                         TexDesiredWidth;    // Texture width desired by user before Build(). Must be a power-of-two. If have many glyphs your graphics API have texture size restrictions you may want to increase texture width to decrease height.
     int                         TexGlyphPadding;    // Padding between glyphs within texture in pixels. Defaults to 1. If your rendering method doesn't rely on bilinear filtering you may set this to 0.
+    ImVec2                      TexGlyphShadowOffset;  // If you would like to use shadows with your text use this to create big enough glyph quad to cover your shadow pixels. Defaults to (0, 0). Defines horizontal and vertical shadows. If positive creates shadows right-bottom else creates shadows top-left. In other words -x=left, -y=top, x=right and y=bottom.
 
     // [Internal]
     // NB: Access texture data via GetTexData*() calls! Which will setup a default font for you.

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -1532,6 +1532,7 @@ ImFontAtlas::ImFontAtlas()
     TexID = (ImTextureID)NULL;
     TexDesiredWidth = 0;
     TexGlyphPadding = 1;
+    TexGlyphShadowOffset = ImVec2(0.0f, 0.0f);
 
     TexPixelsAlpha8 = NULL;
     TexPixelsRGBA32 = NULL;
@@ -2011,7 +2012,7 @@ bool    ImFontAtlasBuildWithStbTruetype(ImFontAtlas* atlas)
 
         // Gather the sizes of all rectangles we will need to pack (this loop is based on stbtt_PackFontRangesGatherRects)
         const float scale = (cfg.SizePixels > 0) ? stbtt_ScaleForPixelHeight(&src_tmp.FontInfo, cfg.SizePixels) : stbtt_ScaleForMappingEmToPixels(&src_tmp.FontInfo, -cfg.SizePixels);
-        const int padding = atlas->TexGlyphPadding;
+        const int padding = atlas->TexGlyphPadding + ImMax(ImFabs(atlas->TexGlyphShadowOffset.x), ImFabs(atlas->TexGlyphShadowOffset.y));
         for (int glyph_i = 0; glyph_i < src_tmp.GlyphsList.Size; glyph_i++)
         {
             int x0, y0, x1, y1;
@@ -2038,7 +2039,8 @@ bool    ImFontAtlasBuildWithStbTruetype(ImFontAtlas* atlas)
     // Pack our extra data rectangles first, so it will be on the upper-left corner of our texture (UV will have small values).
     const int TEX_HEIGHT_MAX = 1024 * 32;
     stbtt_pack_context spc = {};
-    stbtt_PackBegin(&spc, NULL, atlas->TexWidth, TEX_HEIGHT_MAX, 0, atlas->TexGlyphPadding, NULL);
+    const int padding = atlas->TexGlyphPadding + ImMax(ImFabs(atlas->TexGlyphShadowOffset.x), ImFabs(atlas->TexGlyphShadowOffset.y));
+    stbtt_PackBegin(&spc, NULL, atlas->TexWidth, TEX_HEIGHT_MAX, 0, padding, NULL);
     ImFontAtlasBuildPackCustomRects(atlas, spc.pack_info);
 
     // 6. Pack each source font. No rendering yet, we are working with rectangles in an infinitely tall texture at this point.
@@ -2127,7 +2129,26 @@ bool    ImFontAtlasBuildWithStbTruetype(ImFontAtlas* atlas)
             stbtt_aligned_quad q;
             float dummy_x = 0.0f, dummy_y = 0.0f;
             stbtt_GetPackedQuad(src_tmp.PackedChars, atlas->TexWidth, atlas->TexHeight, glyph_i, &dummy_x, &dummy_y, &q, 0);
-            dst_font->AddGlyph((ImWchar)codepoint, q.x0 + char_off_x, q.y0 + font_off_y, q.x1 + char_off_x, q.y1 + font_off_y, q.s0, q.t0, q.s1, q.t1, char_advance_x_mod);
+
+            const ImVec2& shadow_off = atlas->TexGlyphShadowOffset;
+            const ImVec2& uv_scale = atlas->TexUvScale;
+
+            ImVec4 offset = ImVec4(0.0f, 0.0f, 0.0f, 0.0f);
+            offset.x = (shadow_off.x > 0.0f ? 0.0f : shadow_off.x);
+            offset.y = (shadow_off.y > 0.0f ? 0.0f : shadow_off.y);
+            offset.z = (shadow_off.x > 0.0f ? shadow_off.x : 0.0f);
+            offset.w = (shadow_off.y > 0.0f ? shadow_off.y : 0.0f);
+
+            dst_font->AddGlyph((ImWchar)codepoint,
+                               q.x0 + char_off_x + (offset.x / 3), // I don't understand this 3 here, is this OversampleH?
+                               q.y0 + font_off_y + offset.y,
+                               q.x1 + char_off_x + (offset.z / 3), // I don't understand this 3 here, is this OversampleH?
+                               q.y1 + font_off_y + offset.w,
+                               q.s0 + (uv_scale.x * (offset.x)),
+                               q.t0 + (uv_scale.y * offset.y),
+                               q.s1 + (uv_scale.x * (offset.z)),
+                               q.t1 + (uv_scale.y * offset.w),
+                               char_advance_x_mod);
         }
     }
 

--- a/misc/freetype/imgui_freetype.cpp
+++ b/misc/freetype/imgui_freetype.cpp
@@ -455,7 +455,7 @@ bool ImFontAtlasBuildWithFreeType(FT_Library ft_library, ImFontAtlas* atlas, uns
             ImFontAtlasBuildMultiplyCalcLookupTable(multiply_table, cfg.RasterizerMultiply);
 
         // Gather the sizes of all rectangles we will need to pack
-        const int padding = atlas->TexGlyphPadding;
+        const int padding = atlas->TexGlyphPadding + ImMax(ImFabs(atlas->TexGlyphShadowOffset.x), ImFabs(atlas->TexGlyphShadowOffset.y));
         for (int glyph_i = 0; glyph_i < src_tmp.GlyphsList.Size; glyph_i++)
         {
             ImFontBuildSrcGlyphFT& src_glyph = src_tmp.GlyphsList[glyph_i];
@@ -574,6 +574,15 @@ bool ImFontAtlasBuildWithFreeType(FT_Library ft_library, ImFontAtlas* atlas, uns
             if (char_advance_x_org != char_advance_x_mod)
                 char_off_x += cfg.PixelSnapH ? IM_FLOOR((char_advance_x_mod - char_advance_x_org) * 0.5f) : (char_advance_x_mod - char_advance_x_org) * 0.5f;
 
+            const ImVec2& shadow_off = atlas->TexGlyphShadowOffset;
+            const ImVec2& uv_scale = atlas->TexUvScale;
+
+            ImVec4 offset = ImVec4(0.0f, 0.0f, 0.0f, 0.0f);
+            offset.x = (shadow_off.x > 0.0f ? 0.0f : shadow_off.x);
+            offset.y = (shadow_off.y > 0.0f ? 0.0f : shadow_off.y);
+            offset.z = (shadow_off.x > 0.0f ? shadow_off.x : 0.0f);
+            offset.w = (shadow_off.y > 0.0f ? shadow_off.y : 0.0f);
+
             // Register glyph
             float x0 = info.OffsetX + char_off_x;
             float y0 = info.OffsetY + font_off_y;
@@ -583,7 +592,16 @@ bool ImFontAtlasBuildWithFreeType(FT_Library ft_library, ImFontAtlas* atlas, uns
             float v0 = (ty) / (float)atlas->TexHeight;
             float u1 = (tx + info.Width) / (float)atlas->TexWidth;
             float v1 = (ty + info.Height) / (float)atlas->TexHeight;
-            dst_font->AddGlyph((ImWchar)src_glyph.Codepoint, x0, y0, x1, y1, u0, v0, u1, v1, char_advance_x_mod);
+            dst_font->AddGlyph((ImWchar)src_glyph.Codepoint,
+                               x0 + offset.x,
+                               y0 + offset.y,
+                               x1 + offset.z,
+                               y1 + offset.w,
+                               u0 + (uv_scale.x * offset.x),
+                               v0 + (uv_scale.y * offset.y),
+                               u1 + (uv_scale.x * offset.z),
+                               v1 + (uv_scale.y * offset.w),
+                               char_advance_x_mod);
         }
 
         src_tmp.Rects = NULL;


### PR DESCRIPTION
@ocornut Here is the PR requested in https://github.com/ocornut/imgui/issues/745#issuecomment-569945514

This patch adds simple ImVec2 TexGlpyShadowOffset to enable shadow creation in the glyph atlas.
Positive TexGlyphShadowOffset means bottom-right shadow while negative means top-left. By mixing negative and positive you can create shadow on any side or corner.

For example `io.Fonts->TexGlyphShadowOffset = ImVec2(2, 3);` will make sure glyphs are generated far apart in the at last to have 3 pixels padding around it.

Things still missing:
- No handling of cursors and other special characters yet, these needs to be moved according to offset into the texture atlas
- Not sure about the OversampleH
- Shadow color handling in a decent way, right now its a uniform to shaders
- Not sure about the non-uniform size of the box in stb mode. Could be something to do with OversampleH too?

For more context have a look at https://github.com/ocornut/imgui/issues/745#issuecomment-569945514

Some pretty pictures generated with this PR:

Right bottom `(5, 5)`:
<img width="744" alt="right-bottom-s" src="https://user-images.githubusercontent.com/5260991/71774329-3fb0ae00-2f64-11ea-9302-0c1adde11256.png">

Left bottom `(-5, 5)`:
<img width="733" alt="left-bottom-sh" src="https://user-images.githubusercontent.com/5260991/71774328-3fb0ae00-2f64-11ea-9d3a-0b8c682ae802.png">

Top left `(5, -5)`:
<img width="710" alt="top-right-s" src="https://user-images.githubusercontent.com/5260991/71774326-3fb0ae00-2f64-11ea-901a-5a3f551b7b1a.png">

Top left `(-5, -5)`:
<img width="735" alt="top-left-s" src="https://user-images.githubusercontent.com/5260991/71774327-3fb0ae00-2f64-11ea-95c6-32ee3b786c00.png">

Right bottom `(1, 2)`:
<img width="725" alt="right-bottom-s-1x2" src="https://user-images.githubusercontent.com/5260991/71774331-40494480-2f64-11ea-81b8-a90502222a3b.png">

Right bottom `(5, 5)`:
<img width="750" alt="right-bottom" src="https://user-images.githubusercontent.com/5260991/71774322-3f181780-2f64-11ea-92fd-c5076fbac50b.png">

Left bottom `(-5, 5)`:
<img width="751" alt="left-bottom" src="https://user-images.githubusercontent.com/5260991/71774323-3f181780-2f64-11ea-9d41-98f60055c418.png">

Top left `(-5, -5)`:
<img width="730" alt="top-left" src="https://user-images.githubusercontent.com/5260991/71774324-3f181780-2f64-11ea-9deb-bad51327b8ef.png">

Top right `(5, -5)`:
<img width="739" alt="top-right" src="https://user-images.githubusercontent.com/5260991/71774325-3f181780-2f64-11ea-8212-ffba6ee85ddd.png">

