### PR TITLE
Bindings: Improved FreeGLUT support for MinGW

### DIFF
--- a/examples/example_glut_opengl2/Makefile
+++ b/examples/example_glut_opengl2/Makefile
@@ -41,7 +41,13 @@ endif
 
 ifeq ($(findstring MINGW,$(UNAME_S)),MINGW)
 	ECHO_MESSAGE = "MinGW"
-	LIBS += -lgdi32 -lopengl32 -limm32 -lglut
+	LIBS += -lgdi32 -lopengl32 -limm32
+ifeq ($(shell pkg-config freeglut --exists 2> /dev/null && echo yes || echo no),yes)
+	CXXFLAGS += $(shell pkg-config freeglut --cflags)
+	LIBS += $(shell pkg-config freeglut --libs)
+else
+	LIBS += -lglut
+endif
 	CFLAGS = $(CXXFLAGS)
 endif
 

--- a/examples/example_glut_opengl2/main.cpp
+++ b/examples/example_glut_opengl2/main.cpp
@@ -6,8 +6,8 @@
 // !!! Nowadays, prefer using GLFW or SDL instead!
 
 #include "imgui.h"
-#include "../imgui_impl_glut.h"
-#include "../imgui_impl_opengl2.h"
+#include "imgui_impl_glut.h"
+#include "imgui_impl_opengl2.h"
 #ifdef __APPLE__
     #include <GLUT/glut.h>
 #else

--- a/examples/imgui_impl_glut.cpp
+++ b/examples/imgui_impl_glut.cpp
@@ -39,7 +39,12 @@ static int g_Time = 0;          // Current time, in milliseconds
 bool ImGui_ImplGLUT_Init()
 {
     ImGuiIO& io = ImGui::GetIO();
+
+#ifdef FREEGLUT
+    io.BackendPlatformName ="imgui_impl_glut (freeglut)";
+#else
     io.BackendPlatformName ="imgui_impl_glut";
+#endif
 
     g_Time = 0;
 


### PR DESCRIPTION
Not in all cases, just adding `-lglut` to linking is enough. For example, the [MSYS2](https://www.msys2.org/) software distro has its own characteristics for the [freeglut](https://packages.msys2.org/package/mingw-w64-x86_64-freeglut?repo=mingw64) package. These can be taken into account using the `pkg-config` utility, if available.