### PR TITLE
FreeType subpixel rendering support

### DIFF
--- a/examples/example_sdl_opengl3/Makefile
+++ b/examples/example_sdl_opengl3/Makefile
@@ -2,28 +2,36 @@
 # Cross Platform Makefile
 # Compatible with MSYS2/MINGW, Ubuntu 14.04.1 and Mac OS X
 #
-# You will need SDL2 (http://www.libsdl.org):
+# You will need SDL2 (http://www.libsdl.org) and optionally FreeType2 (https://www.freetype.org/) for the FreeType example:
 # Linux:
 #   apt-get install libsdl2-dev
+#   apt-get install libfreetype6-dev
 # Mac OS X:
 #   brew install sdl2
+#   brew install freetype
 # MSYS2:
 #   pacman -S mingw-w64-i686-SDL
+#   pacman -S mingw-w64-i686-freetype
 #
 
 #CXX = g++
 #CXX = clang++
 
 EXE = example_sdl_opengl3
-SOURCES = main.cpp
-SOURCES += ../imgui_impl_sdl.cpp ../imgui_impl_opengl3.cpp
+EXAMPLE_SOURCES = main.cpp
+EXAMPLE_SOURCES += ../imgui_impl_sdl.cpp ../imgui_impl_opengl3.cpp
 SOURCES += ../../imgui.cpp ../../imgui_demo.cpp ../../imgui_draw.cpp ../../imgui_widgets.cpp
-OBJS = $(addsuffix .o, $(basename $(notdir $(SOURCES))))
+OBJS = $(addsuffix .o, $(basename $(notdir $(EXAMPLE_SOURCES) $(SOURCES))))
 UNAME_S := $(shell uname -s)
 
 CXXFLAGS = -I../ -I../../
 CXXFLAGS += -g -Wall -Wformat
 LIBS =
+
+EXE_FREETYPE = example_sdl_opengl3_freetype
+SOURCES_FREETYPE = ../../misc/freetype/imgui_freetype.cpp
+OBJS_FREETYPE = $(addsuffix _freetype.o, $(basename $(notdir $(EXAMPLE_SOURCES)))) \
+	$(addsuffix .o, $(basename $(notdir $(SOURCES) $(SOURCES_FREETYPE))))
 
 ##---------------------------------------------------------------------
 ## OPENGL LOADER
@@ -71,6 +79,10 @@ ifeq ($(findstring MINGW,$(UNAME_S)),MINGW)
    CFLAGS = $(CXXFLAGS)
 endif
 
+LIBS_FREETYPE = $(LIBS) `pkg-config --libs freetype2`
+CXXFLAGS_FREETYPE = -DIMGUI_IMPL_FREETYPE $(CXXFLAGS) `pkg-config --cflags freetype2`
+CFLAGS_FREETYPE = $(CXXFLAGS_FREETYPE)
+
 ##---------------------------------------------------------------------
 ## BUILD RULES
 ##---------------------------------------------------------------------
@@ -94,7 +106,19 @@ all: $(EXE)
 	@echo Build complete for $(ECHO_MESSAGE)
 
 $(EXE): $(OBJS)
-	$(CXX) -o $@ $^ $(CXXFLAGS) $(LIBS)
+	$(CXX) -o $@ $^ $(LIBS)
+
+%_freetype.o:%.cpp
+	$(CXX) $(CXXFLAGS_FREETYPE) -c -o $@ $<
+
+%_freetype.o:../%.cpp
+	$(CXX) $(CXXFLAGS_FREETYPE) -c -o $@ $<
+
+%.o:../../misc/freetype/%.cpp
+	$(CXX) $(CXXFLAGS_FREETYPE) -c -o $@ $<
+
+$(EXE_FREETYPE): $(OBJS_FREETYPE)
+	$(CXX) -o $@ $^ $(LIBS_FREETYPE)
 
 clean:
-	rm -f $(EXE) $(OBJS)
+	rm -f $(EXE) $(EXE_FREETYPE) $(OBJS) $(OBJS_FREETYPE)

--- a/examples/example_sdl_opengl3/README.md
+++ b/examples/example_sdl_opengl3/README.md
@@ -23,3 +23,15 @@ c++ `sdl2-config --cflags` -I .. -I ../.. -I ../libs/gl3w main.cpp ../imgui_impl
 brew install sdl2
 c++ `sdl2-config --cflags` -I .. -I ../.. -I ../libs/gl3w main.cpp ../imgui_impl_sdl.cpp ../imgui_impl_opengl3.cpp ../../imgui*.cpp ../libs/gl3w/GL/gl3w.c `sdl2-config --libs` -framework OpenGl -framework CoreFoundation
 ```
+
+- With make
+
+```
+make
+```
+
+The FreeType example can be built using an explicit target:
+
+```
+make example_sdl_opengl3_freetype
+```

--- a/examples/example_sdl_opengl3/main.cpp
+++ b/examples/example_sdl_opengl3/main.cpp
@@ -6,6 +6,9 @@
 #include "imgui.h"
 #include "imgui_impl_sdl.h"
 #include "imgui_impl_opengl3.h"
+#if defined(IMGUI_IMPL_FREETYPE)
+#include "misc/freetype/imgui_freetype.h"
+#endif
 #include <stdio.h>
 #include <SDL.h>
 
@@ -52,12 +55,23 @@ int main(int, char**)
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
 #endif
 
+#if defined(IMGUI_IMPL_FREETYPE)
+    // Subpixel rendering requires dual source blending support from OpenGL 3.3.
+    const char* title = "Dear ImGui SDL2+OpenGL3 example (FreeType)";
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
+    SDL_GL_SetAttribute(SDL_GL_FRAMEBUFFER_SRGB_CAPABLE, 1);
+    glsl_version = "#version 410";
+#else
+    const char* title = "Dear ImGui SDL2+OpenGL3 example";
+#endif
+
     // Create window with graphics context
     SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
     SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
     SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
     SDL_WindowFlags window_flags = (SDL_WindowFlags)(SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
-    SDL_Window* window = SDL_CreateWindow("Dear ImGui SDL2+OpenGL3 example", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 1280, 720, window_flags);
+    SDL_Window* window = SDL_CreateWindow(title, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 1280, 720, window_flags);
     SDL_GLContext gl_context = SDL_GL_CreateContext(window);
     SDL_GL_MakeCurrent(window, gl_context);
     SDL_GL_SetSwapInterval(1); // Enable vsync
@@ -93,6 +107,7 @@ int main(int, char**)
     ImGui_ImplSDL2_InitForOpenGL(window, gl_context);
     ImGui_ImplOpenGL3_Init(glsl_version);
 
+#if !defined(IMGUI_IMPL_FREETYPE)
     // Load Fonts
     // - If no fonts are loaded, dear imgui will use the default font. You can also load multiple fonts and use ImGui::PushFont()/PopFont() to select them.
     // - AddFontFromFileTTF() will return the ImFont* so you can store it if you need to select the font among multiple.
@@ -107,6 +122,17 @@ int main(int, char**)
     //io.Fonts->AddFontFromFileTTF("../../misc/fonts/ProggyTiny.ttf", 10.0f);
     //ImFont* font = io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\ArialUni.ttf", 18.0f, NULL, io.Fonts->GetGlyphRangesJapanese());
     //IM_ASSERT(font != NULL);
+#else
+    // Load Fonts with FreeType
+    io.Fonts->AddFontFromFileTTF("../../misc/fonts/DroidSans.ttf", 15.0f);
+    io.Fonts->AddFontFromFileTTF("../../misc/fonts/Karla-Regular.ttf", 15.0f);
+    io.Fonts->AddFontFromFileTTF("../../misc/fonts/Cousine-Regular.ttf", 15.0f);
+    io.Fonts->AddFontFromFileTTF("../../misc/fonts/Roboto-Medium.ttf", 15.0f);
+    if (!ImGuiFreeType::BuildFontAtlas(io.Fonts, ImGuiFreeType::LcdMode | ImGuiFreeType::LcdLightFilter | ImGuiFreeType::LightHinting)) {
+        fprintf(stderr, "Failed to build font atlas with FreeType!\n");
+        return 1;
+    }
+#endif
 
     // Our state
     bool show_demo_window = true;

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -1627,7 +1627,10 @@ void    ImFontAtlas::GetTexDataAsRGBA32(unsigned char** out_pixels, int* out_wid
             const unsigned char* src = pixels;
             unsigned int* dst = TexPixelsRGBA32;
             for (int n = TexWidth * TexHeight; n > 0; n--)
-                *dst++ = IM_COL32(255, 255, 255, (unsigned int)(*src++));
+            {
+                const unsigned int alpha8 = (unsigned int)(*src++);
+                *dst++ = IM_COL32(alpha8, alpha8, alpha8, alpha8);
+            }
         }
     }
 
@@ -2210,6 +2213,11 @@ static void ImFontAtlasBuildRenderDefaultTexData(ImFontAtlas* atlas)
                 const int offset1 = offset0 + FONT_ATLAS_DEFAULT_TEX_DATA_W_HALF + 1;
                 atlas->TexPixelsAlpha8[offset0] = FONT_ATLAS_DEFAULT_TEX_DATA_PIXELS[n] == '.' ? 0xFF : 0x00;
                 atlas->TexPixelsAlpha8[offset1] = FONT_ATLAS_DEFAULT_TEX_DATA_PIXELS[n] == 'X' ? 0xFF : 0x00;
+                if (atlas->TexPixelsRGBA32)
+                {
+                    atlas->TexPixelsRGBA32[offset0] = FONT_ATLAS_DEFAULT_TEX_DATA_PIXELS[n] == '.' ? 0xFFFFFFFF : 0x00000000;
+                    atlas->TexPixelsRGBA32[offset1] = FONT_ATLAS_DEFAULT_TEX_DATA_PIXELS[n] == 'X' ? 0xFFFFFFFF : 0x00000000;
+                }
             }
     }
     else
@@ -2217,6 +2225,8 @@ static void ImFontAtlasBuildRenderDefaultTexData(ImFontAtlas* atlas)
         IM_ASSERT(r.Width == 2 && r.Height == 2);
         const int offset = (int)(r.X) + (int)(r.Y) * w;
         atlas->TexPixelsAlpha8[offset] = atlas->TexPixelsAlpha8[offset + 1] = atlas->TexPixelsAlpha8[offset + w] = atlas->TexPixelsAlpha8[offset + w + 1] = 0xFF;
+        if (atlas->TexPixelsRGBA32)
+            atlas->TexPixelsRGBA32[offset] = atlas->TexPixelsRGBA32[offset + 1] = atlas->TexPixelsRGBA32[offset + w] = atlas->TexPixelsRGBA32[offset + w + 1] = 0xFFFFFFFF;
     }
     atlas->TexUvWhitePixel = ImVec2((r.X + 0.5f) * atlas->TexUvScale.x, (r.Y + 0.5f) * atlas->TexUvScale.y);
 }

--- a/misc/freetype/imgui_freetype.cpp
+++ b/misc/freetype/imgui_freetype.cpp
@@ -17,7 +17,7 @@
 // Gamma Correct Blending:
 //  FreeType assumes blending in linear space rather than gamma space.
 //  See https://www.freetype.org/freetype2/docs/reference/ft2-base_interface.html#FT_Render_Glyph
-//  For correct results you need to be using sRGB and convert to linear space in the pixel shader output.
+//  For correct results you need to be using a sRGB framebuffer and convert vertex colors to linear space in the vertex shader.
 //  The default imgui styles will be impacted by this change (alpha values will need tweaking).
 
 // FIXME: cfg.OversampleH, OversampleV are not supported (but perhaps not so necessary with this rasterizer).
@@ -26,6 +26,7 @@
 #include "imgui_internal.h"     // ImMin,ImMax,ImFontAtlasBuild*,
 #include <stdint.h>
 #include <ft2build.h>
+#include <freetype/ftlcdfil.h>
 #include FT_FREETYPE_H          // <freetype/freetype.h>
 #include FT_MODULE_H            // <freetype/ftmodapi.h>
 #include FT_GLYPH_H             // <freetype/ftglyph.h>
@@ -103,22 +104,43 @@ namespace
         void                    SetPixelHeight(int pixel_height); // Change font pixel size. All following calls to RasterizeGlyph() will use this size
         const FT_Glyph_Metrics* LoadGlyph(uint32_t in_codepoint);
         const FT_Bitmap*        RenderGlyphAndGetInfo(GlyphInfo* out_glyph_info);
+        uint8_t                 LuminanceFromLinearRGB(uint8_t r, uint8_t g, uint8_t b);
         void                    BlitGlyph(const FT_Bitmap* ft_bitmap, uint8_t* dst, uint32_t dst_pitch, unsigned char* multiply_table = NULL);
         ~FreeTypeFont()         { CloseFont(); }
 
         // [Internals]
         FontInfo        Info;               // Font descriptor of the current font.
         FT_Face         Face;
-        unsigned int    UserFlags;          // = ImFontConfig::RasterizerFlags
+        unsigned int    UserFlags;          // = ImFontConfig::RasterizerFlags, overridden by extra flags
         FT_Int32        LoadFlags;
         FT_Render_Mode  RenderMode;
     };
 
-    // From SDL_ttf: Handy routines for converting from fixed point
-    #define FT_CEIL(X)  (((X + 63) & -64) / 64)
+    #define FT_CEIL(X)  (((X + 63) & -64) / 64)         // From SDL_ttf: Handy routines for converting from fixed point
+    #define ZERO_OR_ONE_BIT_SET(X) (!((X) & ((X) - 1))) // Named that way to match the intent at call site but it's a basic POW2 check
 
     bool FreeTypeFont::InitFont(FT_Library ft_library, const ImFontConfig& cfg, unsigned int extra_user_flags)
     {
+        // Override font flags with extra flags
+        UserFlags = cfg.RasterizerFlags | (extra_user_flags & ImGuiFreeType::OptionsMask);
+        if (extra_user_flags & ImGuiFreeType::HinterMask)
+        {
+            UserFlags &= ~ImGuiFreeType::HinterMask;
+            UserFlags |= extra_user_flags & ImGuiFreeType::HinterMask;
+        }
+        if (extra_user_flags & ImGuiFreeType::HintingAlgorithmMask)
+        {
+            UserFlags &= ~ImGuiFreeType::HintingAlgorithmMask;
+            UserFlags |= extra_user_flags & ImGuiFreeType::HintingAlgorithmMask;
+        }
+        if (extra_user_flags & ImGuiFreeType::RenderModeMask)
+        {
+            UserFlags &= ~ImGuiFreeType::RenderModeMask;
+            UserFlags |= extra_user_flags & ImGuiFreeType::RenderModeMask;
+        }
+        if (!ZERO_OR_ONE_BIT_SET(UserFlags & ImGuiFreeType::HinterMask) || !ZERO_OR_ONE_BIT_SET(UserFlags & ImGuiFreeType::HintingAlgorithmMask) || !ZERO_OR_ONE_BIT_SET(UserFlags & ImGuiFreeType::RenderModeMask))
+            return false;
+
         FT_Error error = FT_New_Memory_Face(ft_library, (uint8_t*)cfg.FontData, (uint32_t)cfg.FontDataSize, (uint32_t)cfg.FontNo, &Face);
         if (error != 0)
             return false;
@@ -129,26 +151,38 @@ namespace
         memset(&Info, 0, sizeof(Info));
         SetPixelHeight((uint32_t)cfg.SizePixels);
 
-        // Convert to FreeType flags (NB: Bold and Oblique are processed separately)
-        UserFlags = cfg.RasterizerFlags | extra_user_flags;
+        // Convert UserFlags to FreeType flags (NB: Bold and Oblique are processed separately)
         LoadFlags = FT_LOAD_NO_BITMAP;
-        if (UserFlags & ImGuiFreeType::NoHinting)
-            LoadFlags |= FT_LOAD_NO_HINTING;
-        if (UserFlags & ImGuiFreeType::NoAutoHint)
-            LoadFlags |= FT_LOAD_NO_AUTOHINT;
-        if (UserFlags & ImGuiFreeType::ForceAutoHint)
+
+        if (UserFlags & ImGuiFreeType::PreferAutoHinter)
             LoadFlags |= FT_LOAD_FORCE_AUTOHINT;
+        else if (UserFlags & ImGuiFreeType::NoAutoHinter)
+            LoadFlags |= FT_LOAD_NO_AUTOHINT;
+        else if (UserFlags & ImGuiFreeType::NoHinter)
+            LoadFlags |= FT_LOAD_NO_HINTING;
+
         if (UserFlags & ImGuiFreeType::LightHinting)
             LoadFlags |= FT_LOAD_TARGET_LIGHT;
         else if (UserFlags & ImGuiFreeType::MonoHinting)
             LoadFlags |= FT_LOAD_TARGET_MONO;
+        else if (UserFlags & ImGuiFreeType::LcdHinting)
+            LoadFlags |= FT_LOAD_TARGET_LCD;
+        else if (UserFlags & ImGuiFreeType::LcdVHinting)
+            LoadFlags |= FT_LOAD_TARGET_LCD_V;
         else
             LoadFlags |= FT_LOAD_TARGET_NORMAL;
-
-        if (UserFlags & ImGuiFreeType::Monochrome)
+        if (UserFlags & ImGuiFreeType::MonoMode)
             RenderMode = FT_RENDER_MODE_MONO;
+        else if (UserFlags & ImGuiFreeType::LcdMode)
+            RenderMode = FT_RENDER_MODE_LCD;
+        else if (UserFlags & ImGuiFreeType::LcdVMode)
+            RenderMode = FT_RENDER_MODE_LCD_V;
         else
             RenderMode = FT_RENDER_MODE_NORMAL;
+
+        if (UserFlags & (ImGuiFreeType::LcdMode | ImGuiFreeType::LcdVMode))
+            if (FT_Library_SetLcdFilter(ft_library, (UserFlags & ImGuiFreeType::LcdLightFilter) ? FT_LCD_FILTER_LIGHT : FT_LCD_FILTER_DEFAULT) != 0)
+                return false;
 
         return true;
     }
@@ -221,13 +255,20 @@ namespace
             return NULL;
 
         FT_Bitmap* ft_bitmap = &Face->glyph->bitmap;
-        out_glyph_info->Width = (int)ft_bitmap->width;
-        out_glyph_info->Height = (int)ft_bitmap->rows;
+        out_glyph_info->Width = (int)ft_bitmap->width / (RenderMode == FT_RENDER_MODE_LCD ? 3 : 1);
+        out_glyph_info->Height = (int)ft_bitmap->rows / (RenderMode == FT_RENDER_MODE_LCD_V ? 3 : 1);
         out_glyph_info->OffsetX = Face->glyph->bitmap_left;
         out_glyph_info->OffsetY = -Face->glyph->bitmap_top;
         out_glyph_info->AdvanceX = (float)FT_CEIL(slot->advance.x);
 
         return ft_bitmap;
+    }
+
+    uint8_t FreeTypeFont::LuminanceFromLinearRGB(uint8_t r, uint8_t g, uint8_t b)
+    {
+        // Luminance Y is defined by the CIE 1931 XYZ color space. Linear RGB to Y is a weighted average based on factors from the color conversion matrix:
+        // Y = 0.2126*R + 0.7152*G + 0.0722*B. Computed on the integer pipe.
+        return (4732UL * r + 46871UL * g + 13933UL * b) >> 16;
     }
 
     void FreeTypeFont::BlitGlyph(const FT_Bitmap* ft_bitmap, uint8_t* dst, uint32_t dst_pitch, unsigned char* multiply_table)
@@ -240,19 +281,61 @@ namespace
 
         switch (ft_bitmap->pixel_mode)
         {
+        case FT_PIXEL_MODE_LCD: // RGB image, 3 horizontal bytes per pixel.
+            {
+                uint32_t* dst_rgba32 = (uint32_t*)dst;
+                if (multiply_table)
+                    for (uint32_t y = 0; y < h; y++, src += src_pitch, dst_rgba32 += dst_pitch / 4)
+                        for (uint32_t x = 0; x < w; x++)
+                        {
+                            const uint8_t r = multiply_table[src[x * 3]];
+                            const uint8_t g = multiply_table[src[x * 3 + 1]];
+                            const uint8_t b = multiply_table[src[x * 3 + 2]];
+                            dst_rgba32[x] = LuminanceFromLinearRGB(r, g, b) << 24 | b << 16 | g << 8 | r;
+                        }
+                else
+                    for (uint32_t y = 0; y < h; y++, src += src_pitch, dst_rgba32 += dst_pitch / 4)
+                        for (uint32_t x = 0; x < w; x++)
+                        {
+                            const uint8_t r = src[x * 3];
+                            const uint8_t g = src[x * 3 + 1];
+                            const uint8_t b = src[x * 3 + 2];
+                            dst_rgba32[x] = LuminanceFromLinearRGB(r, g, b) << 24 | b << 16 | g << 8 | r;
+                        }
+                break;
+            }
+        case FT_PIXEL_MODE_LCD_V: // RGB image, 3 vertical bytes per pixel.
+            {
+                uint32_t* dst_rgba32 = (uint32_t*)dst;
+                if (multiply_table)
+                    for (uint32_t y = 0; y < h; y += 3, src += 3 * src_pitch, dst_rgba32 += dst_pitch / 4)
+                        for (uint32_t x = 0; x < w; x++)
+                        {
+                            const uint8_t r = multiply_table[src[x]];
+                            const uint8_t g = multiply_table[src[x + src_pitch]];
+                            const uint8_t b = multiply_table[src[x + 2 * src_pitch]];
+                            dst_rgba32[x] = LuminanceFromLinearRGB(r, g, b) << 24 | b << 16 | g << 8 | r;
+                        }
+                else
+                    for (uint32_t y = 0; y < h; y += 3, src += 3 * src_pitch, dst_rgba32 += dst_pitch / 4)
+                        for (uint32_t x = 0; x < w; x++)
+                        {
+                            const uint8_t r = src[x];
+                            const uint8_t g = src[x + src_pitch];
+                            const uint8_t b = src[x + 2 * src_pitch];
+                            dst_rgba32[x] = LuminanceFromLinearRGB(r, g, b) << 24 | b << 16 | g << 8 | r;
+                        }
+                break;
+            }
         case FT_PIXEL_MODE_GRAY: // Grayscale image, 1 byte per pixel.
             {
-                if (multiply_table == NULL)
-                {
-                    for (uint32_t y = 0; y < h; y++, src += src_pitch, dst += dst_pitch)
-                        memcpy(dst, src, w);
-                }
-                else
-                {
+                if (multiply_table)
                     for (uint32_t y = 0; y < h; y++, src += src_pitch, dst += dst_pitch)
                         for (uint32_t x = 0; x < w; x++)
                             dst[x] = multiply_table[src[x]];
-                }
+                else
+                    for (uint32_t y = 0; y < h; y++, src += src_pitch, dst += dst_pitch)
+                        memcpy(dst, src, w);
                 break;
             }
         case FT_PIXEL_MODE_MONO: // Monochrome image, 1 bit per pixel. The bits in each byte are ordered from MSB to LSB.
@@ -331,10 +414,11 @@ bool ImFontAtlasBuildWithFreeType(FT_Library ft_library, ImFontAtlas* atlas, uns
     ImVector<ImFontBuildDstDataFT> dst_tmp_array;
     src_tmp_array.resize(atlas->ConfigData.Size);
     dst_tmp_array.resize(atlas->Fonts.Size);
-    memset(src_tmp_array.Data, 0, (size_t)src_tmp_array.size_in_bytes());
-    memset(dst_tmp_array.Data, 0, (size_t)dst_tmp_array.size_in_bytes());
+    memset((void*)src_tmp_array.Data, 0, (size_t)src_tmp_array.size_in_bytes());
+    memset((void*)dst_tmp_array.Data, 0, (size_t)dst_tmp_array.size_in_bytes());
 
     // 1. Initialize font loading structure, check font data validity
+    bool rgba32_rendering = false;
     for (int src_i = 0; src_i < atlas->ConfigData.Size; src_i++)
     {
         ImFontBuildSrcDataFT& src_tmp = src_tmp_array[src_i];
@@ -362,6 +446,10 @@ bool ImFontAtlasBuildWithFreeType(FT_Library ft_library, ImFontAtlas* atlas, uns
             src_tmp.GlyphsHighest = ImMax(src_tmp.GlyphsHighest, (int)src_range[1]);
         dst_tmp.SrcCount++;
         dst_tmp.GlyphsHighest = ImMax(dst_tmp.GlyphsHighest, src_tmp.GlyphsHighest);
+
+        // A single font using LCD rendering implies that all fonts must be rendered to both Alpha8 and RGBA32 textures for the user to get consistent results.
+        if (font_face.UserFlags & (ImGuiFreeType::LcdMode | ImGuiFreeType::LcdVMode))
+            rgba32_rendering = true;
     }
 
     // 2. For every requested codepoint, check for their presence in the font data, and handle redundancy or overlaps between source fonts to avoid unused glyphs.
@@ -470,7 +558,8 @@ bool ImFontAtlasBuildWithFreeType(FT_Library ft_library, ImFontAtlas* atlas, uns
             IM_ASSERT(ft_bitmap);
 
             // Allocate new temporary chunk if needed
-            const int bitmap_size_in_bytes = src_glyph.Info.Width * src_glyph.Info.Height;
+            const int bitmap_stride = src_glyph.Info.Width * (src_tmp.Font.UserFlags & (ImGuiFreeType::LcdMode | ImGuiFreeType::LcdVMode) ? 4 : 1);
+            const int bitmap_size_in_bytes = bitmap_stride * src_glyph.Info.Height;
             if (buf_bitmap_current_used_bytes + bitmap_size_in_bytes > BITMAP_BUFFERS_CHUNK_SIZE)
             {
                 buf_bitmap_current_used_bytes = 0;
@@ -480,7 +569,7 @@ bool ImFontAtlasBuildWithFreeType(FT_Library ft_library, ImFontAtlas* atlas, uns
             // Blit rasterized pixels to our temporary buffer and keep a pointer to it.
             src_glyph.BitmapData = buf_bitmap_buffers.back() + buf_bitmap_current_used_bytes;
             buf_bitmap_current_used_bytes += bitmap_size_in_bytes;
-            src_tmp.Font.BlitGlyph(ft_bitmap, src_glyph.BitmapData, src_glyph.Info.Width * 1, multiply_enabled ? multiply_table : NULL);
+            src_tmp.Font.BlitGlyph(ft_bitmap, src_glyph.BitmapData, bitmap_stride, multiply_enabled ? multiply_table : NULL);
 
             src_tmp.Rects[glyph_i].w = (stbrp_coord)(src_glyph.Info.Width + padding);
             src_tmp.Rects[glyph_i].h = (stbrp_coord)(src_glyph.Info.Height + padding);
@@ -524,11 +613,16 @@ bool ImFontAtlasBuildWithFreeType(FT_Library ft_library, ImFontAtlas* atlas, uns
                 atlas->TexHeight = ImMax(atlas->TexHeight, src_tmp.Rects[glyph_i].y + src_tmp.Rects[glyph_i].h);
     }
 
-    // 7. Allocate texture
+    // 7. Allocate textures
     atlas->TexHeight = (atlas->Flags & ImFontAtlasFlags_NoPowerOfTwoHeight) ? (atlas->TexHeight + 1) : ImUpperPowerOfTwo(atlas->TexHeight);
     atlas->TexUvScale = ImVec2(1.0f / atlas->TexWidth, 1.0f / atlas->TexHeight);
     atlas->TexPixelsAlpha8 = (unsigned char*)IM_ALLOC(atlas->TexWidth * atlas->TexHeight);
     memset(atlas->TexPixelsAlpha8, 0, atlas->TexWidth * atlas->TexHeight);
+    if (rgba32_rendering)
+    {
+        atlas->TexPixelsRGBA32 = (unsigned int*)IM_ALLOC(4 * atlas->TexWidth * atlas->TexHeight);
+        memset(atlas->TexPixelsRGBA32, 0, 4 * atlas->TexWidth * atlas->TexHeight);
+    }
 
     // 8. Copy rasterized font characters back into the main texture
     // 9. Setup ImFont and glyphs for runtime
@@ -560,13 +654,29 @@ bool ImFontAtlasBuildWithFreeType(FT_Library ft_library, ImFontAtlas* atlas, uns
             const int tx = pack_rect.x + padding;
             const int ty = pack_rect.y + padding;
 
-            // Blit from temporary buffer to final texture
-            size_t blit_src_stride = (size_t)src_glyph.Info.Width;
-            size_t blit_dst_stride = (size_t)atlas->TexWidth;
-            unsigned char* blit_src = src_glyph.BitmapData;
-            unsigned char* blit_dst = atlas->TexPixelsAlpha8 + (ty * blit_dst_stride) + tx;
-            for (int y = info.Height; y > 0; y--, blit_dst += blit_dst_stride, blit_src += blit_src_stride)
-                memcpy(blit_dst, blit_src, blit_src_stride);
+            // Blit from temporary buffer to final textures. 32-bit buffers are written to both the alpha8 (using the alpha value) and the rgba32
+            // textures. 8-bit buffers are written to the alpha8 texture and to the rgba32 texture if at least one of the fonts has a LCD flag set.
+            size_t blit_src_width = (size_t)info.Width;
+            size_t blit_dst_width = (size_t)atlas->TexWidth;
+            unsigned char* blit_src_alpha8 = src_glyph.BitmapData;
+            unsigned char* blit_dst_alpha8 = atlas->TexPixelsAlpha8 + (ty * blit_dst_width) + tx;
+            unsigned int* blit_src_rgba32 = (unsigned int*)src_glyph.BitmapData;
+            unsigned int* blit_dst_rgba32 = atlas->TexPixelsRGBA32 + (ty * blit_dst_width) + tx;
+            if (src_tmp.Font.UserFlags & (ImGuiFreeType::LcdMode | ImGuiFreeType::LcdVMode))
+                for (int y = info.Height; y > 0; y--, blit_dst_alpha8 += blit_dst_width, blit_dst_rgba32 += blit_dst_width, blit_src_rgba32 += blit_src_width)
+                {
+                    for (int x = 0; x < (int)blit_src_width; x++)
+                        blit_dst_alpha8[x] = (blit_src_rgba32[x] >> 24) & 0xff;
+                    memcpy(blit_dst_rgba32, blit_src_rgba32, blit_src_width * 4);
+                }
+            else
+                for (int y = info.Height; y > 0; y--, blit_dst_alpha8 += blit_dst_width, blit_dst_rgba32 += blit_dst_width, blit_src_alpha8 += blit_src_width)
+                {
+                    memcpy(blit_dst_alpha8, blit_src_alpha8, blit_src_width);
+                    if (rgba32_rendering)
+                        for (int x = 0; x < (int)blit_src_width; x++)
+                            blit_dst_rgba32[x] = blit_src_alpha8[x] << 24 | blit_src_alpha8[x] << 16 | blit_src_alpha8[x] << 8 | blit_src_alpha8[x];
+                }
 
             float char_advance_x_org = info.AdvanceX;
             float char_advance_x_mod = ImClamp(char_advance_x_org, cfg.GlyphMinAdvanceX, cfg.GlyphMaxAdvanceX);

--- a/misc/freetype/imgui_freetype.h
+++ b/misc/freetype/imgui_freetype.h
@@ -17,15 +17,41 @@ namespace ImGuiFreeType
     // Use the 'extra_flags' parameter of BuildFontAtlas() to force a flag on all your fonts.
     enum RasterizerFlags
     {
-        // By default, hinting is enabled and the font's native hinter is preferred over the auto-hinter.
-        NoHinting       = 1 << 0,   // Disable hinting. This generally generates 'blurrier' bitmap glyphs when the glyph are rendered in any of the anti-aliased modes.
-        NoAutoHint      = 1 << 1,   // Disable auto-hinter.
-        ForceAutoHint   = 1 << 2,   // Indicates that the auto-hinter is preferred over the font's native hinter.
-        LightHinting    = 1 << 3,   // A lighter hinting algorithm for gray-level modes. Many generated glyphs are fuzzier but better resemble their original shape. This is achieved by snapping glyphs to the pixel grid only vertically (Y-axis), as is done by Microsoft's ClearType and Adobe's proprietary font renderer. This preserves inter-glyph spacing in horizontal text.
-        MonoHinting     = 1 << 4,   // Strong hinting algorithm that should only be used for monochrome output.
-        Bold            = 1 << 5,   // Styling: Should we artificially embolden the font?
-        Oblique         = 1 << 6,   // Styling: Should we slant the font, emulating italic style?
-        Monochrome      = 1 << 7    // Disable anti-aliasing. Combine this with MonoHinting for best results!
+        // Hinter options. By default, PreferFontHinter is enabled.
+        PreferFontHinter     = 1 << 0,   // Indicates that the font's native hinter is prefered over the auto hinter.
+        PreferAutoHinter     = 1 << 1,   // Indicates that the auto-hinter is prefered over the font's native hinter.
+        NoAutoHinter         = 1 << 2,   // Disable auto-hinter.
+        NoHinter             = 1 << 3,   // Disable hinting. This generally generates 'blurrier' bitmap glyphs when the glyph are rendered in any of the anti-aliased modes.
+
+        // Hinting algorithms. By default, GrayHinting is enabled.
+        GrayHinting          = 1 << 4,   // Hinting algorithm for gray-level rendering.
+        LightHinting         = 1 << 5,   // A lighter hinting algorithm for gray-level modes. Many generated glyphs are fuzzier but better resemble their original shape. This is achieved by snapping glyphs to the pixel grid only vertically (Y-axis), as is done by Microsoft's ClearType and Adobe's proprietary font renderer. This preserves inter-glyph spacing in horizontal text.
+        MonoHinting          = 1 << 6,   // Strong hinting algorithm that should only be used for monochrome output.
+        LcdHinting           = 1 << 7,   // Optimal hinting for horizontally decimated LCD displays.
+        LcdVHinting          = 1 << 8,   // Optimal hinting for vertically decimated LCD displays.
+
+        // Render mode. By default, GrayMode is enabled.
+        GrayMode             = 1 << 9,   // 8-bit anti-aliased gray-level output.
+        MonoMode             = 1 << 10,  // 8-bit aliased monochrome output (either 0x00 or 0xff). Combine this with MonoHinting for best results!
+        LcdMode              = 1 << 11,  // Horizontal LCD output. Enable subpixel rendering by exploiting the color-striped structure of LCD pixels, increasing the available resolution in the direction of the stripe by a factor of 3. Mutually exclusive with Monochrome and LcdV. Combine this with LcdHinting for best results! Implementations must retrieve the resulting RGBA32 texture data with GetTexDataAsRGBA32().
+        LcdVMode             = 1 << 12,  // Vertical LCD output. Same as LcdMode but for vertically decimated LCD displays (or when a text must be rendered rotated by 90° or 270°). Mutually exclusive with Monochrome and Lcd. Combine this with LcdVHinting for best results! Implementations must retrieve the resulting RGBA32 texture data with GetTexDataAsRGBA32().
+
+        // Various options.
+        Bold                 = 1 << 13,  // Styling: Should we artificially embolden the font?
+        Oblique              = 1 << 14,  // Styling: Should we slant the font, emulating italic style?
+        LcdLightFilter       = 1 << 15,  // A sharper LCD filter but less tolerant of uncalibrated screens.
+
+        HinterMask           = PreferFontHinter | PreferAutoHinter | NoAutoHinter | NoHinter,
+        HintingAlgorithmMask = GrayHinting | LightHinting | MonoHinting | LcdHinting | LcdVHinting,
+        RenderModeMask       = GrayMode | MonoMode | LcdMode | LcdVMode,
+        OptionsMask          = Bold | Oblique | LcdLightFilter
+    };
+    enum RasterizerFlagsObsolete
+    {
+        NoHinting            = NoHinter,
+        NoAutoHint           = NoAutoHinter,
+        ForceAutoHint        = PreferAutoHinter,
+        Monochrome           = MonoMode
     };
 
     IMGUI_API bool BuildFontAtlas(ImFontAtlas* atlas, unsigned int extra_flags = 0);


### PR DESCRIPTION
The FreeType Atlas builder is extended with support for horizontal and vertical LCD rendering, dedicated LCD hinting algorithms and a light LCD color filtering option. Each flag can be passed on a per font basis and overridden by a global `BuildFontAtlas()` parameter.

If at least a font requests LCD rendering, `BuildFontAtlas()` writes to both Alpha8 and RGBA32 textures, if no fonts request LCD rendering, BuildFontAtlas() writes only to the Alpha8 texture. If the RGBA32 texture has been written to, `ImFontAtlasBuildRenderDefaultTexData()` now writes default texture data in there as well.

Subpixel rendering requires dual source blending for efficient and correct blending over any destination color. That implies changes in shaders and states to set the right blending factors when LCD rendering is used. This change takes care not to break ImGui batching by keeping the nice feature of being able to render UI elements and texts using the same states. The SDL/OpenGL3 example has been updated for people to test the new feature and understand what changes should be applied in their implementations if they want FreeType LCD rendering. The FreeType version of the example can be built with a dedicated make target:

`$ make example_sdl_opengl3_freetype`

taking care of not breaking the default one. The FreeType README.md now contains updated test code in order to fully test the new flags.

`GetTexDataAsRGBA32()` has been changed to fill the R, G and B channels with the Alpha8 value instead of 0 in order to be able to use the same shading and blending states for 8-bit modes (STB, FreeType Mono and Gray) and 32-bit modes (FreeType horizontal and vertical LCD).

Changing all the colors and alpha values of ImGui themes seems too intrusive to reflect the required switch to blending in linear RGB space. So this change shows how to do the conversion in the vertex shader expecting users to either keep it that way or manually set fixed up colors in their own implementations. Not sure what's the best solution though.