### PR TITLE
Suppressed MSVC++ warning C5054

### DIFF
--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -5492,7 +5492,7 @@ bool ImGui::CollapsingHeader(const char* label, bool* p_open, ImGuiTreeNodeFlags
         return false;
 
     ImGuiID id = window->GetID(label);
-    flags |= ImGuiTreeNodeFlags_CollapsingHeader | (p_open ? ImGuiTreeNodeFlags_AllowItemOverlap | ImGuiTreeNodeFlags_ClipLabelForTrailingButton : 0);
+    flags |= ImGuiTreeNodeFlags_CollapsingHeader | (p_open ? ImGuiTreeNodeFlags_AllowItemOverlap | (ImGuiTreeNodeFlags)ImGuiTreeNodeFlags_ClipLabelForTrailingButton : 0);
     bool is_open = TreeNodeBehavior(id, flags, label);
     if (p_open)
     {


### PR DESCRIPTION
warning C5054: operator '|': deprecated between enumerations of different types
