### PR TITLE
Emscripten: Allow filesystem support

### DIFF
--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -269,9 +269,6 @@ static inline ImVec4 operator*(const ImVec4& lhs, const ImVec4& rhs)            
 #endif
 
 // Helpers: File System
-#if defined(__EMSCRIPTEN__) && !defined(IMGUI_DISABLE_FILE_FUNCTIONS)
-#define IMGUI_DISABLE_FILE_FUNCTIONS
-#endif
 #ifdef IMGUI_DISABLE_FILE_FUNCTIONS
 #define IMGUI_DISABLE_DEFAULT_FILE_FUNCTIONS
 typedef void* ImFileHandle;


### PR DESCRIPTION
Filesystem functions perfectly work for `Emscripten` platform.

This changes remove extra changes added by #2734.

The #2734 disallow filesystem support for Emscripten platform and we have no method to allow it again.

You can still disable filesystem functions by defining `IMGUI_DISABLE_FILE_FUNCTIONS`.
