### PR TITLE
Tables: Fix sorting order in demo->tables->sorting

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -2136,7 +2136,7 @@ void ImGuiTextBuffer::appendfv(const char* fmt, va_list args)
 static bool GetSkipItemForListClipping()
 {
     ImGuiContext& g = *GImGui;
-    return (g.CurrentTable ? g.CurrentTable->BackupSkipItems : g.CurrentWindow->SkipItems);
+    return (g.CurrentTable ? g.CurrentTable->HostSkipItems : g.CurrentWindow->SkipItems);
 }
 
 // Helper to calculate coarse clipping of large list of evenly sized items.

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -6460,6 +6460,8 @@ const char* ImGui::GetStyleColorName(ImGuiCol idx)
     case ImGuiCol_PlotHistogram: return "PlotHistogram";
     case ImGuiCol_PlotHistogramHovered: return "PlotHistogramHovered";
     case ImGuiCol_TableHeaderBg: return "TableHeaderBg";
+    case ImGuiCol_TableBorderStrong: return "TableBorderStrong";
+    case ImGuiCol_TableBorderLight: return "TableBorderLight";
     case ImGuiCol_TableRowBg: return "TableRowBg";
     case ImGuiCol_TableRowBgAlt: return "TableRowBgAlt";
     case ImGuiCol_TextSelectedBg: return "TextSelectedBg";

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -973,6 +973,7 @@ ImGuiStyle::ImGuiStyle()
     FrameBorderSize         = 0.0f;             // Thickness of border around frames. Generally set to 0.0f or 1.0f. Other values not well tested.
     ItemSpacing             = ImVec2(8,4);      // Horizontal and vertical spacing between widgets/lines
     ItemInnerSpacing        = ImVec2(4,4);      // Horizontal and vertical spacing between within elements of a composed widget (e.g. a slider and its label)
+    CellPadding             = ImVec2(4,2);      // Padding within a table cell
     TouchExtraPadding       = ImVec2(0,0);      // Expand reactive bounding box for touch-based system where touch position is not accurate enough. Unfortunately we don't sort widgets so priority on overlap will always be given to the first widget. So don't grow this too much!
     IndentSpacing           = 21.0f;            // Horizontal spacing when e.g. entering a tree node. Generally == (FontSize + FramePadding.x*2).
     ColumnsMinSpacing       = 6.0f;             // Minimum horizontal spacing between two columns. Preferably > (FramePadding.x + 1).
@@ -1010,6 +1011,7 @@ void ImGuiStyle::ScaleAllSizes(float scale_factor)
     FrameRounding = ImFloor(FrameRounding * scale_factor);
     ItemSpacing = ImFloor(ItemSpacing * scale_factor);
     ItemInnerSpacing = ImFloor(ItemInnerSpacing * scale_factor);
+    CellPadding = ImFloor(CellPadding * scale_factor);
     TouchExtraPadding = ImFloor(TouchExtraPadding * scale_factor);
     IndentSpacing = ImFloor(IndentSpacing * scale_factor);
     ColumnsMinSpacing = ImFloor(ColumnsMinSpacing * scale_factor);
@@ -2129,6 +2131,14 @@ void ImGuiTextBuffer::appendfv(const char* fmt, va_list args)
 // the API mid-way through development and support two ways to using the clipper, needs some rework (see TODO)
 //-----------------------------------------------------------------------------
 
+// FIXME-TABLE: This prevents us from using ImGuiListClipper _inside_ a table cell.
+// The problem we have is that without a Begin/End scheme for rows using the clipper is ambiguous.
+static bool GetSkipItemForListClipping()
+{
+    ImGuiContext& g = *GImGui;
+    return (g.CurrentTable ? g.CurrentTable->BackupSkipItems : g.CurrentWindow->SkipItems);
+}
+
 // Helper to calculate coarse clipping of large list of evenly sized items.
 // NB: Prefer using the ImGuiListClipper higher-level helper if you can! Read comments and instructions there on how those use this sort of pattern.
 // NB: 'items_count' is only used to clamp the result, if you don't know your count you can use INT_MAX
@@ -2143,7 +2153,7 @@ void ImGui::CalcListClipping(int items_count, float items_height, int* out_items
         *out_items_display_end = items_count;
         return;
     }
-    if (window->SkipItems)
+    if (GetSkipItemForListClipping())
     {
         *out_items_display_start = *out_items_display_end = 0;
         return;
@@ -2177,12 +2187,20 @@ static void SetCursorPosYAndSetupDummyPrevLine(float pos_y, float line_height)
     // The clipper should probably have a 4th step to display the last item in a regular manner.
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
+    float off_y = pos_y - window->DC.CursorPos.y;
     window->DC.CursorPos.y = pos_y;
     window->DC.CursorMaxPos.y = ImMax(window->DC.CursorMaxPos.y, pos_y);
     window->DC.CursorPosPrevLine.y = window->DC.CursorPos.y - line_height;  // Setting those fields so that SetScrollHereY() can properly function after the end of our clipper usage.
     window->DC.PrevLineSize.y = (line_height - g.Style.ItemSpacing.y);      // If we end up needing more accurate data (to e.g. use SameLine) we may as well make the clipper have a fourth step to let user process and display the last item in their list.
     if (ImGuiColumns* columns = window->DC.CurrentColumns)
-        columns->LineMinY = window->DC.CursorPos.y;                         // Setting this so that cell Y position are set properly
+        columns->LineMinY = window->DC.CursorPos.y;                         // Setting this so that cell Y position are set properly // FIXME-TABLE
+    if (ImGuiTable* table = g.CurrentTable)
+    {
+        if (table->IsInsideRow)
+            ImGui::TableEndRow(table);
+        table->RowPosY2 = window->DC.CursorPos.y;
+        table->RowBgColorCounter += (int)((off_y / line_height) + 0.5f);
+    }
 }
 
 // Use case A: Begin() called from constructor with items_height<0, then called again from Sync() in StepNo 1
@@ -2192,6 +2210,10 @@ void ImGuiListClipper::Begin(int count, float items_height)
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
+
+    if (ImGuiTable* table = g.CurrentTable)
+        if (table->IsInsideRow)
+            ImGui::TableEndRow(table);
 
     StartPosY = window->DC.CursorPos.y;
     ItemsHeight = items_height;
@@ -2223,7 +2245,11 @@ bool ImGuiListClipper::Step()
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
 
-    if (ItemsCount == 0 || window->SkipItems)
+    ImGuiTable* table = g.CurrentTable;
+    if (table && table->IsInsideRow)
+        ImGui::TableEndRow(table);
+
+    if (ItemsCount == 0 || GetSkipItemForListClipping())
     {
         ItemsCount = -1;
         return false;
@@ -2239,8 +2265,21 @@ bool ImGuiListClipper::Step()
     if (StepNo == 1) // Step 1: the clipper infer height from first element, calculate the actual range of elements to display, and position the cursor before the first element.
     {
         if (ItemsCount == 1) { ItemsCount = -1; return false; }
-        float items_height = window->DC.CursorPos.y - StartPosY;
-        IM_ASSERT(items_height > 0.0f);   // If this triggers, it means Item 0 hasn't moved the cursor vertically
+
+        float items_height;
+        if (table)
+        {
+            const float pos_y1 = table->RowPosY1;   // Using this instead of StartPosY to handle clipper straddling the frozen row
+            const float pos_y2 = table->RowPosY2;   // Using this instead of CursorPos.y to take account of tallest cell.
+            items_height = pos_y2 - pos_y1;
+            window->DC.CursorPos.y = pos_y2;
+            IM_ASSERT(items_height > 0.0f);   // If this triggers, it means Item 0 hasn't moved the cursor vertically
+        }
+        else
+        {
+            items_height = window->DC.CursorPos.y - StartPosY;
+            IM_ASSERT(items_height > 0.0f);         // If this triggers, it means Item 0 hasn't moved the cursor vertically
+        }
         Begin(ItemsCount - 1, items_height);
         DisplayStart++;
         DisplayEnd++;
@@ -3909,6 +3948,10 @@ void ImGui::Shutdown(ImGuiContext* context)
     g.TabBars.Clear();
     g.CurrentTabBarStack.clear();
     g.ShrinkWidthBuffer.clear();
+
+    g.Tables.Clear();
+    g.CurrentTableStack.clear();
+    g.DrawChannelsTempMergeBuffer.clear();
 
     g.PrivateClipboard.clear();
     g.InputTextState.ClearFreeMemory();
@@ -6307,6 +6350,7 @@ static const ImGuiStyleVarInfo GStyleVarInfo[] =
     { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImGuiStyle, FrameBorderSize) },     // ImGuiStyleVar_FrameBorderSize
     { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImGuiStyle, ItemSpacing) },         // ImGuiStyleVar_ItemSpacing
     { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImGuiStyle, ItemInnerSpacing) },    // ImGuiStyleVar_ItemInnerSpacing
+    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImGuiStyle, CellPadding) },         // ImGuiStyleVar_CellPadding
     { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImGuiStyle, IndentSpacing) },       // ImGuiStyleVar_IndentSpacing
     { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImGuiStyle, ScrollbarSize) },       // ImGuiStyleVar_ScrollbarSize
     { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImGuiStyle, ScrollbarRounding) },   // ImGuiStyleVar_ScrollbarRounding
@@ -6415,6 +6459,9 @@ const char* ImGui::GetStyleColorName(ImGuiCol idx)
     case ImGuiCol_PlotLinesHovered: return "PlotLinesHovered";
     case ImGuiCol_PlotHistogram: return "PlotHistogram";
     case ImGuiCol_PlotHistogramHovered: return "PlotHistogramHovered";
+    case ImGuiCol_TableHeaderBg: return "TableHeaderBg";
+    case ImGuiCol_TableRowBg: return "TableRowBg";
+    case ImGuiCol_TableRowBgAlt: return "TableRowBgAlt";
     case ImGuiCol_TextSelectedBg: return "TextSelectedBg";
     case ImGuiCol_DragDropTarget: return "DragDropTarget";
     case ImGuiCol_NavHighlight: return "NavHighlight";
@@ -6725,7 +6772,7 @@ ImVec2 ImGui::GetContentRegionMax()
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
     ImVec2 mx = window->ContentRegionRect.Max - window->Pos;
-    if (window->DC.CurrentColumns)
+    if (window->DC.CurrentColumns || g.CurrentTable)
         mx.x = window->WorkRect.Max.x - window->Pos.x;
     return mx;
 }
@@ -6736,7 +6783,7 @@ ImVec2 ImGui::GetContentRegionMaxAbs()
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
     ImVec2 mx = window->ContentRegionRect.Max;
-    if (window->DC.CurrentColumns)
+    if (window->DC.CurrentColumns || g.CurrentTable)
         mx.x = window->WorkRect.Max.x;
     return mx;
 }
@@ -9903,6 +9950,23 @@ void ImGui::ShowMetricsWindow(bool* p_open)
     // - NodeStorage()
     struct Funcs
     {
+        static ImRect GetTableRect(ImGuiTable* table, int rect_type, int n)
+        {
+            if (rect_type == TRT_OuterRect)                 { return table->OuterRect; }
+            else if (rect_type == TRT_WorkRect)             { return table->WorkRect; }
+            else if (rect_type == TRT_HostClipRect)         { return table->HostClipRect; }
+            else if (rect_type == TRT_InnerClipRect)        { return table->InnerClipRect; }
+            else if (rect_type == TRT_BackgroundClipRect)   { return table->BackgroundClipRect; }
+            else if (rect_type == TRT_ColumnsRect)                  { ImGuiTableColumn* c = &table->Columns[n]; return ImRect(c->MinX, table->InnerClipRect.Min.y, c->MaxX, table->InnerClipRect.Min.y + table->LastOuterHeight); }
+            else if (rect_type == TRT_ColumnsClipRect)              { ImGuiTableColumn* c = &table->Columns[n]; return c->ClipRect; }
+            else if (rect_type == TRT_ColumnsContentHeadersUsed)    { ImGuiTableColumn* c = &table->Columns[n]; return ImRect(c->MinX, table->InnerClipRect.Min.y, c->MinX + c->ContentWidthHeadersUsed, table->InnerClipRect.Min.y + table->LastFirstRowHeight); }    // Note: y1/y2 not always accurate
+            else if (rect_type == TRT_ColumnsContentHeadersDesired) { ImGuiTableColumn* c = &table->Columns[n]; return ImRect(c->MinX, table->InnerClipRect.Min.y, c->MinX + c->ContentWidthHeadersDesired, table->InnerClipRect.Min.y + table->LastFirstRowHeight); } // "
+            else if (rect_type == TRT_ColumnsContentRowsFrozen)     { ImGuiTableColumn* c = &table->Columns[n]; return ImRect(c->MinX, table->InnerClipRect.Min.y, c->MinX + c->ContentWidthRowsFrozen, table->InnerClipRect.Min.y + table->LastFirstRowHeight); }     // "
+            else if (rect_type == TRT_ColumnsContentRowsUnfrozen)   { ImGuiTableColumn* c = &table->Columns[n]; return ImRect(c->MinX, table->InnerClipRect.Min.y + table->LastFirstRowHeight, c->MinX + c->ContentWidthRowsUnfrozen, table->InnerClipRect.Max.y); }   // "
+            IM_ASSERT(0);
+            return ImRect();
+        }
+
         static ImRect GetWindowRect(ImGuiWindow* window, int rect_type)
         {
             if (rect_type == WRT_OuterRect)                 { return window->Rect(); }
@@ -10122,6 +10186,51 @@ void ImGui::ShowMetricsWindow(bool* p_open)
             }
             ImGui::TreePop();
         }
+
+        static void NodeTable(ImGuiTable* table)
+        {
+            char buf[256];
+            char* p = buf;
+            const char* buf_end = buf + IM_ARRAYSIZE(buf);
+            ImFormatString(p, buf_end - p, "Table 0x%08X (%d columns, in '%s')", table->ID, table->ColumnsCount, table->OuterWindow->Name);
+            bool open = ImGui::TreeNode(table, "%s", buf);
+            if (ImGui::IsItemHovered())
+                ImGui::GetForegroundDrawList()->AddRect(table->OuterRect.Min, table->OuterRect.Max, IM_COL32(255, 255, 0, 255));
+            if (open)
+            {
+                for (int n = 0; n < table->ColumnsCount; n++)
+                {
+                    ImGuiTableColumn* column = &table->Columns[n];
+                    const char* name = TableGetColumnName(table, n);
+                    ImGui::BulletText("Column %d order %d name '%s': +%.1f to +%.1f\n"
+                        "Active: %d, DrawChannels: %d,%d\n"
+                        "WidthGiven/Requested: %.1f/%.1f, Weight: %.2f\n"
+                        "UserID: 0x%08X, Flags: 0x%04X: %s%s%s%s..",
+                        n, column->IndexDisplayOrder, name ? name : "NULL", column->MinX - table->WorkRect.Min.x, column->MaxX - table->WorkRect.Min.x,
+                        column->IsActive, column->DrawChannelRowsBeforeFreeze, column->DrawChannelRowsAfterFreeze,
+                        column->WidthGiven, column->WidthRequested, column->ResizeWeight,
+                        column->UserID, column->Flags,
+                        (column->Flags & ImGuiTableColumnFlags_WidthFixed) ? "WidthFixed " : "",
+                        (column->Flags & ImGuiTableColumnFlags_WidthStretch) ? "WidthStretch " : "",
+                        (column->Flags & ImGuiTableColumnFlags_WidthAlwaysAutoResize) ? "WidthAlwaysAutoResize " : "",
+                        (column->Flags & ImGuiTableColumnFlags_NoResize) ? "NoResize " : "");
+                }
+                ImGuiTableSettings* settings = TableFindSettings(table);
+                if (settings && ImGui::TreeNode("Settings"))
+                {
+                    ImGui::BulletText("SaveFlags: 0x%08X", settings->SaveFlags);
+                    ImGui::BulletText("ColumnsCount: %d (max %d)", settings->ColumnsCount, settings->ColumnsCountMax);
+                    for (int n = 0; n < settings->ColumnsCount; n++)
+                    {
+                        ImGuiTableColumnSettings* column_settings = &settings->GetColumnSettings()[n];
+                        ImGui::BulletText("Column %d Order %d SortOrder %d Visible %d UserID 0x%08X WidthOrWeight %.3f",
+                            n, column_settings->DisplayOrder, column_settings->SortOrder, column_settings->Visible, column_settings->UserID, column_settings->WidthOrWeight);
+                    }
+                    ImGui::TreePop();
+                }
+                ImGui::TreePop();
+            }
+        }
     };
 
     Funcs::NodeWindows(g.Windows, "Windows");
@@ -10153,9 +10262,6 @@ void ImGui::ShowMetricsWindow(bool* p_open)
     }
 
     // Details for Tables
-    IM_UNUSED(trt_rects_names);
-    IM_UNUSED(show_tables_rects);
-    IM_UNUSED(show_tables_rect_type);
 #ifdef IMGUI_HAS_TABLE
     if (ImGui::TreeNode("Tables", "Tables (%d)", g.Tables.GetSize()))
     {
@@ -10219,6 +10325,49 @@ void ImGui::ShowMetricsWindow(bool* p_open)
             }
             ImGui::Unindent();
         }
+
+        ImGui::Checkbox("Show tables rectangles", &show_tables_rects);
+        ImGui::SameLine();
+        ImGui::SetNextItemWidth(ImGui::GetFontSize() * 12);
+        show_tables_rects |= ImGui::Combo("##show_table_rects_type", &show_tables_rect_type, trt_rects_names, TRT_Count, TRT_Count);
+        if (show_tables_rects && g.NavWindow)
+        {
+            for (int table_n = 0; table_n < g.Tables.GetSize(); table_n++)
+            {
+                ImGuiTable* table = g.Tables.GetByIndex(table_n);
+                if (table->LastFrameActive < g.FrameCount - 1 || table->OuterWindow != g.NavWindow)
+                    continue;
+
+                ImGui::BulletText("Table 0x%08X (%d columns, in '%s')", table->ID, table->ColumnsCount, table->OuterWindow->Name);
+                if (ImGui::IsItemHovered())
+                    ImGui::GetForegroundDrawList()->AddRect(table->OuterRect.Min - ImVec2(1, 1), table->OuterRect.Max + ImVec2(1, 1), IM_COL32(255, 255, 0, 255), 0.0f, ~0, 2.0f);
+                ImGui::Indent();
+                for (int rect_n = 0; rect_n < TRT_Count; rect_n++)
+                {
+                    if (rect_n >= TRT_ColumnsRect)
+                    {
+                        if (rect_n != TRT_ColumnsRect && rect_n != TRT_ColumnsClipRect)
+                            continue;
+                        for (int column_n = 0; column_n < table->ColumnsCount; column_n++)
+                        {
+                            ImRect r = Funcs::GetTableRect(table, rect_n, column_n);
+                            ImGui::Text("(%6.1f,%6.1f) (%6.1f,%6.1f) Size (%6.1f,%6.1f) Col %d %s", r.Min.x, r.Min.y, r.Max.x, r.Max.y, r.GetWidth(), r.GetHeight(), column_n, trt_rects_names[rect_n]);
+                            if (ImGui::IsItemHovered())
+                                ImGui::GetForegroundDrawList()->AddRect(r.Min - ImVec2(1, 1), r.Max + ImVec2(1, 1), IM_COL32(255, 255, 0, 255), 0.0f, ~0, 2.0f);
+                        }
+                    }
+                    else
+                    {
+                        ImRect r = Funcs::GetTableRect(table, rect_n, -1);
+                        ImGui::Text("(%6.1f,%6.1f) (%6.1f,%6.1f) Size (%6.1f,%6.1f) %s", r.Min.x, r.Min.y, r.Max.x, r.Max.y, r.GetWidth(), r.GetHeight(), trt_rects_names[rect_n]);
+                        if (ImGui::IsItemHovered())
+                            ImGui::GetForegroundDrawList()->AddRect(r.Min - ImVec2(1, 1), r.Max + ImVec2(1, 1), IM_COL32(255, 255, 0, 255), 0.0f, ~0, 2.0f);
+                    }
+                }
+                ImGui::Unindent();
+            }
+        }
+
         ImGui::Checkbox("Show details when hovering ImDrawCmd node", &show_drawcmd_details);
         ImGui::TreePop();
     }
@@ -10255,6 +10404,24 @@ void ImGui::ShowMetricsWindow(bool* p_open)
         for (int table_n = 0; table_n < g.Tables.GetSize(); table_n++)
         {
             ImGuiTable* table = g.Tables.GetByIndex(table_n);
+            if (table->LastFrameActive < g.FrameCount - 1)
+                continue;
+            ImDrawList* draw_list = GetForegroundDrawList(table->OuterWindow);
+            if (show_tables_rect_type >= TRT_ColumnsRect)
+            {
+                for (int column_n = 0; column_n < table->ColumnsCount; column_n++)
+                {
+                    ImRect r = Funcs::GetTableRect(table, show_tables_rect_type, column_n);
+                    ImU32 col = (table->HoveredColumnBody == column_n) ? IM_COL32(255, 255, 128, 255) : IM_COL32(255, 0, 128, 255);
+                    float thickness = (table->HoveredColumnBody == column_n) ? 3.0f : 1.0f;
+                    draw_list->AddRect(r.Min, r.Max, col, 0.0f, ~0, thickness);
+                }
+            }
+            else
+            {
+                ImRect r = Funcs::GetTableRect(table, show_tables_rect_type, -1);
+                draw_list->AddRect(r.Min, r.Max, IM_COL32(255, 0, 128, 255));
+            }
         }
     }
 #endif // #define IMGUI_HAS_TABLE

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -10207,10 +10207,12 @@ void ImGui::ShowMetricsWindow(bool* p_open)
                     ImGui::BulletText("Column %d order %d name '%s': +%.1f to +%.1f\n"
                         "Active: %d, Clipped: %d, DrawChannels: %d,%d\n"
                         "WidthGiven/Requested: %.1f/%.1f, Weight: %.2f\n"
+                        "ContentWidth: RowsFrozen %d, RowsUnfrozen %d, HeadersUsed/Desired %d/%d\n"
                         "UserID: 0x%08X, Flags: 0x%04X: %s%s%s%s..",
                         n, column->IndexDisplayOrder, name ? name : "NULL", column->MinX - table->WorkRect.Min.x, column->MaxX - table->WorkRect.Min.x,
                         column->IsActive, column->IsClipped, column->DrawChannelRowsBeforeFreeze, column->DrawChannelRowsAfterFreeze,
                         column->WidthGiven, column->WidthRequested, column->ResizeWeight,
+                        column->ContentWidthRowsFrozen, column->ContentWidthRowsUnfrozen, column->ContentWidthHeadersUsed, column->ContentWidthHeadersDesired,
                         column->UserID, column->Flags,
                         (column->Flags & ImGuiTableColumnFlags_WidthFixed) ? "WidthFixed " : "",
                         (column->Flags & ImGuiTableColumnFlags_WidthStretch) ? "WidthStretch " : "",

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -10203,11 +10203,11 @@ void ImGui::ShowMetricsWindow(bool* p_open)
                     ImGuiTableColumn* column = &table->Columns[n];
                     const char* name = TableGetColumnName(table, n);
                     ImGui::BulletText("Column %d order %d name '%s': +%.1f to +%.1f\n"
-                        "Active: %d, DrawChannels: %d,%d\n"
+                        "Active: %d, Clipped: %d, DrawChannels: %d,%d\n"
                         "WidthGiven/Requested: %.1f/%.1f, Weight: %.2f\n"
                         "UserID: 0x%08X, Flags: 0x%04X: %s%s%s%s..",
                         n, column->IndexDisplayOrder, name ? name : "NULL", column->MinX - table->WorkRect.Min.x, column->MaxX - table->WorkRect.Min.x,
-                        column->IsActive, column->DrawChannelRowsBeforeFreeze, column->DrawChannelRowsAfterFreeze,
+                        column->IsActive, column->IsClipped, column->DrawChannelRowsBeforeFreeze, column->DrawChannelRowsAfterFreeze,
                         column->WidthGiven, column->WidthRequested, column->ResizeWeight,
                         column->UserID, column->Flags,
                         (column->Flags & ImGuiTableColumnFlags_WidthFixed) ? "WidthFixed " : "",

--- a/imgui.h
+++ b/imgui.h
@@ -981,9 +981,9 @@ enum ImGuiTableColumnFlags_
     ImGuiTableColumnFlags_None                      = 0,
     ImGuiTableColumnFlags_DefaultHide               = 1 << 0,   // Default as a hidden column.
     ImGuiTableColumnFlags_DefaultSort               = 1 << 1,   // Default as a sorting column.
-    ImGuiTableColumnFlags_WidthFixed                = 1 << 2,   // Column will keep a fixed size, preferable with horizontal scrolling enabled (default if table sizing policy is SizingPolicyFixedX).
+    ImGuiTableColumnFlags_WidthFixed                = 1 << 2,   // Column will keep a fixed size, preferable with horizontal scrolling enabled (default if table sizing policy is SizingPolicyFixedX and table is resizable).
     ImGuiTableColumnFlags_WidthStretch              = 1 << 3,   // Column will stretch, preferable with horizontal scrolling disabled (default if table sizing policy is SizingPolicyStretchX).
-    ImGuiTableColumnFlags_WidthAlwaysAutoResize     = 1 << 4,   // Column will keep resizing based on submitted contents (with a one frame delay) == Fixed with auto resize
+    ImGuiTableColumnFlags_WidthAlwaysAutoResize     = 1 << 4,   // Column will keep resizing based on submitted contents (with a one frame delay) == Fixed with auto resize (default if table sizing policy is SizingPolicyFixedX and table is not resizable).
     ImGuiTableColumnFlags_NoResize                  = 1 << 5,   // Disable manual resizing.
     ImGuiTableColumnFlags_NoClipX                   = 1 << 6,   // Disable clipping for this column (all NoClipX columns will render in a same draw command).
     ImGuiTableColumnFlags_NoSort                    = 1 << 7,   // Disable ability to sort on this field (even if ImGuiTableFlags_Sortable is set on the table).

--- a/imgui.h
+++ b/imgui.h
@@ -955,21 +955,22 @@ enum ImGuiTableFlags_
     ImGuiTableFlags_SizingPolicyStretchX            = 1 << 14,  // Default if ScrollX is off. Columns will default to use WidthStretch policy. Read description above for more details.
     ImGuiTableFlags_NoHeadersWidth                  = 1 << 15,  // Disable header width contribution to automatic width calculation.
     ImGuiTableFlags_NoHostExtendY                   = 1 << 16,  // (FIXME-TABLE: Reword as SizingPolicy?) Disable extending past the limit set by outer_size.y, only meaningful when neither of ScrollX|ScrollY are set (data below the limit will be clipped and not visible)
+    ImGuiTableFlags_NoKeepColumnsVisible            = 1 << 17,  // (FIXME-TABLE) Disable code that keeps column always minimally visible when table width gets too small.
     // Scrolling
-    ImGuiTableFlags_ScrollX                         = 1 << 17,  // Enable horizontal scrolling. Require 'outer_size' parameter of BeginTable() to specify the container size. Because this create a child window, ScrollY is currently generally recommended when using ScrollX.
-    ImGuiTableFlags_ScrollY                         = 1 << 18,  // Enable vertical scrolling. Require 'outer_size' parameter of BeginTable() to specify the container size.
+    ImGuiTableFlags_ScrollX                         = 1 << 18,  // Enable horizontal scrolling. Require 'outer_size' parameter of BeginTable() to specify the container size. Because this create a child window, ScrollY is currently generally recommended when using ScrollX.
+    ImGuiTableFlags_ScrollY                         = 1 << 19,  // Enable vertical scrolling. Require 'outer_size' parameter of BeginTable() to specify the container size.
     ImGuiTableFlags_Scroll                          = ImGuiTableFlags_ScrollX | ImGuiTableFlags_ScrollY,
-    ImGuiTableFlags_ScrollFreezeTopRow              = 1 << 19,  // We can lock 1 to 3 rows (starting from the top). Use with ScrollY enabled.
-    ImGuiTableFlags_ScrollFreeze2Rows               = 2 << 19,
-    ImGuiTableFlags_ScrollFreeze3Rows               = 3 << 19,
-    ImGuiTableFlags_ScrollFreezeLeftColumn          = 1 << 21,  // We can lock 1 to 3 columns (starting from the left). Use with ScrollX enabled.
-    ImGuiTableFlags_ScrollFreeze2Columns            = 2 << 21,
-    ImGuiTableFlags_ScrollFreeze3Columns            = 3 << 21,
+    ImGuiTableFlags_ScrollFreezeTopRow              = 1 << 20,  // We can lock 1 to 3 rows (starting from the top). Use with ScrollY enabled.
+    ImGuiTableFlags_ScrollFreeze2Rows               = 2 << 20,
+    ImGuiTableFlags_ScrollFreeze3Rows               = 3 << 20,
+    ImGuiTableFlags_ScrollFreezeLeftColumn          = 1 << 22,  // We can lock 1 to 3 columns (starting from the left). Use with ScrollX enabled.
+    ImGuiTableFlags_ScrollFreeze2Columns            = 2 << 22,
+    ImGuiTableFlags_ScrollFreeze3Columns            = 3 << 22,
 
     // [Internal] Combinations and masks
     ImGuiTableFlags_SizingPolicyMaskX_              = ImGuiTableFlags_SizingPolicyStretchX | ImGuiTableFlags_SizingPolicyFixedX,
-    ImGuiTableFlags_ScrollFreezeRowsShift_          = 19,
-    ImGuiTableFlags_ScrollFreezeColumnsShift_       = 21,
+    ImGuiTableFlags_ScrollFreezeRowsShift_          = 20,
+    ImGuiTableFlags_ScrollFreezeColumnsShift_       = 22,
     ImGuiTableFlags_ScrollFreezeRowsMask_           = 0x03 << ImGuiTableFlags_ScrollFreezeRowsShift_,
     ImGuiTableFlags_ScrollFreezeColumnsMask_        = 0x03 << ImGuiTableFlags_ScrollFreezeColumnsShift_
 };

--- a/imgui.h
+++ b/imgui.h
@@ -993,9 +993,12 @@ enum ImGuiTableColumnFlags_
     ImGuiTableColumnFlags_NoHeaderWidth             = 1 << 11,  // Header width don't contribute to automatic column width.
     ImGuiTableColumnFlags_PreferSortAscending       = 1 << 12,  // Make the initial sort direction Ascending when first sorting on this column (default).
     ImGuiTableColumnFlags_PreferSortDescending      = 1 << 13,  // Make the initial sort direction Descending when first sorting on this column.
+    ImGuiTableColumnFlags_IndentEnable              = 1 << 14,  // Use current Indent value when entering cell (default for 1st column).
+    ImGuiTableColumnFlags_IndentDisable             = 1 << 15,  // Ignore current Indent value when entering cell (default for columns after the 1st one). Indentation changes _within_ the cell will still be honored.
 
     // [Internal] Combinations and masks
     ImGuiTableColumnFlags_WidthMask_                = ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_WidthAlwaysAutoResize,
+    ImGuiTableColumnFlags_IndentMask_               = ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_IndentDisable,
     ImGuiTableColumnFlags_NoDirectResize_           = 1 << 20   // [Internal] Disable user resizing this column directly (it may however we resized indirectly from its left edge)
 };
 

--- a/imgui.h
+++ b/imgui.h
@@ -621,6 +621,8 @@ namespace ImGui
     // - In most situations you can use TableNextRow() + TableSetColumnIndex() to populate a table.
     // - If you are using tables as a sort of grid, populating every columns with the same type of contents,
     //   you may prefer using TableNextCell() instead of TableNextRow() + TableSetColumnIndex().
+    // - See Demo->Tables for details.
+    // - See ImGuiTableFlags_ enums for a description of available flags. 
     #define IMGUI_HAS_TABLE 1
     IMGUI_API bool          BeginTable(const char* str_id, int columns_count, ImGuiTableFlags flags = 0, const ImVec2& outer_size = ImVec2(0, 0), float inner_width = 0.0f);
     IMGUI_API void          EndTable();                                 // only call EndTable() if BeginTable() returns true!
@@ -628,14 +630,14 @@ namespace ImGui
     IMGUI_API bool          TableNextCell();                            // append into the next column (next column, or next row if currently in last column). Return true if column is visible.
     IMGUI_API bool          TableSetColumnIndex(int column_n);          // append into the specified column. Return true if column is visible.
     IMGUI_API int           TableGetColumnIndex();                      // return current column index.
-    IMGUI_API const char*   TableGetColumnName(int column_n = -1);      // return NULL if column didn't have a name declared by TableSetupColumn(). Use pass -1 to use current column.
-    IMGUI_API bool          TableGetColumnIsVisible(int column_n = -1); // return true if column is visible. Same value is also returned by TableNextCell() and TableSetColumnIndex(). Use pass -1 to use current column.
-    IMGUI_API bool          TableGetColumnIsSorted(int column_n = -1);  // return true if column is included in the sort specs. Rarely used, can be useful to tell if a data change should trigger resort. Equivalent to test ImGuiTableSortSpecs's ->ColumnsMask & (1 << column_n). Use pass -1 to use current column.
+    IMGUI_API const char*   TableGetColumnName(int column_n = -1);      // return NULL if column didn't have a name declared by TableSetupColumn(). Pass -1 to use current column.
+    IMGUI_API bool          TableGetColumnIsVisible(int column_n = -1); // return true if column is visible. Same value is also returned by TableNextCell() and TableSetColumnIndex(). Pass -1 to use current column.
+    IMGUI_API bool          TableGetColumnIsSorted(int column_n = -1);  // return true if column is included in the sort specs. Rarely used, can be useful to tell if a data change should trigger resort. Equivalent to test ImGuiTableSortSpecs's ->ColumnsMask & (1 << column_n). Pass -1 to use current column.
     // Tables: Headers & Columns declaration
-    // - Use TableSetupColumn() to specify resizing policy, default width, name, id, specific flags etc.
+    // - Use TableSetupColumn() to specify label, resizing policy, default width, id, various other flags etc.
     // - The name passed to TableSetupColumn() is used by TableAutoHeaders() and by the context-menu
     // - Use TableAutoHeaders() to submit the whole header row, otherwise you may treat the header row as a regular row, manually call TableHeader() and other widgets.
-    // - Headers are required to perform some interactions: reordering, sorting, context menu // FIXME-TABLES: remove context from this list!
+    // - Headers are required to perform some interactions: reordering, sorting, context menu // FIXME-TABLE: remove context from this list!
     IMGUI_API void          TableSetupColumn(const char* label, ImGuiTableColumnFlags flags = 0, float init_width_or_weight = -1.0f, ImU32 user_id = 0);
     IMGUI_API void          TableAutoHeaders();                         // submit all headers cells based on data provided to TableSetupColumn() + submit context menu
     IMGUI_API void          TableHeader(const char* label);             // submit one header cell manually.
@@ -920,6 +922,10 @@ enum ImGuiTabItemFlags_
 };
 
 // Flags for ImGui::BeginTable()
+// - Columns can either varying resizing policy: "Fixed", "Stretch" or "AlwaysAutoResize". Toggling ScrollX needs to alter default sizing policy.
+// - Sizing policy have many subtle side effects which may be hard to fully comprehend at first.. They'll eventually make sense.
+//   - with SizingPolicyFixedX (default is ScrollX is on):     Columns can be enlarged as needed. Enable scrollbar if ScrollX is enabled, otherwise extend parent window's contents rect. Only Fixed columns allowed. Weighted columns will calculate their width assuming no scrolling.
+//   - with SizingPolicyStretchX (default is ScrollX is off):  Fit all columns within available table width (so it doesn't make sense to use ScrollX with Stretch columns!). Fixed and Weighted columns allowed.
 enum ImGuiTableFlags_
 {
     // Features
@@ -938,26 +944,26 @@ enum ImGuiTableFlags_
     ImGuiTableFlags_BordersFullHeight               = 1 << 10,  // Borders covers all lines even when Headers are being used, allow resizing all rows.
     ImGuiTableFlags_Borders                         = ImGuiTableFlags_BordersOuter | ImGuiTableFlags_BordersV | ImGuiTableFlags_BordersH,
     // Padding, Sizing
-    ImGuiTableFlags_NoClipX                         = 1 << 12,  // Disable pushing clipping rectangle for every individual columns (reduce draw command count, items with be able to overflow)
-    ImGuiTableFlags_SizingPolicyStretchX            = 1 << 13,  // (Default if ScrollX is off) Columns will default to use ImGuiTableColumnFlags_WidthStretch. Fit all columns within available width. Fixed and Weighted columns allowed.
-    ImGuiTableFlags_SizingPolicyFixedX              = 1 << 14,  // (Default if ScrollX is on) Columns will default to use ImGuiTableColumnFlags_WidthFixed or WidthAuto. Enlarge as needed: enable scrollbar if ScrollX is enabled, otherwise extend parent window's contents rect. Only Fixed columns allowed. Weighted columns will calculate their width assuming no scrolling.
-    ImGuiTableFlags_NoHeadersWidth                  = 1 << 15,  // Disable header width contribute to automatic width calculation for every columns.
+    ImGuiTableFlags_NoClipX                         = 1 << 12,  // Disable pushing clipping rectangle for every individual columns (reduce draw command count, items will be able to overflow)
+    ImGuiTableFlags_SizingPolicyFixedX              = 1 << 13,  // Default if ScrollX is on. Columns will default to use WidthFixed or WidthAlwaysAutoResize policy. Read description above for more details.
+    ImGuiTableFlags_SizingPolicyStretchX            = 1 << 14,  // Default if ScrollX is off. Columns will default to use WidthStretch policy. Read description above for more details.
+    ImGuiTableFlags_NoHeadersWidth                  = 1 << 15,  // Disable header width contribution to automatic width calculation.
     ImGuiTableFlags_NoHostExtendY                   = 1 << 16,  // (FIXME-TABLE: Reword as SizingPolicy?) Disable extending past the limit set by outer_size.y, only meaningful when neither of ScrollX|ScrollY are set (data below the limit will be clipped and not visible)
     // Scrolling
     ImGuiTableFlags_ScrollX                         = 1 << 17,  // Enable horizontal scrolling. Require 'outer_size' parameter of BeginTable() to specify the container size. Because this create a child window, ScrollY is currently generally recommended when using ScrollX.
     ImGuiTableFlags_ScrollY                         = 1 << 18,  // Enable vertical scrolling. Require 'outer_size' parameter of BeginTable() to specify the container size.
     ImGuiTableFlags_Scroll                          = ImGuiTableFlags_ScrollX | ImGuiTableFlags_ScrollY,
-    ImGuiTableFlags_ScrollFreezeRowsShift_          = 19,       // We can lock 1 to 3 rows (starting from the top). Encode each of those values as dedicated flags.
-    ImGuiTableFlags_ScrollFreezeTopRow              = 1 << ImGuiTableFlags_ScrollFreezeRowsShift_,
-    ImGuiTableFlags_ScrollFreeze2Rows               = 2 << ImGuiTableFlags_ScrollFreezeRowsShift_,
-    ImGuiTableFlags_ScrollFreeze3Rows               = 3 << ImGuiTableFlags_ScrollFreezeRowsShift_,
-    ImGuiTableFlags_ScrollFreezeColumnsShift_       = 21,       // We can lock 1 to 3 columns (starting from the left). Encode each of those values as dedicated flags.
-    ImGuiTableFlags_ScrollFreezeLeftColumn          = 1 << ImGuiTableFlags_ScrollFreezeColumnsShift_,
-    ImGuiTableFlags_ScrollFreeze2Columns            = 2 << ImGuiTableFlags_ScrollFreezeColumnsShift_,
-    ImGuiTableFlags_ScrollFreeze3Columns            = 3 << ImGuiTableFlags_ScrollFreezeColumnsShift_,
+    ImGuiTableFlags_ScrollFreezeTopRow              = 1 << 19,  // We can lock 1 to 3 rows (starting from the top). Use with ScrollY enabled.
+    ImGuiTableFlags_ScrollFreeze2Rows               = 2 << 19,
+    ImGuiTableFlags_ScrollFreeze3Rows               = 3 << 19,
+    ImGuiTableFlags_ScrollFreezeLeftColumn          = 1 << 21,  // We can lock 1 to 3 columns (starting from the left). Use with ScrollX enabled.
+    ImGuiTableFlags_ScrollFreeze2Columns            = 2 << 21,
+    ImGuiTableFlags_ScrollFreeze3Columns            = 3 << 21,
 
-    // Combinations and masks
+    // [Internal] Combinations and masks
     ImGuiTableFlags_SizingPolicyMaskX_              = ImGuiTableFlags_SizingPolicyStretchX | ImGuiTableFlags_SizingPolicyFixedX,
+    ImGuiTableFlags_ScrollFreezeRowsShift_          = 19,
+    ImGuiTableFlags_ScrollFreezeColumnsShift_       = 21,
     ImGuiTableFlags_ScrollFreezeRowsMask_           = 0x03 << ImGuiTableFlags_ScrollFreezeRowsShift_,
     ImGuiTableFlags_ScrollFreezeColumnsMask_        = 0x03 << ImGuiTableFlags_ScrollFreezeColumnsShift_
 };
@@ -981,13 +987,13 @@ enum ImGuiTableColumnFlags_
     ImGuiTableColumnFlags_NoHeaderWidth             = 1 << 11,  // Header width don't contribute to automatic column width.
     ImGuiTableColumnFlags_PreferSortAscending       = 1 << 12,  // Make the initial sort direction Ascending when first sorting on this column (default).
     ImGuiTableColumnFlags_PreferSortDescending      = 1 << 13,  // Make the initial sort direction Descending when first sorting on this column.
+
+    // [Internal] Combinations and masks
+    ImGuiTableColumnFlags_WidthMask_                = ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_WidthAlwaysAutoResize,
+    ImGuiTableColumnFlags_NoDirectResize_           = 1 << 20   // [Internal] Disable user resizing this column directly (it may however we resized indirectly from its left edge)
     //ImGuiTableColumnFlags_AlignLeft               = 1 << 14,
     //ImGuiTableColumnFlags_AlignCenter             = 1 << 15,
     //ImGuiTableColumnFlags_AlignRight              = 1 << 16,
-
-    // Combinations and masks
-    ImGuiTableColumnFlags_WidthMask_                = ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_WidthAlwaysAutoResize,
-    ImGuiTableColumnFlags_NoDirectResize_           = 1 << 20   // [Internal] Disable user resizing this column directly (it may however we resized indirectly from its left edge)
     //ImGuiTableColumnFlags_AlignMask_              = ImGuiTableColumnFlags_AlignLeft | ImGuiTableColumnFlags_AlignCenter | ImGuiTableColumnFlags_AlignRight
 };
 

--- a/imgui.h
+++ b/imgui.h
@@ -996,10 +996,6 @@ enum ImGuiTableColumnFlags_
     // [Internal] Combinations and masks
     ImGuiTableColumnFlags_WidthMask_                = ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_WidthAlwaysAutoResize,
     ImGuiTableColumnFlags_NoDirectResize_           = 1 << 20   // [Internal] Disable user resizing this column directly (it may however we resized indirectly from its left edge)
-    //ImGuiTableColumnFlags_AlignLeft               = 1 << 14,
-    //ImGuiTableColumnFlags_AlignCenter             = 1 << 15,
-    //ImGuiTableColumnFlags_AlignRight              = 1 << 16,
-    //ImGuiTableColumnFlags_AlignMask_              = ImGuiTableColumnFlags_AlignLeft | ImGuiTableColumnFlags_AlignCenter | ImGuiTableColumnFlags_AlignRight
 };
 
 // Flags for ImGui::TableNextRow()

--- a/imgui.h
+++ b/imgui.h
@@ -1229,6 +1229,8 @@ enum ImGuiCol_
     ImGuiCol_PlotHistogram,
     ImGuiCol_PlotHistogramHovered,
     ImGuiCol_TableHeaderBg,         // Table header background
+    ImGuiCol_TableBorderStrong,     // Table outer and header borders (prefer using Alpha=1.0 here)
+    ImGuiCol_TableBorderLight,      // Table inner borders (prefer using Alpha=1.0 here)
     ImGuiCol_TableRowBg,            // Table row background (even rows)
     ImGuiCol_TableRowBgAlt,         // Table row background (odd rows)
     ImGuiCol_TextSelectedBg,

--- a/imgui.h
+++ b/imgui.h
@@ -33,6 +33,8 @@ Index of this file:
 // Draw List API (ImDrawCallback, ImDrawCmd, ImDrawIdx, ImDrawVert, ImDrawChannel, ImDrawListSplitter, ImDrawListFlags, ImDrawList, ImDrawData)
 // Font API (ImFontConfig, ImFontGlyph, ImFontGlyphRangesBuilder, ImFontAtlasFlags, ImFontAtlas, ImFont)
 
+// FIXME-TABLE: Add ImGuiTableSortSpecsColumn and ImGuiTableSortSpecs in "Misc data structures" section above (we don't do it right now to facilitate merging various branches)
+
 */
 
 #pragma once
@@ -134,6 +136,8 @@ struct ImGuiPayload;                // User data payload for drag and drop opera
 struct ImGuiSizeCallbackData;       // Callback data when using SetNextWindowSizeConstraints() (rare/advanced use)
 struct ImGuiStorage;                // Helper for key->value storage
 struct ImGuiStyle;                  // Runtime data for styling/colors
+struct ImGuiTableSortSpecs;         // Sorting specifications for a table (often handling sort specs for a single column, occasionally more)
+struct ImGuiTableSortSpecsColumn;   // Sorting specification for one column of a table
 struct ImGuiTextBuffer;             // Helper to hold and append into a text buffer (~string builder)
 struct ImGuiTextFilter;             // Helper to parse and apply text filters (e.g. "aaaaa[,bbbb][,ccccc]")
 
@@ -152,6 +156,7 @@ typedef int ImGuiKey;               // -> enum ImGuiKey_             // Enum: A 
 typedef int ImGuiNavInput;          // -> enum ImGuiNavInput_        // Enum: An input identifier for navigation
 typedef int ImGuiMouseButton;       // -> enum ImGuiMouseButton_     // Enum: A mouse button identifier (0=left, 1=right, 2=middle)
 typedef int ImGuiMouseCursor;       // -> enum ImGuiMouseCursor_     // Enum: A mouse cursor identifier
+typedef int ImGuiSortDirection;     // -> enum ImGuiSortDirection_   // Enum: A sorting direction (ascending or descending)
 typedef int ImGuiStyleVar;          // -> enum ImGuiStyleVar_        // Enum: A variable identifier for styling
 typedef int ImDrawCornerFlags;      // -> enum ImDrawCornerFlags_    // Flags: for ImDrawList::AddRect(), AddRectFilled() etc.
 typedef int ImDrawListFlags;        // -> enum ImDrawListFlags_      // Flags: for ImDrawList
@@ -167,6 +172,9 @@ typedef int ImGuiInputTextFlags;    // -> enum ImGuiInputTextFlags_  // Flags: f
 typedef int ImGuiSelectableFlags;   // -> enum ImGuiSelectableFlags_ // Flags: for Selectable()
 typedef int ImGuiTabBarFlags;       // -> enum ImGuiTabBarFlags_     // Flags: for BeginTabBar()
 typedef int ImGuiTabItemFlags;      // -> enum ImGuiTabItemFlags_    // Flags: for BeginTabItem()
+typedef int ImGuiTableFlags;        // -> enum ImGuiTableFlags_      // Flags: For BeginTable()
+typedef int ImGuiTableColumnFlags;  // -> enum ImGuiTableColumnFlags_// Flags: For TableSetupColumn() 
+typedef int ImGuiTableRowFlags;     // -> enum ImGuiTableRowFlags_   // Flags: For TableNextRow()
 typedef int ImGuiTreeNodeFlags;     // -> enum ImGuiTreeNodeFlags_   // Flags: for TreeNode(), TreeNodeEx(), CollapsingHeader()
 typedef int ImGuiWindowFlags;       // -> enum ImGuiWindowFlags_     // Flags: for Begin(), BeginChild()
 typedef int (*ImGuiInputTextCallback)(ImGuiInputTextCallbackData *data);
@@ -607,6 +615,35 @@ namespace ImGui
     IMGUI_API void          SetColumnOffset(int column_index, float offset_x);                  // set position of column line (in pixels, from the left side of the contents region). pass -1 to use current column
     IMGUI_API int           GetColumnsCount();
 
+    // Tables
+    // [ALPHA API] API will evolve! (FIXME-TABLE)
+    // - Full-featured replacement for old Columns API
+    // - In most situations you can use TableNextRow() + TableSetColumnIndex() to populate a table.
+    // - If you are using tables as a sort of grid, populating every columns with the same type of contents,
+    //   you may prefer using TableNextCell() instead of TableNextRow() + TableSetColumnIndex().
+    #define IMGUI_HAS_TABLE 1
+    IMGUI_API bool          BeginTable(const char* str_id, int columns_count, ImGuiTableFlags flags = 0, const ImVec2& outer_size = ImVec2(0, 0), float inner_width = 0.0f);
+    IMGUI_API void          EndTable();                                 // only call EndTable() if BeginTable() returns true!
+    IMGUI_API void          TableNextRow(ImGuiTableRowFlags row_flags = 0, float min_row_height = 0.0f); // append into the first cell of a new row.
+    IMGUI_API bool          TableNextCell();                            // append into the next column (next column, or next row if currently in last column). Return true if column is visible.
+    IMGUI_API bool          TableSetColumnIndex(int column_n);          // append into the specified column. Return true if column is visible.
+    IMGUI_API int           TableGetColumnIndex();                      // return current column index.
+    IMGUI_API const char*   TableGetColumnName(int column_n = -1);      // return NULL if column didn't have a name declared by TableSetupColumn(). Use pass -1 to use current column.
+    IMGUI_API bool          TableGetColumnIsVisible(int column_n = -1); // return true if column is visible. Same value is also returned by TableNextCell() and TableSetColumnIndex(). Use pass -1 to use current column.
+    IMGUI_API bool          TableGetColumnIsSorted(int column_n = -1);  // return true if column is included in the sort specs. Rarely used, can be useful to tell if a data change should trigger resort. Equivalent to test ImGuiTableSortSpecs's ->ColumnsMask & (1 << column_n). Use pass -1 to use current column.
+    // Tables: Headers & Columns declaration
+    // - Use TableSetupColumn() to specify resizing policy, default width, name, id, specific flags etc.
+    // - The name passed to TableSetupColumn() is used by TableAutoHeaders() and by the context-menu
+    // - Use TableAutoHeaders() to submit the whole header row, otherwise you may treat the header row as a regular row, manually call TableHeader() and other widgets.
+    // - Headers are required to perform some interactions: reordering, sorting, context menu // FIXME-TABLES: remove context from this list!
+    IMGUI_API void          TableSetupColumn(const char* label, ImGuiTableColumnFlags flags = 0, float init_width_or_weight = -1.0f, ImU32 user_id = 0);
+    IMGUI_API void          TableAutoHeaders();                         // submit all headers cells based on data provided to TableSetupColumn() + submit context menu
+    IMGUI_API void          TableHeader(const char* label);             // submit one header cell manually.
+    // Tables: Sorting
+    // - Call TableGetSortSpecs() to retrieve latest sort specs for the table. Return value will be NULL if no sorting.
+    // - Read ->SpecsChanged to tell if the specs have changed since last call.
+    IMGUI_API const ImGuiTableSortSpecs* TableGetSortSpecs();           // get latest sort specs for the table (NULL if not sorting).
+
     // Tab Bars, Tabs
     IMGUI_API bool          BeginTabBar(const char* str_id, ImGuiTabBarFlags flags = 0);        // create and append into a TabBar
     IMGUI_API void          EndTabBar();                                                        // only call EndTabBar() if BeginTabBar() returns true!
@@ -882,6 +919,85 @@ enum ImGuiTabItemFlags_
     ImGuiTabItemFlags_NoPushId                      = 1 << 3    // Don't call PushID(tab->ID)/PopID() on BeginTabItem()/EndTabItem()
 };
 
+// Flags for ImGui::BeginTable()
+enum ImGuiTableFlags_
+{
+    // Features
+    ImGuiTableFlags_None                            = 0,
+    ImGuiTableFlags_Resizable                       = 1 << 0,   // Allow resizing columns.
+    ImGuiTableFlags_Reorderable                     = 1 << 1,   // Allow reordering columns (need calling TableSetupColumn() + TableAutoHeaders() or TableHeaders() to display headers)
+    ImGuiTableFlags_Hideable                        = 1 << 2,   // Allow hiding columns (with right-click on header) (FIXME-TABLE: allow without headers).
+    ImGuiTableFlags_Sortable                        = 1 << 3,   // Allow sorting on one column (sort_specs_count will always be == 1). Call TableGetSortSpecs() to obtain sort specs.
+    ImGuiTableFlags_MultiSortable                   = 1 << 4,   // Allow sorting on multiple columns by holding Shift (sort_specs_count may be > 1). Call TableGetSortSpecs() to obtain sort specs.
+    ImGuiTableFlags_NoSavedSettings                 = 1 << 5,   // Disable persisting columns order, width and sort settings in the .ini file.
+    // Decoration
+    ImGuiTableFlags_RowBg                           = 1 << 6,   // Use ImGuiCol_TableRowBg and ImGuiCol_TableRowBgAlt colors behind each rows.
+    ImGuiTableFlags_BordersOuter                    = 1 << 7,   // Draw outer borders.
+    ImGuiTableFlags_BordersV                        = 1 << 8,   // Draw vertical borders between columns.
+    ImGuiTableFlags_BordersH                        = 1 << 9,   // Draw horizontal borders between rows.
+    ImGuiTableFlags_BordersFullHeight               = 1 << 10,  // Borders covers all lines even when Headers are being used, allow resizing all rows.
+    ImGuiTableFlags_Borders                         = ImGuiTableFlags_BordersOuter | ImGuiTableFlags_BordersV | ImGuiTableFlags_BordersH,
+    // Padding, Sizing
+    ImGuiTableFlags_NoClipX                         = 1 << 12,  // Disable pushing clipping rectangle for every individual columns (reduce draw command count, items with be able to overflow)
+    ImGuiTableFlags_SizingPolicyStretchX            = 1 << 13,  // (Default if ScrollX is off) Columns will default to use ImGuiTableColumnFlags_WidthStretch. Fit all columns within available width. Fixed and Weighted columns allowed.
+    ImGuiTableFlags_SizingPolicyFixedX              = 1 << 14,  // (Default if ScrollX is on) Columns will default to use ImGuiTableColumnFlags_WidthFixed or WidthAuto. Enlarge as needed: enable scrollbar if ScrollX is enabled, otherwise extend parent window's contents rect. Only Fixed columns allowed. Weighted columns will calculate their width assuming no scrolling.
+    ImGuiTableFlags_NoHeadersWidth                  = 1 << 15,  // Disable header width contribute to automatic width calculation for every columns.
+    ImGuiTableFlags_NoHostExtendY                   = 1 << 16,  // (FIXME-TABLE: Reword as SizingPolicy?) Disable extending past the limit set by outer_size.y, only meaningful when neither of ScrollX|ScrollY are set (data below the limit will be clipped and not visible)
+    // Scrolling
+    ImGuiTableFlags_ScrollX                         = 1 << 17,  // Enable horizontal scrolling. Require 'outer_size' parameter of BeginTable() to specify the container size. Because this create a child window, ScrollY is currently generally recommended when using ScrollX.
+    ImGuiTableFlags_ScrollY                         = 1 << 18,  // Enable vertical scrolling. Require 'outer_size' parameter of BeginTable() to specify the container size.
+    ImGuiTableFlags_Scroll                          = ImGuiTableFlags_ScrollX | ImGuiTableFlags_ScrollY,
+    ImGuiTableFlags_ScrollFreezeRowsShift_          = 19,       // We can lock 1 to 3 rows (starting from the top). Encode each of those values as dedicated flags.
+    ImGuiTableFlags_ScrollFreezeTopRow              = 1 << ImGuiTableFlags_ScrollFreezeRowsShift_,
+    ImGuiTableFlags_ScrollFreeze2Rows               = 2 << ImGuiTableFlags_ScrollFreezeRowsShift_,
+    ImGuiTableFlags_ScrollFreeze3Rows               = 3 << ImGuiTableFlags_ScrollFreezeRowsShift_,
+    ImGuiTableFlags_ScrollFreezeColumnsShift_       = 21,       // We can lock 1 to 3 columns (starting from the left). Encode each of those values as dedicated flags.
+    ImGuiTableFlags_ScrollFreezeLeftColumn          = 1 << ImGuiTableFlags_ScrollFreezeColumnsShift_,
+    ImGuiTableFlags_ScrollFreeze2Columns            = 2 << ImGuiTableFlags_ScrollFreezeColumnsShift_,
+    ImGuiTableFlags_ScrollFreeze3Columns            = 3 << ImGuiTableFlags_ScrollFreezeColumnsShift_,
+
+    // Combinations and masks
+    ImGuiTableFlags_SizingPolicyMaskX_              = ImGuiTableFlags_SizingPolicyStretchX | ImGuiTableFlags_SizingPolicyFixedX,
+    ImGuiTableFlags_ScrollFreezeRowsMask_           = 0x03 << ImGuiTableFlags_ScrollFreezeRowsShift_,
+    ImGuiTableFlags_ScrollFreezeColumnsMask_        = 0x03 << ImGuiTableFlags_ScrollFreezeColumnsShift_
+};
+
+// Flags for ImGui::TableSetupColumn()
+// FIXME-TABLE: Rename to ImGuiColumns_*, stick old columns api flags in there under an obsolete api block
+enum ImGuiTableColumnFlags_
+{
+    ImGuiTableColumnFlags_None                      = 0,
+    ImGuiTableColumnFlags_DefaultHide               = 1 << 0,   // Default as a hidden column.
+    ImGuiTableColumnFlags_DefaultSort               = 1 << 1,   // Default as a sorting column.
+    ImGuiTableColumnFlags_WidthFixed                = 1 << 2,   // Column will keep a fixed size, preferable with horizontal scrolling enabled (default if table sizing policy is SizingPolicyFixedX).
+    ImGuiTableColumnFlags_WidthStretch              = 1 << 3,   // Column will stretch, preferable with horizontal scrolling disabled (default if table sizing policy is SizingPolicyStretchX).
+    ImGuiTableColumnFlags_WidthAlwaysAutoResize     = 1 << 4,   // Column will keep resizing based on submitted contents (with a one frame delay) == Fixed with auto resize
+    ImGuiTableColumnFlags_NoResize                  = 1 << 5,   // Disable manual resizing.
+    ImGuiTableColumnFlags_NoClipX                   = 1 << 6,   // Disable clipping for this column (all NoClipX columns will render in a same draw command).
+    ImGuiTableColumnFlags_NoSort                    = 1 << 7,   // Disable ability to sort on this field (even if ImGuiTableFlags_Sortable is set on the table).
+    ImGuiTableColumnFlags_NoSortAscending           = 1 << 8,   // Disable ability to sort in the ascending direction.
+    ImGuiTableColumnFlags_NoSortDescending          = 1 << 9,   // Disable ability to sort in the descending direction.
+    ImGuiTableColumnFlags_NoHide                    = 1 << 10,  // Disable hiding this column.
+    ImGuiTableColumnFlags_NoHeaderWidth             = 1 << 11,  // Header width don't contribute to automatic column width.
+    ImGuiTableColumnFlags_PreferSortAscending       = 1 << 12,  // Make the initial sort direction Ascending when first sorting on this column (default).
+    ImGuiTableColumnFlags_PreferSortDescending      = 1 << 13,  // Make the initial sort direction Descending when first sorting on this column.
+    //ImGuiTableColumnFlags_AlignLeft               = 1 << 14,
+    //ImGuiTableColumnFlags_AlignCenter             = 1 << 15,
+    //ImGuiTableColumnFlags_AlignRight              = 1 << 16,
+
+    // Combinations and masks
+    ImGuiTableColumnFlags_WidthMask_                = ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_WidthAlwaysAutoResize,
+    ImGuiTableColumnFlags_NoDirectResize_           = 1 << 20   // [Internal] Disable user resizing this column directly (it may however we resized indirectly from its left edge)
+    //ImGuiTableColumnFlags_AlignMask_              = ImGuiTableColumnFlags_AlignLeft | ImGuiTableColumnFlags_AlignCenter | ImGuiTableColumnFlags_AlignRight
+};
+
+// Flags for ImGui::TableNextRow()
+enum ImGuiTableRowFlags_
+{
+    ImGuiTableRowFlags_None                         = 0,
+    ImGuiTableRowFlags_Headers                      = 1 << 0    // Identify header row (set default background color + width of its contents accounted different for auto column width)
+};
+
 // Flags for ImGui::IsWindowFocused()
 enum ImGuiFocusedFlags_
 {
@@ -957,6 +1073,14 @@ enum ImGuiDir_
     ImGuiDir_Up      = 2,
     ImGuiDir_Down    = 3,
     ImGuiDir_COUNT
+};
+
+// A sorting direction
+enum ImGuiSortDirection_
+{
+    ImGuiSortDirection_None         = 0,
+    ImGuiSortDirection_Ascending    = 1,    // Ascending = 0->9, A->Z etc.
+    ImGuiSortDirection_Descending   = 2     // Descending = 9->0, Z->A etc.
 };
 
 // User fill ImGuiIO.KeyMap[] array with indices into the ImGuiIO.KeysDown[512] array
@@ -1093,6 +1217,9 @@ enum ImGuiCol_
     ImGuiCol_PlotLinesHovered,
     ImGuiCol_PlotHistogram,
     ImGuiCol_PlotHistogramHovered,
+    ImGuiCol_TableHeaderBg,         // Table header background
+    ImGuiCol_TableRowBg,            // Table row background (even rows)
+    ImGuiCol_TableRowBgAlt,         // Table row background (odd rows)
     ImGuiCol_TextSelectedBg,
     ImGuiCol_DragDropTarget,
     ImGuiCol_NavHighlight,          // Gamepad/keyboard: current highlighted item
@@ -1129,6 +1256,7 @@ enum ImGuiStyleVar_
     ImGuiStyleVar_FrameBorderSize,     // float     FrameBorderSize
     ImGuiStyleVar_ItemSpacing,         // ImVec2    ItemSpacing
     ImGuiStyleVar_ItemInnerSpacing,    // ImVec2    ItemInnerSpacing
+    ImGuiStyleVar_CellPadding,         // ImVec2    CellPadding
     ImGuiStyleVar_IndentSpacing,       // float     IndentSpacing
     ImGuiStyleVar_ScrollbarSize,       // float     ScrollbarSize
     ImGuiStyleVar_ScrollbarRounding,   // float     ScrollbarRounding
@@ -1343,6 +1471,7 @@ struct ImGuiStyle
     float       FrameBorderSize;            // Thickness of border around frames. Generally set to 0.0f or 1.0f. (Other values are not well tested and more CPU/GPU costly).
     ImVec2      ItemSpacing;                // Horizontal and vertical spacing between widgets/lines.
     ImVec2      ItemInnerSpacing;           // Horizontal and vertical spacing between within elements of a composed widget (e.g. a slider and its label).
+    ImVec2      CellPadding;                // Padding within a table cell
     ImVec2      TouchExtraPadding;          // Expand reactive bounding box for touch-based system where touch position is not accurate enough. Unfortunately we don't sort widgets so priority on overlap will always be given to the first widget. So don't grow this too much!
     float       IndentSpacing;              // Horizontal indentation when e.g. entering a tree node. Generally == (FontSize + FramePadding.x*2).
     float       ColumnsMinSpacing;          // Minimum horizontal spacing between two columns. Preferably > (FramePadding.x + 1).
@@ -1574,6 +1703,30 @@ struct ImGuiPayload
     bool IsDataType(const char* type) const { return DataFrameCount != -1 && strcmp(type, DataType) == 0; }
     bool IsPreview() const                  { return Preview; }
     bool IsDelivery() const                 { return Delivery; }
+};
+
+// Sorting specification for one column of a table (sizeof == 8 bytes)
+struct ImGuiTableSortSpecsColumn
+{
+    ImGuiID         ColumnUserID;       // User id of the column (if specified by a TableSetupColumn() call)
+    ImU8            ColumnIndex;        // Index of the column
+    ImU8            SortOrder;          // Index within parent ImGuiTableSortSpecs (always stored in order starting from 0, tables sorted on a single criteria will always have a 0 here)
+    ImS8            SortSign;           // +1 or -1 (you can use this or SortDirection, whichever is more convenient for your sort function)
+    ImS8            SortDirection;      // ImGuiSortDirection_Ascending or ImGuiSortDirection_Descending (you can use this or SortSign, whichever is more convenient for your sort function)
+
+    ImGuiTableSortSpecsColumn() { ColumnUserID = 0; ColumnIndex = 0; SortOrder = 0; SortSign = +1; SortDirection = ImGuiSortDirection_Ascending; }
+};
+
+// Sorting specifications for a table (often handling sort specs for a single column, occasionally more)
+// Obtained by calling TableGetSortSpecs()
+struct ImGuiTableSortSpecs
+{
+    const ImGuiTableSortSpecsColumn* Specs;     // Pointer to sort spec array.
+    int                         SpecsCount;     // Sort spec count. Most often 1 unless e.g. ImGuiTableFlags_MultiSortable is enabled.
+    bool                        SpecsChanged;   // Set to true by TableGetSortSpecs() call if the specs have changed since the previous call.
+    ImU64                       ColumnsMask;    // Set to the mask of column indexes included in the Specs array. e.g. (1 << N) when column N is sorted.
+
+    ImGuiTableSortSpecs()       { Specs = NULL; SpecsCount = 0; SpecsChanged = false; ColumnsMask = 0x00; }
 };
 
 //-----------------------------------------------------------------------------

--- a/imgui.h
+++ b/imgui.h
@@ -938,11 +938,16 @@ enum ImGuiTableFlags_
     ImGuiTableFlags_NoSavedSettings                 = 1 << 5,   // Disable persisting columns order, width and sort settings in the .ini file.
     // Decoration
     ImGuiTableFlags_RowBg                           = 1 << 6,   // Use ImGuiCol_TableRowBg and ImGuiCol_TableRowBgAlt colors behind each rows.
-    ImGuiTableFlags_BordersOuter                    = 1 << 7,   // Draw outer borders.
-    ImGuiTableFlags_BordersV                        = 1 << 8,   // Draw vertical borders between columns.
-    ImGuiTableFlags_BordersH                        = 1 << 9,   // Draw horizontal borders between rows.
-    ImGuiTableFlags_BordersFullHeight               = 1 << 10,  // Borders covers all lines even when Headers are being used, allow resizing all rows.
-    ImGuiTableFlags_Borders                         = ImGuiTableFlags_BordersOuter | ImGuiTableFlags_BordersV | ImGuiTableFlags_BordersH,
+    ImGuiTableFlags_BordersHInner                   = 1 << 7,   // Draw horizontal borders between rows.
+    ImGuiTableFlags_BordersHOuter                   = 1 << 8,   // Draw horizontal borders at the top and bottom.
+    ImGuiTableFlags_BordersVInner                   = 1 << 9,   // Draw vertical borders between columns.
+    ImGuiTableFlags_BordersVOuter                   = 1 << 10,  // Draw vertical borders on the left and right sides.
+    ImGuiTableFlags_BordersH                        = ImGuiTableFlags_BordersHInner | ImGuiTableFlags_BordersHOuter, // Draw horizontal borders.
+    ImGuiTableFlags_BordersV                        = ImGuiTableFlags_BordersVInner | ImGuiTableFlags_BordersVOuter, // Draw vertical borders.
+    ImGuiTableFlags_BordersInner                    = ImGuiTableFlags_BordersVInner | ImGuiTableFlags_BordersHInner, // Draw inner borders.
+    ImGuiTableFlags_BordersOuter                    = ImGuiTableFlags_BordersVOuter | ImGuiTableFlags_BordersHOuter, // Draw outer borders.
+    ImGuiTableFlags_Borders                         = ImGuiTableFlags_BordersInner | ImGuiTableFlags_BordersOuter,   // Draw all borders.
+    ImGuiTableFlags_BordersVFullHeight              = 1 << 11,  // Borders covers all rows even when Headers are being used. Allow resizing from any rows.
     // Padding, Sizing
     ImGuiTableFlags_NoClipX                         = 1 << 12,  // Disable pushing clipping rectangle for every individual columns (reduce draw command count, items will be able to overflow)
     ImGuiTableFlags_SizingPolicyFixedX              = 1 << 13,  // Default if ScrollX is on. Columns will default to use WidthFixed or WidthAlwaysAutoResize policy. Read description above for more details.

--- a/imgui.h
+++ b/imgui.h
@@ -644,7 +644,7 @@ namespace ImGui
     // Tables: Sorting
     // - Call TableGetSortSpecs() to retrieve latest sort specs for the table. Return value will be NULL if no sorting.
     // - You can sort your data again when 'SpecsChanged == true'. It will be true with sorting specs have changed since last call, or the first time.
-    // - Don't hold on this structure over multiple frames.
+    // - Lifetime: don't hold on this pointer over multiple frames or past any subsequent call to BeginTable()!
     IMGUI_API const ImGuiTableSortSpecs* TableGetSortSpecs();           // get latest sort specs for the table (NULL if not sorting).
 
     // Tab Bars, Tabs

--- a/imgui.h
+++ b/imgui.h
@@ -643,7 +643,8 @@ namespace ImGui
     IMGUI_API void          TableHeader(const char* label);             // submit one header cell manually.
     // Tables: Sorting
     // - Call TableGetSortSpecs() to retrieve latest sort specs for the table. Return value will be NULL if no sorting.
-    // - Read ->SpecsChanged to tell if the specs have changed since last call.
+    // - You can sort your data again when 'SpecsChanged == true'. It will be true with sorting specs have changed since last call, or the first time.
+    // - Don't hold on this structure over multiple frames.
     IMGUI_API const ImGuiTableSortSpecs* TableGetSortSpecs();           // get latest sort specs for the table (NULL if not sorting).
 
     // Tab Bars, Tabs
@@ -1732,7 +1733,7 @@ struct ImGuiTableSortSpecs
 {
     const ImGuiTableSortSpecsColumn* Specs;     // Pointer to sort spec array.
     int                         SpecsCount;     // Sort spec count. Most often 1 unless e.g. ImGuiTableFlags_MultiSortable is enabled.
-    bool                        SpecsChanged;   // Set to true by TableGetSortSpecs() call if the specs have changed since the previous call.
+    bool                        SpecsChanged;   // Set to true by TableGetSortSpecs() call if the specs have changed since the previous call. Use this to sort again!
     ImU64                       ColumnsMask;    // Set to the mask of column indexes included in the Specs array. e.g. (1 << N) when column N is sorted.
 
     ImGuiTableSortSpecs()       { Specs = NULL; SpecsCount = 0; SpecsChanged = false; ColumnsMask = 0x00; }

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -2860,17 +2860,31 @@ static void ShowDemoWindowTables()
 
     if (open_action != -1)
         ImGui::SetNextItemOpen(open_action != 0);
-    if (ImGui::TreeNode("With borders, background"))
+    if (ImGui::TreeNode("Borders, background"))
     {
         // Expose a few Borders related flags interactively
         static ImGuiTableFlags flags = ImGuiTableFlags_BordersOuter | ImGuiTableFlags_RowBg;
         static bool display_width = false;
         ImGui::CheckboxFlags("ImGuiTableFlags_RowBg", (unsigned int*)&flags, ImGuiTableFlags_RowBg);
         ImGui::CheckboxFlags("ImGuiTableFlags_Borders", (unsigned int*)&flags, ImGuiTableFlags_Borders);
-        ImGui::SameLine(); HelpMarker("ImGuiTableFlags_Borders\n = ImGuiTableFlags_BordersOuter\n | ImGuiTableFlags_BordersV\n | ImGuiTableFlags_BordersH");
-        ImGui::CheckboxFlags("ImGuiTableFlags_BordersOuter", (unsigned int*)&flags, ImGuiTableFlags_BordersOuter);
-        ImGui::CheckboxFlags("ImGuiTableFlags_BordersV", (unsigned int*)&flags, ImGuiTableFlags_BordersV);
+        ImGui::SameLine(); HelpMarker("ImGuiTableFlags_Borders\n = ImGuiTableFlags_BordersVInner\n | ImGuiTableFlags_BordersVOuter\n | ImGuiTableFlags_BordersHInner\n | ImGuiTableFlags_BordersHOuter");
+        ImGui::Indent();
+
         ImGui::CheckboxFlags("ImGuiTableFlags_BordersH", (unsigned int*)&flags, ImGuiTableFlags_BordersH);
+        ImGui::Indent();
+        ImGui::CheckboxFlags("ImGuiTableFlags_BordersHOuter", (unsigned int*)&flags, ImGuiTableFlags_BordersHOuter);
+        ImGui::CheckboxFlags("ImGuiTableFlags_BordersHInner", (unsigned int*)&flags, ImGuiTableFlags_BordersHInner);
+        ImGui::Unindent();
+
+        ImGui::CheckboxFlags("ImGuiTableFlags_BordersV", (unsigned int*)&flags, ImGuiTableFlags_BordersV);
+        ImGui::Indent();
+        ImGui::CheckboxFlags("ImGuiTableFlags_BordersVOuter", (unsigned int*)&flags, ImGuiTableFlags_BordersVOuter);
+        ImGui::CheckboxFlags("ImGuiTableFlags_BordersVInner", (unsigned int*)&flags, ImGuiTableFlags_BordersVInner);
+        ImGui::Unindent();
+
+        ImGui::CheckboxFlags("ImGuiTableFlags_BordersOuter", (unsigned int*)&flags, ImGuiTableFlags_BordersOuter);
+        ImGui::CheckboxFlags("ImGuiTableFlags_BordersInner", (unsigned int*)&flags, ImGuiTableFlags_BordersInner);
+        ImGui::Unindent();
         ImGui::Checkbox("Debug Display width", &display_width);
 
         if (ImGui::BeginTable("##table1", 3, flags))
@@ -3177,7 +3191,7 @@ static void ShowDemoWindowTables()
     {
         HelpMarker("This demonstrate embedding a table into another table cell.");
         
-        if (ImGui::BeginTable("recurse1", 2, ImGuiTableFlags_Borders | ImGuiTableFlags_BordersFullHeight | ImGuiTableFlags_Resizable | ImGuiTableFlags_Reorderable))
+        if (ImGui::BeginTable("recurse1", 2, ImGuiTableFlags_Borders | ImGuiTableFlags_BordersVFullHeight | ImGuiTableFlags_Resizable | ImGuiTableFlags_Reorderable))
         {
             ImGui::TableSetupColumn("A0");
             ImGui::TableSetupColumn("A1");
@@ -3186,7 +3200,7 @@ static void ShowDemoWindowTables()
             ImGui::TableNextRow();  ImGui::Text("A0 Cell 0");
             {
                 float rows_height = ImGui::GetTextLineHeightWithSpacing() * 2;
-                if (ImGui::BeginTable("recurse2", 2, ImGuiTableFlags_Borders | ImGuiTableFlags_BordersFullHeight | ImGuiTableFlags_Resizable | ImGuiTableFlags_Reorderable))
+                if (ImGui::BeginTable("recurse2", 2, ImGuiTableFlags_Borders | ImGuiTableFlags_BordersVFullHeight | ImGuiTableFlags_Resizable | ImGuiTableFlags_Reorderable))
                 {
                     ImGui::TableSetupColumn("B0");
                     ImGui::TableSetupColumn("B1");
@@ -3218,13 +3232,15 @@ static void ShowDemoWindowTables()
     {
         HelpMarker("This section allows you to interact and see the effect of StretchX vs FixedX sizing policies depending on whether Scroll is enabled and the contents of your columns.");
         enum ContentsType { CT_ShortText, CT_LongText, CT_Button, CT_StretchButton, CT_InputText };
-        static int contents_type = CT_ShortText;
+        static int contents_type = CT_StretchButton;
         ImGui::SetNextItemWidth(ImGui::GetFontSize() * 12);
         ImGui::Combo("Contents", &contents_type, "Short Text\0Long Text\0Button\0Stretch Button\0InputText\0");
 
         static ImGuiTableFlags flags = ImGuiTableFlags_ScrollY | ImGuiTableFlags_BordersOuter | ImGuiTableFlags_RowBg;
-        ImGui::CheckboxFlags("ImGuiTableFlags_BordersH", (unsigned int*)&flags, ImGuiTableFlags_BordersH);
-        ImGui::CheckboxFlags("ImGuiTableFlags_BordersV", (unsigned int*)&flags, ImGuiTableFlags_BordersV);
+        ImGui::CheckboxFlags("ImGuiTableFlags_BordersHInner", (unsigned int*)&flags, ImGuiTableFlags_BordersHInner);
+        ImGui::CheckboxFlags("ImGuiTableFlags_BordersHOuter", (unsigned int*)&flags, ImGuiTableFlags_BordersHOuter);
+        ImGui::CheckboxFlags("ImGuiTableFlags_BordersVInner", (unsigned int*)&flags, ImGuiTableFlags_BordersVInner);
+        ImGui::CheckboxFlags("ImGuiTableFlags_BordersVOuter", (unsigned int*)&flags, ImGuiTableFlags_BordersVOuter);
         ImGui::CheckboxFlags("ImGuiTableFlags_ScrollX", (unsigned int*)&flags, ImGuiTableFlags_ScrollX);
         ImGui::CheckboxFlags("ImGuiTableFlags_ScrollY", (unsigned int*)&flags, ImGuiTableFlags_ScrollY);
         if (ImGui::CheckboxFlags("ImGuiTableFlags_SizingPolicyStretchX", (unsigned int*)&flags, ImGuiTableFlags_SizingPolicyStretchX))
@@ -3433,10 +3449,13 @@ static void ShowDemoWindowTables()
             ImGui::BulletText("Decoration:");
             ImGui::Indent();
             ImGui::CheckboxFlags("ImGuiTableFlags_RowBg", (unsigned int*)&flags, ImGuiTableFlags_RowBg);
-            ImGui::CheckboxFlags("ImGuiTableFlags_BordersOuter", (unsigned int*)&flags, ImGuiTableFlags_BordersOuter);
-            ImGui::CheckboxFlags("ImGuiTableFlags_BordersH", (unsigned int*)&flags, ImGuiTableFlags_BordersH);
             ImGui::CheckboxFlags("ImGuiTableFlags_BordersV", (unsigned int*)&flags, ImGuiTableFlags_BordersV);
-            ImGui::CheckboxFlags("ImGuiTableFlags_BordersFullHeight", (unsigned int*)&flags, ImGuiTableFlags_BordersFullHeight);
+            ImGui::CheckboxFlags("ImGuiTableFlags_BordersVOuter", (unsigned int*)&flags, ImGuiTableFlags_BordersVOuter);
+            ImGui::CheckboxFlags("ImGuiTableFlags_BordersVInner", (unsigned int*)&flags, ImGuiTableFlags_BordersVInner);
+            ImGui::CheckboxFlags("ImGuiTableFlags_BordersH", (unsigned int*)&flags, ImGuiTableFlags_BordersH);
+            ImGui::CheckboxFlags("ImGuiTableFlags_BordersHOuter", (unsigned int*)&flags, ImGuiTableFlags_BordersHOuter);
+            ImGui::CheckboxFlags("ImGuiTableFlags_BordersHInner", (unsigned int*)&flags, ImGuiTableFlags_BordersHInner);
+            ImGui::CheckboxFlags("ImGuiTableFlags_BordersVFullHeight", (unsigned int*)&flags, ImGuiTableFlags_BordersVFullHeight);
             ImGui::Unindent();
 
             ImGui::BulletText("Padding, Sizing:");

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -2794,10 +2794,12 @@ static void ShowDemoWindowTables()
     // About Styling of tables
     // Most settings are configured on a per-table basis via the flags passed to BeginTable() and TableSetupColumns APIs.
     // There are however a few settings that a shared and part of the ImGuiStyle structure:
-    //   style.CellPadding                      // Padding within each cell
-    //   style.Colors[ImGuiCol_TableHeaderBg]   // Table header background
-    //   style.Colors[ImGuiCol_TableRowBg]      // Table row background when ImGuiTableFlags_RowBg is enabled (even rows)
-    //   style.Colors[ImGuiCol_TableRowBgAlt]   // Table row background when ImGuiTableFlags_RowBg is enabled (odds rows)
+    //   style.CellPadding                          // Padding within each cell
+    //   style.Colors[ImGuiCol_TableHeaderBg]       // Table header background
+    //   style.Colors[ImGuiCol_TableBorderStrong]   // Table outer and header borders
+    //   style.Colors[ImGuiCol_TableBorderLight]    // Table inner borders
+    //   style.Colors[ImGuiCol_TableRowBg]          // Table row background when ImGuiTableFlags_RowBg is enabled (even rows)
+    //   style.Colors[ImGuiCol_TableRowBgAlt]       // Table row background when ImGuiTableFlags_RowBg is enabled (odds rows)
 
     // Demos
     if (open_action != -1)

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -445,7 +445,6 @@ void ImGui::ShowDemoWindow(bool* p_open)
     ShowDemoWindowLayout();
     ShowDemoWindowPopups();
     ShowDemoWindowTables();
-    ShowDemoWindowColumns();
     ShowDemoWindowMisc();
 
     // End of ShowDemoWindow()
@@ -2770,7 +2769,7 @@ const ImGuiTableSortSpecs* MyItem::s_current_sort_specs = NULL;
 static void ShowDemoWindowTables()
 {
     //ImGui::SetNextItemOpen(true, ImGuiCond_Once);
-    if (!ImGui::CollapsingHeader("Tables"))
+    if (!ImGui::CollapsingHeader("Tables & Columns"))
         return;
 
     ImGui::PushID("Tables");
@@ -3656,27 +3655,23 @@ static void ShowDemoWindowTables()
         ImGui::TreePop();
     }
 
+    ImGui::PopID();
+
+    ShowDemoWindowColumns();
+
     if (disable_indent)
         ImGui::PopStyleVar();
-    ImGui::PopID();
 }
 
-// 2020: Columns are under-featured and not maintained. Prefer using the more flexible and powerful Tables API!
+// Demonstrate old/legacy Columns API!
+// [2020: Columns are under-featured and not maintained. Prefer using the more flexible and powerful BeginTable() API!]
 static void ShowDemoWindowColumns()
 {
-    if (!ImGui::CollapsingHeader("Columns"))
-        return;
-
-    ImGui::PushID("Columns");
-
-    static bool disable_indent = false;
-    ImGui::Checkbox("Disable tree indentation", &disable_indent);
+    bool open = ImGui::TreeNode("Legacy Columns API");
     ImGui::SameLine();
-    HelpMarker("Disable the indenting of tree nodes so demo columns can use the full window width.");
-    if (disable_indent)
-        ImGui::PushStyleVar(ImGuiStyleVar_IndentSpacing, 0.0f);
-
-    ImGui::TextWrapped("Note: Columns are under-featured and not maintained. Prefer using the more flexible and powerful Tables API!");
+    HelpMarker("Columns() is an old API! Prefer using the more flexible and powerful BeginTable() API!");
+    if (!open)
+        return;
 
     // Basic columns
     if (ImGui::TreeNode("Basic"))
@@ -3886,9 +3881,7 @@ static void ShowDemoWindowColumns()
         ImGui::TreePop();
     }
 
-    if (disable_indent)
-        ImGui::PopStyleVar();
-    ImGui::PopID();
+    ImGui::TreePop();
 }
 
 static void ShowDemoWindowMisc()

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -3323,6 +3323,27 @@ static void ShowDemoWindowTables()
         ImGui::TreePop();
     }
 
+    if (open_action != -1)
+        ImGui::SetNextItemOpen(open_action != 0);
+    if (ImGui::TreeNode("Row height"))
+    {
+        HelpMarker("You can pass a 'min_row_height' to TableNextRow().\n\nRows are padded with 'style.CellPadding.y' on top and bottom, so effectively the minimum row height will always be >= 'style.CellPadding.y * 2.0f'.\n\nWe cannot honor a _maximum_ row height as that would requires a unique clipping rectangle per row.");
+        if (ImGui::BeginTable("##2ways", 2, ImGuiTableFlags_Borders))
+        {
+            float min_row_height = ImGui::GetFontSize() + ImGui::GetStyle().CellPadding.y * 2.0f;
+            ImGui::TableNextRow(ImGuiTableRowFlags_None, min_row_height);
+            ImGui::Text("min_row_height = %.2f", min_row_height);
+            for (int row = 0; row < 10; row++)
+            {
+                min_row_height = (float)(int)(ImGui::GetFontSize() * 0.30f * row);
+                ImGui::TableNextRow(ImGuiTableRowFlags_None, min_row_height);
+                ImGui::Text("min_row_height = %.2f", min_row_height);
+            }
+            ImGui::EndTable();
+        }
+        ImGui::TreePop();
+    }
+
     static const char* template_items_names[] =
     {
         "Banana", "Apple", "Cherry", "Watermelon", "Grapefruit", "Strawberry", "Mango",

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -3276,7 +3276,7 @@ static void ShowDemoWindowTables()
                     case CT_LongText:       ImGui::Text("Some longer text %d,%d\nOver two lines..", row, column); break;
                     case CT_Button:         ImGui::Button(label); break;
                     case CT_StretchButton:  ImGui::Button(label, ImVec2(-FLT_MIN, 0.0f)); break;
-                    case CT_InputText:      ImGui::SetNextItemWidth(-FLT_MIN); ImGui::InputText(label, text_buf, IM_ARRAYSIZE(text_buf)); break;
+                    case CT_InputText:      ImGui::SetNextItemWidth(-FLT_MIN); ImGui::InputText("##", text_buf, IM_ARRAYSIZE(text_buf)); break;
                     }
                 }
             }

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -3421,6 +3421,54 @@ static void ShowDemoWindowTables()
         ImGui::TreePop();
     }
 
+    // Demonstrate using TableHeader() calls instead of TableAutoHeaders()
+    // FIXME-TABLE: Currently this doesn't get us feature-parity with TableAutoHeaders(), e.g. missing context menu.  Tables API needs some work! 
+    if (open_action != -1)
+        ImGui::SetNextItemOpen(open_action != 0);
+    if (ImGui::TreeNode("Custom headers"))
+    {
+        const int COLUMNS_COUNT = 3;
+        if (ImGui::BeginTable("##table1", COLUMNS_COUNT, ImGuiTableFlags_Borders | ImGuiTableFlags_Reorderable))
+        {
+            ImGui::TableSetupColumn("Apricot");
+            ImGui::TableSetupColumn("Banana");
+            ImGui::TableSetupColumn("Cherry");
+
+            // Dummy entire-column selection storage
+            // FIXME: It would be nice to actually demonstrate full-featured selection using those checkbox.
+            static bool column_selected[3] = {};
+
+            // Instead of calling TableAutoHeaders() we'll submit custom headers ourselves
+            ImGui::TableNextRow(ImGuiTableRowFlags_Headers);
+            for (int column = 0; column < COLUMNS_COUNT; column++)
+            {
+                ImGui::TableSetColumnIndex(column);
+                const char* column_name = ImGui::TableGetColumnName(column); // Retrieve name passed to TableSetupColumn()
+                ImGui::PushID(column);
+                ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
+                ImGui::Checkbox("##checkall", &column_selected[column]);
+                ImGui::PopStyleVar();
+                ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
+                ImGui::TableHeader(column_name);
+                ImGui::PopID();
+            }
+
+            for (int row = 0; row < 5; row++)
+            {
+                ImGui::TableNextRow();
+                for (int column = 0; column < 3; column++)
+                {
+                    char buf[32];
+                    sprintf(buf, "Cell %d,%d", row, column);
+                    ImGui::TableSetColumnIndex(column);
+                    ImGui::Selectable(buf, column_selected[column]);
+                }
+            }
+            ImGui::EndTable();
+        }
+        ImGui::TreePop();
+    }
+
     static const char* template_items_names[] =
     {
         "Banana", "Apple", "Cherry", "Watermelon", "Grapefruit", "Strawberry", "Mango",

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -2746,10 +2746,10 @@ struct MyItem
             int delta = 0;
             switch (sort_spec->ColumnUserID)
             {
-            case MyItemColumnID_ID:             delta = (a->ID - b->ID);                break;
-            case MyItemColumnID_Name:           delta = (strcmp(a->Name, b->Name));     break;
-            case MyItemColumnID_Quantity:       delta = (a->Quantity - b->Quantity);    break;
-            case MyItemColumnID_Description:    delta = (strcmp(a->Name, b->Name));     break;
+            case MyItemColumnID_ID:             delta = (b->ID - a->ID);                break;
+            case MyItemColumnID_Name:           delta = (strcmp(b->Name, a->Name));     break;
+            case MyItemColumnID_Quantity:       delta = (b->Quantity - a->Quantity);    break;
+            case MyItemColumnID_Description:    delta = (strcmp(b->Name, a->Name));     break;
             default: IM_ASSERT(0); break;
             }
             if (delta < 0)
@@ -2760,7 +2760,7 @@ struct MyItem
 
         // qsort() is instable so always return a way to differenciate items.
         // Your own compare function may want to avoid fallback on implicit sort specs e.g. a Name compare if it wasn't already part of the sort specs.
-        return (a->ID - b->ID);
+        return (b->ID - a->ID);
     }
 };
 const ImGuiTableSortSpecs* MyItem::s_current_sort_specs = NULL;

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -3099,7 +3099,7 @@ static void ShowDemoWindowTables()
         ImGui::CheckboxFlags("ImGuiTableFlags_ScrollY", (unsigned int*)&flags, ImGuiTableFlags_ScrollY);
         ImGui::CheckboxFlags("ImGuiTableFlags_ScrollFreezeTopRow", (unsigned int*)&flags, ImGuiTableFlags_ScrollFreezeTopRow);
         ImGui::CheckboxFlags("ImGuiTableFlags_ScrollFreezeLeftColumn", (unsigned int*)&flags, ImGuiTableFlags_ScrollFreezeLeftColumn);
-        
+
         if (ImGui::BeginTable("##table1", 7, flags, size))
         {
             ImGui::TableSetupColumn("Line #", ImGuiTableColumnFlags_NoHide); // Make the first column not hideable to match our use of ImGuiTableFlags_ScrollFreezeLeftColumn

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -3142,14 +3142,14 @@ static void ShowDemoWindowTables()
         {
             for (int column = 0; column < column_count; column++)
             {
-                ImGui::TableNextCell();
                 // Make the UI compact because there are so many fields
+                ImGui::TableNextCell();
                 ImGuiStyle& style = ImGui::GetStyle();
                 ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(style.FramePadding.x, 2));
                 ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(style.ItemSpacing.x, 2));
                 ImGui::PushID(column);
                 ImGui::AlignTextToFramePadding(); // FIXME-TABLE: Workaround for wrong text baseline propagation
-                ImGui::Text("Column '%s'", column_names[column]);
+                ImGui::Text("Flags for '%s'", column_names[column]);
                 ImGui::CheckboxFlags("_NoResize", (unsigned int*)&column_flags[column], ImGuiTableColumnFlags_NoResize);
                 ImGui::CheckboxFlags("_NoClipX", (unsigned int*)&column_flags[column], ImGuiTableColumnFlags_NoClipX);
                 ImGui::CheckboxFlags("_NoHide", (unsigned int*)&column_flags[column], ImGuiTableColumnFlags_NoHide);
@@ -3361,8 +3361,8 @@ static void ShowDemoWindowTables()
         {
             // The first column will use the default _WidthStretch when ScrollX is Off and _WidthFixed when ScrollX is On
             ImGui::TableSetupColumn("Name", ImGuiTableColumnFlags_NoHide);
-            ImGui::TableSetupColumn("Size", ImGuiTableColumnFlags_WidthFixed, ImGui::GetFontSize() * 10);
-            ImGui::TableSetupColumn("Type", ImGuiTableColumnFlags_WidthFixed, ImGui::GetFontSize() * 20);
+            ImGui::TableSetupColumn("Size", ImGuiTableColumnFlags_WidthFixed, ImGui::GetFontSize() * 6);
+            ImGui::TableSetupColumn("Type", ImGuiTableColumnFlags_WidthFixed, ImGui::GetFontSize() * 10);
             ImGui::TableAutoHeaders();
 
             // Simple storage to output a dummy file-system.
@@ -3524,10 +3524,10 @@ static void ShowDemoWindowTables()
         static float inner_width_without_scroll = 0.0f; // Fill 
         static float inner_width_with_scroll = 0.0f; // Auto-extend
         static bool outer_size_enabled = true;
-        static bool lock_left_column_visibility = false;
+        static bool lock_first_column_visibility = false;
         static bool show_headers = true;
         static bool show_wrapped_text = false;
-        static ImGuiTextFilter filter;
+        //static ImGuiTextFilter filter;
         //ImGui::SetNextItemOpen(true, ImGuiCond_Once); // FIXME-TABLE: Enabling this results in initial clipped first pass on table which affects sizing
         if (ImGui::TreeNodeEx("Options"))
         {
@@ -3611,10 +3611,10 @@ static void ShowDemoWindowTables()
             ImGui::SameLine(); HelpMarker("Specify height of the Selectable item.");
             ImGui::DragInt("items_count", &items_count, 0.1f, 0, 5000);
             ImGui::Combo("contents_type (first column)", &contents_type, contents_type_names, IM_ARRAYSIZE(contents_type_names));
-            filter.Draw("filter");
+            //filter.Draw("filter");
             ImGui::Checkbox("show_headers", &show_headers);
             ImGui::Checkbox("show_wrapped_text", &show_wrapped_text);
-            ImGui::Checkbox("lock_left_column_visibility", &lock_left_column_visibility);
+            ImGui::Checkbox("lock_first_column_visibility", &lock_first_column_visibility);
             ImGui::Unindent();
 
             ImGui::PopItemWidth();
@@ -3649,7 +3649,7 @@ static void ShowDemoWindowTables()
             // Declare columns
             // We use the "user_id" parameter of TableSetupColumn() to specify a user id that will be stored in the sort specifications.
             // This is so our sort function can identify a column given our own identifier. We could also identify them based on their index!
-            ImGui::TableSetupColumn("ID",          ImGuiTableColumnFlags_DefaultSort | ImGuiTableColumnFlags_WidthFixed | (lock_left_column_visibility ? ImGuiTableColumnFlags_NoHide : 0), -1.0f, MyItemColumnID_ID);
+            ImGui::TableSetupColumn("ID",          ImGuiTableColumnFlags_DefaultSort | ImGuiTableColumnFlags_WidthFixed | (lock_first_column_visibility ? ImGuiTableColumnFlags_NoHide : 0), -1.0f, MyItemColumnID_ID);
             ImGui::TableSetupColumn("Name",        ImGuiTableColumnFlags_WidthFixed, -1.0f, MyItemColumnID_Name);
             ImGui::TableSetupColumn("Action",      ImGuiTableColumnFlags_NoSort | ImGuiTableColumnFlags_WidthFixed, -1.0f, MyItemColumnID_Action);
             ImGui::TableSetupColumn("Quantity Long Label", ImGuiTableColumnFlags_PreferSortDescending | ImGuiTableColumnFlags_WidthStretch, 1.0f, MyItemColumnID_Quantity);// , ImGuiTableColumnFlags_None | ImGuiTableColumnFlags_WidthAlwaysAutoResize);
@@ -3690,8 +3690,8 @@ static void ShowDemoWindowTables()
 #endif
                 {
                     MyItem* item = &items[row_n];
-                    if (!filter.PassFilter(item->Name))
-                        continue;
+                    //if (!filter.PassFilter(item->Name))
+                    //    continue;
 
                     const bool item_is_selected = selection.contains(item->ID);
                     ImGui::PushID(item->ID);

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -3100,7 +3100,9 @@ static void ShowDemoWindowTables()
                 ImGui::TableNextRow();
                 for (int column = 0; column < 7; column++)
                 {
-                    ImGui::TableSetColumnIndex(column);
+                    // Both TableNextCell() and TableSetColumnIndex() return false when a column is not visible, which can be used for clipping.
+                    if (!ImGui::TableSetColumnIndex(column))
+                        continue;
                     if (column == 0)
                         ImGui::Text("Line %d", row);
                     else

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -120,6 +120,15 @@ Index of this file:
 #define vsnprintf   _vsnprintf
 #endif
 
+// Enforce cdecl calling convention for functions called by the standard library, in case compilation settings changed the default to e.g. __vectorcall
+#ifndef IMGUI_CDECL
+#ifdef _MSC_VER
+#define IMGUI_CDECL __cdecl
+#else
+#define IMGUI_CDECL
+#endif
+#endif
+
 //-----------------------------------------------------------------------------
 // [SECTION] Forward Declarations, Helpers
 //-----------------------------------------------------------------------------
@@ -192,6 +201,7 @@ void ImGui::ShowUserGuide()
 // - ShowDemoWindowWidgets()
 // - ShowDemoWindowLayout()
 // - ShowDemoWindowPopups()
+// - ShowDemoWindowTables()
 // - ShowDemoWindowColumns()
 // - ShowDemoWindowMisc()
 //-----------------------------------------------------------------------------
@@ -200,6 +210,7 @@ void ImGui::ShowUserGuide()
 static void ShowDemoWindowWidgets();
 static void ShowDemoWindowLayout();
 static void ShowDemoWindowPopups();
+static void ShowDemoWindowTables();
 static void ShowDemoWindowColumns();
 static void ShowDemoWindowMisc();
 
@@ -433,6 +444,7 @@ void ImGui::ShowDemoWindow(bool* p_open)
     ShowDemoWindowWidgets();
     ShowDemoWindowLayout();
     ShowDemoWindowPopups();
+    ShowDemoWindowTables();
     ShowDemoWindowColumns();
     ShowDemoWindowMisc();
 
@@ -2692,6 +2704,962 @@ static void ShowDemoWindowPopups()
     }
 }
 
+// Dummy data structure that we use for the Table demo.
+// (pre-C++11 doesn't allow us to instantiate ImVector<MyItem> template if this structure if defined inside the demo function)
+namespace
+{
+// We are passing our own identifier to TableSetupColumn() to facilitate identifying columns in the sorting code.
+// This identifier will be passed down into ImGuiTableSortSpec::ColumnUserID.
+// But it is possible to omit the user id parameter of TableSetupColumn() and just use the column index instead! (ImGuiTableSortSpec::ColumnIndex)
+// If you don't use sorting, you will generally never care about giving column an ID!
+enum MyItemColumnID
+{
+    MyItemColumnID_ID,
+    MyItemColumnID_Name,
+    MyItemColumnID_Action,
+    MyItemColumnID_Quantity,
+    MyItemColumnID_Description
+};
+
+struct MyItem
+{
+    int         ID;
+    const char* Name;
+    int         Quantity;
+
+    // We have a problem which is affecting _only this demo_ and should not affect your code:
+    // As we don't rely on std:: or other third-party library to compile dear imgui, we only have reliable access to qsort(), 
+    // however qsort doesn't allow passing user data to comparing function.
+    // As a workaround, we are storing the sort specs in a static/global for the comparing function to access.
+    // In your own use case you would probably pass the sort specs to your sorting/comparing functions directly and not use a global.
+    static const ImGuiTableSortSpecs* s_current_sort_specs;
+
+    // Compare function to be used by qsort()
+    static int IMGUI_CDECL CompareWithSortSpecs(const void* lhs, const void* rhs)
+    {
+        const MyItem* a = (const MyItem*)lhs;
+        const MyItem* b = (const MyItem*)rhs;
+        for (int n = 0; n < s_current_sort_specs->SpecsCount; n++)
+        {
+            // Here we identify columns using the ColumnUserID value that we ourselves passed to TableSetupColumn()
+            // We could also choose to identify columns based on their index (sort_spec->ColumnIndex), which is simpler!
+            const ImGuiTableSortSpecsColumn* sort_spec = &s_current_sort_specs->Specs[n];
+            int delta = 0;
+            switch (sort_spec->ColumnUserID)
+            {
+            case MyItemColumnID_ID:             delta = (a->ID - b->ID);                break;
+            case MyItemColumnID_Name:           delta = (strcmp(a->Name, b->Name));     break;
+            case MyItemColumnID_Quantity:       delta = (a->Quantity - b->Quantity);    break;
+            case MyItemColumnID_Description:    delta = (strcmp(a->Name, b->Name));     break;
+            default: IM_ASSERT(0); break;
+            }
+            if (delta < 0)
+                return -1 * sort_spec->SortSign;
+            if (delta > 0)
+                return +1 * sort_spec->SortSign;
+        }
+
+        // qsort() is instable so always return a way to differenciate items.
+        // Your own compare function may want to avoid fallback on implicit sort specs e.g. a Name compare if it wasn't already part of the sort specs.
+        return (a->ID - b->ID);
+    }
+};
+const ImGuiTableSortSpecs* MyItem::s_current_sort_specs = NULL;
+}
+
+static void ShowDemoWindowTables()
+{
+    //ImGui::SetNextItemOpen(true, ImGuiCond_Once);
+    if (!ImGui::CollapsingHeader("Tables"))
+        return;
+
+    ImGui::PushID("Tables");
+
+    int open_action = -1;
+    if (ImGui::Button("Open all"))
+        open_action = 1;
+    ImGui::SameLine();
+    if (ImGui::Button("Close all"))
+        open_action = 0;
+    ImGui::SameLine();
+
+    // Options
+    static bool disable_indent = false;
+    ImGui::Checkbox("Disable tree indentation", &disable_indent);
+    ImGui::SameLine();
+    HelpMarker("Disable the indenting of tree nodes so demo tables can use the full window width.");
+    ImGui::Separator();
+    if (disable_indent)
+        ImGui::PushStyleVar(ImGuiStyleVar_IndentSpacing, 0.0f);
+
+    // About Styling of tables
+    // Most settings are configured on a per-table basis via the flags passed to BeginTable() and TableSetupColumns APIs.
+    // There are however a few settings that a shared and part of the ImGuiStyle structure:
+    //   style.CellPadding                      // Padding within each cell
+    //   style.Colors[ImGuiCol_TableHeaderBg]   // Table header background
+    //   style.Colors[ImGuiCol_TableRowBg]      // Table row background when ImGuiTableFlags_RowBg is enabled (even rows)
+    //   style.Colors[ImGuiCol_TableRowBgAlt]   // Table row background when ImGuiTableFlags_RowBg is enabled (odds rows)
+
+    // Demos
+    if (open_action != -1)
+        ImGui::SetNextItemOpen(open_action != 0);
+    if (ImGui::TreeNode("Basic"))
+    {
+        // Here we will showcase 4 different ways to output a table. They are very simple variations of a same thing!
+        
+        // Basic use of tables using TableNextRow() to create a new row, and TableSetColumnIndex() to select the column.
+        // In many situations, this is the most flexible and easy to use pattern. 
+        HelpMarker("Using TableNextRow() + calling TableSetColumnIndex() _before_ each cell, in a loop.");
+        if (ImGui::BeginTable("##table1", 3))
+        {
+            for (int row = 0; row < 4; row++)
+            {
+                ImGui::TableNextRow();
+                for (int column = 0; column < 3; column++)
+                {
+                    ImGui::TableSetColumnIndex(column);
+                    ImGui::Text("Row %d Column %d", row, column);
+                }
+            }
+            ImGui::EndTable();
+        }
+
+        // This essentially the same as above, except instead of using a for loop we call TableSetColumnIndex() manually.
+        // Sometimes this makes more sense.
+        HelpMarker("Using TableNextRow() + calling TableSetColumnIndex() _before_ each cell, manually.");
+        if (ImGui::BeginTable("##table2", 3))
+        {
+            for (int row = 0; row < 4; row++)
+            {
+                ImGui::TableNextRow();
+                ImGui::TableSetColumnIndex(0);
+                ImGui::Text("Row %d", row);
+                ImGui::TableSetColumnIndex(1);
+                ImGui::Text("Some contents");
+                ImGui::TableSetColumnIndex(2);
+                ImGui::Text("123.456");
+            }
+            ImGui::EndTable();
+        }
+
+        // Another subtle variant, we call TableNextCell() _before_ each cell. At the end of a row, TableNextCell() will create a new row.
+        // Note that we don't call TableNextRow() here! 
+        // If we want to call TableNextRow(), then we don't need to call TableNextCell() for the first cell.
+        HelpMarker("Only using TableNextCell(), which tends to be convenient for tables where every cells contains the same type of contents.\nThis is also more similar to the old NextColumn() function of the Columns API, and provided to facilitate the Columns->Tables API transition.");
+        if (ImGui::BeginTable("##table4", 3))
+        {
+            for (int item = 0; item < 14; item++)
+            {
+                ImGui::TableNextCell();
+                ImGui::Text("Item %d", item);
+            }
+            ImGui::EndTable();
+        }
+
+        ImGui::TreePop();
+    }
+
+    if (open_action != -1)
+        ImGui::SetNextItemOpen(open_action != 0);
+    if (ImGui::TreeNode("With borders, background"))
+    {
+        // Expose a few Borders related flags interactively
+        static ImGuiTableFlags flags = ImGuiTableFlags_BordersOuter | ImGuiTableFlags_RowBg;
+        static bool display_width = false;
+        ImGui::CheckboxFlags("ImGuiTableFlags_RowBg", (unsigned int*)&flags, ImGuiTableFlags_RowBg);
+        ImGui::CheckboxFlags("ImGuiTableFlags_Borders", (unsigned int*)&flags, ImGuiTableFlags_Borders);
+        ImGui::SameLine(); HelpMarker("ImGuiTableFlags_Borders\n = ImGuiTableFlags_BordersOuter\n | ImGuiTableFlags_BordersV\n | ImGuiTableFlags_BordersH");
+        ImGui::CheckboxFlags("ImGuiTableFlags_BordersOuter", (unsigned int*)&flags, ImGuiTableFlags_BordersOuter);
+        ImGui::CheckboxFlags("ImGuiTableFlags_BordersV", (unsigned int*)&flags, ImGuiTableFlags_BordersV);
+        ImGui::CheckboxFlags("ImGuiTableFlags_BordersH", (unsigned int*)&flags, ImGuiTableFlags_BordersH);
+        ImGui::Checkbox("Debug Display width", &display_width);
+
+        if (ImGui::BeginTable("##table1", 3, flags))
+        {
+            for (int row = 0; row < 5; row++)
+            {
+                ImGui::TableNextRow();
+                for (int column = 0; column < 3; column++)
+                {
+                    ImGui::TableSetColumnIndex(column);
+                    if (display_width)
+                    {
+                        ImVec2 p = ImGui::GetCursorScreenPos();
+                        ImDrawList* draw_list = ImGui::GetWindowDrawList();
+                        float x1 = p.x;
+                        float x2 = ImGui::GetWindowPos().x + ImGui::GetContentRegionMax().x;
+                        float x3 = draw_list->GetClipRectMax().x;
+                        float y2 = p.y + ImGui::GetTextLineHeight();
+                        draw_list->AddLine(ImVec2(x1, y2), ImVec2(x3, y2), IM_COL32(255, 255, 0, 255)); // Hard clipping limit
+                        draw_list->AddLine(ImVec2(x1, y2), ImVec2(x2, y2), IM_COL32(255, 0, 0, 255));   // Normal limit
+                        ImGui::Text("w=%.2f", x2 - x1);
+                    }
+                    else
+                    {
+                        ImGui::Text("Hello %d,%d", row, column);
+                    }
+                }
+            }
+            ImGui::EndTable();
+        }
+        ImGui::TreePop();
+    }
+
+    if (open_action != -1)
+        ImGui::SetNextItemOpen(open_action != 0);
+    if (ImGui::TreeNode("Resizable, stretch"))
+    {
+        // By default, if we don't enable ScrollX the sizing policy for each columns is "Stretch"
+        // Each columns maintain a sizing weight, and they will occupy all available width.
+        static ImGuiTableFlags flags = ImGuiTableFlags_Resizable | ImGuiTableFlags_BordersOuter | ImGuiTableFlags_BordersV;
+        ImGui::CheckboxFlags("ImGuiTableFlags_Resizable", (unsigned int*)&flags, ImGuiTableFlags_Resizable);
+        ImGui::CheckboxFlags("ImGuiTableFlags_BordersV", (unsigned int*)&flags, ImGuiTableFlags_BordersV);
+        ImGui::SameLine(); HelpMarker("Using the _Resizable flag automatically enables the _BordersV flag as well.");
+        
+        if (ImGui::BeginTable("##table1", 3, flags))
+        {
+            for (int row = 0; row < 5; row++)
+            {
+                ImGui::TableNextRow();
+                for (int column = 0; column < 3; column++)
+                {
+                    ImGui::TableSetColumnIndex(column);
+                    ImGui::Text("Hello %d,%d", row, column);
+                }
+            }
+            ImGui::EndTable();
+        }
+        ImGui::TreePop();
+    }
+
+    if (open_action != -1)
+        ImGui::SetNextItemOpen(open_action != 0);
+    if (ImGui::TreeNode("Resizable, fixed"))
+    {
+        // Here we use ImGuiTableFlags_SizingPolicyFixedX (even though _ScrollX is not set)
+        // So columns will adopt the "Fixed" policy and will maintain a fixed weight regardless of the whole available width.
+        // If there is not enough available width to fit all columns, they will however be resized down.
+        // FIXME-TABLE: Providing a stretch-on-init would make sense especially for tables which don't have saved settings
+        HelpMarker("Using _Resizable + _SizingPolicyFixedX flags.\nFixed-width columns generally makes more sense if you want to use horizontal scrolling.");
+        static ImGuiTableFlags flags = ImGuiTableFlags_Resizable | ImGuiTableFlags_SizingPolicyFixedX | ImGuiTableFlags_BordersOuter | ImGuiTableFlags_BordersV;
+        //ImGui::CheckboxFlags("ImGuiTableFlags_ScrollX", (unsigned int*)&flags, ImGuiTableFlags_ScrollX); // FIXME-TABLE: Explain or fix the effect of enable Scroll on outer_size
+        if (ImGui::BeginTable("##table1", 3, flags))
+        {
+            for (int row = 0; row < 5; row++)
+            {
+                ImGui::TableNextRow();
+                for (int column = 0; column < 3; column++)
+                {
+                    ImGui::TableSetColumnIndex(column);
+                    ImGui::Text("Hello %d,%d", row, column);
+                }
+            }
+            ImGui::EndTable();
+        }
+        ImGui::TreePop();
+    }
+
+    if (open_action != -1)
+        ImGui::SetNextItemOpen(open_action != 0);
+    if (ImGui::TreeNode("Resizable, mixed"))
+    {
+        HelpMarker("Using columns flag to alter resizing policy on a per-column basis.");
+        static ImGuiTableFlags flags = ImGuiTableFlags_SizingPolicyFixedX | ImGuiTableFlags_RowBg | ImGuiTableFlags_Borders | ImGuiTableFlags_Resizable | ImGuiTableFlags_Reorderable | ImGuiTableFlags_Hideable;
+        //ImGui::CheckboxFlags("ImGuiTableFlags_ScrollX", (unsigned int*)&flags, ImGuiTableFlags_ScrollX); // FIXME-TABLE: Explain or fix the effect of enable Scroll on outer_size
+
+        if (ImGui::BeginTable("##table1", 3, flags, ImVec2(0, ImGui::GetTextLineHeightWithSpacing() * 6)))
+        {
+            ImGui::TableSetupColumn("AAA", ImGuiTableColumnFlags_WidthFixed);// | ImGuiTableColumnFlags_NoResize);
+            ImGui::TableSetupColumn("BBB", ImGuiTableColumnFlags_WidthFixed);
+            ImGui::TableSetupColumn("CCC", ImGuiTableColumnFlags_WidthStretch);
+            ImGui::TableAutoHeaders();
+            for (int row = 0; row < 5; row++)
+            {
+                ImGui::TableNextRow();
+                for (int column = 0; column < 3; column++)
+                {
+                    ImGui::TableSetColumnIndex(column);
+                    ImGui::Text("%s %d,%d", (column == 2) ? "Stretch" : "Fixed", row, column);
+                }
+            }
+            ImGui::EndTable();
+        }
+        if (ImGui::BeginTable("##table2", 6, flags, ImVec2(0, ImGui::GetTextLineHeightWithSpacing() * 6)))
+        {
+            ImGui::TableSetupColumn("AAA", ImGuiTableColumnFlags_WidthFixed);
+            ImGui::TableSetupColumn("BBB", ImGuiTableColumnFlags_WidthFixed);
+            ImGui::TableSetupColumn("CCC", ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_DefaultHide);
+            ImGui::TableSetupColumn("DDD", ImGuiTableColumnFlags_WidthStretch);
+            ImGui::TableSetupColumn("EEE", ImGuiTableColumnFlags_WidthStretch);
+            ImGui::TableSetupColumn("FFF", ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_DefaultHide);
+            ImGui::TableAutoHeaders();
+            for (int row = 0; row < 5; row++)
+            {
+                ImGui::TableNextRow();
+                for (int column = 0; column < 6; column++)
+                {
+                    ImGui::TableSetColumnIndex(column);
+                    ImGui::Text("%s %d,%d", (column >= 3) ? "Stretch" : "Fixed", row, column);
+                }
+            }
+            ImGui::EndTable();
+        }
+        ImGui::TreePop();
+    }
+
+    if (open_action != -1)
+        ImGui::SetNextItemOpen(open_action != 0);
+    if (ImGui::TreeNode("Reorderable, hideable, with headers"))
+    {
+        HelpMarker("Click and drag column headers to reorder columns.\n\nYou can also right-click on a header to open a context menu.");
+        static ImGuiTableFlags flags = ImGuiTableFlags_Resizable | ImGuiTableFlags_Reorderable | ImGuiTableFlags_Hideable | ImGuiTableFlags_BordersOuter | ImGuiTableFlags_BordersV;
+        ImGui::CheckboxFlags("ImGuiTableFlags_Resizable", (unsigned int*)&flags, ImGuiTableFlags_Resizable);
+        ImGui::CheckboxFlags("ImGuiTableFlags_Reorderable", (unsigned int*)&flags, ImGuiTableFlags_Reorderable);
+        ImGui::CheckboxFlags("ImGuiTableFlags_Hideable", (unsigned int*)&flags, ImGuiTableFlags_Hideable);
+        
+        if (ImGui::BeginTable("##table1", 3, flags))
+        {
+            // Submit columns name with TableSetupColumn() and call TableAutoHeaders() to create a row with a header in each column.
+            // (Later we will show how TableSetupColumn() has other uses, optional flags, sizing weight etc.)
+            ImGui::TableSetupColumn("One");
+            ImGui::TableSetupColumn("Two");
+            ImGui::TableSetupColumn("Three");
+            ImGui::TableAutoHeaders();
+            for (int row = 0; row < 6; row++)
+            {
+                ImGui::TableNextRow();
+                for (int column = 0; column < 3; column++)
+                {
+                    ImGui::TableSetColumnIndex(column);
+                    ImGui::Text("Hello %d,%d", row, column);
+                }
+            }
+            ImGui::EndTable();
+        }
+        ImGui::TreePop();
+    }
+
+    if (open_action != -1)
+        ImGui::SetNextItemOpen(open_action != 0);
+    if (ImGui::TreeNode("Vertical scrolling, with clipping"))
+    {
+        HelpMarker("Here we activate ScrollY, which will create a child window container to allow hosting scrollable contents.\n\nWe also demonstrate using ImGuiListClipper to virtualize the submission of many items.");
+        ImVec2 size = ImVec2(0, ImGui::GetTextLineHeightWithSpacing() * 7);
+        static ImGuiTableFlags flags = ImGuiTableFlags_ScrollY | ImGuiTableFlags_ScrollFreezeTopRow | ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersOuter | ImGuiTableFlags_BordersV | ImGuiTableFlags_Resizable | ImGuiTableFlags_Reorderable | ImGuiTableFlags_Hideable;
+        ImGui::CheckboxFlags("ImGuiTableFlags_ScrollY", (unsigned int*)&flags, ImGuiTableFlags_ScrollY);
+        ImGui::CheckboxFlags("ImGuiTableFlags_ScrollFreezeTopRow", (unsigned int*)&flags, ImGuiTableFlags_ScrollFreezeTopRow);
+        
+        if (ImGui::BeginTable("##table1", 3, flags, size))
+        {
+            ImGui::TableSetupColumn("One", ImGuiTableColumnFlags_None);
+            ImGui::TableSetupColumn("Two", ImGuiTableColumnFlags_None);
+            ImGui::TableSetupColumn("Three", ImGuiTableColumnFlags_None);
+            ImGui::TableAutoHeaders();
+            ImGuiListClipper clipper;
+            clipper.Begin(1000);
+            while (clipper.Step())
+            {
+                for (int row = clipper.DisplayStart; row < clipper.DisplayEnd; row++)
+                {
+                    ImGui::TableNextRow();
+                    for (int column = 0; column < 3; column++)
+                    {
+                        ImGui::TableSetColumnIndex(column);
+                        ImGui::Text("Hello %d,%d", row, column);
+                    }
+                }
+            }
+            ImGui::EndTable();
+        }
+        ImGui::TreePop();
+    }
+
+    if (open_action != -1)
+        ImGui::SetNextItemOpen(open_action != 0);
+    if (ImGui::TreeNode("Horizontal scrolling"))
+    {
+        HelpMarker("When ScrollX is enabled, the default sizing policy becomes ImGuiTableFlags_SizingPolicyFixedX, as automatically stretching columns doesn't make much sense with horizontal scrolling.\n\nAlso note that as of the current version, you will almost always want to enable ScrollY along with ScrollX, because the container window won't automatically extend vertically to fix contents (this may be improved in future versions).");
+        ImVec2 size = ImVec2(0, ImGui::GetTextLineHeightWithSpacing() * 10);
+        static ImGuiTableFlags flags = ImGuiTableFlags_ScrollX | ImGuiTableFlags_ScrollY | ImGuiTableFlags_ScrollFreezeTopRow | ImGuiTableFlags_ScrollFreezeLeftColumn | ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersOuter | ImGuiTableFlags_BordersV | ImGuiTableFlags_Resizable | ImGuiTableFlags_Reorderable | ImGuiTableFlags_Hideable;
+        ImGui::CheckboxFlags("ImGuiTableFlags_ScrollY", (unsigned int*)&flags, ImGuiTableFlags_ScrollY);
+        ImGui::CheckboxFlags("ImGuiTableFlags_ScrollFreezeTopRow", (unsigned int*)&flags, ImGuiTableFlags_ScrollFreezeTopRow);
+        ImGui::CheckboxFlags("ImGuiTableFlags_ScrollFreezeLeftColumn", (unsigned int*)&flags, ImGuiTableFlags_ScrollFreezeLeftColumn);
+        
+        if (ImGui::BeginTable("##table1", 7, flags, size))
+        {
+            ImGui::TableSetupColumn("Line #", ImGuiTableColumnFlags_NoHide); // Make the first column not hideable to match our use of ImGuiTableFlags_ScrollFreezeLeftColumn
+            ImGui::TableSetupColumn("One", ImGuiTableColumnFlags_None);
+            ImGui::TableSetupColumn("Two", ImGuiTableColumnFlags_None);
+            ImGui::TableSetupColumn("Three", ImGuiTableColumnFlags_None);
+            ImGui::TableSetupColumn("Four", ImGuiTableColumnFlags_None);
+            ImGui::TableSetupColumn("Five", ImGuiTableColumnFlags_None);
+            ImGui::TableSetupColumn("Six", ImGuiTableColumnFlags_None);
+            ImGui::TableAutoHeaders();
+            for (int row = 0; row < 20; row++)
+            {
+                ImGui::TableNextRow();
+                for (int column = 0; column < 7; column++)
+                {
+                    ImGui::TableSetColumnIndex(column);
+                    if (column == 0)
+                        ImGui::Text("Line %d", row);
+                    else
+                        ImGui::Text("Hello world %d,%d", row, column);
+                }
+            }
+            ImGui::EndTable();
+        }
+        ImGui::TreePop();
+    }
+
+    if (open_action != -1)
+        ImGui::SetNextItemOpen(open_action != 0);
+    if (ImGui::TreeNode("Columns flags"))
+    {
+        // Create a first table just to show all the options/flags we want to make visible in our example!
+        const int column_count = 3;
+        const char* column_names[column_count] = { "One", "Two", "Three" };
+        static ImGuiTableColumnFlags column_flags[column_count] = { ImGuiTableColumnFlags_DefaultSort, ImGuiTableColumnFlags_None, ImGuiTableColumnFlags_DefaultHide };
+
+        if (ImGui::BeginTable("##flags", column_count, ImGuiTableFlags_None))
+        {
+            for (int column = 0; column < column_count; column++)
+            {
+                ImGui::TableNextCell();
+                // Make the UI compact because there are so many fields
+                ImGuiStyle& style = ImGui::GetStyle();
+                ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(style.FramePadding.x, 2));
+                ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(style.ItemSpacing.x, 2));
+                ImGui::PushID(column);
+                ImGui::AlignTextToFramePadding(); // FIXME-TABLE: Workaround for wrong text baseline propagation
+                ImGui::Text("Column '%s'", column_names[column]);
+                ImGui::CheckboxFlags("_NoResize", (unsigned int*)&column_flags[column], ImGuiTableColumnFlags_NoResize);
+                ImGui::CheckboxFlags("_NoClipX", (unsigned int*)&column_flags[column], ImGuiTableColumnFlags_NoClipX);
+                ImGui::CheckboxFlags("_NoHide", (unsigned int*)&column_flags[column], ImGuiTableColumnFlags_NoHide);
+                ImGui::CheckboxFlags("_DefaultSort", (unsigned int*)&column_flags[column], ImGuiTableColumnFlags_DefaultSort);
+                ImGui::CheckboxFlags("_DefaultHide", (unsigned int*)&column_flags[column], ImGuiTableColumnFlags_DefaultHide);
+                ImGui::CheckboxFlags("_NoSort", (unsigned int*)&column_flags[column], ImGuiTableColumnFlags_NoSort);
+                ImGui::CheckboxFlags("_NoSortAscending", (unsigned int*)&column_flags[column], ImGuiTableColumnFlags_NoSortAscending);
+                ImGui::CheckboxFlags("_NoSortDescending", (unsigned int*)&column_flags[column], ImGuiTableColumnFlags_NoSortDescending);
+                ImGui::CheckboxFlags("_PreferSortAscending", (unsigned int*)&column_flags[column], ImGuiTableColumnFlags_PreferSortAscending);
+                ImGui::CheckboxFlags("_PreferSortDescending", (unsigned int*)&column_flags[column], ImGuiTableColumnFlags_PreferSortDescending);
+                ImGui::PopID();
+                ImGui::PopStyleVar(2);
+            }
+            ImGui::EndTable();
+        }
+
+        // Create the real table we care about for the example!
+        const ImGuiTableFlags flags = ImGuiTableFlags_SizingPolicyFixedX | ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersOuter | ImGuiTableFlags_BordersV | ImGuiTableFlags_Resizable | ImGuiTableFlags_Reorderable | ImGuiTableFlags_Hideable | ImGuiTableFlags_Sortable;
+        if (ImGui::BeginTable("##table1", column_count, flags))
+        {
+            for (int column = 0; column < column_count; column++)
+                ImGui::TableSetupColumn(column_names[column], column_flags[column]);
+            ImGui::TableAutoHeaders();
+            for (int row = 0; row < 8; row++)
+            {
+                ImGui::TableNextRow();
+                for (int column = 0; column < column_count; column++)
+                {
+                    ImGui::TableSetColumnIndex(column);
+                    ImGui::Text("Hello %s", ImGui::TableGetColumnName(column));
+                }
+            }
+            ImGui::EndTable();
+        }
+        ImGui::TreePop();
+    }
+
+    if (open_action != -1)
+        ImGui::SetNextItemOpen(open_action != 0);
+    if (ImGui::TreeNode("Recursive"))
+    {
+        HelpMarker("This demonstrate embedding a table into another table cell.");
+        
+        if (ImGui::BeginTable("recurse1", 2, ImGuiTableFlags_Borders | ImGuiTableFlags_BordersFullHeight | ImGuiTableFlags_Resizable | ImGuiTableFlags_Reorderable))
+        {
+            ImGui::TableSetupColumn("A0");
+            ImGui::TableSetupColumn("A1");
+            ImGui::TableAutoHeaders();
+
+            ImGui::TableNextRow();  ImGui::Text("A0 Cell 0");
+            {
+                float rows_height = ImGui::GetTextLineHeightWithSpacing() * 2;
+                if (ImGui::BeginTable("recurse2", 2, ImGuiTableFlags_Borders | ImGuiTableFlags_BordersFullHeight | ImGuiTableFlags_Resizable | ImGuiTableFlags_Reorderable))
+                {
+                    ImGui::TableSetupColumn("B0");
+                    ImGui::TableSetupColumn("B1");
+                    ImGui::TableAutoHeaders();
+
+                    ImGui::TableNextRow(ImGuiTableRowFlags_None, rows_height);
+                    ImGui::Text("B0 Cell 0");
+                    ImGui::TableNextCell();
+                    ImGui::Text("B0 Cell 1");
+                    ImGui::TableNextRow(ImGuiTableRowFlags_None, rows_height);
+                    ImGui::Text("B1 Cell 0");
+                    ImGui::TableNextCell();
+                    ImGui::Text("B1 Cell 1");
+
+                    ImGui::EndTable();
+                }
+            }
+            ImGui::TableNextCell(); ImGui::Text("A0 Cell 1");
+            ImGui::TableNextRow();  ImGui::Text("A1 Cell 0");
+            ImGui::TableNextCell(); ImGui::Text("A1 Cell 1");
+            ImGui::EndTable();
+        }
+        ImGui::TreePop();
+    }
+
+    if (open_action != -1)
+        ImGui::SetNextItemOpen(open_action != 0);
+    if (ImGui::TreeNode("Sizing policies, cell contents"))
+    {
+        HelpMarker("This section allows you to interact and see the effect of StretchX vs FixedX sizing policies depending on whether Scroll is enabled and the contents of your columns.");
+        enum ContentsType { CT_ShortText, CT_LongText, CT_Button, CT_StretchButton, CT_InputText };
+        static int contents_type = CT_ShortText;
+        ImGui::SetNextItemWidth(ImGui::GetFontSize() * 12);
+        ImGui::Combo("Contents", &contents_type, "Short Text\0Long Text\0Button\0Stretch Button\0InputText\0");
+
+        static ImGuiTableFlags flags = ImGuiTableFlags_ScrollY | ImGuiTableFlags_BordersOuter | ImGuiTableFlags_RowBg;
+        ImGui::CheckboxFlags("ImGuiTableFlags_BordersH", (unsigned int*)&flags, ImGuiTableFlags_BordersH);
+        ImGui::CheckboxFlags("ImGuiTableFlags_BordersV", (unsigned int*)&flags, ImGuiTableFlags_BordersV);
+        ImGui::CheckboxFlags("ImGuiTableFlags_ScrollX", (unsigned int*)&flags, ImGuiTableFlags_ScrollX);
+        ImGui::CheckboxFlags("ImGuiTableFlags_ScrollY", (unsigned int*)&flags, ImGuiTableFlags_ScrollY);
+        if (ImGui::CheckboxFlags("ImGuiTableFlags_SizingPolicyStretchX", (unsigned int*)&flags, ImGuiTableFlags_SizingPolicyStretchX))
+            flags &= ~(ImGuiTableFlags_SizingPolicyMaskX_ ^ ImGuiTableFlags_SizingPolicyStretchX);  // Can't specify both sizing polices so we clear the other
+        ImGui::SameLine(); HelpMarker("Default if _ScrollX if disabled.");
+        if (ImGui::CheckboxFlags("ImGuiTableFlags_SizingPolicyFixedX", (unsigned int*)&flags, ImGuiTableFlags_SizingPolicyFixedX))
+            flags &= ~(ImGuiTableFlags_SizingPolicyMaskX_ ^ ImGuiTableFlags_SizingPolicyFixedX);    // Can't specify both sizing polices so we clear the other
+        ImGui::SameLine(); HelpMarker("Default if _ScrollX if enabled.");
+        ImGui::CheckboxFlags("ImGuiTableFlags_Resizable", (unsigned int*)&flags, ImGuiTableFlags_Resizable);
+        ImGui::CheckboxFlags("ImGuiTableFlags_NoClipX", (unsigned int*)&flags, ImGuiTableFlags_NoClipX);
+
+        if (ImGui::BeginTable("##3ways", 3, flags, ImVec2(0, 100)))
+        {
+            for (int row = 0; row < 10; row++)
+            {
+                ImGui::TableNextRow();
+                for (int column = 0; column < 3; column++)
+                {
+                    ImGui::TableSetColumnIndex(column);
+                    char label[32];
+                    static char text_buf[32] = "";
+                    sprintf(label, "Hello %d,%d", row, column);
+                    switch (contents_type)
+                    {
+                    case CT_ShortText:      ImGui::TextUnformatted(label); break;
+                    case CT_LongText:       ImGui::Text("Some longer text %d,%d\nOver two lines..", row, column); break;
+                    case CT_Button:         ImGui::Button(label); break;
+                    case CT_StretchButton:  ImGui::Button(label, ImVec2(-FLT_MIN, 0.0f)); break;
+                    case CT_InputText:      ImGui::SetNextItemWidth(-FLT_MIN); ImGui::InputText(label, text_buf, IM_ARRAYSIZE(text_buf)); break;
+                    }
+                }
+            }
+            ImGui::EndTable();
+        }
+        ImGui::TreePop();
+    }
+
+    if (open_action != -1)
+        ImGui::SetNextItemOpen(open_action != 0);
+    if (ImGui::TreeNode("Compact table"))
+    {
+        // FIXME-TABLE: Vertical border not overridden the same way as horizontal one
+        HelpMarker("Setting style.CellPadding to (0,0).");
+
+        static ImGuiTableFlags flags = ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg;
+        ImGui::CheckboxFlags("ImGuiTableFlags_BordersOuter", (unsigned int*)&flags, ImGuiTableFlags_BordersOuter);
+        ImGui::CheckboxFlags("ImGuiTableFlags_BordersH", (unsigned int*)&flags, ImGuiTableFlags_BordersH);
+        ImGui::CheckboxFlags("ImGuiTableFlags_BordersV", (unsigned int*)&flags, ImGuiTableFlags_BordersV);
+        ImGui::CheckboxFlags("ImGuiTableFlags_RowBg", (unsigned int*)&flags, ImGuiTableFlags_RowBg);
+        ImGui::CheckboxFlags("ImGuiTableFlags_Resizable", (unsigned int*)&flags, ImGuiTableFlags_Resizable);
+
+        static bool no_widget_frame = false;
+        ImGui::Checkbox("no_widget_frame", &no_widget_frame);
+
+        ImGui::PushStyleVar(ImGuiStyleVar_CellPadding, ImVec2(0, 0));
+        if (ImGui::BeginTable("##3ways", 3, flags))
+        {
+            for (int row = 0; row < 10; row++)
+            {
+                static char text_buf[32] = "";
+                ImGui::TableNextRow();
+                for (int column = 0; column < 3; column++)
+                {
+                    ImGui::TableSetColumnIndex(column);
+                    ImGui::SetNextItemWidth(-FLT_MIN);
+                    ImGui::PushID(row * 3 + column);
+                    if (no_widget_frame)
+                        ImGui::PushStyleColor(ImGuiCol_FrameBg, 0);
+                    ImGui::InputText("##cell", text_buf, IM_ARRAYSIZE(text_buf));
+                    if (no_widget_frame)
+                        ImGui::PopStyleColor();
+                    ImGui::PopID();
+                }
+            }
+            ImGui::EndTable();
+        }
+        ImGui::PopStyleVar();
+        ImGui::TreePop();
+    }
+
+    static const char* template_items_names[] =
+    {
+        "Banana", "Apple", "Cherry", "Watermelon", "Grapefruit", "Strawberry", "Mango",
+        "Kiwi", "Orange", "Pineapple", "Blueberry", "Plum", "Coconut", "Pear", "Apricot"
+    };
+
+    // This is a simplified version of the "Advanced" example, where we mostly focus on the code necessary to handle sorting.
+    // Note that the "Advanced" example also showcase manually triggering a sort (e.g. if item quantities have been modified)
+    if (open_action != -1)
+        ImGui::SetNextItemOpen(open_action != 0);
+    if (ImGui::TreeNode("Sorting"))
+    {
+        HelpMarker("Use Shift+Click to sort on multiple columns");
+
+        // Create item list
+        static ImVector<MyItem> items;
+        if (items.Size == 0)
+        {
+            items.resize(50, MyItem());
+            for (int n = 0; n < items.Size; n++)
+            {
+                const int template_n = n % IM_ARRAYSIZE(template_items_names);
+                MyItem& item = items[n];
+                item.ID = n;
+                item.Name = template_items_names[template_n];
+                item.Quantity = (n * n - n) % 20; // Assign default quantities
+            }
+        }
+
+        static ImGuiTableFlags flags =
+            ImGuiTableFlags_Resizable | ImGuiTableFlags_Reorderable | ImGuiTableFlags_Hideable | ImGuiTableFlags_MultiSortable
+            | ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersOuter | ImGuiTableFlags_BordersV
+            | ImGuiTableFlags_ScrollY | ImGuiTableFlags_ScrollFreezeTopRow;
+        if (ImGui::BeginTable("##table", 4, flags, ImVec2(0, 250), 0.0f))
+        {
+            // Declare columns
+            // We use the "user_id" parameter of TableSetupColumn() to specify a user id that will be stored in the sort specifications.
+            // This is so our sort function can identify a column given our own identifier. We could also identify them based on their index!
+            // Demonstrate using a mixture of flags among available sort-related flags:
+            // - ImGuiTableColumnFlags_DefaultSort
+            // - ImGuiTableColumnFlags_NoSort / ImGuiTableColumnFlags_NoSortAscending / ImGuiTableColumnFlags_NoSortDescending
+            // - ImGuiTableColumnFlags_PreferSortAscending / ImGuiTableColumnFlags_PreferSortDescending
+            ImGui::TableSetupColumn("ID",       ImGuiTableColumnFlags_DefaultSort          | ImGuiTableColumnFlags_WidthFixed,   -1.0f, MyItemColumnID_ID);
+            ImGui::TableSetupColumn("Name",                                                  ImGuiTableColumnFlags_WidthFixed,   -1.0f, MyItemColumnID_Name);
+            ImGui::TableSetupColumn("Action",   ImGuiTableColumnFlags_NoSort               | ImGuiTableColumnFlags_WidthFixed,   -1.0f, MyItemColumnID_Action);
+            ImGui::TableSetupColumn("Quantity", ImGuiTableColumnFlags_PreferSortDescending | ImGuiTableColumnFlags_WidthStretch, -1.0f, MyItemColumnID_Quantity);
+
+            // Sort our data if sort specs have been changed!
+            if (const ImGuiTableSortSpecs* sorts_specs = ImGui::TableGetSortSpecs())
+                if (sorts_specs->SpecsChanged && items.Size > 1)
+                {
+                    MyItem::s_current_sort_specs = sorts_specs; // Store in variable accessible by the sort function.
+                    qsort(&items[0], (size_t)items.Size, sizeof(items[0]), MyItem::CompareWithSortSpecs);
+                }
+
+            // Display data
+            ImGui::TableAutoHeaders();
+            ImGuiListClipper clipper;
+            clipper.Begin(items.Size);
+            while (clipper.Step())
+                for (int row_n = clipper.DisplayStart; row_n < clipper.DisplayEnd; row_n++)
+                {
+                    MyItem* item = &items[row_n];
+                    ImGui::PushID(item->ID);
+                    ImGui::TableNextRow();
+                    ImGui::TableSetColumnIndex(0);
+                    ImGui::Text("%04d", item->ID);
+                    ImGui::TableSetColumnIndex(1);
+                    ImGui::TextUnformatted(item->Name);
+                    ImGui::TableSetColumnIndex(2);
+                    ImGui::SmallButton("None");
+                    ImGui::TableSetColumnIndex(3);
+                    ImGui::Text("%d", item->Quantity);
+                    ImGui::PopID();
+                }
+            ImGui::EndTable();
+        }
+        ImGui::TreePop();
+    }
+
+    if (open_action != -1)
+        ImGui::SetNextItemOpen(open_action != 0);
+    if (ImGui::TreeNode("Advanced"))
+    {
+        static ImGuiTableFlags flags =
+            ImGuiTableFlags_Resizable | ImGuiTableFlags_Reorderable | ImGuiTableFlags_Hideable | ImGuiTableFlags_MultiSortable
+            | ImGuiTableFlags_RowBg | ImGuiTableFlags_Borders
+            | ImGuiTableFlags_ScrollX | ImGuiTableFlags_ScrollY
+            | ImGuiTableFlags_ScrollFreezeTopRow | ImGuiTableFlags_ScrollFreezeLeftColumn
+            | ImGuiTableFlags_SizingPolicyFixedX
+            ;
+
+        enum ContentsType { CT_Text, CT_Button, CT_SmallButton, CT_Selectable };
+        static int contents_type = CT_Button;
+        const char* contents_type_names[] = { "Text", "Button", "SmallButton", "Selectable" };
+
+        static int items_count = IM_ARRAYSIZE(template_items_names);
+        static ImVec2 outer_size_value = ImVec2(0, 250);
+        static float row_min_height = 0.0f; // Auto
+        static float inner_width_without_scroll = 0.0f; // Fill 
+        static float inner_width_with_scroll = 0.0f; // Auto-extend
+        static bool outer_size_enabled = true;
+        static bool lock_left_column_visibility = false;
+        static bool show_headers = true;
+        static bool show_wrapped_text = false;
+        static ImGuiTextFilter filter;
+        //ImGui::SetNextItemOpen(true, ImGuiCond_Once); // FIXME-TABLE: Enabling this results in initial clipped first pass on table which affects sizing
+        if (ImGui::TreeNodeEx("Options"))
+        {
+            // Make the UI compact because there are so many fields
+            ImGuiStyle& style = ImGui::GetStyle();
+            ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(style.FramePadding.x, 1));
+            ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(style.ItemSpacing.x, 2));
+            ImGui::PushItemWidth(200);
+
+            ImGui::BulletText("Features:");
+            ImGui::Indent();
+            ImGui::CheckboxFlags("ImGuiTableFlags_Resizable", (unsigned int*)&flags, ImGuiTableFlags_Resizable);
+            ImGui::CheckboxFlags("ImGuiTableFlags_Reorderable", (unsigned int*)&flags, ImGuiTableFlags_Reorderable);
+            ImGui::CheckboxFlags("ImGuiTableFlags_Hideable", (unsigned int*)&flags, ImGuiTableFlags_Hideable);
+            ImGui::CheckboxFlags("ImGuiTableFlags_Sortable", (unsigned int*)&flags, ImGuiTableFlags_Sortable);
+            ImGui::CheckboxFlags("ImGuiTableFlags_MultiSortable", (unsigned int*)&flags, ImGuiTableFlags_MultiSortable);
+            ImGui::CheckboxFlags("ImGuiTableFlags_NoSavedSettings", (unsigned int*)&flags, ImGuiTableFlags_NoSavedSettings);
+            ImGui::Unindent();
+
+            ImGui::BulletText("Decoration:");
+            ImGui::Indent();
+            ImGui::CheckboxFlags("ImGuiTableFlags_RowBg", (unsigned int*)&flags, ImGuiTableFlags_RowBg);
+            ImGui::CheckboxFlags("ImGuiTableFlags_BordersOuter", (unsigned int*)&flags, ImGuiTableFlags_BordersOuter);
+            ImGui::CheckboxFlags("ImGuiTableFlags_BordersH", (unsigned int*)&flags, ImGuiTableFlags_BordersH);
+            ImGui::CheckboxFlags("ImGuiTableFlags_BordersV", (unsigned int*)&flags, ImGuiTableFlags_BordersV);
+            ImGui::CheckboxFlags("ImGuiTableFlags_BordersFullHeight", (unsigned int*)&flags, ImGuiTableFlags_BordersFullHeight);
+            ImGui::Unindent();
+
+            ImGui::BulletText("Padding, Sizing:");
+            ImGui::Indent();
+            ImGui::CheckboxFlags("ImGuiTableFlags_NoClipX", (unsigned int*)&flags, ImGuiTableFlags_NoClipX);
+            if (ImGui::CheckboxFlags("ImGuiTableFlags_SizingPolicyStretchX", (unsigned int*)&flags, ImGuiTableFlags_SizingPolicyStretchX))
+                flags &= ~(ImGuiTableFlags_SizingPolicyMaskX_ ^ ImGuiTableFlags_SizingPolicyStretchX);  // Can't specify both sizing polices so we clear the other
+            ImGui::SameLine(); HelpMarker("[Default if ScrollX is off]\nFit all columns within available width (or specified inner_width). Fixed and Stretch columns allowed.");
+            if (ImGui::CheckboxFlags("ImGuiTableFlags_SizingPolicyFixedX", (unsigned int*)&flags, ImGuiTableFlags_SizingPolicyFixedX))
+                flags &= ~(ImGuiTableFlags_SizingPolicyMaskX_ ^ ImGuiTableFlags_SizingPolicyFixedX);    // Can't specify both sizing polices so we clear the other
+            ImGui::SameLine(); HelpMarker("[Default if ScrollX is on]\nEnlarge as needed: enable scrollbar if ScrollX is enabled, otherwise extend parent window's contents rectangle. Only Fixed columns allowed. Stretched columns will calculate their width assuming no scrolling.");
+            ImGui::CheckboxFlags("ImGuiTableFlags_NoHeadersWidth", (unsigned int*)&flags, ImGuiTableFlags_NoHeadersWidth);
+            ImGui::CheckboxFlags("ImGuiTableFlags_NoHostExtendY", (unsigned int*)&flags, ImGuiTableFlags_NoHostExtendY);
+            ImGui::Unindent();
+
+            ImGui::BulletText("Scrolling:");
+            ImGui::Indent();
+            ImGui::CheckboxFlags("ImGuiTableFlags_ScrollX", (unsigned int*)&flags, ImGuiTableFlags_ScrollX);
+            ImGui::CheckboxFlags("ImGuiTableFlags_ScrollY", (unsigned int*)&flags, ImGuiTableFlags_ScrollY);
+
+            // For the purpose of our "advanced" demo, we expose the 3 freezing variants on both axises instead of only exposing the most common flag.
+            //ImGui::CheckboxFlags("ImGuiTableFlags_ScrollFreezeTopRow", (unsigned int*)&flags, ImGuiTableFlags_ScrollFreezeTopRow);
+            //ImGui::CheckboxFlags("ImGuiTableFlags_ScrollFreezeLeftColumn", (unsigned int*)&flags, ImGuiTableFlags_ScrollFreezeLeftColumn);
+            int freeze_row_count = (flags & ImGuiTableFlags_ScrollFreezeRowsMask_) >> ImGuiTableFlags_ScrollFreezeRowsShift_;
+            int freeze_col_count = (flags & ImGuiTableFlags_ScrollFreezeColumnsMask_) >> ImGuiTableFlags_ScrollFreezeColumnsShift_;
+            ImGui::SetNextItemWidth(ImGui::GetFrameHeight());
+            if (ImGui::DragInt("ImGuiTableFlags_ScrollFreezeTopRow/2Rows/3Rows", &freeze_row_count, 0.2f, 0, 3))
+                if (freeze_row_count >= 0 && freeze_row_count <= 3)
+                    flags = (flags & ~ImGuiTableFlags_ScrollFreezeRowsMask_) | (freeze_row_count << ImGuiTableFlags_ScrollFreezeRowsShift_);
+            ImGui::SetNextItemWidth(ImGui::GetFrameHeight());
+            if (ImGui::DragInt("ImGuiTableFlags_ScrollFreezeLeftColumn/2Columns/3Columns", &freeze_col_count, 0.2f, 0, 3))
+                if (freeze_col_count >= 0 && freeze_col_count <= 3)
+                    flags = (flags & ~ImGuiTableFlags_ScrollFreezeColumnsMask_) | (freeze_col_count << ImGuiTableFlags_ScrollFreezeColumnsShift_);
+
+            ImGui::Unindent();
+
+            ImGui::BulletText("Other:");
+            ImGui::Indent();
+            ImGui::DragFloat2("##OuterSize", &outer_size_value.x);
+            ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
+            ImGui::Checkbox("outer_size", &outer_size_enabled);
+            ImGui::SameLine();
+            HelpMarker("If scrolling is disabled (ScrollX and ScrollY not set), the table is output directly in the parent window. OuterSize.y then becomes the minimum size for the table, which will extend vertically if there are more rows (unless NoHostExtendV is set).");
+
+            // From a user point of view we will tend to use 'inner_width' differently depending on whether our table is embedding scrolling.
+            // To facilitate experimentation we expose two values and will select the right one depending on active flags.
+            if (flags & ImGuiTableFlags_ScrollX)
+                ImGui::DragFloat("inner_width (when ScrollX active)", &inner_width_with_scroll, 1.0f, 0.0f, FLT_MAX);
+            else
+                ImGui::DragFloat("inner_width (when ScrollX inactive)", &inner_width_without_scroll, 1.0f, 0.0f, FLT_MAX);
+            ImGui::DragFloat("row_min_height", &row_min_height, 1.0f, 0.0f, FLT_MAX);
+            ImGui::SameLine(); HelpMarker("Specify height of the Selectable item.");
+            ImGui::DragInt("items_count", &items_count, 0.1f, 0, 5000);
+            ImGui::Combo("contents_type (first column)", &contents_type, contents_type_names, IM_ARRAYSIZE(contents_type_names));
+            filter.Draw("filter");
+            ImGui::Checkbox("show_headers", &show_headers);
+            ImGui::Checkbox("show_wrapped_text", &show_wrapped_text);
+            ImGui::Checkbox("lock_left_column_visibility", &lock_left_column_visibility);
+            ImGui::Unindent();
+
+            ImGui::PopItemWidth();
+            ImGui::PopStyleVar(2);
+            ImGui::Spacing();
+            ImGui::TreePop();
+        }
+
+        // Recreate/reset item list if we changed the number of items
+        static ImVector<MyItem> items;
+        static ImVector<int> selection;
+        static bool items_need_sort = false;
+        if (items.Size != items_count)
+        {
+            items.resize(items_count, MyItem());
+            for (int n = 0; n < items_count; n++)
+            {
+                const int template_n = n % IM_ARRAYSIZE(template_items_names);
+                MyItem& item = items[n];
+                item.ID = n;
+                item.Name = template_items_names[template_n];
+                item.Quantity = (template_n == 3) ? 10 : (template_n == 4) ? 20 : 0; // Assign default quantities
+            }
+        }
+
+        const ImDrawList* parent_draw_list = ImGui::GetWindowDrawList();
+        const int parent_draw_list_draw_cmd_count = parent_draw_list->CmdBuffer.Size;
+
+        const float inner_width_to_use = (flags & ImGuiTableFlags_ScrollX) ? inner_width_with_scroll : inner_width_without_scroll;
+        if (ImGui::BeginTable("##table", 5, flags, outer_size_enabled ? outer_size_value : ImVec2(0, 0), inner_width_to_use))
+        {
+            // Declare columns
+            // We use the "user_id" parameter of TableSetupColumn() to specify a user id that will be stored in the sort specifications.
+            // This is so our sort function can identify a column given our own identifier. We could also identify them based on their index!
+            ImGui::TableSetupColumn("ID",          ImGuiTableColumnFlags_DefaultSort | ImGuiTableColumnFlags_WidthFixed | (lock_left_column_visibility ? ImGuiTableColumnFlags_NoHide : 0), -1.0f, MyItemColumnID_ID);
+            ImGui::TableSetupColumn("Name",        ImGuiTableColumnFlags_WidthFixed, -1.0f, MyItemColumnID_Name);
+            ImGui::TableSetupColumn("Action",      ImGuiTableColumnFlags_NoSort | ImGuiTableColumnFlags_WidthFixed, -1.0f, MyItemColumnID_Action);
+            ImGui::TableSetupColumn("Quantity Long Label", ImGuiTableColumnFlags_PreferSortDescending | ImGuiTableColumnFlags_WidthStretch, 1.0f, MyItemColumnID_Quantity);// , ImGuiTableColumnFlags_None | ImGuiTableColumnFlags_WidthAlwaysAutoResize);
+            ImGui::TableSetupColumn("Description", ImGuiTableColumnFlags_WidthStretch, 1.0f, MyItemColumnID_Description);// , ImGuiTableColumnFlags_WidthAlwaysAutoResize);
+
+            // Sort our data if sort specs have been changed!
+            const ImGuiTableSortSpecs* sorts_specs = ImGui::TableGetSortSpecs();
+            if (sorts_specs && sorts_specs->SpecsChanged)
+                items_need_sort = true;
+            if (sorts_specs && items_need_sort && items.Size > 1)
+            {
+                MyItem::s_current_sort_specs = sorts_specs; // Store in variable accessible by the sort function.
+                qsort(&items[0], (size_t)items.Size, sizeof(items[0]), MyItem::CompareWithSortSpecs);
+            }
+            items_need_sort = false;
+
+            // Take note of whether we are currently sorting based on the Quantity field,
+            // we will use this to trigger sorting when we know the data of this column has been modified.
+            const bool sorts_specs_using_quantity = ImGui::TableGetColumnIsSorted(3);
+
+            // Show headers
+            if (show_headers)
+                ImGui::TableAutoHeaders();
+
+            // Show data
+            // FIXME-TABLE FIXME-NAV: How we can get decent up/down even though we have the buttons here?
+            ImGui::PushButtonRepeat(true);
+#if 1
+            ImGuiListClipper clipper;
+            clipper.Begin(items.Size);
+            while (clipper.Step())
+            {
+                for (int row_n = clipper.DisplayStart; row_n < clipper.DisplayEnd; row_n++)
+#else
+            {
+                for (int row_n = 0; row_n < items_count; n++)
+#endif
+                {
+                    MyItem* item = &items[row_n];
+                    if (!filter.PassFilter(item->Name))
+                        continue;
+
+                    const bool item_is_selected = selection.contains(item->ID);
+                    ImGui::PushID(item->ID);
+                    ImGui::TableNextRow(ImGuiTableRowFlags_None, row_min_height);
+
+                    // For the demo purpose we can select among different type of items submitted in the first column
+                    char label[32];
+                    sprintf(label, "%04d", item->ID);
+                    if (contents_type == CT_Text)
+                        ImGui::TextUnformatted(label);
+                    else if (contents_type == CT_Button)
+                        ImGui::Button(label);
+                    else if (contents_type == CT_SmallButton)
+                        ImGui::SmallButton(label);
+                    else if (contents_type == CT_Selectable)
+                    {
+                        if (ImGui::Selectable(label, item_is_selected, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_AllowItemOverlap, ImVec2(0, row_min_height)))
+                        {
+                            if (ImGui::GetIO().KeyCtrl)
+                            {
+                                if (item_is_selected)
+                                    selection.find_erase_unsorted(item->ID);
+                                else
+                                    selection.push_back(item->ID);
+                            }
+                            else
+                            {
+                                selection.clear();
+                                selection.push_back(item->ID);
+                            }
+                        }
+                    }
+
+                    ImGui::TableNextCell();
+                    ImGui::TextUnformatted(item->Name);
+
+                    // Here we demonstrate marking our data set as needing to be sorted again if we modified a quantity,
+                    // and we are currently sorting on the column showing the Quantity.
+                    // To avoid triggering a sort while holding the button, we only trigger it when the button has been released.
+                    // You will probably need a more advanced system in your code if you want to automatically sort when a specific entry changes.
+                    if (ImGui::TableNextCell())
+                    {
+                        if (ImGui::SmallButton("Chop")) { item->Quantity += 1; }
+                        if (sorts_specs_using_quantity && ImGui::IsItemDeactivated()) { items_need_sort = true; }
+                        ImGui::SameLine();
+                        if (ImGui::SmallButton("Eat")) { item->Quantity -= 1; }
+                        if (sorts_specs_using_quantity && ImGui::IsItemDeactivated()) { items_need_sort = true; }
+                    }
+
+                    ImGui::TableNextCell();
+                    ImGui::Text("%d", item->Quantity);
+
+                    ImGui::TableNextCell();
+                    if (show_wrapped_text)
+                        ImGui::TextWrapped("Lorem ipsum dolor sit amet");
+                    else
+                        ImGui::Text("Lorem ipsum dolor sit amet");
+
+                    ImGui::PopID();
+                }
+            }
+            ImGui::PopButtonRepeat();
+
+            const ImVec2 table_scroll_cur = ImVec2(ImGui::GetScrollX(), ImGui::GetScrollY());
+            const ImVec2 table_scroll_max = ImVec2(ImGui::GetScrollMaxX(), ImGui::GetScrollMaxY());
+            const ImDrawList* table_draw_list = ImGui::GetWindowDrawList();
+            ImGui::EndTable();
+
+            static bool show_debug_details = false;
+            ImGui::Checkbox("Debug details", &show_debug_details);
+            if (show_debug_details)
+            {
+                ImGui::SameLine(0.0f, 0.0f);
+                const int table_draw_list_draw_cmd_count = table_draw_list->CmdBuffer.Size;
+                if (table_draw_list == parent_draw_list)
+                    ImGui::Text(": DrawCmd: +%d (in same window)", table_draw_list_draw_cmd_count - parent_draw_list_draw_cmd_count);
+                else
+                    ImGui::Text(": DrawCmd: +%d (in child window), Scroll: (%.f/%.f) (%.f/%.f)",
+                        table_draw_list_draw_cmd_count - 1, table_scroll_cur.x, table_scroll_max.x, table_scroll_cur.y, table_scroll_max.y);
+            }
+        }
+        ImGui::TreePop();
+    }
+
+    if (disable_indent)
+        ImGui::PopStyleVar();
+    ImGui::PopID();
+}
+
+// 2020: Columns are under-featured and not maintained. Prefer using the more flexible and powerful Tables API!
 static void ShowDemoWindowColumns()
 {
     if (!ImGui::CollapsingHeader("Columns"))
@@ -2705,6 +3673,8 @@ static void ShowDemoWindowColumns()
     HelpMarker("Disable the indenting of tree nodes so demo columns can use the full window width.");
     if (disable_indent)
         ImGui::PushStyleVar(ImGuiStyleVar_IndentSpacing, 0.0f);
+
+    ImGui::TextWrapped("Note: Columns are under-featured and not maintained. Prefer using the more flexible and powerful Tables API!");
 
     // Basic columns
     if (ImGui::TreeNode("Basic"))
@@ -3318,6 +4288,7 @@ void ImGui::ShowStyleEditor(ImGuiStyle* ref)
             ImGui::SliderFloat2("FramePadding", (float*)&style.FramePadding, 0.0f, 20.0f, "%.0f");
             ImGui::SliderFloat2("ItemSpacing", (float*)&style.ItemSpacing, 0.0f, 20.0f, "%.0f");
             ImGui::SliderFloat2("ItemInnerSpacing", (float*)&style.ItemInnerSpacing, 0.0f, 20.0f, "%.0f");
+            ImGui::SliderFloat2("CellPadding", (float*)&style.CellPadding, 0.0f, 20.0f, "%.0f");
             ImGui::SliderFloat2("TouchExtraPadding", (float*)&style.TouchExtraPadding, 0.0f, 10.0f, "%.0f");
             ImGui::SliderFloat("IndentSpacing", &style.IndentSpacing, 0.0f, 30.0f, "%.0f");
             ImGui::SliderFloat("ScrollbarSize", &style.ScrollbarSize, 1.0f, 20.0f, "%.0f");

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -3160,6 +3160,8 @@ static void ShowDemoWindowTables()
                 ImGui::CheckboxFlags("_NoSortDescending", (unsigned int*)&column_flags[column], ImGuiTableColumnFlags_NoSortDescending);
                 ImGui::CheckboxFlags("_PreferSortAscending", (unsigned int*)&column_flags[column], ImGuiTableColumnFlags_PreferSortAscending);
                 ImGui::CheckboxFlags("_PreferSortDescending", (unsigned int*)&column_flags[column], ImGuiTableColumnFlags_PreferSortDescending);
+                ImGui::CheckboxFlags("_IndentEnable", (unsigned int*)&column_flags[column], ImGuiTableColumnFlags_IndentEnable);
+                ImGui::CheckboxFlags("_IndentDisable", (unsigned int*)&column_flags[column], ImGuiTableColumnFlags_IndentDisable);
                 ImGui::PopID();
                 ImGui::PopStyleVar(2);
             }
@@ -3168,20 +3170,23 @@ static void ShowDemoWindowTables()
 
         // Create the real table we care about for the example!
         const ImGuiTableFlags flags = ImGuiTableFlags_SizingPolicyFixedX | ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersOuter | ImGuiTableFlags_BordersV | ImGuiTableFlags_Resizable | ImGuiTableFlags_Reorderable | ImGuiTableFlags_Hideable | ImGuiTableFlags_Sortable;
-        if (ImGui::BeginTable("##table1", column_count, flags))
+        if (ImGui::BeginTable("##table", column_count, flags))
         {
             for (int column = 0; column < column_count; column++)
                 ImGui::TableSetupColumn(column_names[column], column_flags[column]);
             ImGui::TableAutoHeaders();
             for (int row = 0; row < 8; row++)
             {
+                ImGui::Indent(2.0f); // Add some indentation to demonstrate usage of per-column IndentEnable/IndentDisable flags.
                 ImGui::TableNextRow();
                 for (int column = 0; column < column_count; column++)
                 {
                     ImGui::TableSetColumnIndex(column);
-                    ImGui::Text("Hello %s", ImGui::TableGetColumnName(column));
+                    ImGui::Text("%s %s", (column == 0) ? "Indented" : "Hello", ImGui::TableGetColumnName(column));
                 }
             }
+            ImGui::Unindent(2.0f * 8.0f);
+
             ImGui::EndTable();
         }
         ImGui::TreePop();
@@ -3339,6 +3344,78 @@ static void ShowDemoWindowTables()
                 ImGui::TableNextRow(ImGuiTableRowFlags_None, min_row_height);
                 ImGui::Text("min_row_height = %.2f", min_row_height);
             }
+            ImGui::EndTable();
+        }
+        ImGui::TreePop();
+    }
+
+    if (open_action != -1)
+        ImGui::SetNextItemOpen(open_action != 0);
+    if (ImGui::TreeNode("Tree view"))
+    {
+        static ImGuiTableFlags flags = ImGuiTableFlags_BordersV | ImGuiTableFlags_BordersHOuter | ImGuiTableFlags_Resizable | ImGuiTableFlags_RowBg;
+        //ImGui::CheckboxFlags("ImGuiTableFlags_Scroll", (unsigned int*)&flags, ImGuiTableFlags_Scroll);
+        //ImGui::CheckboxFlags("ImGuiTableFlags_ScrollFreezeLeftColumn", (unsigned int*)&flags, ImGuiTableFlags_ScrollFreezeLeftColumn);
+
+        if (ImGui::BeginTable("##3ways", 3, flags))
+        {
+            // The first column will use the default _WidthStretch when ScrollX is Off and _WidthFixed when ScrollX is On
+            ImGui::TableSetupColumn("Name", ImGuiTableColumnFlags_NoHide);
+            ImGui::TableSetupColumn("Size", ImGuiTableColumnFlags_WidthFixed, ImGui::GetFontSize() * 10);
+            ImGui::TableSetupColumn("Type", ImGuiTableColumnFlags_WidthFixed, ImGui::GetFontSize() * 20);
+            ImGui::TableAutoHeaders();
+
+            // Simple storage to output a dummy file-system.
+            struct MyTreeNode 
+            { 
+                const char*     Name; 
+                const char*     Type; 
+                int             Size; 
+                int             ChildIdx; 
+                int             ChildCount; 
+                static void DisplayNode(const MyTreeNode* node, const MyTreeNode* all_nodes)
+                {
+                    ImGui::TableNextRow();
+                    const bool is_folder = (node->ChildCount > 0);
+                    if (is_folder)
+                    {
+                        bool open = ImGui::TreeNodeEx(node->Name, ImGuiTreeNodeFlags_SpanFullWidth);
+                        ImGui::TableNextCell();
+                        ImGui::TextDisabled("--");
+                        ImGui::TableNextCell();
+                        ImGui::TextUnformatted(node->Type);
+                        if (open)
+                        {
+                            for (int child_n = 0; child_n < node->ChildCount; child_n++)
+                                DisplayNode(&all_nodes[node->ChildIdx + child_n], all_nodes);
+                            ImGui::TreePop();
+                        }
+                    }
+                    else
+                    {
+                        ImGui::TreeNodeEx(node->Name, ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_Bullet | ImGuiTreeNodeFlags_NoTreePushOnOpen | ImGuiTreeNodeFlags_SpanFullWidth);
+                        ImGui::TableNextCell();
+                        ImGui::Text("%d", node->Size);
+                        ImGui::TableNextCell();
+                        ImGui::TextUnformatted(node->Type);
+                    }
+                }
+            };
+            static const MyTreeNode nodes[] =
+            {
+                { "Root",                         "Folder",       -1,       1, 3    }, // 0
+                { "Music",                        "Folder",       -1,       4, 2    }, // 1
+                { "Textures",                     "Folder",       -1,       6, 3    }, // 2
+                { "desktop.ini",                  "System file",  1024,    -1,-1    }, // 3
+                { "File1_a.wav",                  "Audio file",   123000,  -1,-1    }, // 4
+                { "File1_b.wav",                  "Audio file",   456000,  -1,-1    }, // 5
+                { "Image001.png",                 "Image file",   203128,  -1,-1    }, // 6
+                { "Copy of Image001.png",         "Image file",   203256,  -1,-1    }, // 7
+                { "Copy of Image001 (Final2).png","Image file",   203512,  -1,-1    }, // 8
+            };
+
+            MyTreeNode::DisplayNode(&nodes[0], nodes);
+
             ImGui::EndTable();
         }
         ImGui::TreePop();

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -3397,6 +3397,7 @@ static void ShowDemoWindowTables()
                 {
                     MyItem::s_current_sort_specs = sorts_specs; // Store in variable accessible by the sort function.
                     qsort(&items[0], (size_t)items.Size, sizeof(items[0]), MyItem::CompareWithSortSpecs);
+                    MyItem::s_current_sort_specs = NULL;
                 }
 
             // Display data
@@ -3585,6 +3586,7 @@ static void ShowDemoWindowTables()
             {
                 MyItem::s_current_sort_specs = sorts_specs; // Store in variable accessible by the sort function.
                 qsort(&items[0], (size_t)items.Size, sizeof(items[0]), MyItem::CompareWithSortSpecs);
+                MyItem::s_current_sort_specs = NULL;
             }
             items_need_sort = false;
 

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -222,6 +222,9 @@ void ImGui::StyleColorsDark(ImGuiStyle* dst)
     colors[ImGuiCol_PlotLinesHovered]       = ImVec4(1.00f, 0.43f, 0.35f, 1.00f);
     colors[ImGuiCol_PlotHistogram]          = ImVec4(0.90f, 0.70f, 0.00f, 1.00f);
     colors[ImGuiCol_PlotHistogramHovered]   = ImVec4(1.00f, 0.60f, 0.00f, 1.00f);
+    colors[ImGuiCol_TableHeaderBg]          = ImVec4(0.19f, 0.19f, 0.20f, 1.00f);
+    colors[ImGuiCol_TableRowBg]             = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
+    colors[ImGuiCol_TableRowBgAlt]          = ImVec4(1.00f, 1.00f, 1.00f, 0.07f);
     colors[ImGuiCol_TextSelectedBg]         = ImVec4(0.26f, 0.59f, 0.98f, 0.35f);
     colors[ImGuiCol_DragDropTarget]         = ImVec4(1.00f, 1.00f, 0.00f, 0.90f);
     colors[ImGuiCol_NavHighlight]           = ImVec4(0.26f, 0.59f, 0.98f, 1.00f);
@@ -277,6 +280,9 @@ void ImGui::StyleColorsClassic(ImGuiStyle* dst)
     colors[ImGuiCol_PlotLinesHovered]       = ImVec4(0.90f, 0.70f, 0.00f, 1.00f);
     colors[ImGuiCol_PlotHistogram]          = ImVec4(0.90f, 0.70f, 0.00f, 1.00f);
     colors[ImGuiCol_PlotHistogramHovered]   = ImVec4(1.00f, 0.60f, 0.00f, 1.00f);
+    colors[ImGuiCol_TableHeaderBg]          = ImVec4(0.27f, 0.27f, 0.38f, 1.00f);
+    colors[ImGuiCol_TableRowBg]             = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
+    colors[ImGuiCol_TableRowBgAlt]          = ImVec4(1.00f, 1.00f, 1.00f, 0.07f);
     colors[ImGuiCol_TextSelectedBg]         = ImVec4(0.00f, 0.00f, 1.00f, 0.35f);
     colors[ImGuiCol_DragDropTarget]         = ImVec4(1.00f, 1.00f, 0.00f, 0.90f);
     colors[ImGuiCol_NavHighlight]           = colors[ImGuiCol_HeaderHovered];
@@ -333,6 +339,9 @@ void ImGui::StyleColorsLight(ImGuiStyle* dst)
     colors[ImGuiCol_PlotLinesHovered]       = ImVec4(1.00f, 0.43f, 0.35f, 1.00f);
     colors[ImGuiCol_PlotHistogram]          = ImVec4(0.90f, 0.70f, 0.00f, 1.00f);
     colors[ImGuiCol_PlotHistogramHovered]   = ImVec4(1.00f, 0.45f, 0.00f, 1.00f);
+    colors[ImGuiCol_TableHeaderBg]          = ImVec4(0.78f, 0.87f, 0.98f, 1.00f);
+    colors[ImGuiCol_TableRowBg]             = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
+    colors[ImGuiCol_TableRowBgAlt]          = ImVec4(0.30f, 0.30f, 0.30f, 0.07f);
     colors[ImGuiCol_TextSelectedBg]         = ImVec4(0.26f, 0.59f, 0.98f, 0.35f);
     colors[ImGuiCol_DragDropTarget]         = ImVec4(0.26f, 0.59f, 0.98f, 0.95f);
     colors[ImGuiCol_NavHighlight]           = colors[ImGuiCol_HeaderHovered];

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -223,6 +223,8 @@ void ImGui::StyleColorsDark(ImGuiStyle* dst)
     colors[ImGuiCol_PlotHistogram]          = ImVec4(0.90f, 0.70f, 0.00f, 1.00f);
     colors[ImGuiCol_PlotHistogramHovered]   = ImVec4(1.00f, 0.60f, 0.00f, 1.00f);
     colors[ImGuiCol_TableHeaderBg]          = ImVec4(0.19f, 0.19f, 0.20f, 1.00f);
+    colors[ImGuiCol_TableBorderStrong]      = ImVec4(0.31f, 0.31f, 0.35f, 1.00f);   // Prefer using Alpha=1.0 here
+    colors[ImGuiCol_TableBorderLight]       = ImVec4(0.23f, 0.23f, 0.25f, 1.00f);   // Prefer using Alpha=1.0 here
     colors[ImGuiCol_TableRowBg]             = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
     colors[ImGuiCol_TableRowBgAlt]          = ImVec4(1.00f, 1.00f, 1.00f, 0.07f);
     colors[ImGuiCol_TextSelectedBg]         = ImVec4(0.26f, 0.59f, 0.98f, 0.35f);
@@ -281,6 +283,8 @@ void ImGui::StyleColorsClassic(ImGuiStyle* dst)
     colors[ImGuiCol_PlotHistogram]          = ImVec4(0.90f, 0.70f, 0.00f, 1.00f);
     colors[ImGuiCol_PlotHistogramHovered]   = ImVec4(1.00f, 0.60f, 0.00f, 1.00f);
     colors[ImGuiCol_TableHeaderBg]          = ImVec4(0.27f, 0.27f, 0.38f, 1.00f);
+    colors[ImGuiCol_TableBorderStrong]      = ImVec4(0.31f, 0.31f, 0.45f, 1.00f);   // Prefer using Alpha=1.0 here
+    colors[ImGuiCol_TableBorderLight]       = ImVec4(0.26f, 0.26f, 0.28f, 1.00f);   // Prefer using Alpha=1.0 here
     colors[ImGuiCol_TableRowBg]             = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
     colors[ImGuiCol_TableRowBgAlt]          = ImVec4(1.00f, 1.00f, 1.00f, 0.07f);
     colors[ImGuiCol_TextSelectedBg]         = ImVec4(0.00f, 0.00f, 1.00f, 0.35f);
@@ -340,6 +344,8 @@ void ImGui::StyleColorsLight(ImGuiStyle* dst)
     colors[ImGuiCol_PlotHistogram]          = ImVec4(0.90f, 0.70f, 0.00f, 1.00f);
     colors[ImGuiCol_PlotHistogramHovered]   = ImVec4(1.00f, 0.45f, 0.00f, 1.00f);
     colors[ImGuiCol_TableHeaderBg]          = ImVec4(0.78f, 0.87f, 0.98f, 1.00f);
+    colors[ImGuiCol_TableBorderStrong]      = ImVec4(0.57f, 0.57f, 0.64f, 1.00f);   // Prefer using Alpha=1.0 here
+    colors[ImGuiCol_TableBorderLight]       = ImVec4(0.68f, 0.68f, 0.74f, 1.00f);   // Prefer using Alpha=1.0 here
     colors[ImGuiCol_TableRowBg]             = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
     colors[ImGuiCol_TableRowBgAlt]          = ImVec4(0.30f, 0.30f, 0.30f, 0.07f);
     colors[ImGuiCol_TextSelectedBg]         = ImVec4(0.26f, 0.59f, 0.98f, 0.35f);

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -1878,9 +1878,11 @@ struct ImGuiTable
     float                       ResizedColumnNextWidth;
     ImRect                      OuterRect;                  // Note: OuterRect.Max.y is often FLT_MAX until EndTable(), unless a height has been specified in BeginTable().
     ImRect                      WorkRect;
-    ImRect                      HostClipRect;               // This is used to check if we can eventually merge our columns draw calls into the current draw call of the current window.
     ImRect                      InnerClipRect;
     ImRect                      BackgroundClipRect;         // We use this to cpu-clip cell background color fill
+    ImRect                      HostClipRect;               // This is used to check if we can eventually merge our columns draw calls into the current draw call of the current window.
+    ImRect                      HostWorkRect;               // Backup of InnerWindow->WorkRect at the end of BeginTable()
+    ImVec2                      HostCursorMaxPos;           // Backup of InnerWindow->DC.CursorMaxPos at the end of BeginTable()
     ImGuiWindow*                OuterWindow;                // Parent window for the table
     ImGuiWindow*                InnerWindow;                // Window holding the table data (== OuterWindow or a child window)
     ImGuiTextBuffer             ColumnsNames;               // Contiguous buffer holding columns names
@@ -1916,9 +1918,7 @@ struct ImGuiTable
     bool                        IsDefaultDisplayOrder;      // Set when display order is unchanged from default (DisplayOrder contains 0...Count-1)
     bool                        IsResetDisplayOrderRequest;
     bool                        IsFreezeRowsPassed;         // Set when we got past the frozen row (the first one).
-    bool                        BackupSkipItems;            // Backup of InnerWindow->SkipItem at the end of BeginTable(), because we will overwrite InnerWindow->SkipItem on a per-column basis
-    ImRect                      BackupWorkRect;             // Backup of InnerWindow->WorkRect at the end of BeginTable()
-    ImVec2                      BackupCursorMaxPos;         // Backup of InnerWindow->DC.CursorMaxPos at the end of BeginTable()
+    bool                        HostSkipItems;              // Backup of InnerWindow->SkipItem at the end of BeginTable(), because we will overwrite InnerWindow->SkipItem on a per-column basis
 
     ImGuiTable()
     {

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -1790,9 +1790,9 @@ struct ImGuiTableColumn
     ImGuiID                 UserID;                         // Optional, value passed to TableSetupColumn()
     ImGuiTableColumnFlags   FlagsIn;                        // Flags as they were provided by user. See ImGuiTableColumnFlags_
     ImGuiTableColumnFlags   Flags;                          // Effective flags. See ImGuiTableColumnFlags_
-    float                   ResizeWeight;                   //  ~1.0f. Master width data when (Flags & _WidthStretch)
     float                   MinX;                           // Absolute positions
     float                   MaxX;
+    float                   ResizeWeight;                   //  ~1.0f. Master width data when (Flags & _WidthStretch)
     float                   WidthRequested;                 // Master width data when !(Flags & _WidthStretch)
     float                   WidthGiven;                     // == (MaxX - MinX). FIXME-TABLE: Store all persistent width in multiple of FontSize?
     float                   StartXRows;                     // Start position for the frame, currently ~(MinX + CellPaddingX)
@@ -1825,8 +1825,7 @@ struct ImGuiTableColumn
     ImGuiTableColumn()
     {
         memset(this, 0, sizeof(*this));
-        ResizeWeight = 1.0f;
-        WidthRequested = WidthGiven = -1.0f;
+        ResizeWeight = WidthRequested = WidthGiven = -1.0f;
         NameOffset = -1;
         IsActive = NextIsActive = true;
         IndexDisplayOrder = IndexWithinActiveSet = -1;

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -1858,6 +1858,7 @@ struct ImGuiTable
     ImS16                       InstanceInteracted;         // Mark which instance (generally 0) of the same ID is being interacted with
     float                       RowPosY1;
     float                       RowPosY2;
+    float                       RowMinHeight;               // Height submitted to TableNextRow()
     float                       RowTextBaseline;
     ImGuiTableRowFlags          RowFlags : 16;              // Current row flags, see ImGuiTableRowFlags_
     ImGuiTableRowFlags          LastRowFlags : 16;

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -1892,8 +1892,8 @@ struct ImGuiTable
     ImS8                        HoveredColumnBody;          // [DEBUG] Unlike HoveredColumnBorder this doesn't fulfill all Hovering rules properly. Used for debugging/tools for now.
     ImS8                        HoveredColumnBorder;        // Index of column whose right-border is being hovered (for resizing).
     ImS8                        ResizedColumn;              // Index of column being resized. Reset by InstanceNo==0.
-    ImS8                        HeadHeaderColumn;           // Index of column header being held. 
-    ImS8                        LastResizedColumn;
+    ImS8                        LastResizedColumn;          // Index of column being resized from previous frame.
+    ImS8                        HeldHeaderColumn;           // Index of column header being held. 
     ImS8                        ReorderColumn;              // Index of column being reordered. (not cleared)
     ImS8                        ReorderColumnDir;           // -1 or +1
     ImS8                        RightMostActiveColumn;      // Index of right-most non-hidden column.
@@ -1905,11 +1905,11 @@ struct ImGuiTable
     ImS8                        FreezeColumnsRequest;       // Requested frozen columns count
     ImS8                        FreezeColumnsCount;         // Actual frozen columns count (== FreezeColumnsRequest, or == 0 when no scrolling offset)
     bool                        IsLayoutLocked;             // Set by TableUpdateLayout() which is called when beginning the first row.
-    bool                        IsInsideRow;                // Set if inside TableBeginRow()/TableEndRow().
-    bool                        IsFirstFrame;
+    bool                        IsInsideRow;                // Set when inside TableBeginRow()/TableEndRow().
+    bool                        IsInitializing;
     bool                        IsSortSpecsDirty;
-    bool                        IsUsingHeaders;             // Set if the first row had the ImGuiTableRowFlags_Headers flag.
-    bool                        IsContextPopupOpen;
+    bool                        IsUsingHeaders;             // Set when the first row had the ImGuiTableRowFlags_Headers flag.
+    bool                        IsContextPopupOpen;         // Set when default context menu is open (also see: ContextPopupColumn, InstanceInteracted).
     bool                        IsSettingsRequestLoad;
     bool                        IsSettingsLoaded;
     bool                        IsSettingsDirty;            // Set when table settings have changed and needs to be reported into ImGuiTableSetttings data.

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -1855,7 +1855,7 @@ struct ImGuiTable
     int                         CurrentColumn;
     int                         CurrentRow;
     ImS16                       InstanceNo;                 // Count of BeginTable() calls with same ID in the same frame (generally 0)
-    ImS16                       InstanceInteracted;
+    ImS16                       InstanceInteracted;         // Mark which instance (generally 0) of the same ID is being interacted with
     float                       RowPosY1;
     float                       RowPosY2;
     float                       RowTextBaseline;

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -1868,6 +1868,7 @@ struct ImGuiTable
     ImU32                       BorderColorLight;
     float                       BorderX1;
     float                       BorderX2;
+    float                       HostIndentX;
     float                       CellPaddingX1;              // Padding from each borders
     float                       CellPaddingX2;
     float                       CellPaddingY;

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -1863,8 +1863,8 @@ struct ImGuiTable
     ImGuiTableRowFlags          LastRowFlags : 16;
     int                         RowBgColorCounter;          // Counter for alternating background colors (can be fast-forwarded by e.g clipper)
     ImU32                       RowBgColor;                 // Request for current row background color
-    ImU32                       BorderOuterColor;
-    ImU32                       BorderInnerColor;
+    ImU32                       BorderColorStrong;
+    ImU32                       BorderColorLight;
     float                       BorderX1;
     float                       BorderX2;
     float                       CellPaddingX1;              // Padding from each borders

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -1851,6 +1851,8 @@ struct ImGuiTable
     int                         ColumnsActiveCount;         // Number of non-hidden columns (<= ColumnsCount)
     int                         CurrentColumn;
     int                         CurrentRow;
+    ImS16                       InstanceNo;                 // Count of BeginTable() calls with same ID in the same frame (generally 0)
+    ImS16                       InstanceInteracted;
     float                       RowPosY1;
     float                       RowPosY2;
     float                       RowTextBaseline;
@@ -1870,6 +1872,7 @@ struct ImGuiTable
     float                       LastFirstRowHeight;         // Height of first row from last frame
     float                       ColumnsTotalWidth;
     float                       InnerWidth;
+    float                       ResizedColumnNextWidth;
     ImRect                      OuterRect;                  // Note: OuterRect.Max.y is often FLT_MAX until EndTable(), unless a height has been specified in BeginTable().
     ImRect                      WorkRect;
     ImRect                      HostClipRect;               // This is used to check if we can eventually merge our columns draw calls into the current draw call of the current window.
@@ -1885,7 +1888,8 @@ struct ImGuiTable
     ImS8                        DeclColumnsCount;           // Count calls to TableSetupColumn()
     ImS8                        HoveredColumnBody;          // [DEBUG] Unlike HoveredColumnBorder this doesn't fulfill all Hovering rules properly. Used for debugging/tools for now.
     ImS8                        HoveredColumnBorder;        // Index of column whose right-border is being hovered (for resizing).
-    ImS8                        ResizedColumn;              // Index of column being resized.
+    ImS8                        ResizedColumn;              // Index of column being resized. Reset by InstanceNo==0.
+    ImS8                        HeadHeaderColumn;           // Index of column header being held. 
     ImS8                        LastResizedColumn;
     ImS8                        ReorderColumn;              // Index of column being reordered. (not cleared)
     ImS8                        ReorderColumnDir;           // -1 or +1
@@ -1917,6 +1921,7 @@ struct ImGuiTable
     {
         memset(this, 0, sizeof(*this));
         SettingsOffset = -1;
+        InstanceInteracted = -1;
         LastFrameActive = -1;
         LastResizedColumn = -1;
         ContextPopupColumn = -1;

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -1783,11 +1783,12 @@ namespace ImGui
 #define IM_COL32_DISABLE            IM_COL32(0,0,0,1)   // Special sentinel code
 #define IMGUI_TABLE_MAX_COLUMNS     64                  // sizeof(ImU64) * 8. This is solely because we frequently encode columns set in a ImU64.
 
-// [Internal] sizeof() ~ 96
+// [Internal] sizeof() ~ 100
 struct ImGuiTableColumn
 {
+    ImRect                  ClipRect;                       // Clipping rectangle for the column
     ImGuiID                 UserID;                         // Optional, value passed to TableSetupColumn()
-    ImGuiTableColumnFlags   FlagsIn;                        // Flags as input by user. See ImGuiTableColumnFlags_
+    ImGuiTableColumnFlags   FlagsIn;                        // Flags as they were provided by user. See ImGuiTableColumnFlags_
     ImGuiTableColumnFlags   Flags;                          // Effective flags. See ImGuiTableColumnFlags_
     float                   ResizeWeight;                   //  ~1.0f. Master width data when (Flags & _WidthStretch)
     float                   MinX;                           // Absolute positions
@@ -1796,19 +1797,19 @@ struct ImGuiTableColumn
     float                   WidthGiven;                     // == (MaxX - MinX). FIXME-TABLE: Store all persistent width in multiple of FontSize?
     float                   StartXRows;                     // Start position for the frame, currently ~(MinX + CellPaddingX)
     float                   StartXHeaders;                  
-    ImS16                   ContentWidthRowsFrozen;         // Contents width. Because freezing is non correlated from headers we need all 4 variants (ImDrawCmd merging uses different data than alignment code).
-    ImS16                   ContentWidthRowsUnfrozen;       // (encoded as ImS16 because we actually rarely use those width)
-    ImS16                   ContentWidthHeadersUsed;        // TableHeader() automatically softclip itself + report ideal desired size, to avoid creating extraneous draw calls
-    ImS16                   ContentWidthHeadersDesired;
     float                   ContentMaxPosRowsFrozen;        // Submitted contents absolute maximum position, from which we can infer width.
     float                   ContentMaxPosRowsUnfrozen;      // (kept as float because we need to manipulate those between each cell change)
     float                   ContentMaxPosHeadersUsed;
     float                   ContentMaxPosHeadersDesired;
-    ImRect                  ClipRect;
-    ImS16                   NameOffset;                     // Offset into parent ColumnsName[]
+    ImS16                   ContentWidthRowsFrozen;         // Contents width. Because row freezing is not correlated with headers/not-headers we need all 4 variants (ImDrawCmd merging uses different data than alignment code).
+    ImS16                   ContentWidthRowsUnfrozen;       // (encoded as ImS16 because we actually rarely use those width)
+    ImS16                   ContentWidthHeadersUsed;        // TableHeader() automatically softclip itself + report ideal desired size, to avoid creating extraneous draw calls
+    ImS16                   ContentWidthHeadersDesired;
+    ImS16                   NameOffset;                     // Offset into parent ColumnsNames[]
     bool                    IsActive;                       // Is the column not marked Hidden by the user (regardless of clipping). We're not calling this "Visible" here because visibility also depends on clipping.
     bool                    NextIsActive;
     bool                    IsClipped;                      // Set when not overlapping the host window clipping rectangle. We don't use the opposite "!Visible" name because Clipped can be altered by events.
+    bool                    SkipItems;
     ImS8                    IndexDisplayOrder;              // Index within DisplayOrder[] (column may be reordered by users)
     ImS8                    IndexWithinActiveSet;           // Index within active set (<= IndexOrder)
     ImS8                    DrawChannelCurrent;             // Index within DrawSplitter.Channels[]
@@ -1968,11 +1969,6 @@ struct ImGuiTableSettings
 
 namespace ImGui
 {
-    // Tables (Columns V2)
-    //IMGUI_API int         GetTableColumnNo();
-    //IMGUI_API bool        SetTableColumnNo(int column_n);
-    //IMGUI_API int         GetTableLineNo();
-
     // [Internal]
     IMGUI_API bool          BeginTableEx(const char* name, ImGuiID id, int columns_count, ImGuiTableFlags flags = 0, const ImVec2& outer_size = ImVec2(0, 0), float inner_width = 0.0f);
     IMGUI_API void          TableBeginUpdateColumns(ImGuiTable* table);

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -1975,7 +1975,7 @@ namespace ImGui
 
     // [Internal]
     IMGUI_API bool          BeginTableEx(const char* name, ImGuiID id, int columns_count, ImGuiTableFlags flags = 0, const ImVec2& outer_size = ImVec2(0, 0), float inner_width = 0.0f);
-    IMGUI_API void          TableBeginInitVisibility(ImGuiTable* table);
+    IMGUI_API void          TableBeginUpdateColumns(ImGuiTable* table);
     IMGUI_API void          TableUpdateDrawChannels(ImGuiTable* table);
     IMGUI_API void          TableUpdateLayout(ImGuiTable* table);
     IMGUI_API void          TableUpdateBorders(ImGuiTable* table);

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -94,6 +94,10 @@ struct ImGuiSettingsHandler;        // Storage for one type registered in the .i
 struct ImGuiStyleMod;               // Stacked style modifier, backup of modified data so we can restore it
 struct ImGuiTabBar;                 // Storage for a tab bar
 struct ImGuiTabItem;                // Storage for a tab item (within a tab bar)
+struct ImGuiTable;                  // Storage for a table
+struct ImGuiTableColumn;            // Storage for one column of a table
+struct ImGuiTableSettings;          // Storage for a table .ini settings
+struct ImGuiTableColumnsSettings;   // Storage for a column .ini settings
 struct ImGuiWindow;                 // Storage for one window
 struct ImGuiWindowTempData;         // Temporary storage for one window (that's the data which in theory we could ditch at the end of the frame)
 struct ImGuiWindowSettings;         // Storage for a window .ini settings (we keep one of those even if the actual window wasn't instanced during this session)
@@ -219,6 +223,7 @@ static inline ImU32     ImHash(const void* data, int size, ImU32 seed = 0) { ret
 
 // Helpers: Bit manipulation
 static inline bool      ImIsPowerOfTwo(int v)           { return v != 0 && (v & (v - 1)) == 0; }
+static inline bool      ImIsPowerOfTwo(ImU64 v)         { return v != 0 && (v & (v - 1)) == 0; }
 static inline int       ImUpperPowerOfTwo(int v)        { v--; v |= v >> 1; v |= v >> 2; v |= v >> 4; v |= v >> 8; v |= v >> 16; v++; return v; }
 
 // Helpers: String, Formatting
@@ -1137,6 +1142,12 @@ struct ImGuiContext
     ImVector<unsigned char> DragDropPayloadBufHeap;             // We don't expose the ImVector<> directly, ImGuiPayload only holds pointer+size
     unsigned char           DragDropPayloadBufLocal[16];        // Local buffer for small payloads
 
+    // Table
+    ImGuiTable*                     CurrentTable;
+    ImPool<ImGuiTable>              Tables;
+    ImVector<ImGuiPtrOrIndex>       CurrentTableStack;
+    ImVector<ImDrawChannel>         DrawChannelsTempMergeBuffer;
+
     // Tab bars
     ImGuiTabBar*                    CurrentTabBar;
     ImPool<ImGuiTabBar>             TabBars;
@@ -1170,6 +1181,7 @@ struct ImGuiContext
     ImGuiTextBuffer         SettingsIniData;                    // In memory .ini settings
     ImVector<ImGuiSettingsHandler>      SettingsHandlers;       // List of .ini settings handlers
     ImChunkStream<ImGuiWindowSettings>  SettingsWindows;        // ImGuiWindow .ini settings entries
+    ImChunkStream<ImGuiTableSettings>   SettingsTables;         // ImGuiTable .ini settings entries
 
     // Capture/Logging
     bool                    LogEnabled;
@@ -1288,6 +1300,7 @@ struct ImGuiContext
         DragDropAcceptFrameCount = -1;
         memset(DragDropPayloadBufLocal, 0, sizeof(DragDropPayloadBufLocal));
 
+        CurrentTable = NULL;
         CurrentTabBar = NULL;
 
         LastValidMousePos = ImVec2(0.0f, 0.0f);
@@ -1370,6 +1383,7 @@ struct IMGUI_API ImGuiWindowTempData
     ImVector<ImGuiWindow*>  ChildWindows;
     ImGuiStorage*           StateStorage;           // Current persistent per-window storage (store e.g. tree node open/close state)
     ImGuiColumns*           CurrentColumns;         // Current columns set
+    ImGuiTable*             CurrentTable;           // Current table set
     ImGuiLayoutType         LayoutType;
     ImGuiLayoutType         ParentLayoutType;       // Layout type of parent window at the time of Begin()
     int                     FocusCounterRegular;    // (Legacy Focus/Tabbing system) Sequential counter, start at -1 and increase as assigned via FocusableItemRegister() (FIXME-NAV: Needs redesign)
@@ -1412,6 +1426,7 @@ struct IMGUI_API ImGuiWindowTempData
         TreeJumpToParentOnPopMask = 0x00;
         StateStorage = NULL;
         CurrentColumns = NULL;
+        CurrentTable = NULL;
         LayoutType = ParentLayoutType = ImGuiLayoutType_Vertical;
         FocusCounterRegular = FocusCounterTabStop = -1;
 
@@ -1763,6 +1778,218 @@ namespace ImGui
     IMGUI_API ImGuiColumns* FindOrCreateColumns(ImGuiWindow* window, ImGuiID id);
     IMGUI_API float         GetColumnOffsetFromNorm(const ImGuiColumns* columns, float offset_norm);
     IMGUI_API float         GetColumnNormFromOffset(const ImGuiColumns* columns, float offset);
+}
+
+#define IM_COL32_DISABLE            IM_COL32(0,0,0,1)   // Special sentinel code
+#define IMGUI_TABLE_MAX_COLUMNS     64                  // sizeof(ImU64) * 8. This is solely because we frequently encode columns set in a ImU64.
+
+// [Internal] sizeof() ~ 96
+struct ImGuiTableColumn
+{
+    ImGuiID                 UserID;                         // Optional, value passed to TableSetupColumn()
+    ImGuiTableColumnFlags   FlagsIn;                        // Flags as input by user. See ImGuiTableColumnFlags_
+    ImGuiTableColumnFlags   Flags;                          // Effective flags. See ImGuiTableColumnFlags_
+    float                   ResizeWeight;                   //  ~1.0f. Master width data when (Flags & _WidthStretch)
+    float                   MinX;                           // Absolute positions
+    float                   MaxX;
+    float                   WidthRequested;                 // Master width data when !(Flags & _WidthStretch)
+    float                   WidthGiven;                     // == (MaxX - MinX). FIXME-TABLE: Store all persistent width in multiple of FontSize?
+    float                   StartXRows;                     // Start position for the frame, currently ~(MinX + CellPaddingX)
+    float                   StartXHeaders;                  
+    ImS16                   ContentWidthRowsFrozen;         // Contents width. Because freezing is non correlated from headers we need all 4 variants (ImDrawCmd merging uses different data than alignment code).
+    ImS16                   ContentWidthRowsUnfrozen;       // (encoded as ImS16 because we actually rarely use those width)
+    ImS16                   ContentWidthHeadersUsed;        // TableHeader() automatically softclip itself + report ideal desired size, to avoid creating extraneous draw calls
+    ImS16                   ContentWidthHeadersDesired;
+    float                   ContentMaxPosRowsFrozen;        // Submitted contents absolute maximum position, from which we can infer width.
+    float                   ContentMaxPosRowsUnfrozen;      // (kept as float because we need to manipulate those between each cell change)
+    float                   ContentMaxPosHeadersUsed;
+    float                   ContentMaxPosHeadersDesired;
+    ImRect                  ClipRect;
+    ImS16                   NameOffset;                     // Offset into parent ColumnsName[]
+    bool                    IsActive;                       // Is the column not marked Hidden by the user (regardless of clipping). We're not calling this "Visible" here because visibility also depends on clipping.
+    bool                    NextIsActive;
+    ImS8                    IndexDisplayOrder;              // Index within DisplayOrder[] (column may be reordered by users)
+    ImS8                    IndexWithinActiveSet;           // Index within active set (<= IndexOrder)
+    ImS8                    DrawChannelCurrent;             // Index within DrawSplitter.Channels[]
+    ImS8                    DrawChannelRowsBeforeFreeze;
+    ImS8                    DrawChannelRowsAfterFreeze;
+    ImS8                    PrevActiveColumn;               // Index of prev active column within Columns[], -1 if first active column
+    ImS8                    NextActiveColumn;               // Index of next active column within Columns[], -1 if last active column
+    ImS8                    AutoFitFrames;
+    ImS8                    SortOrder;                      // -1: Not sorting on this column
+    ImS8                    SortDirection;                  // enum ImGuiSortDirection_
+
+    ImGuiTableColumn()
+    {
+        memset(this, 0, sizeof(*this));
+        ResizeWeight = 1.0f;
+        WidthRequested = WidthGiven = -1.0f;
+        NameOffset = -1;
+        IsActive = NextIsActive = true;
+        IndexDisplayOrder = IndexWithinActiveSet = -1;
+        DrawChannelCurrent = DrawChannelRowsBeforeFreeze = DrawChannelRowsAfterFreeze = -1;
+        PrevActiveColumn = NextActiveColumn = -1;
+        AutoFitFrames = 3;
+        SortOrder = -1;
+        SortDirection = ImGuiSortDirection_Ascending;
+    }
+};
+
+// FIXME-OPT: Since CountColumns is invariant, we could use a single alloc for ImGuiTable + the three vectors it is carrying.
+struct ImGuiTable
+{
+    ImGuiID                     ID;
+    ImGuiTableFlags             Flags;
+    ImVector<ImGuiTableColumn>  Columns;
+    ImVector<ImU8>              DisplayOrder;               // Store display order of columns (when not reordered, the values are 0...Count-1)
+    ImU64                       ActiveMaskByIndex;          // Column Index -> IsActive map (Active == not hidden by user/api) in a format adequate for iterating column without touching cold data
+    ImU64                       ActiveMaskByDisplayOrder;   // Column DisplayOrder -> IsActive map
+    ImGuiTableFlags             SettingsSaveFlags;          // Pre-compute which data we are going to save into the .ini file (e.g. when order is not altered we won't save order)
+    int                         SettingsOffset;             // Offset in g.SettingsTables
+    int                         LastFrameActive;
+    int                         ColumnsCount;               // Number of columns declared in BeginTable()
+    int                         ColumnsActiveCount;         // Number of non-hidden columns (<= ColumnsCount)
+    int                         CurrentColumn;
+    int                         CurrentRow;
+    float                       RowPosY1;
+    float                       RowPosY2;
+    float                       RowTextBaseline;
+    ImGuiTableRowFlags          RowFlags : 16;              // Current row flags, see ImGuiTableRowFlags_
+    ImGuiTableRowFlags          LastRowFlags : 16;
+    int                         RowBgColorCounter;          // Counter for alternating background colors (can be fast-forwarded by e.g clipper)
+    ImU32                       RowBgColor;                 // Request for current row background color
+    ImU32                       BorderOuterColor;
+    ImU32                       BorderInnerColor;
+    float                       BorderX1;
+    float                       BorderX2;
+    float                       CellPaddingX1;              // Padding from each borders
+    float                       CellPaddingX2;
+    float                       CellPaddingY;
+    float                       CellSpacingX;               // Spacing between non-bordered cells
+    float                       LastOuterHeight;            // Outer height from last frame
+    float                       LastFirstRowHeight;         // Height of first row from last frame
+    float                       ColumnsTotalWidth;
+    float                       InnerWidth;
+    ImRect                      OuterRect;                  // Note: OuterRect.Max.y is often FLT_MAX until EndTable(), unless a height has been specified in BeginTable().
+    ImRect                      WorkRect;
+    ImRect                      HostClipRect;               // This is used to check if we can eventually merge our columns draw calls into the current draw call of the current window.
+    ImRect                      InnerClipRect;
+    ImRect                      BackgroundClipRect;         // We use this to cpu-clip cell background color fill
+    ImGuiWindow*                OuterWindow;                // Parent window for the table
+    ImGuiWindow*                InnerWindow;                // Window holding the table data (== OuterWindow or a child window)
+    ImGuiTextBuffer             ColumnsNames;               // Contiguous buffer holding columns names
+    ImDrawListSplitter          DrawSplitter;               // We carry our own ImDrawList splitter to allow recursion (could be stored outside?)
+    ImVector<ImGuiTableSortSpecsColumn> SortSpecsData;      // FIXME-OPT: Fixed-size array / small-vector pattern, optimize for single sort spec
+    ImGuiTableSortSpecs         SortSpecs;                  // Public facing sorts specs, this is what we return in TableGetSortSpecs()
+    ImS8                        SortSpecsCount;
+    ImS8                        DeclColumnsCount;           // Count calls to TableSetupColumn()
+    ImS8                        HoveredColumnBody;          // [DEBUG] Unlike HoveredColumnBorder this doesn't fulfill all Hovering rules properly. Used for debugging/tools for now.
+    ImS8                        HoveredColumnBorder;        // Index of column whose right-border is being hovered (for resizing).
+    ImS8                        ResizedColumn;              // Index of column being resized.
+    ImS8                        LastResizedColumn;
+    ImS8                        ReorderColumn;              // Index of column being reordered. (not cleared)
+    ImS8                        ReorderColumnDir;           // -1 or +1
+    ImS8                        RightMostActiveColumn;      // Index of right-most non-hidden column.
+    ImS8                        LeftMostStretchedColumnDisplayOrder; // Display order of left-most stretched column.
+    ImS8                        ContextPopupColumn;         // Column right-clicked on, of -1 if opening context menu from a neutral/empty spot
+    ImS8                        DummyDrawChannel;           // Redirect non-visible columns here.
+    ImS8                        FreezeRowsRequest;          // Requested frozen rows count
+    ImS8                        FreezeRowsCount;            // Actual frozen row count (== FreezeRowsRequest, or == 0 when no scrolling offset)
+    ImS8                        FreezeColumnsRequest;       // Requested frozen columns count
+    ImS8                        FreezeColumnsCount;         // Actual frozen columns count (== FreezeColumnsRequest, or == 0 when no scrolling offset)
+    bool                        IsLayoutLocked;             // Set by TableUpdateLayout() which is called when beginning the first row.
+    bool                        IsInsideRow;                // Set if inside TableBeginRow()/TableEndRow().
+    bool                        IsFirstFrame;
+    bool                        IsSortSpecsDirty;
+    bool                        IsUsingHeaders;             // Set if the first row had the ImGuiTableRowFlags_Headers flag.
+    bool                        IsContextPopupOpen;
+    bool                        IsSettingsRequestLoad;
+    bool                        IsSettingsLoaded;
+    bool                        IsSettingsDirty;            // Set when table settings have changed and needs to be reported into ImGuiTableSetttings data.
+    bool                        IsDefaultDisplayOrder;      // Set when display order is unchanged from default (DisplayOrder contains 0...Count-1)
+    bool                        IsResetDisplayOrderRequest;
+    bool                        IsFreezeRowsPassed;         // Set when we got past the frozen row (the first one).
+    bool                        BackupSkipItems;            // Backup of InnerWindow->SkipItem at the end of BeginTable(), because we will overwrite InnerWindow->SkipItem on a per-column basis
+    ImRect                      BackupWorkRect;             // Backup of InnerWindow->WorkRect at the end of BeginTable()
+    ImVec2                      BackupCursorMaxPos;         // Backup of InnerWindow->DC.CursorMaxPos at the end of BeginTable()
+
+    ImGuiTable()
+    {
+        memset(this, 0, sizeof(*this));
+        SettingsOffset = -1;
+        LastFrameActive = -1;
+        LastResizedColumn = -1;
+        ContextPopupColumn = -1;
+        ReorderColumn = -1;
+    }
+};
+
+// sizeof() ~ 12
+struct ImGuiTableColumnSettings
+{
+    float   WidthOrWeight;
+    ImGuiID UserID;
+    ImS8    Index;
+    ImS8    DisplayOrder;
+    ImS8    SortOrder;
+    ImS8    SortDirection : 7;
+    ImU8    Visible : 1;        // This is called Active in ImGuiTableColumn, in .ini file we call it Visible.
+
+    ImGuiTableColumnSettings()
+    {
+        WidthOrWeight = 0.0f;
+        UserID = 0;
+        Index = -1;
+        DisplayOrder = SortOrder = -1;
+        SortDirection = ImGuiSortDirection_None;
+        Visible = 1;
+    }
+};
+
+// This is designed to be stored in a single ImChunkStream (1 header followed by N ImGuiTableColumnSettings, etc.)
+struct ImGuiTableSettings
+{
+    ImGuiID                     ID;                     // Set to 0 to invalidate/delete the setting
+    ImGuiTableFlags             SaveFlags;
+    ImS8                        ColumnsCount;
+    ImS8                        ColumnsCountMax;
+
+    ImGuiTableSettings()        { memset(this, 0, sizeof(*this)); }
+    ImGuiTableColumnSettings*   GetColumnSettings()     { return (ImGuiTableColumnSettings*)(this + 1); }
+};
+
+namespace ImGui
+{
+    // Tables (Columns V2)
+    //IMGUI_API int         GetTableColumnNo();
+    //IMGUI_API bool        SetTableColumnNo(int column_n);
+    //IMGUI_API int         GetTableLineNo();
+
+    // [Internal]
+    IMGUI_API void          TableBeginInitVisibility(ImGuiTable* table);
+    IMGUI_API void          TableBeginInitDrawChannels(ImGuiTable* table);
+    IMGUI_API void          TableUpdateLayout(ImGuiTable* table);
+    IMGUI_API void          TableUpdateBorders(ImGuiTable* table);
+    IMGUI_API void          TableSetColumnWidth(ImGuiTable* table, ImGuiTableColumn* column, float width);
+    IMGUI_API void          TableDrawBorders(ImGuiTable* table);
+    IMGUI_API void          TableDrawMergeChannels(ImGuiTable* table);
+    IMGUI_API void          TableDrawContextMenu(ImGuiTable* table, int column_n);
+    IMGUI_API void          TableSortSpecsClickColumn(ImGuiTable* table, ImGuiTableColumn* column, bool add_to_existing_sort_orders);
+    IMGUI_API void          TableSortSpecsSanitize(ImGuiTable* table);
+    IMGUI_API void          TableBeginRow(ImGuiTable* table);
+    IMGUI_API void          TableEndRow(ImGuiTable* table);
+    IMGUI_API void          TableBeginCell(ImGuiTable* table, int column_no);
+    IMGUI_API void          TableEndCell(ImGuiTable* table);
+    IMGUI_API ImRect        TableGetCellRect();
+    IMGUI_API const char*   TableGetColumnName(ImGuiTable* table, int column_no);
+    IMGUI_API void          PushTableBackground();
+    IMGUI_API void          PopTableBackground();
+    IMGUI_API void          TableLoadSettings(ImGuiTable* table);
+    IMGUI_API void          TableSaveSettings(ImGuiTable* table);
+    IMGUI_API ImGuiTableSettings* TableFindSettings(ImGuiTable* table);
+    IMGUI_API void*         TableSettingsHandler_ReadOpen(ImGuiContext*, ImGuiSettingsHandler*, const char* name);
+    IMGUI_API void          TableSettingsHandler_ReadLine(ImGuiContext*, ImGuiSettingsHandler*, void* entry, const char* line);
+    IMGUI_API void          TableSettingsHandler_WriteAll(ImGuiContext*, ImGuiSettingsHandler*, ImGuiTextBuffer* buf);
 
     // Tab Bars
     IMGUI_API bool          BeginTabBarEx(ImGuiTabBar* tab_bar, const ImRect& bb, ImGuiTabBarFlags flags);

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -1974,6 +1974,7 @@ namespace ImGui
     //IMGUI_API int         GetTableLineNo();
 
     // [Internal]
+    IMGUI_API bool          BeginTableEx(const char* name, ImGuiID id, int columns_count, ImGuiTableFlags flags = 0, const ImVec2& outer_size = ImVec2(0, 0), float inner_width = 0.0f);
     IMGUI_API void          TableBeginInitVisibility(ImGuiTable* table);
     IMGUI_API void          TableUpdateDrawChannels(ImGuiTable* table);
     IMGUI_API void          TableUpdateLayout(ImGuiTable* table);

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -1808,6 +1808,7 @@ struct ImGuiTableColumn
     ImS16                   NameOffset;                     // Offset into parent ColumnsName[]
     bool                    IsActive;                       // Is the column not marked Hidden by the user (regardless of clipping). We're not calling this "Visible" here because visibility also depends on clipping.
     bool                    NextIsActive;
+    bool                    IsClipped;                      // Set when not overlapping the host window clipping rectangle. We don't use the opposite "!Visible" name because Clipped can be altered by events.
     ImS8                    IndexDisplayOrder;              // Index within DisplayOrder[] (column may be reordered by users)
     ImS8                    IndexWithinActiveSet;           // Index within active set (<= IndexOrder)
     ImS8                    DrawChannelCurrent;             // Index within DrawSplitter.Channels[]
@@ -1815,7 +1816,8 @@ struct ImGuiTableColumn
     ImS8                    DrawChannelRowsAfterFreeze;
     ImS8                    PrevActiveColumn;               // Index of prev active column within Columns[], -1 if first active column
     ImS8                    NextActiveColumn;               // Index of next active column within Columns[], -1 if last active column
-    ImS8                    AutoFitFrames;
+    ImS8                    AutoFitQueue;                   // Queue of 8 values for the next 8 frames to request auto-fit
+    ImS8                    CannotSkipItemsQueue;           // Queue of 8 values for the next 8 frames to disable Clipped/SkipItem
     ImS8                    SortOrder;                      // -1: Not sorting on this column
     ImS8                    SortDirection;                  // enum ImGuiSortDirection_
 
@@ -1829,7 +1831,7 @@ struct ImGuiTableColumn
         IndexDisplayOrder = IndexWithinActiveSet = -1;
         DrawChannelCurrent = DrawChannelRowsBeforeFreeze = DrawChannelRowsAfterFreeze = -1;
         PrevActiveColumn = NextActiveColumn = -1;
-        AutoFitFrames = 3;
+        AutoFitQueue = CannotSkipItemsQueue = (1 << 3) - 1; // Skip for three frames
         SortOrder = -1;
         SortDirection = ImGuiSortDirection_Ascending;
     }
@@ -1844,6 +1846,7 @@ struct ImGuiTable
     ImVector<ImU8>              DisplayOrder;               // Store display order of columns (when not reordered, the values are 0...Count-1)
     ImU64                       ActiveMaskByIndex;          // Column Index -> IsActive map (Active == not hidden by user/api) in a format adequate for iterating column without touching cold data
     ImU64                       ActiveMaskByDisplayOrder;   // Column DisplayOrder -> IsActive map
+    ImU64                       VisibleMaskByIndex;         // Visible (== Active and not Clipped)
     ImGuiTableFlags             SettingsSaveFlags;          // Pre-compute which data we are going to save into the .ini file (e.g. when order is not altered we won't save order)
     int                         SettingsOffset;             // Offset in g.SettingsTables
     int                         LastFrameActive;
@@ -1972,7 +1975,7 @@ namespace ImGui
 
     // [Internal]
     IMGUI_API void          TableBeginInitVisibility(ImGuiTable* table);
-    IMGUI_API void          TableBeginInitDrawChannels(ImGuiTable* table);
+    IMGUI_API void          TableUpdateDrawChannels(ImGuiTable* table);
     IMGUI_API void          TableUpdateLayout(ImGuiTable* table);
     IMGUI_API void          TableUpdateBorders(ImGuiTable* table);
     IMGUI_API void          TableSetColumnWidth(ImGuiTable* table, ImGuiTableColumn* column, float width);
@@ -1987,6 +1990,7 @@ namespace ImGui
     IMGUI_API void          TableEndCell(ImGuiTable* table);
     IMGUI_API ImRect        TableGetCellRect();
     IMGUI_API const char*   TableGetColumnName(ImGuiTable* table, int column_no);
+    IMGUI_API void          TableSetColumnAutofit(ImGuiTable* table, int column_no);
     IMGUI_API void          PushTableBackground();
     IMGUI_API void          PopTableBackground();
     IMGUI_API void          TableLoadSettings(ImGuiTable* table);

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -7896,6 +7896,7 @@ bool    ImGui::BeginTableEx(const char* name, ImGuiID id, int columns_count, ImG
 
     // Backup a copy of host window members we will modify
     ImGuiWindow* inner_window = table->InnerWindow;
+    table->HostIndentX = inner_window->DC.Indent.x;
     table->HostClipRect = inner_window->ClipRect;
     table->HostSkipItems = inner_window->SkipItems;
     table->HostWorkRect = inner_window->WorkRect;
@@ -8212,6 +8213,8 @@ void    ImGui::TableUpdateLayout(ImGuiTable* table)
         // Adjust flags: default width mode + weighted columns are not allowed when auto extending
         // FIXME-TABLE: Clarify why we need to do this again here and not just in TableSetupColumn()
         column->Flags = TableFixColumnFlags(table, column->FlagsIn);
+        if ((column->Flags & ImGuiTableColumnFlags_IndentMask_) == 0)
+            column->Flags |= (column_n == 0) ? ImGuiTableColumnFlags_IndentEnable : ImGuiTableColumnFlags_IndentDisable;
 
         // We have a unusual edge case where if the user doesn't call TableGetSortSpecs() but has sorting enabled
         // or varying sorting flags, we still want the sorting arrows to honor those flags.
@@ -9240,7 +9243,9 @@ void    ImGui::TableBeginCell(ImGuiTable* table, int column_no)
     ImGuiTableColumn* column = &table->Columns[column_no];
     ImGuiWindow* window = table->InnerWindow;
 
-    const float start_x = (table->RowFlags & ImGuiTableRowFlags_Headers) ? column->StartXHeaders : column->StartXRows;
+    float start_x = (table->RowFlags & ImGuiTableRowFlags_Headers) ? column->StartXHeaders : column->StartXRows;
+    if (column->Flags & ImGuiTableColumnFlags_IndentEnable)
+        start_x += window->DC.Indent.x - table->HostIndentX;
 
     window->DC.LastItemId = 0;
     window->DC.CursorPos.x = start_x;

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -8384,9 +8384,9 @@ void    ImGui::TableUpdateLayout(ImGuiTable* table)
             // FIXME-TABLE: This align based on the whole column width, not per-cell, and therefore isn't useful in many cases.
             // (To be able to honor this we might be able to store a log of cells width, per row, for visible rows, but nav/programmatic scroll would have visible artifacts.)
             //if (column->Flags & ImGuiTableColumnFlags_AlignRight)
-            //    column->StartXRows = ImMax(column->StartXRows, column->MaxX - column->WidthContent[0]);
+            //    column->StartXRows = ImMax(column->StartXRows, column->MaxX - column->ContentWidthRowsUnfrozen);
             //else if (column->Flags & ImGuiTableColumnFlags_AlignCenter)
-            //    column->StartXRows = ImLerp(column->StartXRows, ImMax(column->StartXRows, column->MaxX - column->WidthContent[0]), 0.5f);
+            //    column->StartXRows = ImLerp(column->StartXRows, ImMax(column->StartXRows, column->MaxX - column->ContentWidthRowsUnfrozen), 0.5f);
 
             // Reset content width variables
             const float initial_max_pos_x = column->MinX + table->CellPaddingX1;
@@ -9061,8 +9061,10 @@ void    ImGui::TableNextRow(ImGuiTableRowFlags row_flags, float min_row_height)
     table->RowFlags = row_flags;
     TableBeginRow(table);
 
-    // We honor min_height requested by user, but cannot guarantee per-row maximum height as that would essentially require a unique clipping rectangle per-cell.
-    table->RowPosY2 += min_row_height;
+    // We honor min_row_height requested by user, but cannot guarantee per-row maximum height,
+    // because that would essentially require a unique clipping rectangle per-cell.
+    table->RowPosY2 += table->CellPaddingY * 2.0f;
+    table->RowPosY2 = ImMax(table->RowPosY2, table->RowPosY1 + min_row_height);
 
     TableBeginCell(table, 0);
 }
@@ -9106,8 +9108,6 @@ void    ImGui::TableEndRow(ImGuiTable* table)
     IM_ASSERT(table->IsInsideRow);
 
     TableEndCell(table);
-
-    table->RowPosY2 += table->CellPaddingY;
 
     // Position cursor at the bottom of our row so it can be used for e.g. clipping calculation.
     // However it is likely that the next call to TableBeginCell() will reposition the cursor to take account of vertical padding.
@@ -9265,7 +9265,7 @@ void    ImGui::TableEndCell(ImGuiTable* table)
     else
         p_max_pos_x = table->IsFreezeRowsPassed ? &column->ContentMaxPosRowsUnfrozen : &column->ContentMaxPosRowsFrozen;
     *p_max_pos_x = ImMax(*p_max_pos_x, window->DC.CursorMaxPos.x);
-    table->RowPosY2 = ImMax(table->RowPosY2, window->DC.CursorMaxPos.y);
+    table->RowPosY2 = ImMax(table->RowPosY2, window->DC.CursorMaxPos.y + table->CellPaddingY);
 
     // Propagate text baseline for the entire row
     // FIXME-TABLE: Here we propagate text baseline from the last line of the cell.. instead of the first one.
@@ -9342,6 +9342,9 @@ bool    ImGui::TableSetColumnIndex(int column_idx)
     return (table->VisibleMaskByIndex & ((ImU64)1 << column_idx)) != 0;
 }
 
+// Return the cell rectangle based on currently known height.
+// Important: we generally don't know our row height until the end of the row, so Max.y will be incorrect in many situations.
+// The only case where this is correct is if we provided a min_row_height to TableNextRow() and don't go below it.
 ImRect  ImGui::TableGetCellRect()
 {
     ImGuiContext& g = *GImGui;
@@ -9465,7 +9468,7 @@ void    ImGui::TableAutoHeaders()
     ImGuiTable* table = g.CurrentTable;
     IM_ASSERT(table != NULL && "Need to call TableAutoHeaders() after BeginTable()!");
 
-    TableNextRow(ImGuiTableRowFlags_Headers, GetTextLineHeight());
+    TableNextRow(ImGuiTableRowFlags_Headers, GetTextLineHeight() + g.Style.CellPadding.y * 2.0f);
     if (window->SkipItems)
         return;
 
@@ -9569,6 +9572,7 @@ void    ImGui::TableHeader(const char* label)
 
     float row_height = GetTextLineHeight();
     ImRect cell_r = TableGetCellRect();
+    //GetForegroundDrawList()->AddRect(cell_r.Min, cell_r.Max, IM_COL32(255, 0, 0, 255)); // [DEBUG]
     ImRect work_r = cell_r;
     work_r.Min.x = window->DC.CursorPos.x;
     work_r.Max.y = work_r.Min.y + row_height;

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -8159,8 +8159,8 @@ static float TableGetMinColumnWidth()
 
 // Layout columns for the frame
 // Runs on the first call to TableNextRow(), to give a chance for TableSetupColumn() to be called first.
-// FIXME-TABLE: Our width (and therefore our WorkRect) will be minimal in the first frame for WidthAuto columns, 
-// increase feedback side-effect with widgets relying on WorkRect.Max.x. Maybe provide a default distribution for WidthAuto columns?
+// FIXME-TABLE: Our width (and therefore our WorkRect) will be minimal in the first frame for WidthAlwaysAutoResize columns, 
+// increase feedback side-effect with widgets relying on WorkRect.Max.x. Maybe provide a default distribution for WidthAlwaysAutoResize columns?
 void    ImGui::TableUpdateLayout(ImGuiTable* table)
 {
     IM_ASSERT(table->IsLayoutLocked == false);
@@ -8182,6 +8182,7 @@ void    ImGui::TableUpdateLayout(ImGuiTable* table)
         ImGuiTableColumn* column = &table->Columns[column_n];
 
         // Adjust flags: default width mode + weighted columns are not allowed when auto extending
+        // FIXME-TABLE: Clarify why we need to do this again here and not just in TableSetupColumn()
         column->Flags = TableFixColumnFlags(table, column->FlagsIn);
 
         // We have a unusual edge case where if the user doesn't call TableGetSortSpecs() but has sorting enabled
@@ -8928,6 +8929,12 @@ void    ImGui::TableSetupColumn(const char* label, ImGuiTableColumnFlags flags, 
 
     ImGuiTableColumn* column = &table->Columns[table->DeclColumnsCount];
     table->DeclColumnsCount++;
+
+    // When passing a width automatically enforce WidthFixed policy (vs TableFixColumnFlags would default to WidthAlwaysAutoResize)
+    // (we write down to FlagsIn which is a little misleading, another solution would be to pass init_width_or_weight to TableFixColumnFlags)
+    if ((flags & ImGuiTableColumnFlags_WidthMask_) == 0)
+        if ((table->Flags & ImGuiTableFlags_SizingPolicyFixedX) && (init_width_or_weight > 0.0f))
+            flags |= ImGuiTableColumnFlags_WidthFixed;
 
     column->UserID = user_id;
     column->FlagsIn = flags;

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -8147,6 +8147,7 @@ static ImGuiTableColumnFlags TableFixColumnFlags(ImGuiTable* table, ImGuiTableCo
     // Sizing Policy
     if ((flags & ImGuiTableColumnFlags_WidthMask_) == 0)
     {
+        // FIXME-TABLE: Inconsistent to promote columns to WidthAlwaysAutoResize
         if (table->Flags & ImGuiTableFlags_SizingPolicyFixedX)
             flags |= ((table->Flags & ImGuiTableFlags_Resizable) && !(flags & ImGuiTableColumnFlags_NoResize)) ? ImGuiTableColumnFlags_WidthFixed : ImGuiTableColumnFlags_WidthAlwaysAutoResize;
         else
@@ -8196,7 +8197,7 @@ void    ImGui::TableUpdateLayout(ImGuiTable* table)
 
     // Compute offset, clip rect for the frame
     const ImRect work_rect = table->WorkRect;
-    const float padding_auto_x = table->CellPaddingX1; // Can't make auto padding larger than what WorkRect knows about so right-alignment matches.
+    const float padding_auto_x = table->CellPaddingX2; // Can't make auto padding larger than what WorkRect knows about so right-alignment matches.
     const float min_column_width = TableGetMinColumnWidth();
 
     int count_fixed = 0;
@@ -8255,12 +8256,13 @@ void    ImGui::TableUpdateLayout(ImGuiTable* table)
     }
 
     // Layout
+    // Remove -1.0f to cancel out the +1.0f we are doing in EndTable() to make last column line visible
     const float width_spacings = table->CellSpacingX * (table->ColumnsActiveCount - 1);
     float width_avail;
     if ((table->Flags & ImGuiTableFlags_ScrollX) && (table->InnerWidth == 0.0f))
         width_avail = table->InnerClipRect.GetWidth() - width_spacings - 1.0f;
     else
-        width_avail = work_rect.GetWidth() - width_spacings - 1.0f; // Remove -1.0f to cancel out the +1.0f we are doing in EndTable() to make last column line visible
+        width_avail = work_rect.GetWidth() - width_spacings - 1.0f;
     const float width_avail_for_stretched_columns = width_avail - width_fixed;
     float width_remaining_for_stretched_columns = width_avail_for_stretched_columns;
 
@@ -9066,7 +9068,10 @@ void    ImGui::TableSetupColumn(const char* label, ImGuiTableColumnFlags flags, 
         if (flags & ImGuiTableColumnFlags_DefaultHide)
             column->IsActive = column->NextIsActive = false;
         if (flags & ImGuiTableColumnFlags_DefaultSort)
+        {
             column->SortOrder = 0; // Multiple columns using _DefaultSort will be reordered when building the sort specs.
+            column->SortDirection = (column->Flags & ImGuiTableColumnFlags_PreferSortDescending) ? (ImS8)ImGuiSortDirection_Descending : (ImU8)(ImGuiSortDirection_Ascending);
+        }
     }
 
     // Store name (append with zero-terminator in contiguous buffer)
@@ -9750,7 +9755,7 @@ void ImGui::TableSortSpecsClickColumn(ImGuiTable* table, ImGuiTableColumn* click
     table->IsSortSpecsDirty = true;
 }
 
-// Return NULL if no sort specs.
+// Return NULL if no sort specs (most often when ImGuiTableFlags_Sortable is not set) 
 // You can sort your data again when 'SpecsChanged == true'. It will be true with sorting specs have changed since last call, or the first time.
 // Lifetime: don't hold on this pointer over multiple frames or past any subsequent call to BeginTable()!
 const ImGuiTableSortSpecs* ImGui::TableGetSortSpecs()

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -25,6 +25,7 @@ Index of this file:
 // [SECTION] Widgets: BeginTabBar, EndTabBar, etc.
 // [SECTION] Widgets: BeginTabItem, EndTabItem, etc.
 // [SECTION] Widgets: Columns, BeginColumns, EndColumns, etc.
+// [SECTION] Widgets: BeginTable, EndTable, etc.
 
 */
 
@@ -5598,6 +5599,8 @@ bool ImGui::Selectable(const char* label, bool selected, ImGuiSelectableFlags fl
 
     if ((flags & ImGuiSelectableFlags_SpanAllColumns) && window->DC.CurrentColumns) // FIXME-OPT: Avoid if vertically clipped.
         PushColumnsBackground();
+    else if ((flags & ImGuiSelectableFlags_SpanAllColumns) && g.CurrentTable) // FIXME-TABLE: Make it possible to colorize a whole line
+        PushTableBackground();
 
     ImGuiID id = window->GetID(label);
     ImVec2 label_size = CalcTextSize(label, NULL, true);
@@ -5608,8 +5611,9 @@ bool ImGui::Selectable(const char* label, bool selected, ImGuiSelectableFlags fl
     ItemSize(size, 0.0f);
 
     // Fill horizontal space.
+    // FIXME-TABLE: Span row min
     ImVec2 window_padding = window->WindowPadding;
-    float max_x = (flags & ImGuiSelectableFlags_SpanAllColumns) ? GetWindowContentRegionMax().x : GetContentRegionMax().x;
+    float max_x = (flags & ImGuiSelectableFlags_SpanAllColumns) ? GetWindowContentRegionMax().x : GetContentRegionMax().x; // FIXME-TABLE
     float w_draw = ImMax(label_size.x, window->Pos.x + max_x - window_padding.x - pos.x);
     ImVec2 size_draw((size_arg.x != 0 && !(flags & ImGuiSelectableFlags_DrawFillAvailWidth)) ? size_arg.x : w_draw, size_arg.y != 0.0f ? size_arg.y : size.y);
     ImRect bb(pos, pos + size_draw);
@@ -5642,6 +5646,8 @@ bool ImGui::Selectable(const char* label, bool selected, ImGuiSelectableFlags fl
     {
         if ((flags & ImGuiSelectableFlags_SpanAllColumns) && window->DC.CurrentColumns)
             PopColumnsBackground();
+        else if ((flags & ImGuiSelectableFlags_SpanAllColumns) && g.CurrentTable)
+            PopTableBackground();
         return false;
     }
 
@@ -5693,6 +5699,11 @@ bool ImGui::Selectable(const char* label, bool selected, ImGuiSelectableFlags fl
     if ((flags & ImGuiSelectableFlags_SpanAllColumns) && window->DC.CurrentColumns)
     {
         PopColumnsBackground();
+        bb.Max.x -= (GetContentRegionMax().x - max_x);
+    }
+    else if ((flags & ImGuiSelectableFlags_SpanAllColumns) && g.CurrentTable)
+    {
+        PopTableBackground();
         bb.Max.x -= (GetContentRegionMax().x - max_x);
     }
 
@@ -7703,6 +7714,2191 @@ void ImGui::Columns(int columns_count, const char* id, bool border)
 
     if (columns_count != 1)
         BeginColumns(id, columns_count, flags);
+}
+
+
+//-----------------------------------------------------------------------------
+// [SECTION] Widgets: BeginTable, EndTable, etc.
+//-----------------------------------------------------------------------------
+
+// Typical call flow: (root level is public API):
+// - BeginTable()                               user begin into a table
+//    - BeginChild()                            - (if ScrollX/ScrollY is set)
+//    - TableBeginInitVisibility()              - lock columns visibility
+//    - TableBeginInitDrawChannels()            - setup ImDrawList channels
+// - TableSetupColumn()                         user submit columns details (optional)
+// - TableAutoHeaders() or TableHeader()        user submit a headers row (optional)
+//    - TableSortSpecsClickColumn()
+// - TableGetSortSpecs()                        user queries updated sort specs (optional)
+// - TableNextRow() / TableNextCell()           user begin into the first row, also automatically called by TableAutoHeaders()
+//    - TableUpdateLayout()                     - called by the FIRST call to TableNextRow()
+//      - TableUpdateBorders()                  - detect hovering columns for resize, ahead of contents submission
+//      - TableDrawContextMenu()                - draw right-click context menu
+// - [...]                                      user emit contents
+// - EndTable()                                 user ends the table
+//    - TableDrawBorders()                      - draw outer borders, inner vertical borders
+//    - TableDrawMergeChannels()                - merge draw channels if clipping isn't required
+//    - TableSetColumnWidth()                   - apply resizing width
+//      - TableUpdateColumnsWeightFromWidth()
+//      - EndChild()                            - (if ScrollX/ScrollY is set)
+
+// Configuration
+static const float TABLE_RESIZE_SEPARATOR_HALF_THICKNESS = 4.0f;    // Extend outside inner borders.
+static const float TABLE_RESIZE_SEPARATOR_FEEDBACK_TIMER = 0.06f;   // Delay/timer before making the hover feedback (color+cursor) visible because tables/columns tends to be more cramped.
+
+// Helper
+inline ImGuiTableFlags TableFixFlags(ImGuiTableFlags flags)
+{
+    // Adjust flags: set default sizing policy
+    if ((flags & ImGuiTableFlags_SizingPolicyMaskX_) == 0)
+        flags |= (flags & ImGuiTableFlags_ScrollX) ? ImGuiTableFlags_SizingPolicyFixedX : ImGuiTableFlags_SizingPolicyStretchX;
+
+    // Adjust flags: MultiSortable automatically enable Sortable
+    if (flags & ImGuiTableFlags_MultiSortable)
+        flags |= ImGuiTableFlags_Sortable;
+
+    // Adjust flags: disable saved settings if there's nothing to save
+    if ((flags & (ImGuiTableFlags_Resizable | ImGuiTableFlags_Hideable | ImGuiTableFlags_Reorderable | ImGuiTableFlags_Sortable)) == 0)
+        flags |= ImGuiTableFlags_NoSavedSettings;
+
+    // Adjust flags: enforce borders when resizable
+    if (flags & ImGuiTableFlags_Resizable)
+        flags |= ImGuiTableFlags_BordersV;
+
+    // Adjust flags: disable top rows freezing if there's no scrolling
+    if ((flags & ImGuiTableFlags_ScrollX) == 0)
+        flags &= ~ImGuiTableFlags_ScrollFreezeColumnsMask_;
+    if ((flags & ImGuiTableFlags_ScrollY) == 0)
+        flags &= ~ImGuiTableFlags_ScrollFreezeRowsMask_;
+
+    // Adjust flags: disable NoHostExtendY if we have any scrolling going on
+    if ((flags & ImGuiTableFlags_NoHostExtendY) && (flags & (ImGuiTableFlags_ScrollX | ImGuiTableFlags_ScrollY)) != 0)
+        flags &= ~ImGuiTableFlags_NoHostExtendY;
+
+    // Adjust flags: we don't support NoClipX with (FreezeColumns > 0), we could with some work but it doesn't appear to be worth the effort
+    if (flags & ImGuiTableFlags_ScrollFreezeColumnsMask_)
+        flags &= ~ImGuiTableFlags_NoClipX;
+
+    return flags;
+}
+
+// About 'outer_size':
+//   The meaning of outer_size needs to differ slightly depending of if we are using ScrollX/ScrollY flags.
+//   With ScrollX/ScrollY: using a child window for scrolling:
+//   - outer_size.y < 0.0f  ->  bottom align
+//   - outer_size.y = 0.0f  ->  bottom align: consistent with BeginChild(), best to preserve (0,0) default arg
+//   - outer_size.y > 0.0f  ->  fixed child height
+//   Without scrolling, we output table directly in parent window:
+//   - outer_size.y < 0.0f  ->  bottom align (will auto extend, unless NoHostExtendV is set)
+//   - outer_size.y = 0.0f  ->  zero minimum height (will auto extend, unless NoHostExtendV is set)
+//   - outer_size.y > 0.0f  ->  minimum height (will auto extend, unless NoHostExtendV is set)
+// About: 'inner_width':
+//   With ScrollX:
+//   - inner_width  < 0.0f  ->  *illegal* fit in known width (right align from outer_size.x) <-- weird
+//   - inner_width  = 0.0f  ->  auto enlarge: *only* fixed size columns, which will take space they need (proportional columns becomes fixed columns) <-- desired default :(
+//   - inner_width  > 0.0f  ->  fit in known width: fixed column take space they need if possible (otherwise shrink down), proportional columns share remaining space.
+//   Without ScrollX:
+//   - inner_width  < 0.0f  ->  fit in known width (right align from outer_size.x) <-- desired default
+//   - inner_width  = 0.0f  ->  auto enlarge: will emit contents size in parent window
+//   - inner_width  > 0.0f  ->  fit in known width (bypass outer_size.x, permitted but not useful, should instead alter outer_width)
+// FIXME-TABLE: This is currently not very useful.
+// FIXME-TABLE: Replace enlarge vs fixed width by a flag.
+// Even if not really useful, we allow 'inner_scroll_width < outer_size.x' for consistency and to facilitate understanding of what the value does.
+bool    ImGui::BeginTable(const char* str_id, int columns_count, ImGuiTableFlags flags, const ImVec2& outer_size, float inner_width)
+{
+    ImGuiContext& g = *GImGui;
+    ImGuiWindow* outer_window = GetCurrentWindow();
+    IM_ASSERT(columns_count > 0 && columns_count < IMGUI_TABLE_MAX_COLUMNS && "Only 0..63 columns allowed!");
+    if (flags & ImGuiTableFlags_ScrollX)
+        IM_ASSERT(inner_width >= 0.0f);
+    ImGuiID id = GetID(str_id);
+
+    const bool use_child_window = (flags & (ImGuiTableFlags_ScrollX | ImGuiTableFlags_ScrollY)) != 0;
+    const ImVec2 avail_size = GetContentRegionAvail();
+    ImVec2 actual_outer_size = CalcItemSize(outer_size, ImMax(avail_size.x, 1.0f), use_child_window ? ImMax(avail_size.y, 1.0f) : 0.0f);
+    ImRect outer_rect(outer_window->DC.CursorPos, outer_window->DC.CursorPos + actual_outer_size);
+
+    // If an outer size is specified ahead we will be able to early out when not visible,
+    // The exact rules here can evolve.
+    if (use_child_window && IsClippedEx(outer_rect, id, false))
+    {
+        ItemSize(outer_rect);
+        return false;
+    }
+
+    flags = TableFixFlags(flags);
+    if (outer_window->Flags & ImGuiWindowFlags_NoSavedSettings)
+        flags |= ImGuiTableFlags_NoSavedSettings;
+
+    // Acquire storage for the table
+    ImGuiTable* table = g.Tables.GetOrAddByKey(id);
+    const ImGuiTableFlags table_last_flags = table->Flags;
+    table->ID = id;
+    table->Flags = flags;
+    table->IsFirstFrame = (table->LastFrameActive == -1);
+    table->LastFrameActive = g.FrameCount;
+    table->OuterWindow = table->InnerWindow = outer_window;
+    table->ColumnsCount = columns_count;
+    table->ColumnsNames.Buf.resize(0);
+    table->IsLayoutLocked = false;
+    table->InnerWidth = inner_width;
+    table->OuterRect = outer_rect;
+    table->WorkRect = outer_rect;
+
+    if (use_child_window)
+    {
+        // Ensure no vertical scrollbar appears if we only want horizontal one, to make flag consistent (we have no other way to disable vertical scrollbar of a window while keeping the horizontal one showing)
+        ImVec2 override_content_size(FLT_MAX, FLT_MAX);
+        if ((flags & ImGuiTableFlags_ScrollX) && !(flags & ImGuiTableFlags_ScrollY))
+            override_content_size.y = FLT_MIN;
+
+        // Ensure specified width (when not specified, Stretched columns will act as if the width == OuterWidth and never lead to any scrolling)
+        // We don't handle inner_width < 0.0f, we could potentially use it to right-align based on the right side of the child window work rect, 
+        // which would require knowing ahead if we are going to have decoration taking horizontal spaces (typically a vertical scrollbar).
+        if (inner_width != 0.0f)
+            override_content_size.x = inner_width;
+
+        if (override_content_size.x != FLT_MAX || override_content_size.y != FLT_MAX)
+            SetNextWindowContentSize(ImVec2(override_content_size.x != FLT_MAX ? override_content_size.x : 0.0f, override_content_size.y != FLT_MAX ? override_content_size.y : 0.0f));
+
+        // Create scrolling region (without border = zero window padding)
+        ImGuiWindowFlags child_flags = (flags & ImGuiTableFlags_ScrollX) ? ImGuiWindowFlags_HorizontalScrollbar : ImGuiWindowFlags_None;
+        BeginChildEx(str_id, id, table->OuterRect.GetSize(), false, child_flags);
+        table->InnerWindow = g.CurrentWindow;
+        table->WorkRect = table->InnerWindow->WorkRect;
+        table->OuterRect = table->InnerWindow->Rect();
+    }
+    else
+    {
+        // WorkRect.Max will grow as we append contents.
+        PushID(id);
+    }
+
+    const bool has_cell_padding_x = (flags & (ImGuiTableFlags_BordersOuter | ImGuiTableFlags_BordersV)) != 0;
+    ImGuiWindow* inner_window = table->InnerWindow;
+    table->CurrentColumn = -1;
+    table->CurrentRow = -1;
+    table->RowBgColorCounter = 0;
+    table->LastRowFlags = ImGuiTableRowFlags_None;
+
+    table->CellPaddingX1 = has_cell_padding_x ? g.Style.CellPadding.x + 1.0f : 0.0f;
+    table->CellPaddingX2 = has_cell_padding_x ? g.Style.CellPadding.x : 0.0f;
+    table->CellPaddingY = g.Style.CellPadding.y;
+    table->CellSpacingX = has_cell_padding_x ? 0.0f : g.Style.CellPadding.x;
+
+    table->HostClipRect = inner_window->ClipRect;
+    table->InnerClipRect = (inner_window == outer_window) ? table->WorkRect : inner_window->ClipRect;
+    table->InnerClipRect.ClipWith(table->WorkRect);     // We need this to honor inner_width
+    table->InnerClipRect.ClipWith(table->HostClipRect);
+    table->InnerClipRect.Max.y = (flags & ImGuiTableFlags_NoHostExtendY) ? table->WorkRect.Max.y : inner_window->ClipRect.Max.y;
+    table->BackgroundClipRect = table->InnerClipRect;
+    table->RowPosY1 = table->RowPosY2 = table->WorkRect.Min.y; // This is needed somehow
+    table->RowTextBaseline = 0.0f; // This will be cleared again by TableBeginRow()
+    table->FreezeRowsRequest = (ImS8)((flags & ImGuiTableFlags_ScrollFreezeRowsMask_) >> ImGuiTableFlags_ScrollFreezeRowsShift_);
+    table->FreezeRowsCount = (inner_window->Scroll.y != 0.0f) ? table->FreezeRowsRequest : 0;
+    table->FreezeColumnsRequest = (ImS8)((flags & ImGuiTableFlags_ScrollFreezeColumnsMask_) >> ImGuiTableFlags_ScrollFreezeColumnsShift_);
+    table->FreezeColumnsCount = (inner_window->Scroll.x != 0.0f) ? table->FreezeColumnsRequest : 0;
+    table->IsFreezeRowsPassed = (table->FreezeRowsCount == 0);
+    table->DeclColumnsCount = 0;
+    table->LastResizedColumn = table->ResizedColumn;
+    table->HoveredColumnBody = -1;
+    table->HoveredColumnBorder = -1;
+    table->RightMostActiveColumn = -1;
+    table->LeftMostStretchedColumnDisplayOrder = -1;
+    table->IsFirstFrame = false;
+
+    // FIXME-TABLE FIXME-STYLE: Using opaque colors facilitate overlapping elements of the grid
+    //table->BorderOuterColor = GetColorU32(ImGuiCol_Separator, 1.00f);
+    //table->BorderInnerColor = GetColorU32(ImGuiCol_Separator, 0.60f);
+    table->BorderOuterColor = GetColorU32(ImVec4(0.31f, 0.31f, 0.35f, 1.00f));
+    table->BorderInnerColor = GetColorU32(ImVec4(0.23f, 0.23f, 0.25f, 1.00f));
+    //table->BorderOuterColor = IM_COL32(255, 0, 0, 255);
+    //table->BorderInnerColor = IM_COL32(255, 255, 0, 255);
+    table->BorderX1 = table->InnerClipRect.Min.x;// +((table->Flags & ImGuiTableFlags_BordersOuter) ? 0.0f : -1.0f);
+    table->BorderX2 = table->InnerClipRect.Max.x;// +((table->Flags & ImGuiTableFlags_BordersOuter) ? 0.0f : +1.0f);
+
+    // Make table current
+    g.CurrentTableStack.push_back(ImGuiPtrOrIndex(g.Tables.GetIndex(table)));
+    g.CurrentTable = table;
+    outer_window->DC.CurrentTable = table;
+    if ((table_last_flags & ImGuiTableFlags_Reorderable) && !(flags & ImGuiTableFlags_Reorderable))
+        table->IsResetDisplayOrderRequest = true;
+
+    // Clear data if columns count changed
+    if (table->Columns.Size != 0 && table->Columns.Size != columns_count)
+    {
+        table->Columns.resize(0);
+        table->DisplayOrder.resize(0);
+    }
+
+    // Setup default columns state
+    if (table->Columns.Size == 0)
+    {
+        table->IsFirstFrame = true;
+        table->IsSortSpecsDirty = true;
+        table->Columns.reserve(columns_count);
+        table->DisplayOrder.reserve(columns_count);
+        for (int n = 0; n < columns_count; n++)
+        {
+            ImGuiTableColumn column;
+            column.IndexDisplayOrder = (ImS8)n;
+            table->Columns.push_back(column);
+            table->DisplayOrder.push_back(column.IndexDisplayOrder);
+        }
+    }
+
+    // Load settings
+    if (table->IsFirstFrame || table->IsSettingsRequestLoad)
+        TableLoadSettings(table);
+
+    // Handle reordering request
+    // Note: we don't clear ReorderColumn after handling the request.
+    if (table->ReorderColumn != -1 && table->ReorderColumnDir != 0)
+    {
+        IM_ASSERT(table->ReorderColumnDir == -1 || table->ReorderColumnDir == +1);
+        IM_ASSERT(table->Flags & ImGuiTableFlags_Reorderable);
+        ImGuiTableColumn* dragged_column = &table->Columns[table->ReorderColumn];
+        ImGuiTableColumn* target_column = &table->Columns[(table->ReorderColumnDir == -1) ? dragged_column->PrevActiveColumn : dragged_column->NextActiveColumn];
+        ImSwap(table->DisplayOrder[dragged_column->IndexDisplayOrder], table->DisplayOrder[target_column->IndexDisplayOrder]);
+        ImSwap(dragged_column->IndexDisplayOrder, target_column->IndexDisplayOrder);
+        table->ReorderColumnDir = 0;
+        table->IsSettingsDirty = true;
+    }
+
+    // Handle display order reset request
+    if (table->IsResetDisplayOrderRequest)
+    {
+        for (int n = 0; n < columns_count; n++)
+            table->DisplayOrder[n] = table->Columns[n].IndexDisplayOrder = (ImU8)n;
+        table->IsResetDisplayOrderRequest = false;
+        table->IsSettingsDirty = true;
+    }
+
+    TableBeginInitVisibility(table);
+    TableBeginInitDrawChannels(table);
+
+    // Grab a copy of window fields we will modify
+    table->BackupSkipItems = inner_window->SkipItems;
+    table->BackupWorkRect = inner_window->WorkRect;
+    table->BackupCursorMaxPos = inner_window->DC.CursorMaxPos;
+
+    if (flags & ImGuiTableFlags_NoClipX)
+        table->DrawSplitter.SetCurrentChannel(inner_window->DrawList, 1);
+    else
+        inner_window->DrawList->PushClipRect(inner_window->ClipRect.Min, inner_window->ClipRect.Max, false);
+
+    return true;
+}
+
+void ImGui::TableBeginInitVisibility(ImGuiTable* table)
+{
+    // Setup and lock Active state and order
+    table->ColumnsActiveCount = 0;
+    table->IsDefaultDisplayOrder = true;
+    ImGuiTableColumn* last_active_column = NULL;
+    bool want_column_auto_fit = false;
+    for (int order_n = 0; order_n < table->ColumnsCount; order_n++)
+    {
+        const int column_n = table->DisplayOrder[order_n];
+        if (column_n != order_n)
+            table->IsDefaultDisplayOrder = false;
+        ImGuiTableColumn* column = &table->Columns[column_n];
+        column->NameOffset = -1;
+        if (!(table->Flags & ImGuiTableFlags_Hideable) || (column->Flags & ImGuiTableColumnFlags_NoHide))
+            column->NextIsActive = true;
+        if (column->IsActive != column->NextIsActive)
+        {
+            column->IsActive = column->NextIsActive;
+            table->IsSettingsDirty = true;
+            if (!column->IsActive && column->SortOrder != -1)
+                table->IsSortSpecsDirty = true;
+        }
+        if (column->SortOrder > 0 && !(table->Flags & ImGuiTableFlags_MultiSortable))
+            table->IsSortSpecsDirty = true;
+        if (column->AutoFitFrames > 0)
+            want_column_auto_fit = true;
+
+        ImU64 index_mask = (ImU64)1 << column_n;
+        ImU64 display_order_mask = (ImU64)1 << column->IndexDisplayOrder;
+        if (column->IsActive)
+        {
+            column->PrevActiveColumn = column->NextActiveColumn = -1;
+            if (last_active_column)
+            {
+                last_active_column->NextActiveColumn = (ImS8)column_n;
+                column->PrevActiveColumn = (ImS8)table->Columns.index_from_ptr(last_active_column);
+            }
+            column->IndexWithinActiveSet = (ImS8)table->ColumnsActiveCount;
+            table->ColumnsActiveCount++;
+            table->ActiveMaskByIndex |= index_mask;
+            table->ActiveMaskByDisplayOrder |= display_order_mask;
+            last_active_column = column;
+        }
+        else
+        {
+            column->IndexWithinActiveSet = -1;
+            table->ActiveMaskByIndex &= ~index_mask;
+            table->ActiveMaskByDisplayOrder &= ~display_order_mask;
+        }
+        IM_ASSERT(column->IndexWithinActiveSet <= column->IndexDisplayOrder);
+    }
+    table->RightMostActiveColumn = (ImS8)(last_active_column ? table->Columns.index_from_ptr(last_active_column) : -1);
+
+    // Disable child window clipping while fitting columns. This is not strictly necessary but makes it possible to avoid
+    // the column fitting to wait until the first visible frame of the child container (may or not be a good thing).
+    if (want_column_auto_fit && table->OuterWindow != table->InnerWindow)
+        table->InnerWindow->SkipItems = false;
+}
+
+void ImGui::TableBeginInitDrawChannels(ImGuiTable* table)
+{
+    // Allocate draw channels.
+    // - We allocate them following the storage order instead of the display order so reordering won't needlessly increase overall dormant memory cost
+    // - We isolate headers draw commands in their own channels instead of just altering clip rects. This is in order to facilitate merging of draw commands.
+    // - After crossing FreezeRowsCount, all columns see their current draw channel increased.
+    // - We only use the dummy draw channel so we can push a null clipping rectangle into it without affecting other channels, while simplifying per-row/per-cell overhead. It will be empty and discarded when merged.
+    // Draw channel allocation (before merging):
+    // - NoClip                       --> 1+1 channels: background + foreground (same clip rect == 1 draw call)
+    // - Clip                         --> 1+N channels
+    // - FreezeRows || FreezeColumns  --> 1+N*2 (unless scrolling value is zero)
+    // - FreezeRows && FreezeColunns  --> 2+N*2 (unless scrolling value is zero)
+    const int freeze_row_multiplier = (table->FreezeRowsCount > 0) ? 2 : 1;
+    const int channels_for_row = (table->Flags & ImGuiTableFlags_NoClipX) ? 1 : table->ColumnsActiveCount;
+    const int channels_for_background = 1;
+    const int channels_for_dummy = (table->ColumnsActiveCount < table->ColumnsCount) ? +1 : 0;
+    const int channels_total = channels_for_background + (channels_for_row * freeze_row_multiplier) + channels_for_dummy;
+    table->DrawSplitter.Split(table->InnerWindow->DrawList, channels_total);
+    table->DummyDrawChannel = channels_for_dummy ? (ImS8)(channels_total - 1) : -1;
+
+    int draw_channel_current = 1;
+    for (int column_n = 0; column_n < table->ColumnsCount; column_n++)
+    {
+        ImGuiTableColumn* column = &table->Columns[column_n];
+        if (column->IsActive)
+        {
+            column->DrawChannelRowsBeforeFreeze = (ImS8)(draw_channel_current);
+            column->DrawChannelRowsAfterFreeze = (ImS8)(draw_channel_current + (table->FreezeRowsCount > 0 ? channels_for_row : 0));
+            if (!(table->Flags & ImGuiTableFlags_NoClipX))
+                draw_channel_current++;
+        }
+        else
+        {
+            column->DrawChannelRowsBeforeFreeze = column->DrawChannelRowsAfterFreeze = table->DummyDrawChannel;
+        }
+        column->DrawChannelCurrent = column->DrawChannelRowsBeforeFreeze;
+    }
+}
+
+// Adjust flags: default width mode + weighted columns are not allowed when auto extending
+static ImGuiTableColumnFlags TableFixColumnFlags(ImGuiTable* table, ImGuiTableColumnFlags flags)
+{
+    // Sizing Policy
+    if ((flags & ImGuiTableColumnFlags_WidthMask_) == 0)
+    {
+        if (table->Flags & ImGuiTableFlags_SizingPolicyFixedX)
+            flags |= ((table->Flags & ImGuiTableFlags_Resizable) && !(flags & ImGuiTableColumnFlags_NoResize)) ? ImGuiTableColumnFlags_WidthFixed : ImGuiTableColumnFlags_WidthAlwaysAutoResize;
+        else
+            flags |= ImGuiTableColumnFlags_WidthStretch;
+    }
+    IM_ASSERT(ImIsPowerOfTwo(flags & ImGuiTableColumnFlags_WidthMask_)); // Check that only 1 of each set is used.
+    if ((flags & ImGuiTableColumnFlags_WidthAlwaysAutoResize))// || ((flags & ImGuiTableColumnFlags_WidthStretch) && (table->Flags & ImGuiTableFlags_SizingPolicyStretchX)))
+        flags |= ImGuiTableColumnFlags_NoResize;
+    //if ((flags & ImGuiTableColumnFlags_WidthStretch) && (table->Flags & ImGuiTableFlags_SizingPolicyFixedX))
+    //    flags = (flags & ~ImGuiTableColumnFlags_WidthMask_) | ImGuiTableColumnFlags_WidthFixed;
+
+    // Sorting
+    if ((flags & ImGuiTableColumnFlags_NoSortAscending) && (flags & ImGuiTableColumnFlags_NoSortDescending))
+        flags |= ImGuiTableColumnFlags_NoSort;
+
+    // Alignment
+    //if ((flags & ImGuiTableColumnFlags_AlignMask_) == 0)
+    //    flags |= ImGuiTableColumnFlags_AlignCenter;
+    //IM_ASSERT(ImIsPowerOfTwo(flags & ImGuiTableColumnFlags_AlignMask_)); // Check that only 1 of each set is used.
+
+    return flags;
+}
+
+static void TableFixColumnSortDirection(ImGuiTableColumn* column)
+{
+    // Handle NoSortAscending/NoSortDescending
+    if (column->SortDirection == ImGuiSortDirection_Ascending && (column->Flags & ImGuiTableColumnFlags_NoSortAscending))
+        column->SortDirection = ImGuiSortDirection_Descending;
+    else if (column->SortDirection == ImGuiSortDirection_Descending && (column->Flags & ImGuiTableColumnFlags_NoSortDescending))
+        column->SortDirection = ImGuiSortDirection_Ascending;
+}
+
+static float TableGetMinColumnWidth()
+{
+    ImGuiContext& g = *GImGui;
+    // return g.Style.ColumnsMinSpacing;
+    return g.Style.FramePadding.x * 3.0f;
+}
+
+// Layout columns for the frame
+// Runs on the first call to TableNextRow(), to give a chance for TableSetupColumn() to be called first.
+// FIXME-TABLE: Our width (and therefore our WorkRect) will be minimal in the first frame for WidthAuto columns, 
+// increase feedback side-effect with widgets relying on WorkRect.Max.x. Maybe provide a default distribution for WidthAuto columns?
+void    ImGui::TableUpdateLayout(ImGuiTable* table)
+{
+    IM_ASSERT(table->IsLayoutLocked == false);
+
+    // Compute offset, clip rect for the frame
+    const ImRect work_rect = table->WorkRect;
+    const float padding_auto_x = table->CellPaddingX1; // Can't make auto padding larger than what WorkRect knows about so right-alignment matches.
+    const float min_column_width = TableGetMinColumnWidth();
+
+    int count_fixed = 0;
+    float width_fixed = 0.0f;
+    float total_weights = 0.0f;
+    table->LeftMostStretchedColumnDisplayOrder = -1;
+    for (int order_n = 0; order_n < table->ColumnsCount; order_n++)
+    {
+        if (!(table->ActiveMaskByDisplayOrder & ((ImU64)1 << order_n)))
+            continue;
+        const int column_n = table->DisplayOrder[order_n];
+        ImGuiTableColumn* column = &table->Columns[column_n];
+
+        // Adjust flags: default width mode + weighted columns are not allowed when auto extending
+        column->Flags = TableFixColumnFlags(table, column->FlagsIn);
+
+        // We have a unusual edge case where if the user doesn't call TableGetSortSpecs() but has sorting enabled
+        // or varying sorting flags, we still want the sorting arrows to honor those flags.
+        if (table->Flags & ImGuiTableFlags_Sortable)
+            TableFixColumnSortDirection(column);
+
+        if (column->Flags & (ImGuiTableColumnFlags_WidthAlwaysAutoResize | ImGuiTableColumnFlags_WidthFixed))
+        {
+            // Latch initial size for fixed columns
+            count_fixed += 1;
+            const bool init_size = (column->AutoFitFrames > 0) || (column->Flags & ImGuiTableColumnFlags_WidthAlwaysAutoResize);
+            if (init_size)
+            {
+                // Combine width from regular rows + width from headers unless requested not to
+                float width_request = (float)ImMax(column->ContentWidthRowsFrozen, column->ContentWidthRowsUnfrozen);
+                if (!(table->Flags & ImGuiTableFlags_NoHeadersWidth) && !(column->Flags & ImGuiTableColumnFlags_NoHeaderWidth))
+                    width_request = ImMax(width_request, (float)column->ContentWidthHeadersDesired);
+                column->WidthRequested = ImMax(width_request + padding_auto_x, min_column_width);
+
+                // FIXME-TABLE: Increase minimum size during init frame so avoid biasing auto-fitting widgets (e.g. TextWrapped) too much.
+                // Otherwise what tends to happen is that TextWrapped would output a very large height (= first frame scrollbar display very off + clipper would skip lots of items)
+                // This is merely making the side-effect less extreme, but doesn't properly fixes it.
+                if (column->AutoFitFrames > 1 && table->IsFirstFrame)
+                    column->WidthRequested = ImMax(column->WidthRequested, min_column_width * 4.0f);
+            }
+            width_fixed += column->WidthRequested;
+        }
+        else
+        {
+            IM_ASSERT(column->Flags & ImGuiTableColumnFlags_WidthStretch);
+            IM_ASSERT(column->ResizeWeight > 0.0f);
+            total_weights += column->ResizeWeight;
+            if (table->LeftMostStretchedColumnDisplayOrder == -1)
+                table->LeftMostStretchedColumnDisplayOrder = (ImS8)column->IndexDisplayOrder;
+        }
+
+        // Don't increment auto-fit until container window got a chance to submit its items
+        if (column->AutoFitFrames > 0 && table->BackupSkipItems == false)
+            column->AutoFitFrames--;
+    }
+
+    // Layout
+    const float width_spacings = table->CellSpacingX * (table->ColumnsActiveCount - 1);
+    float width_avail;
+    if ((table->Flags & ImGuiTableFlags_ScrollX) && (table->InnerWidth == 0.0f))
+        width_avail = table->InnerClipRect.GetWidth() - width_spacings - 1.0f;
+    else
+        width_avail = work_rect.GetWidth() - width_spacings - 1.0f; // Remove -1.0f to cancel out the +1.0f we are doing in EndTable() to make last column line visible
+    const float width_avail_for_stretched_columns = width_avail - width_fixed;
+    float width_remaining_for_stretched_columns = width_avail_for_stretched_columns;
+
+    // Apply final width based on requested widths
+    // Mark some columns as not resizable
+    int count_resizable = 0;
+    table->ColumnsTotalWidth = width_spacings;
+    for (int order_n = 0; order_n < table->ColumnsCount; order_n++)
+    {
+        if (!(table->ActiveMaskByDisplayOrder & ((ImU64)1 << order_n)))
+            continue;
+        ImGuiTableColumn* column = &table->Columns[table->DisplayOrder[order_n]];
+
+        // Allocate width for stretched/weighted columns
+        if (column->Flags & ImGuiTableColumnFlags_WidthStretch)
+        {
+            float weight_ratio = column->ResizeWeight / total_weights;
+            column->WidthRequested = IM_FLOOR(ImMax(width_avail_for_stretched_columns * weight_ratio, min_column_width) + 0.01f);
+            width_remaining_for_stretched_columns -= column->WidthRequested;
+
+            // [Resize Rule 2] Resizing from right-side of a weighted column before a fixed column froward sizing to left-side of fixed column
+            // We also need to copy the NoResize flag..
+            if (column->NextActiveColumn != -1)
+                if (ImGuiTableColumn* next_column = &table->Columns[column->NextActiveColumn])
+                    if (next_column->Flags & ImGuiTableColumnFlags_WidthFixed)
+                        column->Flags |= (next_column->Flags & ImGuiTableColumnFlags_NoDirectResize_);
+        }
+
+        // [Resize Rule 1] The right-most active column is not resizable if there is at least one Stretch column (see comments in TableResizeColumn().)
+        if (column->NextActiveColumn == -1 && table->LeftMostStretchedColumnDisplayOrder != -1)
+            column->Flags |= ImGuiTableColumnFlags_NoDirectResize_;
+
+        if (!(column->Flags & ImGuiTableColumnFlags_NoResize))
+            count_resizable++;
+
+        // Assign final width, record width in case we will need to shrink
+        column->WidthGiven = ImFloor(ImMax(column->WidthRequested, min_column_width));
+        table->ColumnsTotalWidth += column->WidthGiven;
+    }
+
+#if 0
+    const float width_excess = table->ColumnsTotalWidth - work_rect.GetWidth();
+    if ((table->Flags & ImGuiTableFlags_SizingPolicyStretchX) && width_excess > 0.0f)
+    {
+        // Shrink widths when the total does not fit
+        // FIXME-TABLE: This is working but confuses/conflicts with manual resizing.
+        // FIXME-TABLE: Policy to shrink down below below ideal/requested width if there's no room?
+        g.ShrinkWidthBuffer.resize(table->ColumnsActiveCount);
+        for (int order_n = 0, active_n = 0; order_n < table->ColumnsCount; order_n++)
+        {
+            if (!(table->ActiveMaskByDisplayOrder & ((ImU64)1 << order_n)))
+                continue;
+            const int column_n = table->DisplayOrder[order_n];
+            g.ShrinkWidthBuffer[active_n].Index = column_n;
+            g.ShrinkWidthBuffer[active_n].Width = table->Columns[column_n].WidthGiven;
+            active_n++;
+        }
+        ShrinkWidths(g.ShrinkWidthBuffer.Data, g.ShrinkWidthBuffer.Size, width_excess);
+        for (int n = 0; n < g.ShrinkWidthBuffer.Size; n++)
+            table->Columns[g.ShrinkWidthBuffer.Data[n].Index].WidthGiven = ImMax(g.ShrinkWidthBuffer.Data[n].Width, min_column_size);
+        // FIXME: Need to alter table->ColumnsTotalWidth
+    }
+    else 
+#endif
+
+    // Redistribute remainder width due to rounding (remainder width is < 1.0f * number of Stretch column)
+    // Using right-to-left distribution (more likely to match resizing cursor), could be adjusted depending where the mouse cursor is and/or relative weights.
+    // FIXME-TABLE: May be simpler to store floating width and floor final positions only
+    // FIXME-TABLE: Make it optional? User might prefer to preserve pixel perfect same size?
+    if (width_remaining_for_stretched_columns >= 1.0f)
+        for (int order_n = table->ColumnsCount - 1; total_weights > 0.0f && width_remaining_for_stretched_columns >= 1.0f && order_n >= 0; order_n--)
+        {
+            if (!(table->ActiveMaskByDisplayOrder & ((ImU64)1 << order_n)))
+                continue;
+            ImGuiTableColumn* column = &table->Columns[table->DisplayOrder[order_n]];
+            if (!(column->Flags & ImGuiTableColumnFlags_WidthStretch))
+                continue;
+            column->WidthRequested += 1.0f;
+            column->WidthGiven += 1.0f;
+            width_remaining_for_stretched_columns -= 1.0f;
+        }
+
+    // Setup final position, offset and clipping rectangles
+    int active_n = 0;
+    float offset_x = (table->FreezeColumnsCount > 0) ? table->OuterRect.Min.x : work_rect.Min.x;
+    ImRect host_clip_rect = table->InnerClipRect;
+    for (int order_n = 0; order_n < table->ColumnsCount; order_n++)
+    {
+        const int column_n = table->DisplayOrder[order_n];
+        ImGuiTableColumn* column = &table->Columns[column_n];
+
+        if (table->FreezeColumnsCount > 0 && table->FreezeColumnsCount == active_n)
+            offset_x += work_rect.Min.x - table->OuterRect.Min.x;
+
+        if (!(table->ActiveMaskByDisplayOrder & ((ImU64)1 << order_n)))
+        {
+            // Hidden column: clear a few fields and we are done with it for the remainder of the function.
+            // We set a zero-width clip rect however we pay attention to set Min.y/Max.y properly to not interfere with the clipper.
+            column->MinX = column->MaxX = offset_x;
+            column->StartXRows = column->StartXHeaders = offset_x;
+            column->WidthGiven = 0.0f;
+            column->ClipRect.Min.x = offset_x;
+            column->ClipRect.Min.y = work_rect.Min.y;
+            column->ClipRect.Max.x = offset_x;
+            column->ClipRect.Max.y = FLT_MAX;
+            column->ClipRect.ClipWithFull(host_clip_rect);
+            continue;
+        }
+
+        // If horizontal scrolling if disabled, we apply a final lossless shrinking of columns in order to make sure they are all visible.
+        // Because of this we also know that all of the columns will always fit in table->WorkRect and therefore in table->InnerRect (because ScrollX is off)
+        if (!(table->Flags & ImGuiTableFlags_ScrollX))
+        {
+            float max_x = table->WorkRect.Max.x - (table->ColumnsActiveCount - (column->IndexWithinActiveSet + 1)) * min_column_width;
+            if (offset_x + column->WidthGiven > max_x)
+                column->WidthGiven = ImMax(max_x - offset_x, min_column_width);
+        }
+
+        column->MinX = offset_x;
+        column->MaxX = column->MinX + column->WidthGiven;
+
+        const float initial_max_pos_x = column->MinX + table->CellPaddingX1;
+        column->ContentMaxPosRowsFrozen = column->ContentMaxPosRowsUnfrozen = initial_max_pos_x;
+        column->ContentMaxPosHeadersUsed = column->ContentMaxPosHeadersDesired = initial_max_pos_x;
+
+        // Starting cursor position
+        column->StartXRows = column->StartXHeaders = column->MinX + table->CellPaddingX1;
+
+        // Alignment
+        // FIXME-TABLE: This align based on the whole column width, not per-cell, and therefore isn't useful in many cases.
+        // (To be able to honor this we might be able to store a log of cells width, per row, for visible rows, but nav/programmatic scroll would have visible artifacts.)
+        //if (column->Flags & ImGuiTableColumnFlags_AlignRight)
+        //    column->StartXRows = ImMax(column->StartXRows, column->MaxX - column->WidthContent[0]);
+        //else if (column->Flags & ImGuiTableColumnFlags_AlignCenter)
+        //    column->StartXRows = ImLerp(column->StartXRows, ImMax(column->StartXRows, column->MaxX - column->WidthContent[0]), 0.5f);
+
+        //// A one pixel padding on the right side makes clipping more noticeable and contents look less cramped.
+        column->ClipRect.Min.x = column->MinX;
+        column->ClipRect.Min.y = work_rect.Min.y;
+        column->ClipRect.Max.x = column->MaxX;// -1.0f;
+        column->ClipRect.Max.y = FLT_MAX;
+        column->ClipRect.ClipWithFull(host_clip_rect);
+
+        if (active_n < table->FreezeColumnsCount)
+            host_clip_rect.Min.x = ImMax(host_clip_rect.Min.x, column->MaxX + 2.0f);
+
+        offset_x += column->WidthGiven + table->CellSpacingX;
+        active_n++;
+    }
+
+    // Clear Resizable flag if none of our column are actually resizable (either via an explicit _NoResize flag, either because of using _WidthAlwaysAutoResize/_WidthStretch)
+    // This will hide the resizing option from the context menu.
+    if (count_resizable == 0 && (table->Flags & ImGuiTableFlags_Resizable))
+        table->Flags &= ~ImGuiTableFlags_Resizable;
+
+    // Borders
+    if (table->Flags & ImGuiTableFlags_Resizable)
+        TableUpdateBorders(table);
+    
+    // Reset fields after we used them in TableSetupResize()
+    table->LastFirstRowHeight = 0.0f;
+    table->IsLayoutLocked = true;
+    table->IsUsingHeaders = false;
+
+    // Context menu
+    if (table->IsContextPopupOpen)
+    {
+        if (BeginPopup("##TableContextMenu"))
+        {
+            TableDrawContextMenu(table, table->ContextPopupColumn);
+            EndPopup();
+        }
+        else
+        {
+            table->IsContextPopupOpen = false;
+        }
+    }
+}
+
+// Process interaction on resizing borders. Actual size change will be applied in EndTable()
+// - Set table->HoveredColumnBorder with a short delay/timer to reduce feedback noise
+// - Submit ahead of table contents and header, use ImGuiButtonFlags_AllowItemOverlap to prioritize widgets overlapping the same area.
+void    ImGui::TableUpdateBorders(ImGuiTable* table)
+{
+    ImGuiContext& g = *GImGui;
+    IM_ASSERT(table->Flags & ImGuiTableFlags_Resizable);
+
+    // At this point OuterRect height may be zero or under actual final height, so we rely on temporal coherency and use
+    // the final height from last frame. Because this is only affecting _interaction_ with columns, it is not really problematic.
+    // (whereas the actual visual will be displayed in EndTable() and using the current frame height)
+    // Actual columns highlight/render will be performed in EndTable() and not be affected.
+    const bool borders_full_height = (table->IsUsingHeaders == false) || (table->Flags & ImGuiTableFlags_BordersFullHeight);
+    const float hit_half_width = TABLE_RESIZE_SEPARATOR_HALF_THICKNESS;
+    const float hit_y1 = table->OuterRect.Min.y;
+    const float hit_y2_full = ImMax(table->OuterRect.Max.y, hit_y1 + table->LastOuterHeight);
+    const float hit_y2 = borders_full_height ? hit_y2_full : (hit_y1 + table->LastFirstRowHeight);
+    const float mouse_x_hover_body = (g.IO.MousePos.y >= hit_y1 && g.IO.MousePos.y < hit_y2_full) ? g.IO.MousePos.x : FLT_MAX;
+
+    for (int order_n = 0; order_n < table->ColumnsCount; order_n++)
+    {
+        if (!(table->ActiveMaskByDisplayOrder & ((ImU64)1 << order_n)))
+            continue;
+
+        const int column_n = table->DisplayOrder[order_n];
+        ImGuiTableColumn* column = &table->Columns[column_n];
+
+        // Detect hovered column: 
+        // - we perform an unusually low-level check here.. not using IsMouseHoveringRect() to avoid touch padding.
+        // - we don't care about the full set of IsItemHovered() feature either.
+        if (mouse_x_hover_body >= column->MinX && mouse_x_hover_body < column->MaxX)
+            table->HoveredColumnBody = (ImS8)column_n;
+
+        if (column->Flags & (ImGuiTableColumnFlags_NoResize | ImGuiTableColumnFlags_NoDirectResize_))
+            continue;
+
+        ImGuiID column_id = table->ID + (ImGuiID)column_n;
+        ImRect hit_rect(column->MaxX - hit_half_width, hit_y1, column->MaxX + hit_half_width, hit_y2);
+        //GetForegroundDrawList()->AddRect(hit_rect.Min, hit_rect.Max, IM_COL32(255, 0, 0, 100));
+        KeepAliveID(column_id);
+
+        bool hovered = false, held = false;
+        ButtonBehavior(hit_rect, column_id, &hovered, &held, ImGuiButtonFlags_FlattenChildren | ImGuiButtonFlags_AllowItemOverlap);
+        if (held)
+            table->ResizedColumn = (ImS8)column_n;
+        if ((hovered && g.HoveredIdTimer > TABLE_RESIZE_SEPARATOR_FEEDBACK_TIMER) || held)
+        {
+            table->HoveredColumnBorder = (ImS8)column_n;
+            SetMouseCursor(ImGuiMouseCursor_ResizeEW);
+        }
+    }
+}
+
+void    ImGui::EndTable()
+{
+    ImGuiContext& g = *GImGui;
+    ImGuiTable* table = g.CurrentTable;
+    IM_ASSERT(table != NULL);
+
+    const ImGuiTableFlags flags = table->Flags;
+    ImGuiWindow* inner_window = table->InnerWindow;
+    ImGuiWindow* outer_window = table->OuterWindow;
+    IM_ASSERT(inner_window == g.CurrentWindow);
+    IM_ASSERT(outer_window == inner_window || outer_window == inner_window->ParentWindow);
+
+    if (table->IsInsideRow)
+        TableEndRow(table);
+
+    // Finalize table height
+    inner_window->SkipItems = table->BackupSkipItems;
+    inner_window->DC.CursorMaxPos = table->BackupCursorMaxPos;
+    if (inner_window != outer_window)
+    {
+        table->OuterRect.Max.y = ImMax(table->OuterRect.Max.y, inner_window->Pos.y + inner_window->Size.y);
+        inner_window->DC.CursorMaxPos.y = table->RowPosY2;
+    }
+    else if (!(flags & ImGuiTableFlags_NoHostExtendY))
+    {
+        table->OuterRect.Max.y = ImMax(table->OuterRect.Max.y, inner_window->DC.CursorPos.y);
+        inner_window->DC.CursorMaxPos.y = table->RowPosY2;
+    }
+    table->WorkRect.Max.y = ImMax(table->WorkRect.Max.y, table->OuterRect.Max.y);
+    table->LastOuterHeight = table->OuterRect.GetHeight();
+
+    // Store content width reference for each column
+    float max_pos_x = inner_window->DC.CursorMaxPos.x;
+    for (int column_n = 0; column_n < table->ColumnsCount; column_n++)
+    {
+        ImGuiTableColumn* column = &table->Columns[column_n];
+        
+        // Store content width (for both Headers and Rows)
+        //float ref_x = column->MinX;
+        float ref_x_rows = column->StartXRows - table->CellPaddingX1;
+        float ref_x_headers = column->StartXHeaders - table->CellPaddingX1;
+        column->ContentWidthRowsFrozen = (ImS16)ImMax(0.0f, column->ContentMaxPosRowsFrozen - ref_x_rows);
+        column->ContentWidthRowsUnfrozen = (ImS16)ImMax(0.0f, column->ContentMaxPosRowsUnfrozen - ref_x_rows);
+        column->ContentWidthHeadersUsed = (ImS16)ImMax(0.0f, column->ContentMaxPosHeadersUsed - ref_x_headers);
+        column->ContentWidthHeadersDesired = (ImS16)ImMax(0.0f, column->ContentMaxPosHeadersDesired - ref_x_headers);
+
+        if (table->ActiveMaskByIndex & ((ImU64)1 << column_n))
+            max_pos_x = ImMax(max_pos_x, column->MaxX);
+    }
+
+    // Add an extra 1 pixel so we can see the last column vertical line if it lies on the right-most edge.
+    inner_window->DC.CursorMaxPos.x = max_pos_x + 1;
+
+    if (!(flags & ImGuiTableFlags_NoClipX))
+        inner_window->DrawList->PopClipRect();
+    inner_window->ClipRect = inner_window->DrawList->_ClipRectStack.back();
+
+    // Draw borders
+    if ((flags & ImGuiTableFlags_Borders) != 0)
+        TableDrawBorders(table);
+
+    // Flatten channels and merge draw calls
+    table->DrawSplitter.SetCurrentChannel(inner_window->DrawList, 0);
+    TableDrawMergeChannels(table);
+
+    // When releasing a column being resized, scroll to keep the resulting column in sight
+    const float min_column_width = TableGetMinColumnWidth();
+    if (!(table->Flags & ImGuiTableFlags_ScrollX) && inner_window != outer_window)
+    {
+        inner_window->Scroll.x = 0.0f;
+    }
+    else if (table->LastResizedColumn != -1 && table->ResizedColumn == -1 && inner_window->ScrollbarX)
+    {
+        ImGuiTableColumn* column = &table->Columns[table->LastResizedColumn];
+        if (column->MaxX < table->InnerClipRect.Min.x)
+            SetScrollFromPosX(inner_window, column->MaxX - inner_window->Pos.x - min_column_width, 1.0f);
+        else if (column->MaxX > table->InnerClipRect.Max.x)
+            SetScrollFromPosX(inner_window, column->MaxX - inner_window->Pos.x + min_column_width, 1.0f);
+    }
+
+    // Apply resizing/dragging at the end of the frame
+    // FIXME-TABLE: Preserve contents width _while resizing down_ until releasing.
+    // FIXME-TABLE: Contains columns if our work area doesn't allow for scrolling. 
+    if (table->ResizedColumn != -1)
+    {
+        ImGuiTableColumn* column = &table->Columns[table->ResizedColumn];
+        const float new_x2 = (g.IO.MousePos.x - g.ActiveIdClickOffset.x + TABLE_RESIZE_SEPARATOR_HALF_THICKNESS);
+        const float new_width = ImFloor(new_x2 - column->MinX);
+        TableSetColumnWidth(table, column, new_width);
+    }
+
+    // Layout in outer window
+    inner_window->WorkRect = table->BackupWorkRect;
+    inner_window->SkipItems = table->BackupSkipItems;
+    outer_window->DC.CursorPos = table->OuterRect.Min;
+    outer_window->DC.ColumnsOffset.x = 0.0f;
+    if (inner_window != outer_window)
+    {
+        // Override EndChild's ItemSize with our own to enable auto-resize on the X axis when possible
+        float backup_outer_cursor_pos_x = outer_window->DC.CursorPos.x;
+        EndChild();
+        outer_window->DC.CursorMaxPos.x = backup_outer_cursor_pos_x + table->ColumnsTotalWidth + 1.0f + inner_window->ScrollbarSizes.x;
+    }
+    else
+    {
+        PopID();
+        ImVec2 item_size = table->OuterRect.GetSize();
+        item_size.x = table->ColumnsTotalWidth;
+        ItemSize(item_size);
+    }
+
+    // Save settings
+    if (table->IsSettingsDirty)
+        TableSaveSettings(table);
+
+    // Clear or restore current table, if any
+    IM_ASSERT(g.CurrentWindow == outer_window);
+    IM_ASSERT(g.CurrentTable == table);
+    outer_window->DC.CurrentTable = NULL;
+    g.CurrentTableStack.pop_back();
+    g.CurrentTable = g.CurrentTableStack.Size ? g.Tables.GetByIndex(g.CurrentTableStack.back().Index) : NULL;
+}
+
+void ImGui::TableDrawBorders(ImGuiTable* table)
+{
+    ImGuiWindow* inner_window = table->InnerWindow;
+    ImGuiWindow* outer_window = table->OuterWindow;
+    table->DrawSplitter.SetCurrentChannel(inner_window->DrawList, 0);
+    if (inner_window->Hidden || !table->HostClipRect.Overlaps(table->InnerClipRect))
+        return;
+
+    // Draw inner border and resizing feedback
+    const float draw_y1 = table->OuterRect.Min.y;
+    float draw_y2_base = (table->FreezeRowsCount >= 1 ? table->OuterRect.Min.y : table->WorkRect.Min.y) + table->LastFirstRowHeight;
+    float draw_y2_full = table->OuterRect.Max.y;
+    ImU32 border_base_col;
+    if (!table->IsUsingHeaders || (table->Flags & ImGuiTableFlags_BordersFullHeight))
+    {
+        draw_y2_base = draw_y2_full;
+        border_base_col = table->BorderInnerColor;
+    }
+    else
+    {
+        border_base_col = table->BorderOuterColor;
+    }
+
+    if (table->Flags & ImGuiTableFlags_BordersV)
+    {
+        const bool draw_left_most_border = (table->Flags & ImGuiTableFlags_BordersOuter) == 0;
+        if (draw_left_most_border)
+            inner_window->DrawList->AddLine(ImVec2(table->OuterRect.Min.x, draw_y1), ImVec2(table->OuterRect.Min.x, draw_y2_base), border_base_col, 1.0f);
+
+        for (int order_n = 0; order_n < table->ColumnsCount; order_n++)
+        {
+            if (!(table->ActiveMaskByDisplayOrder & ((ImU64)1 << order_n)))
+                continue;
+
+            const int column_n = table->DisplayOrder[order_n];
+            ImGuiTableColumn* column = &table->Columns[column_n];
+            const bool is_hovered = (table->HoveredColumnBorder == column_n);
+            const bool is_resized = (table->ResizedColumn == column_n);
+            const bool draw_right_border = (column->MaxX <= table->InnerClipRect.Max.x) || (is_resized || is_hovered);
+            if (draw_right_border && column->MaxX > column->ClipRect.Min.x) // FIXME-TABLE FIXME-STYLE: Assume BorderSize==1, this is problematic if we want to increase the border size..
+            {
+                // Draw in outer window so right-most column won't be clipped
+                // Always draw full height border when:
+                // - not using headers
+                // - user specify ImGuiTableFlags_BordersFullHeight
+                // - being interacted with
+                // - on the delimitation of frozen column scrolling
+                const ImU32 col = is_resized ? GetColorU32(ImGuiCol_SeparatorActive) : is_hovered ? GetColorU32(ImGuiCol_SeparatorHovered) : border_base_col;
+                float draw_y2 = draw_y2_base;
+                if (is_hovered || is_resized || (table->FreezeColumnsCount != -1 && table->FreezeColumnsCount == order_n + 1))
+                    draw_y2 = draw_y2_full;
+                inner_window->DrawList->AddLine(ImVec2(column->MaxX, draw_y1), ImVec2(column->MaxX, draw_y2), col, 1.0f);
+            }
+        }
+    }
+
+    // Draw outer border
+    if (table->Flags & ImGuiTableFlags_BordersOuter)
+    {
+        // Display outer border offset by 1 which is a simple way to display it without adding an extra draw call
+        // (Without the offset, in outer_window it would be rendered behind cells, because child windows are above their parent. 
+        // In inner_window, it won't reach out over scrollbars. Another weird solution would be to display part of it in inner window,
+        // and the part that's over scrollbars in the outer window..)
+        // Either solution currently won't allow us to use a larger border size: the border would clipped.
+        ImRect outer_border = table->OuterRect;
+        if (inner_window != outer_window)
+            outer_border.Expand(1.0f);
+        outer_window->DrawList->AddRect(outer_border.Min, outer_border.Max, table->BorderOuterColor); // IM_COL32(255, 0, 0, 255));
+    }
+    else if (table->Flags & ImGuiTableFlags_BordersH)
+    {
+        // Draw bottom-most border
+        const float border_y = table->RowPosY2;
+        if (border_y >= table->BackgroundClipRect.Min.y && border_y < table->BackgroundClipRect.Max.y)
+            inner_window->DrawList->AddLine(ImVec2(table->BorderX1, border_y), ImVec2(table->BorderX2, border_y), table->BorderOuterColor);
+    }
+}
+
+static void TableUpdateColumnsWeightFromWidth(ImGuiTable* table)
+{
+    IM_ASSERT(table->LeftMostStretchedColumnDisplayOrder != -1);
+
+    // Measure existing quantity
+    float visible_weight = 0.0f;
+    float visible_width = 0.0f;
+    for (int column_n = 0; column_n < table->ColumnsCount; column_n++)
+    {
+        ImGuiTableColumn* column = &table->Columns[column_n];
+        if (!column->IsActive || !(column->Flags & ImGuiTableColumnFlags_WidthStretch))
+            continue;
+        visible_weight += column->ResizeWeight;
+        visible_width += column->WidthRequested;
+    }
+    IM_ASSERT(visible_weight > 0.0f && visible_width > 0.0f);
+
+    // Apply new weights
+    for (int column_n = 0; column_n < table->ColumnsCount; column_n++)
+    {
+        ImGuiTableColumn* column = &table->Columns[column_n];
+        if (!column->IsActive || !(column->Flags & ImGuiTableColumnFlags_WidthStretch))
+            continue;
+        column->ResizeWeight = (column->WidthRequested + 0.0f) / visible_width;
+    }
+}
+
+void ImGui::TableSetColumnWidth(ImGuiTable* table, ImGuiTableColumn* column_0, float column_0_width)
+{
+    // Constraints
+    float min_width = TableGetMinColumnWidth();
+    float max_width_0 = FLT_MAX;
+    if (!(table->Flags & ImGuiTableFlags_ScrollX))
+        max_width_0 = (table->WorkRect.Max.x - column_0->MinX) - (table->ColumnsActiveCount - (column_0->IndexWithinActiveSet + 1)) * min_width;
+    column_0_width = ImClamp(column_0_width, min_width, max_width_0);
+
+    // Compare both requested and actual given width to avoid overwriting requested width when column is stuck (minimum size, bounded)
+    if (column_0->WidthGiven == column_0_width || column_0->WidthRequested == column_0_width)
+        return;
+
+    ImGuiTableColumn* column_1 = (column_0->NextActiveColumn != -1) ? &table->Columns[column_0->NextActiveColumn] : NULL;
+
+    // In this surprisingly not simple because of how we support mixing Fixed and Stretch columns.
+    // When forwarding resize from Wn| to Fn+1| we need to be considerate of the _NoResize flag on Fn+1.
+    // FIXME-TABLE: Find a way to rewrite all of this so interactions feel more consistent for the user.
+    // Scenarios:
+    // - F1 F2 F3  resize from F1| or F2|   --> ok: alter ->WidthRequested of Fixed column. Subsequent columns will be offset.
+    // - F1 F2 F3  resize from F3|          --> ok: alter ->WidthRequested of Fixed column. If active, ScrollX extent can be altered.
+    // - F1 F2 W3  resize from F1| or F2|   --> ok: alter ->WidthRequested of Fixed column. If active, ScrollX extent can be altered, but it doesn't make much sense as the Weighted column will always be minimal size.
+    // - F1 F2 W3  resize from W3|          --> ok: no-op (disabled by Resize Rule 1)
+    // - W1 W2 W3  resize from W1| or W2|   --> FIXME
+    // - W1 W2 W3  resize from W3|          --> ok: no-op (disabled by Resize Rule 1)
+    // - W1 F2 F3  resize from F3|          --> ok: no-op (disabled by Resize Rule 1) 
+    // - W1 F2     resize from F2|          --> ok: no-op (disabled by Resize Rule 1)
+    // - W1 W2 F3  resize from W1| or W2|   --> ok
+    // - W1 F2 W3  resize from W1| or F2|   --> FIXME
+    // - F1 W2 F3  resize from W2|          --> ok
+    // - W1 F2 F3  resize from W1|          --> ok: equivalent to resizing |F2. F3 will not move. (forwarded by Resize Rule 2)
+    // - W1 F2 F3  resize from F2|          --> FIXME should resize F2, F3 and not have effect on W1 (Stretch columns are _before_ the Fixed column).
+
+    // Rules:
+    // - [Resize Rule 1] Can't resize from right of right-most visible column if there is any Stretch column. Implemented in TableSetupLayout().
+    // - [Resize Rule 2] Resizing from right-side of a Stretch column before a fixed column froward sizing to left-side of fixed column.
+    // - [Resize Rule 3] If we are are followed by a fixed column and we have a Stretch column before, we need to ensure that our left border won't move.
+
+    if (column_0->Flags & ImGuiTableColumnFlags_WidthFixed)
+    {
+        // [Resize Rule 3] If we are are followed by a fixed column and we have a Stretch column before, we need to
+        // ensure that our left border won't move, which we can do by making sure column_a/column_b resizes cancels each others.
+        if (column_1 && (column_1->Flags & ImGuiTableColumnFlags_WidthFixed))
+            if (table->LeftMostStretchedColumnDisplayOrder != -1 && table->LeftMostStretchedColumnDisplayOrder < column_0->IndexDisplayOrder)
+            {
+                // (old_a + old_b == new_a + new_b) --> (new_a == old_a + old_b - new_b)
+                float column_1_width = ImMax(column_1->WidthRequested - (column_0_width - column_0->WidthRequested), min_width);
+                column_0_width = column_0->WidthRequested + column_1->WidthRequested - column_1_width;
+                column_1->WidthRequested = column_1_width;
+            }
+
+        // Apply
+        //IMGUI_DEBUG_LOG("TableSetColumnWidth(%d, %.1f->%.1f)\n", column_0_idx, column_0->WidthRequested, column_0_width);
+        column_0->WidthRequested = column_0_width;
+    }
+    else if (column_0->Flags & ImGuiTableColumnFlags_WidthStretch)
+    {
+        // [Resize Rule 2]
+        if (column_1 && (column_1->Flags & ImGuiTableColumnFlags_WidthFixed))
+        {
+            float off = (column_0->WidthGiven - column_0_width);
+            float column_1_width = column_1->WidthGiven + off;
+            column_1->WidthRequested = ImMax(min_width, column_1_width); 
+            return;
+        }
+
+        // (old_a + old_b == new_a + new_b) --> (new_a == old_a + old_b - new_b)
+        float column_1_width = ImMax(column_1->WidthRequested - (column_0_width - column_0->WidthRequested), min_width);
+        column_0_width = column_0->WidthRequested + column_1->WidthRequested - column_1_width;
+        column_1->WidthRequested = column_1_width;
+        column_0->WidthRequested = column_0_width;
+        TableUpdateColumnsWeightFromWidth(table);
+    }
+    table->IsSettingsDirty = true;
+}
+
+// Columns where the contents didn't stray off their local clip rectangle can be merged into a same draw command.
+// To achieve this we merge their clip rect and make them contiguous in the channel list so they can be merged.
+// So here we'll reorder the draw cmd which can be merged, by arranging them into a maximum of 4 distinct groups:
+//
+//   1 group:               2 groups:              2 groups:              4 groups:
+//   [ 0. ] no freeze       [ 0. ] row freeze      [ 01 ] col freeze      [ 01 ] row+col freeze
+//   [ .. ]  or no scroll   [ 1. ]  and v-scroll   [ .. ]  and h-scroll   [ 23 ]  and v+h-scroll
+//
+// Each column itself can use 1 channel (row freeze disabled) or 2 channels (row freeze enabled).
+// When the contents of a column didn't stray off its limit, we move its channels into the corresponding group
+// based on its position (within frozen rows/columns set or not).
+// At the end of the operation our 1-4 groups will each have a ImDrawCmd using the same ClipRect, and they will be merged by the DrawSplitter.Merge() call.
+//
+// Column channels will not be merged into one of the 1-4 groups in the following cases:
+// - The contents stray off its clipping rectangle (we only compare the MaxX value, not the MinX value). 
+//   Direct ImDrawList calls won't be noticed so if you use them make sure the ImGui:: bounds matches, by e.g. calling SetCursorScreenPos().
+// - The channel uses more than one draw command itself (we drop all our merging stuff here.. we could do better but it's going to be rare)
+//
+// This function is particularly tricky to understand.. take a breath.
+void    ImGui::TableDrawMergeChannels(ImGuiTable* table)
+{
+    ImGuiContext& g = *GImGui;
+    ImDrawListSplitter* splitter = &table->DrawSplitter;
+    const bool is_frozen_v = (table->FreezeRowsCount > 0);
+    const bool is_frozen_h = (table->FreezeColumnsCount > 0);
+
+    int merge_set_mask = 0;
+    int merge_set_channels_count[4] = { 0 };
+    ImU64 merge_set_channels_mask[4] = { 0 };
+    ImRect merge_set_clip_rect[4];
+    for (int n = 0; n < IM_ARRAYSIZE(merge_set_clip_rect); n++)
+        merge_set_clip_rect[n] = ImVec4(+FLT_MAX, +FLT_MAX, -FLT_MAX, -FLT_MAX);
+    bool merge_set_all_fit_within_inner_rect = (table->Flags & ImGuiTableFlags_NoHostExtendY) == 0;
+
+    // 1. Scan channels and take note of those who can be merged
+    for (int order_n = 0; order_n < table->ColumnsCount; order_n++)
+    {
+        if (!(table->ActiveMaskByDisplayOrder & ((ImU64)1 << order_n)))
+            continue;
+        const int column_n = table->DisplayOrder[order_n];
+        ImGuiTableColumn* column = &table->Columns[column_n];
+
+        const int merge_set_sub_count = is_frozen_v ? 2 : 1;
+        for (int merge_set_sub_n = 0; merge_set_sub_n < merge_set_sub_count; merge_set_sub_n++)
+        {
+            const int channel_no = (merge_set_sub_n == 0) ? column->DrawChannelRowsBeforeFreeze : column->DrawChannelRowsAfterFreeze;
+
+            // Don't attempt to merge if there are multiple calls within the column
+            ImDrawChannel* src_channel = &splitter->_Channels[channel_no];
+            if (src_channel->_CmdBuffer.Size > 0 && src_channel->_CmdBuffer.back().ElemCount == 0)
+                src_channel->_CmdBuffer.pop_back();
+            if (src_channel->_CmdBuffer.Size != 1)
+                continue;
+
+            // Find out the width of this merge set and check if it will fit in our column.
+            float width_contents;
+            if (merge_set_sub_count == 1)   // No row freeze (same as testing !is_frozen_v)
+                width_contents = ImMax(column->ContentWidthRowsUnfrozen, column->ContentWidthHeadersUsed);
+            else if (merge_set_sub_n == 0)  // Row freeze: use width before freeze
+                width_contents = ImMax(column->ContentWidthRowsFrozen, column->ContentWidthHeadersUsed);
+            else                            // Row freeze: use width after freeze
+                width_contents = column->ContentWidthRowsUnfrozen;
+            if (width_contents > column->WidthGiven && !(column->Flags & ImGuiTableColumnFlags_NoClipX))
+                continue;
+
+            const int dst_merge_set_n = (is_frozen_h && column_n < table->FreezeColumnsCount ? 0 : 2) + (is_frozen_v ? merge_set_sub_n : 1);
+            IM_ASSERT(merge_set_channels_count[dst_merge_set_n] < (int)sizeof(merge_set_channels_mask[dst_merge_set_n]) * 8);
+            merge_set_mask |= (1 << dst_merge_set_n);
+            merge_set_channels_mask[dst_merge_set_n] |= (ImU64)1 << channel_no;
+            merge_set_channels_count[dst_merge_set_n]++;
+            merge_set_clip_rect[dst_merge_set_n].Add(src_channel->_CmdBuffer[0].ClipRect);
+
+            // If we end with a single set and hosted by the outer window, we'll attempt to merge our draw command with
+            // the existing outer window command. But we can only do so if our columns all fit within the expected clip rect, 
+            // otherwise clipping will be incorrect when ScrollX is disabled.
+            // FIXME-TABLE FIXME-WORKRECT: We are wasting a merge opportunity on tables without scrolling if column don't fit within host clip rect, solely because of the half-padding difference between window->WorkRect and window->InnerClipRect
+            
+            // 2019/10/22: (1) This is breaking table_2_draw_calls but I cannot seem to repro what it is attempting to fix...
+            // cf git fce2e8dc "Fixed issue with clipping when outerwindow==innerwindow / support ScrollH without ScrollV."
+            // 2019/10/22: (2) Clamping code in TableSetupLayout() seemingly made this not necessary...
+#if 0
+            if (column->MinX < table->InnerClipRect.Min.x || column->MaxX > table->InnerClipRect.Max.x)
+                merge_set_all_fit_within_inner_rect = false;
+#endif
+        }
+
+        // Invalidate current draw channel (we don't clear DrawChannelBeforeRowFreeze/DrawChannelAfterRowFreeze solely to facilitate debugging)
+        column->DrawChannelCurrent = -1;
+    }
+
+    // 2. Rewrite channel list in our preferred order
+    if (merge_set_mask != 0)
+    {
+        // Use shared temporary storage so the allocation gets amortized
+        g.DrawChannelsTempMergeBuffer.resize(splitter->_Count - 1);
+        ImDrawChannel* dst_tmp = g.DrawChannelsTempMergeBuffer.Data;
+        ImU64 remaining_mask = ((splitter->_Count < 64) ? ((ImU64)1 << splitter->_Count) - 1 : ~(ImU64)0) & ~1;
+        const bool may_extend_clip_rect_to_host_rect = ImIsPowerOfTwo(merge_set_mask);
+        for (int merge_set_n = 0; merge_set_n < 4; merge_set_n++)
+            if (merge_set_channels_count[merge_set_n])
+            {
+                ImU64 merge_channels_mask = merge_set_channels_mask[merge_set_n];
+                ImRect merge_clip_rect = merge_set_clip_rect[merge_set_n];
+                if (may_extend_clip_rect_to_host_rect)
+                {
+                    //GetOverlayDrawList()->AddRect(table->HostClipRect.Min, table->HostClipRect.Max, IM_COL32(255, 0, 0, 200), 0.0f, ~0, 3.0f);
+                    //GetOverlayDrawList()->AddRect(table->InnerClipRect.Min, table->InnerClipRect.Max, IM_COL32(0, 255, 0, 200), 0.0f, ~0, 1.0f);
+                    //GetOverlayDrawList()->AddRect(merge_clip_rect.Min, merge_clip_rect.Max, IM_COL32(255, 0, 0, 200), 0.0f, ~0, 2.0f);
+                    merge_clip_rect.Add(merge_set_all_fit_within_inner_rect ? table->HostClipRect : table->InnerClipRect);
+                    //GetOverlayDrawList()->AddRect(merge_clip_rect.Min, merge_clip_rect.Max, IM_COL32(0, 255, 0, 200));
+                }
+                remaining_mask &= ~merge_channels_mask;
+                for (int n = 0; n < splitter->_Count && merge_channels_mask != 0; n++)
+                {
+                    // Copy + overwrite new clip rect
+                    const ImU64 n_mask = (ImU64)1 << n;
+                    if ((merge_channels_mask & n_mask) == 0)
+                        continue;
+                    ImDrawChannel* channel = &splitter->_Channels[n];
+                    IM_ASSERT(channel->_CmdBuffer.Size == 1 && merge_clip_rect.Contains(ImRect(channel->_CmdBuffer[0].ClipRect)));
+                    channel->_CmdBuffer[0].ClipRect = *(ImVec4*)&merge_clip_rect;
+                    memcpy(dst_tmp++, channel, sizeof(ImDrawChannel));
+                    merge_channels_mask &= ~n_mask;
+                }
+            }
+
+        // Append channels that we didn't reorder at the end of the list
+        for (int n = 0; n < splitter->_Count && remaining_mask != 0; n++)
+        {
+            const ImU64 n_mask = (ImU64)1 << n;
+            if ((remaining_mask & n_mask) == 0)
+                continue;
+            ImDrawChannel* channel = &splitter->_Channels[n];
+            memcpy(dst_tmp++, channel, sizeof(ImDrawChannel));
+            remaining_mask &= ~n_mask;
+        }
+        IM_ASSERT(dst_tmp == g.DrawChannelsTempMergeBuffer.Data + g.DrawChannelsTempMergeBuffer.Size);
+        memcpy(splitter->_Channels.Data + 1, g.DrawChannelsTempMergeBuffer.Data, (splitter->_Count - 1) * sizeof(ImDrawChannel));
+    }
+
+    // 3. Actually merge (channels using the same clip rect will be contiguous and naturally merged)
+    splitter->Merge(table->InnerWindow->DrawList);
+}
+
+// We use a default parameter of 'init_width_or_weight == -1'
+//  ImGuiTableColumnFlags_WidthFixed,    width  <= 0 --> init width == auto
+//  ImGuiTableColumnFlags_WidthFixed,    width  >  0 --> init width == manual
+//  ImGuiTableColumnFlags_WidthStretch,  weight <  0 --> init weight == 1.0f
+//  ImGuiTableColumnFlags_WidthStretch,  weight >= 0 --> init weight == custom
+// Use a different API?
+void    ImGui::TableSetupColumn(const char* label, ImGuiTableColumnFlags flags, float init_width_or_weight, ImGuiID user_id)
+{
+    ImGuiContext& g = *GImGui;
+    ImGuiTable* table = g.CurrentTable;
+    IM_ASSERT(table != NULL && "Can only call TableSetupColumn() after BeginTable()!");
+    IM_ASSERT(!table->IsLayoutLocked && "Can only call TableSetupColumn() before first row!");
+    IM_ASSERT(table->DeclColumnsCount >= 0 && table->DeclColumnsCount < table->ColumnsCount && "Called TableSetupColumn() too many times!");
+
+    ImGuiTableColumn* column = &table->Columns[table->DeclColumnsCount];
+    table->DeclColumnsCount++;
+
+    column->UserID = user_id;
+    column->FlagsIn = flags;
+    column->Flags = TableFixColumnFlags(table, column->FlagsIn);
+    flags = column->Flags;
+
+    // Initialize defaults
+    if (table->IsFirstFrame && !table->IsSettingsLoaded)
+    {
+        // Init width or weight
+        // Disable auto-fit if a default fixed width has been specified
+        if ((flags & ImGuiTableColumnFlags_WidthFixed) && init_width_or_weight > 0.0f)
+        {
+            column->WidthRequested = init_width_or_weight;
+            column->AutoFitFrames = 0;
+        }
+        if (flags & ImGuiTableColumnFlags_WidthStretch)
+        {
+            IM_ASSERT(init_width_or_weight < 0.0f || init_width_or_weight > 0.0f);
+            column->ResizeWeight = (init_width_or_weight < 0.0f ? 1.0f : init_width_or_weight);
+        }
+        else
+        {
+            column->ResizeWeight = 1.0f;
+        }
+
+        // Init default visibility/sort state
+        if (flags & ImGuiTableColumnFlags_DefaultHide)
+            column->IsActive = column->NextIsActive = false;
+        if (flags & ImGuiTableColumnFlags_DefaultSort)
+            column->SortOrder = 0; // Multiple columns using _DefaultSort will be reordered when building the sort specs.
+    }
+
+    // Store name (append with zero-terminator in contiguous buffer)
+    IM_ASSERT(column->NameOffset == -1);
+    if (label != NULL)
+    {
+        column->NameOffset = (ImS16)table->ColumnsNames.size();
+        table->ColumnsNames.append(label, label + strlen(label) + 1);
+    }
+}
+
+// Starts into the first cell of a new row
+void    ImGui::TableNextRow(ImGuiTableRowFlags row_flags, float min_row_height)
+{
+    ImGuiContext& g = *GImGui;
+    ImGuiTable* table = g.CurrentTable;
+
+    if (table->CurrentRow == -1)
+        TableUpdateLayout(table);
+    else if (table->IsInsideRow)
+        TableEndRow(table);
+
+    table->LastRowFlags = table->RowFlags;
+    table->RowFlags = row_flags;
+    TableBeginRow(table);
+
+    // We honor min_height requested by user, but cannot guarantee per-row maximum height as that would essentially require a unique clipping rectangle per-cell.
+    table->RowPosY2 += min_row_height;
+
+    TableBeginCell(table, 0);
+}
+
+// [Internal]
+void    ImGui::TableBeginRow(ImGuiTable* table)
+{
+    ImGuiWindow* window = table->InnerWindow;
+    IM_ASSERT(!table->IsInsideRow);
+
+    // New row
+    table->CurrentRow++;
+    table->CurrentColumn = -1;
+    table->RowBgColor = IM_COL32_DISABLE;
+    table->IsInsideRow = true;
+
+    // Begin frozen rows
+    float next_y1 = table->RowPosY2;
+    if (table->CurrentRow == 0 && table->FreezeRowsCount > 0)
+        next_y1 = window->DC.CursorPos.y = table->OuterRect.Min.y;
+
+    table->RowPosY1 = table->RowPosY2 = next_y1;
+    table->RowTextBaseline = 0.0f;
+    window->DC.CursorMaxPos.y = next_y1;
+
+    // Making the header BG color non-transparent will allow us to overlay it multiple times when handling smooth dragging.
+    if (table->RowFlags & ImGuiTableRowFlags_Headers)
+    {
+        table->RowBgColor = GetColorU32(ImGuiCol_TableHeaderBg);
+        if (table->CurrentRow == 0)
+            table->IsUsingHeaders = true;
+    }
+}
+
+// [Internal]
+void    ImGui::TableEndRow(ImGuiTable* table)
+{
+    ImGuiContext& g = *GImGui;
+    ImGuiWindow* window = g.CurrentWindow;
+    IM_ASSERT(window == table->InnerWindow);
+    IM_ASSERT(table->IsInsideRow);
+
+    TableEndCell(table);
+
+    table->RowPosY2 += table->CellPaddingY;
+
+    // Position cursor at the bottom of our row so it can be used for e.g. clipping calculation.
+    // However it is likely that the next call to TableBeginCell() will reposition the cursor to take account of vertical padding.
+    window->DC.CursorPos.y = table->RowPosY2;
+
+    // Row background fill
+    const float bg_y1 = table->RowPosY1;
+    const float bg_y2 = table->RowPosY2;
+
+    if (table->CurrentRow == 0)
+        table->LastFirstRowHeight = bg_y2 - bg_y1;
+
+    if (table->CurrentRow >= 0 && bg_y2 >= table->InnerClipRect.Min.y && bg_y1 <= table->InnerClipRect.Max.y)
+    {
+        // Decide of background color for the row
+        ImU32 bg_col = 0;
+        if (table->RowBgColor != IM_COL32_DISABLE)
+            bg_col = table->RowBgColor;
+        else if (table->Flags & ImGuiTableFlags_RowBg)
+            bg_col = GetColorU32((table->RowBgColorCounter & 1) ? ImGuiCol_TableRowBgAlt : ImGuiCol_TableRowBg);
+
+        // Decide of separating border color
+        ImU32 border_col = 0;
+        if (table->CurrentRow != 0 || table->InnerWindow == table->OuterWindow)
+        {
+            if (table->Flags & ImGuiTableFlags_BordersH)
+            {
+                if (table->CurrentRow == 0 && table->InnerWindow == table->OuterWindow)
+                    border_col = table->BorderOuterColor;
+                else if (!(table->LastRowFlags & ImGuiTableRowFlags_Headers))
+                    border_col = table->BorderInnerColor;
+            }
+            else
+            {
+                if (table->RowFlags & ImGuiTableRowFlags_Headers)
+                    border_col = table->BorderOuterColor;
+            }
+        }
+
+        if (bg_col != 0 || border_col != 0)
+            table->DrawSplitter.SetCurrentChannel(window->DrawList, 0);
+
+        // Draw background
+        // We soft/cpu clip this so all backgrounds and borders can share the same clipping rectangle
+        if (bg_col)
+        {
+            ImRect bg_rect(table->WorkRect.Min.x, bg_y1, table->WorkRect.Max.x, bg_y2);
+            bg_rect.ClipWith(table->BackgroundClipRect);
+            if (bg_rect.Min.y < bg_rect.Max.y)
+                window->DrawList->AddRectFilledMultiColor(bg_rect.Min, bg_rect.Max, bg_col, bg_col, bg_col, bg_col);
+        }
+
+        // Draw top border
+        const float border_y = bg_y1;
+        if (border_col && border_y >= table->BackgroundClipRect.Min.y && border_y < table->BackgroundClipRect.Max.y)
+            window->DrawList->AddLine(ImVec2(table->BorderX1, border_y), ImVec2(table->BorderX2, border_y), border_col);
+    }
+
+    const bool unfreeze_rows = (table->CurrentRow + 1 == table->FreezeRowsCount && table->FreezeRowsCount > 0);
+
+    // Draw bottom border (always strong)
+    const bool draw_separating_border = unfreeze_rows || (table->RowFlags & ImGuiTableRowFlags_Headers);
+    if (draw_separating_border)
+        if (bg_y2 >= table->BackgroundClipRect.Min.y && bg_y2 < table->BackgroundClipRect.Max.y)
+            window->DrawList->AddLine(ImVec2(table->BorderX1, bg_y2), ImVec2(table->BorderX2, bg_y2), table->BorderOuterColor);
+
+    // End frozen rows (when we are past the last frozen row line, teleport cursor and alter clipping rectangle)
+    // We need to do that in TableEndRow() instead of TableBeginRow() so the list clipper can mark end of row and get the new cursor position.
+    if (unfreeze_rows)
+    {
+        IM_ASSERT(table->IsFreezeRowsPassed == false);
+        table->IsFreezeRowsPassed = true;
+        table->DrawSplitter.SetCurrentChannel(window->DrawList, 0);
+
+        ImRect r;
+        r.Min.x = table->InnerClipRect.Min.x;
+        r.Min.y = ImMax(table->RowPosY2 + 1, window->InnerClipRect.Min.y);
+        r.Max.x = table->InnerClipRect.Max.x;
+        r.Max.y = window->InnerClipRect.Max.y;
+        table->BackgroundClipRect = r;
+
+        float row_height = table->RowPosY2 - table->RowPosY1;
+        table->RowPosY2 = window->DC.CursorPos.y = table->WorkRect.Min.y + table->RowPosY2 - table->OuterRect.Min.y;
+        table->RowPosY1 = table->RowPosY2 - row_height;
+        for (int column_n = 0; column_n < table->ColumnsCount; column_n++)
+        {
+            ImGuiTableColumn* column = &table->Columns[column_n];
+            column->DrawChannelCurrent = column->DrawChannelRowsAfterFreeze;
+            column->ClipRect.Min.y = r.Min.y;
+        }
+    }
+
+    if (!(table->RowFlags & ImGuiTableRowFlags_Headers))
+        table->RowBgColorCounter++;
+    table->IsInsideRow = false;
+}
+
+// [Internal] This is called a lot, so we need to be mindful of unnecessary overhead!
+void    ImGui::TableBeginCell(ImGuiTable* table, int column_no)
+{
+    table->CurrentColumn = column_no;
+    ImGuiTableColumn* column = &table->Columns[column_no];
+    ImGuiWindow* window = table->InnerWindow;
+
+    const float start_x = (table->RowFlags & ImGuiTableRowFlags_Headers) ? column->StartXHeaders : column->StartXRows;
+
+    window->DC.LastItemId = 0;
+    window->DC.CursorPos = ImVec2(start_x, table->RowPosY1 + table->CellPaddingY);
+    window->DC.CursorMaxPos.x = window->DC.CursorPos.x;
+    window->DC.ColumnsOffset.x = start_x - window->Pos.x - window->DC.Indent.x; // FIXME-WORKRECT // FIXME-TABLE: Recurse
+    window->DC.CurrLineTextBaseOffset = table->RowTextBaseline;
+
+    window->WorkRect.Min.y = window->DC.CursorPos.y;
+    window->WorkRect.Min.x = column->MinX + table->CellPaddingX1;
+    window->WorkRect.Max.x = column->MaxX - table->CellPaddingX2;
+
+    // To allow ImGuiListClipper to function we propagate our row height
+    if (!column->IsActive)
+        window->DC.CursorPos.y = ImMax(window->DC.CursorPos.y, table->RowPosY2);
+
+    // FIXME-COLUMNS: Setup baseline, preserve across columns (how can we obtain first line baseline tho..)
+    // window->DC.CurrLineTextBaseOffset = ImMax(window->DC.CurrLineTextBaseOffset, g.Style.FramePadding.y);
+
+    window->SkipItems = column->IsActive ? table->BackupSkipItems : true;
+    if (table->Flags & ImGuiTableFlags_NoClipX)
+    {
+        table->DrawSplitter.SetCurrentChannel(window->DrawList, 1);
+    }
+    else
+    {
+        table->DrawSplitter.SetCurrentChannel(window->DrawList, column->DrawChannelCurrent);
+        //window->ClipRect = column->ClipRect;
+        //IM_ASSERT(column->ClipRect.Max.x > column->ClipRect.Min.x && column->ClipRect.Max.y > column->ClipRect.Min.y);
+        //window->DrawList->_ClipRectStack.back() = ImVec4(column->ClipRect.Min.x, column->ClipRect.Min.y, column->ClipRect.Max.x, column->ClipRect.Max.y);
+        //window->DrawList->UpdateClipRect();
+        window->DrawList->PopClipRect();
+        window->DrawList->PushClipRect(column->ClipRect.Min, column->ClipRect.Max, false);
+        //IMGUI_DEBUG_LOG("%d (%.0f,%.0f)(%.0f,%.0f)\n", column_no, column->ClipRect.Min.x, column->ClipRect.Min.y, column->ClipRect.Max.x, column->ClipRect.Max.y);
+        window->ClipRect = window->DrawList->_ClipRectStack.back();
+    }
+}
+
+// [Internal]
+void    ImGui::TableEndCell(ImGuiTable* table)
+{
+    ImGuiTableColumn* column = &table->Columns[table->CurrentColumn];
+    ImGuiWindow* window = table->InnerWindow;
+
+    // Report maximum position so we can infer content size per column.
+    float* p_max_pos_x;
+    if (table->RowFlags & ImGuiTableRowFlags_Headers)
+        p_max_pos_x = &column->ContentMaxPosHeadersUsed;  // Useful in case user submit contents in header row that is not a TableHeader() call
+    else
+        p_max_pos_x = table->IsFreezeRowsPassed ? &column->ContentMaxPosRowsUnfrozen : &column->ContentMaxPosRowsFrozen;
+    *p_max_pos_x = ImMax(*p_max_pos_x, window->DC.CursorMaxPos.x);
+    table->RowPosY2 = ImMax(table->RowPosY2, window->DC.CursorMaxPos.y);
+
+    // Propagate text baseline for the entire row
+    // FIXME-TABLE: Here we propagate text baseline from the last line of the cell.. instead of the first one.
+    table->RowTextBaseline = ImMax(table->RowTextBaseline, window->DC.PrevLineTextBaseOffset);
+}
+
+// Append into the next cell
+// FIXME-TABLE: Wrapping to next row should be optional?
+bool    ImGui::TableNextCell()
+{
+    ImGuiContext& g = *GImGui;
+    ImGuiTable* table = g.CurrentTable;
+
+    if (table->CurrentColumn != -1 && table->CurrentColumn + 1 < table->ColumnsCount)
+    {
+        TableEndCell(table);
+        TableBeginCell(table, table->CurrentColumn + 1);
+    }
+    else
+    {
+        TableNextRow();
+    }
+
+    ImGuiTableColumn* column = &table->Columns[table->CurrentColumn];
+    return column->IsActive;
+}
+
+const char*   ImGui::TableGetColumnName(int column_n)
+{
+    ImGuiContext& g = *GImGui;
+    ImGuiTable* table = g.CurrentTable;
+    if (!table)
+        return NULL;
+    if (column_n < 0)
+        column_n = table->CurrentColumn;
+    return TableGetColumnName(table, column_n);
+}
+
+bool    ImGui::TableGetColumnIsVisible(int column_n)
+{
+    ImGuiContext& g = *GImGui;
+    ImGuiTable* table = g.CurrentTable;
+    if (!table)
+        return false;
+    if (column_n < 0)
+        column_n = table->CurrentColumn;
+    return (table->ActiveMaskByIndex & ((ImU64)1 << column_n)) != 0;
+}
+
+int     ImGui::TableGetColumnIndex()
+{
+    ImGuiContext& g = *GImGui;
+    ImGuiTable* table = g.CurrentTable;
+    if (!table)
+        return 0;
+    return table->CurrentColumn;
+}
+
+bool    ImGui::TableSetColumnIndex(int column_idx)
+{
+    ImGuiContext& g = *GImGui;
+    ImGuiTable* table = g.CurrentTable;
+    if (!table)
+        return false;
+
+    if (table->CurrentColumn != column_idx)
+    {
+        if (table->CurrentColumn != -1)
+            TableEndCell(table);
+        IM_ASSERT(column_idx >= 0 && table->ColumnsCount);
+        TableBeginCell(table, column_idx);
+    }
+
+    return (table->ActiveMaskByIndex & ((ImU64)1 << column_idx)) != 0;
+}
+
+ImRect  ImGui::TableGetCellRect()
+{
+    ImGuiContext& g = *GImGui;
+    ImGuiTable* table = g.CurrentTable;
+    ImGuiTableColumn* column = &table->Columns[table->CurrentColumn];
+    return ImRect(column->MinX, table->RowPosY1, column->MaxX, table->RowPosY2);
+}
+
+const char* ImGui::TableGetColumnName(ImGuiTable* table, int column_no)
+{
+    ImGuiTableColumn* column = &table->Columns[column_no];
+    if (column->NameOffset == -1)
+        return NULL;
+    return &table->ColumnsNames.Buf[column->NameOffset];
+}
+
+void    ImGui::PushTableBackground()
+{
+    ImGuiContext& g = *GImGui;
+    ImGuiWindow* window = g.CurrentWindow;
+    ImGuiTable* table = g.CurrentTable;
+    table->DrawSplitter.SetCurrentChannel(window->DrawList, 0);
+    PushClipRect(table->HostClipRect.Min, table->HostClipRect.Max, false);
+}
+
+void    ImGui::PopTableBackground()
+{
+    ImGuiContext& g = *GImGui;
+    ImGuiWindow* window = g.CurrentWindow;
+    ImGuiTable* table = g.CurrentTable;
+    ImGuiTableColumn* column = &table->Columns[table->CurrentColumn];
+    table->DrawSplitter.SetCurrentChannel(window->DrawList, column->DrawChannelCurrent);
+    PopClipRect();
+}
+
+// FIXME-TABLE: Ideally this should be writable by the user. Full programmatic access to that data?
+void    ImGui::TableDrawContextMenu(ImGuiTable* table, int selected_column_n)
+{
+    ImGuiContext& g = *GImGui;
+    ImGuiWindow* window = g.CurrentWindow;
+    if (window->SkipItems)
+        return;
+
+    bool want_separator = false;
+    selected_column_n  = ImClamp(selected_column_n, -1, table->ColumnsCount - 1);
+
+    // Sizing
+    if (table->Flags & ImGuiTableFlags_Resizable)
+    {
+        if (ImGuiTableColumn* selected_column = (selected_column_n != -1) ? &table->Columns[selected_column_n] : NULL)
+        {
+            const bool can_resize = !(selected_column->Flags & (ImGuiTableColumnFlags_NoResize | ImGuiTableColumnFlags_WidthStretch)) && selected_column->IsActive;
+            if (MenuItem("Size column to fit", NULL, false, can_resize))
+                selected_column->AutoFitFrames = 1;
+        }
+
+        if (MenuItem("Size all columns to fit", NULL))
+        {
+            for (int column_n = 0; column_n < table->ColumnsCount; column_n++)
+            {
+                ImGuiTableColumn* column = &table->Columns[column_n];
+                if (column->IsActive)
+                    column->AutoFitFrames = 1;
+            }
+        }
+        want_separator = true;
+    }
+
+    // Ordering
+    if (table->Flags & ImGuiTableFlags_Reorderable)
+    {
+        if (MenuItem("Reset order", NULL, false, !table->IsDefaultDisplayOrder))
+            table->IsResetDisplayOrderRequest = true;
+        want_separator = true;
+    }
+
+    // Hiding / Visibility
+    if (table->Flags & ImGuiTableFlags_Hideable)
+    {
+        if (want_separator)
+            Separator();
+        want_separator = false;
+
+        PushItemFlag(ImGuiItemFlags_SelectableDontClosePopup, true);
+        for (int column_n = 0; column_n < table->ColumnsCount; column_n++)
+        {
+            ImGuiTableColumn* column = &table->Columns[column_n];
+            const char* name = TableGetColumnName(table, column_n);
+            if (name == NULL)
+                name = "<Unknown>";
+
+            // Make sure we can't hide the last active column
+            bool menu_item_active = (column->Flags & ImGuiTableColumnFlags_NoHide) ? false : true;
+            if (column->IsActive && table->ColumnsActiveCount <= 1)
+                menu_item_active = false;
+            if (MenuItem(name, NULL, column->IsActive, menu_item_active))
+                column->NextIsActive = !column->IsActive;
+        }
+        PopItemFlag();
+    }
+}
+
+// This is a helper to output headers based on the column names declared in TableSetupColumn()
+// The intent is that advanced users would not need to use this helper and may create their own.
+void    ImGui::TableAutoHeaders()
+{
+    ImGuiContext& g = *GImGui;
+    ImGuiWindow* window = g.CurrentWindow;
+    if (window->SkipItems)
+        return;
+
+    ImGuiTable* table = g.CurrentTable;
+    IM_ASSERT(table && table->CurrentRow == -1);
+
+    int open_context_popup = INT_MAX;
+
+    // This for loop is constructed to not make use of internal functions,
+    // as this is intended to be a base template to copy and build from.
+    TableNextRow(ImGuiTableRowFlags_Headers, GetTextLineHeight());
+    const int columns_count = table->ColumnsCount;
+    for (int column_n = 0; column_n < columns_count; column_n++)
+    {
+        if (!TableSetColumnIndex(column_n))
+            continue;
+
+        const char* name = TableGetColumnName(column_n);
+
+        // FIXME-TABLE: Test custom user elements
+#if 0
+        if (column_n < 2)
+        {
+            static bool b[10] = {};
+            PushID(column_n);
+            PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
+            Checkbox("##", &b[column_n]);
+            PopStyleVar();
+            PopID();
+            SameLine(0.0f, g.Style.ItemInnerSpacing.x);
+        }
+#endif
+
+        // [DEBUG]
+        //if (g.IO.KeyCtrl) { static char buf[32]; name = buf; ImGuiTableColumn* c = &table->Columns[column_n]; if (c->Flags & ImGuiTableColumnFlags_WidthStretch) ImFormatString(buf, 32, "%.3f>%.1f", c->ResizeWeight, c->WidthGiven); else ImFormatString(buf, 32, "%.1f", c->WidthGiven); }
+
+        PushID(column_n); // Allow unnamed labels (generally accidental, but let's behave nicely with them)
+        TableHeader(name);
+        PopID();
+
+        // We don't use BeginPopupContextItem() because we want the popup to stay up even after the column is hidden
+        if (IsMouseReleased(1) && IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup))
+            open_context_popup = column_n;
+    }
+
+    // FIXME-TABLE: This is not user-land code any more... 
+    window->SkipItems = table->BackupSkipItems;
+
+    // Allow opening popup from the right-most section after the last column
+    // FIXME-TABLE: This is not user-land code any more... perhaps instead we should expose hovered column.
+    // and allow some sort of row-centric IsItemHovered() for full flexibility?
+    const float unused_x1 = (table->RightMostActiveColumn != -1) ? table->Columns[table->RightMostActiveColumn].MaxX : table->WorkRect.Min.x;
+    if (unused_x1 < table->WorkRect.Max.x)
+    {
+        // FIXME: We inherit ClipRect/SkipItem from last submitted column (active or not), let's override
+        window->ClipRect = table->InnerClipRect;
+
+        ImVec2 backup_cursor_max_pos = window->DC.CursorMaxPos;
+        window->DC.CursorPos = ImVec2(unused_x1, table->RowPosY1);
+        ImVec2 size = ImVec2(table->WorkRect.Max.x - window->DC.CursorPos.x, table->RowPosY2 - table->RowPosY1);
+        if (size.x > 0.0f && size.y > 0.0f)
+        {
+            InvisibleButton("##RemainingSpace", size);
+            window->DC.CursorPos.y -= g.Style.ItemSpacing.y;
+            window->DC.CursorMaxPos = backup_cursor_max_pos;    // Don't feed back into the width of the Header row
+
+            // We don't use BeginPopupContextItem() because we want the popup to stay up even after the column is hidden
+            if (IsMouseReleased(1) && IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup))
+                open_context_popup = -1;
+        }
+
+        window->ClipRect = window->DrawList->_ClipRectStack.back();
+    }
+
+    // Context Menu
+    if (open_context_popup != INT_MAX)
+    {
+        table->IsContextPopupOpen = true;
+        table->ContextPopupColumn = (ImS8)open_context_popup;
+        OpenPopup("##TableContextMenu");
+    }
+}
+
+// Emit a column header (text + optional sort order)
+// We cpu-clip text here so that all columns headers can be merged into a same draw call.
+// FIXME-TABLE: Should hold a selection state.
+void    ImGui::TableHeader(const char* label)
+{
+    ImGuiContext& g = *GImGui;
+    ImGuiWindow* window = g.CurrentWindow;
+    if (window->SkipItems)
+        return;
+
+    ImGuiTable* table = g.CurrentTable;
+    IM_ASSERT(table->CurrentColumn != -1);
+    const int column_n = table->CurrentColumn;
+    ImGuiTableColumn* column = &table->Columns[column_n];
+
+    float row_height = GetTextLineHeight();
+    ImRect cell_r = TableGetCellRect();
+    ImRect work_r = cell_r;
+    work_r.Min.x = window->DC.CursorPos.x;
+    work_r.Max.y = work_r.Min.y + row_height;
+
+    // Label
+    if (label == NULL)
+        label = "";
+    const char* label_end = FindRenderedTextEnd(label);
+    ImVec2 label_size = CalcTextSize(label, label_end, true);
+    ImVec2 label_pos = window->DC.CursorPos;
+    float ellipsis_max = work_r.Max.x;
+
+    // Selectable
+    PushID(label);
+
+    // FIXME-TABLE: Fix when padding are disabled.
+    //window->DC.CursorPos.x = column->MinX + table->CellPadding.x;
+
+    // Keep header highlighted when context menu is open. (FIXME-TABLE: however we cannot assume the ID of said popup if it has been created by the user...)
+    const bool selected = (table->IsContextPopupOpen && table->ContextPopupColumn == column_n);
+    const bool pressed = Selectable("", selected, ImGuiSelectableFlags_DrawHoveredWhenHeld, ImVec2(0.0f, row_height));
+    const bool held = IsItemActive();
+    window->DC.CursorPos.y -= g.Style.ItemSpacing.y * 0.5f;
+
+    // Drag and drop: re-order columns. Frozen columns are not reorderable.
+    // FIXME-TABLE: Scroll request while reordering a column and it lands out of the scrolling zone.
+    if (held && (table->Flags & ImGuiTableFlags_Reorderable) && IsMouseDragging(0) && !g.DragDropActive)
+    {
+        // While moving a column it will jump on the other side of the mouse, so we also test for MouseDelta.x
+        table->ReorderColumn = (ImS8)column_n;
+        if (g.IO.MouseDelta.x < 0.0f && g.IO.MousePos.x < cell_r.Min.x)
+            if (column->PrevActiveColumn != -1 && (column->IndexWithinActiveSet < table->FreezeColumnsRequest) == (table->Columns[column->PrevActiveColumn].IndexWithinActiveSet < table->FreezeColumnsRequest))
+                table->ReorderColumnDir = -1;
+        if (g.IO.MouseDelta.x > 0.0f && g.IO.MousePos.x > cell_r.Max.x)
+            if (column->NextActiveColumn != -1 && (column->IndexWithinActiveSet < table->FreezeColumnsRequest) == (table->Columns[column->NextActiveColumn].IndexWithinActiveSet < table->FreezeColumnsRequest))
+                table->ReorderColumnDir = +1;
+    }
+
+    // Sort order arrow
+    float w_arrow = 0.0f;
+    float w_sort_text = 0.0f;
+    if ((table->Flags & ImGuiTableFlags_Sortable) && !(column->Flags & ImGuiTableColumnFlags_NoSort))
+    {
+        const float ARROW_SCALE = 0.75f;
+        w_arrow = ImFloor(g.FontSize * ARROW_SCALE + g.Style.FramePadding.x);// table->CellPadding.x);
+        if (column->SortOrder != -1)
+        {
+            w_sort_text = 0.0f;
+
+            char sort_order_suf[8];
+            if (column->SortOrder > 0)
+            {
+                ImFormatString(sort_order_suf, IM_ARRAYSIZE(sort_order_suf), "%d", column->SortOrder + 1);
+                w_sort_text = g.Style.ItemInnerSpacing.x + CalcTextSize(sort_order_suf).x;
+            }
+
+            float x = ImMax(cell_r.Min.x, work_r.Max.x - w_arrow - w_sort_text);
+            ellipsis_max -= w_arrow + w_sort_text;
+
+            float y = label_pos.y;
+            ImU32 col = GetColorU32(ImGuiCol_Text);
+            if (column->SortOrder > 0)
+            {
+                PushStyleColor(ImGuiCol_Text, GetColorU32(ImGuiCol_Text, 0.70f));
+                RenderText(ImVec2(x + g.Style.ItemInnerSpacing.x, y), sort_order_suf);
+                PopStyleColor();
+                x += w_sort_text;
+            }
+            RenderArrow(window->DrawList, ImVec2(x, y), col, column->SortDirection == ImGuiSortDirection_Ascending ? ImGuiDir_Down : ImGuiDir_Up, ARROW_SCALE);
+        }
+
+        // Handle clicking on column header to adjust Sort Order
+        if (pressed && table->ReorderColumn != column_n)
+            TableSortSpecsClickColumn(table, column, g.IO.KeyShift);
+    }
+    if (!held && table->ReorderColumn == column_n)
+        table->ReorderColumn = -1;
+
+    // Render clipped label
+    // Clipping here ensure that in the majority of situations, all our header cells will be merged into a single draw call.
+    //window->DrawList->AddCircleFilled(ImVec2(ellipsis_max, label_pos.y), 40, IM_COL32_WHITE);
+    RenderTextEllipsis(window->DrawList, label_pos, ImVec2(ellipsis_max, label_pos.y + row_height + g.Style.FramePadding.y), ellipsis_max, ellipsis_max, label, label_end, &label_size);
+
+    // We feed our unclipped width to the column without writing on CursorMaxPos, so that column is still considering for merging.
+    // FIXME-TABLE: Clarify policies of how label width and potential decorations (arrows) fit into auto-resize of the column
+    float max_pos_x = label_pos.x + label_size.x + w_sort_text + w_arrow;
+    column->ContentMaxPosHeadersUsed = ImMax(column->ContentMaxPosHeadersUsed, work_r.Max.x);// ImMin(max_pos_x, work_r.Max.x));
+    column->ContentMaxPosHeadersDesired = ImMax(column->ContentMaxPosHeadersDesired, max_pos_x);
+
+    PopID();
+}
+
+void ImGui::TableSortSpecsClickColumn(ImGuiTable* table, ImGuiTableColumn* clicked_column, bool add_to_existing_sort_orders)
+{
+    if (!(table->Flags & ImGuiTableFlags_MultiSortable))
+        add_to_existing_sort_orders = false;
+
+    ImS8 sort_order_max = 0;
+    if (add_to_existing_sort_orders)
+        for (int column_n = 0; column_n < table->ColumnsCount; column_n++)
+            sort_order_max = ImMax(sort_order_max, table->Columns[column_n].SortOrder);
+
+    for (int column_n = 0; column_n < table->ColumnsCount; column_n++)
+    {
+        ImGuiTableColumn* column = &table->Columns[column_n];
+        if (column == clicked_column)
+        {
+            // Set new sort direction and sort order
+            // - If the PreferSortDescending flag is set, we will default to a Descending direction on the first click.
+            // - Note that the PreferSortAscending flag is never checked, it is essentially the default and therefore a no-op.
+            // - Note that the NoSortAscending/NoSortDescending flags are processed in TableSortSpecsSanitize(), and they may change/revert
+            //   the value of SortDirection. We could technically also do it here but it would be unnecessary and duplicate code.
+            if (column->SortOrder == -1)
+                column->SortDirection = (column->Flags & ImGuiTableColumnFlags_PreferSortDescending) ? (ImS8)ImGuiSortDirection_Descending : (ImU8)(ImGuiSortDirection_Ascending);
+            else
+                column->SortDirection = (ImU8)((column->SortDirection == ImGuiSortDirection_Ascending) ? ImGuiSortDirection_Descending : ImGuiSortDirection_Ascending);
+            if (column->SortOrder == -1 || !add_to_existing_sort_orders)
+                column->SortOrder = add_to_existing_sort_orders ? sort_order_max + 1 : 0;
+        }
+        else
+        {
+            if (!add_to_existing_sort_orders)
+                column->SortOrder = -1;
+        }
+        TableFixColumnSortDirection(column);
+    }
+    table->IsSettingsDirty = true;
+    table->IsSortSpecsDirty = true;
+}
+
+// Return NULL if no sort specs.
+// Return ->WantSort == true when the specs have changed since the last query.
+const ImGuiTableSortSpecs* ImGui::TableGetSortSpecs()
+{
+    ImGuiContext& g = *GImGui;
+    ImGuiTable* table = g.CurrentTable;
+    IM_ASSERT(table != NULL);
+
+    if (!(table->Flags & ImGuiTableFlags_Sortable))
+        return NULL;
+
+    // Flatten sort specs into user facing data
+    const bool was_dirty = table->IsSortSpecsDirty;
+    if (was_dirty)
+    {
+        TableSortSpecsSanitize(table);
+
+        // Write output
+        table->SortSpecsData.resize(table->SortSpecsCount);
+        table->SortSpecs.ColumnsMask = 0x00;
+        for (int column_n = 0; column_n < table->ColumnsCount; column_n++)
+        {
+            ImGuiTableColumn* column = &table->Columns[column_n];
+            if (column->SortOrder == -1)
+                continue;
+            ImGuiTableSortSpecsColumn* sort_spec = &table->SortSpecsData[column->SortOrder];
+            sort_spec->ColumnUserID = column->UserID;
+            sort_spec->ColumnIndex = (ImU8)column_n;
+            sort_spec->SortOrder = (ImU8)column->SortOrder;
+            sort_spec->SortSign = (column->SortDirection == ImGuiSortDirection_Ascending) ? +1 : -1;
+            sort_spec->SortDirection = column->SortDirection;
+            table->SortSpecs.ColumnsMask |= (ImU64)1 << column_n;
+        }
+    }
+
+    // User facing data
+    table->SortSpecs.Specs = table->SortSpecsData.Data;
+    table->SortSpecs.SpecsCount = table->SortSpecsData.Size;
+    table->SortSpecs.SpecsChanged = was_dirty;
+    table->IsSortSpecsDirty = false;
+    return table->SortSpecs.SpecsCount ? &table->SortSpecs : NULL;
+}
+
+bool ImGui::TableGetColumnIsSorted(int column_n)
+{
+    ImGuiContext& g = *GImGui;
+    ImGuiTable* table = g.CurrentTable;
+    if (!table)
+        return false;
+    if (column_n < 0)
+        column_n = table->CurrentColumn;
+    ImGuiTableColumn* column = &table->Columns[column_n];
+    return (column->SortOrder != -1);
+}
+
+void ImGui::TableSortSpecsSanitize(ImGuiTable* table)
+{
+    // Clear SortOrder from hidden column and verify that there's no gap or duplicate.
+    int sort_order_count = 0;
+    ImU64 sort_order_mask = 0x00;
+    for (int column_n = 0; column_n < table->ColumnsCount; column_n++)
+    {
+        ImGuiTableColumn* column = &table->Columns[column_n];
+        if (column->SortOrder != -1 && !column->IsActive)
+            column->SortOrder = -1;
+        if (column->SortOrder == -1)
+            continue;
+        sort_order_count++;
+        sort_order_mask |= ((ImU64)1 << column->SortOrder);
+        IM_ASSERT(sort_order_count < (int)sizeof(sort_order_mask) * 8);
+    }
+
+    const bool need_fix_linearize = ((ImU64)1 << sort_order_count) != (sort_order_mask + 1);
+    const bool need_fix_single_sort_order = (sort_order_count > 1) && !(table->Flags & ImGuiTableFlags_MultiSortable);
+    if (need_fix_linearize || need_fix_single_sort_order)
+    {
+        ImU64 fixed_mask = 0x00;
+        for (int sort_n = 0; sort_n < sort_order_count; sort_n++)
+        {
+            // Fix: Rewrite sort order fields if needed so they have no gap or duplicate.
+            // (e.g. SortOrder 0 disappeared, SortOrder 1..2 exists --> rewrite then as SortOrder 0..1)
+            int column_with_smallest_sort_order = -1;
+            for (int column_n = 0; column_n < table->ColumnsCount; column_n++)
+                if ((fixed_mask & ((ImU64)1 << (ImU64)column_n)) == 0 && table->Columns[column_n].SortOrder != -1)
+                    if (column_with_smallest_sort_order == -1 || table->Columns[column_n].SortOrder < table->Columns[column_with_smallest_sort_order].SortOrder)
+                        column_with_smallest_sort_order = column_n;
+            IM_ASSERT(column_with_smallest_sort_order != -1);
+            fixed_mask |= ((ImU64)1 << column_with_smallest_sort_order);
+            table->Columns[column_with_smallest_sort_order].SortOrder = (ImS8)sort_n;
+
+            // Fix: Make sure only one column has a SortOrder if ImGuiTableFlags_MultiSortable is not set.
+            if (need_fix_single_sort_order)
+            {
+                for (int column_n = 0; column_n < table->ColumnsCount; column_n++)
+                    if (column_n != column_with_smallest_sort_order)
+                        table->Columns[column_n].SortOrder = -1;
+                break;
+            }
+        }
+    }
+
+    // Fallback default sort order (if no column has the ImGuiTableColumnFlags_DefaultSort flag)
+    if (sort_order_count == 0 && table->IsFirstFrame)
+        for (int column_n = 0; column_n < table->ColumnsCount; column_n++)
+        {
+            ImGuiTableColumn* column = &table->Columns[column_n];
+            if (!(column->Flags & ImGuiTableColumnFlags_NoSort) && column->IsActive)
+            {
+                sort_order_count = 1;
+                column->SortOrder = 0;
+                break;
+            }
+        }
+
+    table->SortSpecsCount = (ImS8)sort_order_count;
+}
+
+//-------------------------------------------------------------------------
+// TABLE - .ini settings
+//-------------------------------------------------------------------------
+// [Init] 1: TableSettingsHandler_ReadXXXX()   Load and parse .ini file into TableSettings.
+// [Main] 2: TableLoadSettings()               When table is created, bind Table to TableSettings, serialize TableSettings data into Table.
+// [Main] 3: TableSaveSettings()               When table properties are modified, serialize Table data into bound or new TableSettings, mark .ini as dirty.
+// [Main] 4: TableSettingsHandler_WriteAll()   When .ini file is dirty (which can come from other source), save TableSettings into .ini file.
+//-------------------------------------------------------------------------
+
+static ImGuiTableSettings* CreateTableSettings(ImGuiID id, int columns_count)
+{
+    ImGuiContext& g = *GImGui;
+    ImGuiTableSettings* settings = g.SettingsTables.alloc_chunk(sizeof(ImGuiTableSettings) + (size_t)columns_count * sizeof(ImGuiTableColumnSettings));
+    IM_PLACEMENT_NEW(settings) ImGuiTableSettings();
+    ImGuiTableColumnSettings* settings_column = settings->GetColumnSettings();
+    for (int n = 0; n < columns_count; n++, settings_column++)
+        IM_PLACEMENT_NEW(settings_column) ImGuiTableColumnSettings();
+    settings->ID = id;
+    settings->ColumnsCount = settings->ColumnsCountMax = (ImS8)columns_count;
+    return settings;
+}
+
+static ImGuiTableSettings* FindTableSettingsByID(ImGuiID id)
+{
+    // FIXME-OPT: Might want to store a lookup map for this?
+    ImGuiContext& g = *GImGui;
+    for (ImGuiTableSettings* settings = g.SettingsTables.begin(); settings != NULL; settings = g.SettingsTables.next_chunk(settings))
+        if (settings->ID == id)
+            return settings;
+    return NULL;
+}
+
+ImGuiTableSettings* ImGui::TableFindSettings(ImGuiTable* table)
+{
+    if (table->SettingsOffset == -1)
+        return NULL;
+
+    ImGuiContext& g = *GImGui;
+    ImGuiTableSettings* settings = g.SettingsTables.ptr_from_offset(table->SettingsOffset);
+    IM_ASSERT(settings->ID == table->ID);
+    if (settings->ColumnsCountMax < table->ColumnsCount)
+    {
+        settings->ID = 0; // Ditch storage if we won't fit because of a count change
+        return NULL;
+    }
+    return settings;
+}
+
+void ImGui::TableSaveSettings(ImGuiTable* table)
+{
+    table->IsSettingsDirty = false;
+    if (table->Flags & ImGuiTableFlags_NoSavedSettings)
+        return;
+
+    // Bind or create settings data
+    ImGuiContext& g = *GImGui;
+    ImGuiTableSettings* settings = TableFindSettings(table);
+    if (settings == NULL)
+    {
+        settings = CreateTableSettings(table->ID, table->ColumnsCount);
+        table->SettingsOffset = g.SettingsTables.offset_from_ptr(settings);
+    }
+    settings->ColumnsCount = (ImS8)table->ColumnsCount;
+    
+    // Serialize ImGuiTableSettings/ImGuiTableColumnSettings --> ImGuiTable/ImGuiTableColumn
+    IM_ASSERT(settings->ID == table->ID);
+    IM_ASSERT(settings->ColumnsCount == table->ColumnsCount && settings->ColumnsCountMax >= settings->ColumnsCount);
+    ImGuiTableColumn* column = table->Columns.Data;
+    ImGuiTableColumnSettings* column_settings = settings->GetColumnSettings();
+    
+    // FIXME-TABLE: Logic to avoid saving default widths?
+    settings->SaveFlags = ImGuiTableFlags_Resizable;
+    for (int n = 0; n < table->ColumnsCount; n++, column++, column_settings++)
+    {
+        //column_settings->WidthOrWeight = column->WidthRequested; // FIXME-WIP
+        column_settings->Index = (ImS8)n;
+        column_settings->DisplayOrder = column->IndexDisplayOrder;
+        column_settings->SortOrder = column->SortOrder;
+        column_settings->SortDirection = column->SortDirection;
+        column_settings->Visible = column->IsActive;
+
+        // We skip saving some data in the .ini file when they are unnecessary to restore our state
+        // FIXME-TABLE: We don't have logic to easily compare SortOrder to DefaultSortOrder yet.
+        if (column->IndexDisplayOrder != n)
+            settings->SaveFlags |= ImGuiTableFlags_Reorderable;;
+        if (column_settings->SortOrder != -1)   
+            settings->SaveFlags |= ImGuiTableFlags_Sortable;
+        if (column_settings->Visible != ((column->Flags & ImGuiTableColumnFlags_DefaultHide) == 0))
+            settings->SaveFlags |= ImGuiTableFlags_Hideable;
+    }
+    settings->SaveFlags &= table->Flags;
+
+    MarkIniSettingsDirty();
+}
+
+void ImGui::TableLoadSettings(ImGuiTable* table)
+{
+    ImGuiContext& g = *GImGui;
+    table->IsSettingsRequestLoad = false;
+    if (table->Flags & ImGuiTableFlags_NoSavedSettings)
+        return;
+
+    // Bind settings
+    ImGuiTableSettings* settings;
+    if (table->SettingsOffset == -1)
+    {
+        settings = FindTableSettingsByID(table->ID);
+        if (settings == NULL)
+            return;
+        table->SettingsOffset = g.SettingsTables.offset_from_ptr(settings);
+    }
+    else
+    {
+        settings = g.SettingsTables.ptr_from_offset(table->SettingsOffset);
+    }
+    table->IsSettingsLoaded = true;
+    settings->SaveFlags = table->Flags;
+
+    // Serialize ImGuiTable/ImGuiTableColumn --> ImGuiTableSettings/ImGuiTableColumnSettings
+    ImGuiTableColumnSettings* column_settings = settings->GetColumnSettings();
+    for (int data_n = 0; data_n < settings->ColumnsCount; data_n++, column_settings++)
+    {
+        int column_n = column_settings->Index;
+        if (column_n < 0 || column_n >= table->ColumnsCount)
+            continue;
+        ImGuiTableColumn* column = &table->Columns[column_n];
+        //column->WidthRequested = column_settings->WidthOrWeight; // FIXME-WIP
+        if (column_settings->DisplayOrder != -1)
+            column->IndexDisplayOrder = column_settings->DisplayOrder;
+        if (column_settings->SortOrder != -1)
+        {
+            column->SortOrder = column_settings->SortOrder;
+            column->SortDirection = column_settings->SortDirection;
+        }
+        column->IsActive = column->NextIsActive = column_settings->Visible;
+    }
+
+    // FIXME-TABLE: Need to validate .ini data
+    for (int column_n = 0; column_n < table->ColumnsCount; column_n++)
+        table->DisplayOrder[table->Columns[column_n].IndexDisplayOrder] = (ImU8)column_n;
+}
+
+void*   ImGui::TableSettingsHandler_ReadOpen(ImGuiContext*, ImGuiSettingsHandler*, const char* name)
+{
+    ImGuiID id = 0;
+    int columns_count = 0;
+    if (sscanf(name, "0x%08X,%d", &id, &columns_count) < 2)
+        return NULL;
+    return CreateTableSettings(id, columns_count);
+}
+
+void    ImGui::TableSettingsHandler_ReadLine(ImGuiContext*, ImGuiSettingsHandler*, void* entry, const char* line)
+{
+    // "Column 0  UserID=0x42AD2D21 Width=100 Visible=1 Order=0 Sort=0v"
+    ImGuiTableSettings* settings = (ImGuiTableSettings*)entry;
+    int column_n = 0, r = 0, n = 0;
+    if (sscanf(line, "Column %d%n", &column_n, &r) == 1)        { line = ImStrSkipBlank(line + r); } else { return; }
+    if (column_n < 0 || column_n >= settings->ColumnsCount)
+        return;
+
+    char c = 0;
+    ImGuiTableColumnSettings* column = settings->GetColumnSettings() + column_n;
+    column->Index = (ImS8)column_n;
+    if (sscanf(line, "UserID=0x%08X%n", (ImU32*)&n, &r) == 1)   { line = ImStrSkipBlank(line + r); column->UserID = (ImGuiID)n; }
+    if (sscanf(line, "Width=%d%n", &n, &r) == 1)                { line = ImStrSkipBlank(line + r); /* .. */ settings->SaveFlags |= ImGuiTableFlags_Resizable; }
+    if (sscanf(line, "Visible=%d%n", &n, &r) == 1)              { line = ImStrSkipBlank(line + r); column->Visible = (ImU8)n; settings->SaveFlags |= ImGuiTableFlags_Hideable; }
+    if (sscanf(line, "Order=%d%n", &n, &r) == 1)                { line = ImStrSkipBlank(line + r); column->DisplayOrder = (ImS8)n; settings->SaveFlags |= ImGuiTableFlags_Reorderable; }
+    if (sscanf(line, "Sort=%d%c%n", &n, &c, &r) == 2)           { line = ImStrSkipBlank(line + r); column->SortOrder = (ImS8)n; column->SortDirection = (c == '^') ? ImGuiSortDirection_Descending : ImGuiSortDirection_Ascending; settings->SaveFlags |= ImGuiTableFlags_Sortable; }
+}
+
+void    ImGui::TableSettingsHandler_WriteAll(ImGuiContext* ctx, ImGuiSettingsHandler* handler, ImGuiTextBuffer* buf)
+{
+    ImGuiContext& g = *ctx;
+    for (ImGuiTableSettings* settings = g.SettingsTables.begin(); settings != NULL; settings = g.SettingsTables.next_chunk(settings))
+    {
+        if (settings->ID == 0) // Skip ditched settings
+            continue;
+        
+        // TableSaveSettings() may clear some of those flags when we establish that the data can be stripped (e.g. Order was unchanged)
+        const bool save_size    = (settings->SaveFlags & ImGuiTableFlags_Resizable) != 0;
+        const bool save_visible = (settings->SaveFlags & ImGuiTableFlags_Hideable) != 0;
+        const bool save_order   = (settings->SaveFlags & ImGuiTableFlags_Reorderable) != 0;
+        const bool save_sort    = (settings->SaveFlags & ImGuiTableFlags_Sortable) != 0;
+        if (!save_size && !save_visible && !save_order && !save_sort)
+            continue;
+
+        buf->reserve(buf->size() + 30 + settings->ColumnsCount * 50); // ballpark reserve
+        buf->appendf("[%s][0x%08X,%d]\n", handler->TypeName, settings->ID, settings->ColumnsCount);
+        ImGuiTableColumnSettings* column = settings->GetColumnSettings();
+        for (int column_n = 0; column_n < settings->ColumnsCount; column_n++, column++)
+        {
+            // "Column 0  UserID=0x42AD2D21 Width=100 Visible=1 Order=0 Sort=0v"
+            if (column->UserID != 0)
+                buf->appendf("Column %-2d UserID=%08X", column_n, column->UserID);
+            else
+                buf->appendf("Column %-2d", column_n);
+            if (save_size)                              buf->appendf(" Width=%d", 0);// (int)settings_column->WidthOrWeight);  // FIXME-TABLE
+            if (save_visible)                           buf->appendf(" Visible=%d", column->Visible);
+            if (save_order)                             buf->appendf(" Order=%d", column->DisplayOrder);
+            if (save_sort && column->SortOrder != -1)   buf->appendf(" Sort=%d%c", column->SortOrder, (column->SortDirection == ImGuiSortDirection_Ascending) ? 'v' : '^');
+            buf->append("\n");
+        }       
+        buf->append("\n");
+    }
 }
 
 //-------------------------------------------------------------------------

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -7765,7 +7765,7 @@ inline ImGuiTableFlags TableFixFlags(ImGuiTableFlags flags)
 
     // Adjust flags: enforce borders when resizable
     if (flags & ImGuiTableFlags_Resizable)
-        flags |= ImGuiTableFlags_BordersV;
+        flags |= ImGuiTableFlags_BordersVInner;
 
     // Adjust flags: disable top rows freezing if there's no scrolling
     // In theory we could want to assert if ScrollFreeze was set without the corresponding scroll flag, but that would hinder demos.
@@ -7892,18 +7892,23 @@ bool    ImGui::BeginTableEx(const char* name, ImGuiID id, int columns_count, ImG
         PushID(instance_id);
     }
 
-    const bool has_cell_padding_x = (flags & (ImGuiTableFlags_BordersOuter | ImGuiTableFlags_BordersV)) != 0;
-    ImGuiWindow* inner_window = table->InnerWindow;
-    table->CurrentColumn = -1;
-    table->CurrentRow = -1;
-    table->RowBgColorCounter = 0;
-    table->LastRowFlags = ImGuiTableRowFlags_None;
+    // Borders
+    // - None               ........Content..... Pad .....Content........
+    // - VOuter             | Pad ..Content..... Pad .....Content.. Pad |       // FIXME-TABLE: Not handled properly
+    // - VInner             ........Content.. Pad | Pad ..Content........       // FIXME-TABLE: Not handled properly
+    // - VOuter+VInner      | Pad ..Content.. Pad | Pad ..Content.. Pad |
 
+    const bool has_cell_padding_x = (flags & ImGuiTableFlags_BordersVOuter) != 0;
+    ImGuiWindow* inner_window = table->InnerWindow;
     table->CellPaddingX1 = has_cell_padding_x ? g.Style.CellPadding.x + 1.0f : 0.0f;
     table->CellPaddingX2 = has_cell_padding_x ? g.Style.CellPadding.x : 0.0f;
     table->CellPaddingY = g.Style.CellPadding.y;
     table->CellSpacingX = has_cell_padding_x ? 0.0f : g.Style.CellPadding.x;
 
+    table->CurrentColumn = -1;
+    table->CurrentRow = -1;
+    table->RowBgColorCounter = 0;
+    table->LastRowFlags = ImGuiTableRowFlags_None;
     table->HostClipRect = inner_window->ClipRect;
     table->InnerClipRect = (inner_window == outer_window) ? table->WorkRect : inner_window->ClipRect;
     table->InnerClipRect.ClipWith(table->WorkRect);     // We need this to honor inner_width
@@ -7925,8 +7930,8 @@ bool    ImGui::BeginTableEx(const char* name, ImGuiID id, int columns_count, ImG
     // FIXME-TABLE FIXME-STYLE: Using opaque colors facilitate overlapping elements of the grid
     //table->BorderOuterColor = GetColorU32(ImGuiCol_Separator, 1.00f);
     //table->BorderInnerColor = GetColorU32(ImGuiCol_Separator, 0.60f);
-    table->BorderOuterColor = GetColorU32(ImVec4(0.31f, 0.31f, 0.35f, 1.00f));
-    table->BorderInnerColor = GetColorU32(ImVec4(0.23f, 0.23f, 0.25f, 1.00f));
+    table->BorderColorStrong = GetColorU32(ImVec4(0.31f, 0.31f, 0.35f, 1.00f));
+    table->BorderColorLight = GetColorU32(ImVec4(0.23f, 0.23f, 0.25f, 1.00f));
     //table->BorderOuterColor = IM_COL32(255, 0, 0, 255);
     //table->BorderInnerColor = IM_COL32(255, 255, 0, 255);
     table->BorderX1 = table->InnerClipRect.Min.x;// +((table->Flags & ImGuiTableFlags_BordersOuter) ? 0.0f : -1.0f);
@@ -8458,7 +8463,7 @@ void    ImGui::TableUpdateBorders(ImGuiTable* table)
     // the final height from last frame. Because this is only affecting _interaction_ with columns, it is not really problematic.
     // (whereas the actual visual will be displayed in EndTable() and using the current frame height)
     // Actual columns highlight/render will be performed in EndTable() and not be affected.
-    const bool borders_full_height = (table->IsUsingHeaders == false) || (table->Flags & ImGuiTableFlags_BordersFullHeight);
+    const bool borders_full_height = (table->IsUsingHeaders == false) || (table->Flags & ImGuiTableFlags_BordersVFullHeight);
     const float hit_half_width = TABLE_RESIZE_SEPARATOR_HALF_THICKNESS;
     const float hit_y1 = table->OuterRect.Min.y;
     const float hit_y2_full = ImMax(table->OuterRect.Max.y, hit_y1 + table->LastOuterHeight);
@@ -8639,6 +8644,7 @@ void    ImGui::EndTable()
     g.CurrentTable = g.CurrentTableStack.Size ? g.Tables.GetByIndex(g.CurrentTableStack.back().Index) : NULL;
 }
 
+// FIXME-TABLE: This is a mess, need to redesign how we render borders.
 void ImGui::TableDrawBorders(ImGuiTable* table)
 {
     ImGuiWindow* inner_window = table->InnerWindow;
@@ -8646,28 +8652,29 @@ void ImGui::TableDrawBorders(ImGuiTable* table)
     table->DrawSplitter.SetCurrentChannel(inner_window->DrawList, 0);
     if (inner_window->Hidden || !table->HostClipRect.Overlaps(table->InnerClipRect))
         return;
+    ImDrawList* inner_drawlist = inner_window->DrawList;
+    ImDrawList* outer_drawlist = outer_window->DrawList;
 
     // Draw inner border and resizing feedback
     const float draw_y1 = table->OuterRect.Min.y;
     float draw_y2_base = (table->FreezeRowsCount >= 1 ? table->OuterRect.Min.y : table->WorkRect.Min.y) + table->LastFirstRowHeight;
     float draw_y2_full = table->OuterRect.Max.y;
     ImU32 border_base_col;
-    if (!table->IsUsingHeaders || (table->Flags & ImGuiTableFlags_BordersFullHeight))
+    if (!table->IsUsingHeaders || (table->Flags & ImGuiTableFlags_BordersVFullHeight))
     {
         draw_y2_base = draw_y2_full;
-        border_base_col = table->BorderInnerColor;
+        border_base_col = table->BorderColorLight;
     }
     else
     {
-        border_base_col = table->BorderOuterColor;
+        border_base_col = table->BorderColorStrong;
     }
 
-    if (table->Flags & ImGuiTableFlags_BordersV)
-    {
-        const bool draw_left_most_border = (table->Flags & ImGuiTableFlags_BordersOuter) == 0;
-        if (draw_left_most_border)
-            inner_window->DrawList->AddLine(ImVec2(table->OuterRect.Min.x, draw_y1), ImVec2(table->OuterRect.Min.x, draw_y2_base), border_base_col, 1.0f);
+    if ((table->Flags & ImGuiTableFlags_BordersVOuter) && (table->InnerWindow == table->OuterWindow))
+        inner_drawlist->AddLine(ImVec2(table->OuterRect.Min.x, draw_y1), ImVec2(table->OuterRect.Min.x, draw_y2_base), border_base_col, 1.0f);
 
+    if (table->Flags & ImGuiTableFlags_BordersVInner)
+    {
         for (int order_n = 0; order_n < table->ColumnsCount; order_n++)
         {
             if (!(table->ActiveMaskByDisplayOrder & ((ImU64)1 << order_n)))
@@ -8677,7 +8684,10 @@ void ImGui::TableDrawBorders(ImGuiTable* table)
             ImGuiTableColumn* column = &table->Columns[column_n];
             const bool is_hovered = (table->HoveredColumnBorder == column_n);
             const bool is_resized = (table->ResizedColumn == column_n) && (table->InstanceInteracted == table->InstanceNo);
-            const bool draw_right_border = (column->MaxX <= table->InnerClipRect.Max.x) || (is_resized || is_hovered);
+            const bool is_resizable = (column->Flags & (ImGuiTableColumnFlags_NoResize | ImGuiTableColumnFlags_NoDirectResize_)) == 0;
+            bool draw_right_border = (column->MaxX <= table->InnerClipRect.Max.x) || (is_resized || is_hovered);
+            if (column->NextActiveColumn == -1 && !is_resizable)
+                draw_right_border = false;
             if (draw_right_border && column->MaxX > column->ClipRect.Min.x) // FIXME-TABLE FIXME-STYLE: Assume BorderSize==1, this is problematic if we want to increase the border size..
             {
                 // Draw in outer window so right-most column won't be clipped
@@ -8690,7 +8700,7 @@ void ImGui::TableDrawBorders(ImGuiTable* table)
                 float draw_y2 = draw_y2_base;
                 if (is_hovered || is_resized || (table->FreezeColumnsCount != -1 && table->FreezeColumnsCount == order_n + 1))
                     draw_y2 = draw_y2_full;
-                inner_window->DrawList->AddLine(ImVec2(column->MaxX, draw_y1), ImVec2(column->MaxX, draw_y2), col, 1.0f);
+                inner_drawlist->AddLine(ImVec2(column->MaxX, draw_y1), ImVec2(column->MaxX, draw_y2), col, 1.0f);
             }
         }
     }
@@ -8704,16 +8714,28 @@ void ImGui::TableDrawBorders(ImGuiTable* table)
         // and the part that's over scrollbars in the outer window..)
         // Either solution currently won't allow us to use a larger border size: the border would clipped.
         ImRect outer_border = table->OuterRect;
+        const ImU32 outer_col = table->BorderColorStrong;
         if (inner_window != outer_window)
             outer_border.Expand(1.0f);
-        outer_window->DrawList->AddRect(outer_border.Min, outer_border.Max, table->BorderOuterColor); // IM_COL32(255, 0, 0, 255));
+        if ((table->Flags & ImGuiTableFlags_BordersOuter) == ImGuiTableFlags_BordersOuter)
+            outer_drawlist->AddRect(outer_border.Min, outer_border.Max, outer_col);
+        else if (table->Flags & ImGuiTableFlags_BordersVOuter)
+        {
+            outer_drawlist->AddLine(outer_border.Min, ImVec2(outer_border.Min.x, outer_border.Max.y), outer_col);
+            outer_drawlist->AddLine(ImVec2(outer_border.Max.x, outer_border.Min.y), outer_border.Max, outer_col);
+        }
+        else if (table->Flags & ImGuiTableFlags_BordersHOuter)
+        {
+            outer_drawlist->AddLine(outer_border.Min, ImVec2(outer_border.Max.x, outer_border.Min.y), outer_col);
+            outer_drawlist->AddLine(ImVec2(outer_border.Min.x, outer_border.Max.y), outer_border.Max, outer_col);
+        }
     }
-    else if (table->Flags & ImGuiTableFlags_BordersH)
+    if ((table->Flags & ImGuiTableFlags_BordersHInner) && table->RowPosY2 < table->OuterRect.Max.y)
     {
-        // Draw bottom-most border
+        // Draw bottom-most row border
         const float border_y = table->RowPosY2;
         if (border_y >= table->BackgroundClipRect.Min.y && border_y < table->BackgroundClipRect.Max.y)
-            inner_window->DrawList->AddLine(ImVec2(table->BorderX1, border_y), ImVec2(table->BorderX2, border_y), table->BorderOuterColor);
+            inner_drawlist->AddLine(ImVec2(table->BorderX1, border_y), ImVec2(table->BorderX2, border_y), table->BorderColorLight);
     }
 }
 
@@ -9111,21 +9133,22 @@ void    ImGui::TableEndRow(ImGuiTable* table)
         else if (table->Flags & ImGuiTableFlags_RowBg)
             bg_col = GetColorU32((table->RowBgColorCounter & 1) ? ImGuiCol_TableRowBgAlt : ImGuiCol_TableRowBg);
 
-        // Decide of separating border color
+        // Decide of top border color
         ImU32 border_col = 0;
         if (table->CurrentRow != 0 || table->InnerWindow == table->OuterWindow)
         {
-            if (table->Flags & ImGuiTableFlags_BordersH)
+            if (table->Flags & ImGuiTableFlags_BordersHInner)
             {
-                if (table->CurrentRow == 0 && table->InnerWindow == table->OuterWindow)
-                    border_col = table->BorderOuterColor;
-                else if (!(table->LastRowFlags & ImGuiTableRowFlags_Headers))
-                    border_col = table->BorderInnerColor;
+                //if (table->CurrentRow == 0 && table->InnerWindow == table->OuterWindow)
+                //    border_col = table->BorderOuterColor;
+                //else
+                if (table->CurrentRow > 0)// && !(table->LastRowFlags & ImGuiTableRowFlags_Headers))
+                    border_col = (table->LastRowFlags & ImGuiTableRowFlags_Headers) ? table->BorderColorStrong : table->BorderColorLight;
             }
             else
             {
-                if (table->RowFlags & ImGuiTableRowFlags_Headers)
-                    border_col = table->BorderOuterColor;
+                //if (table->RowFlags & ImGuiTableRowFlags_Headers)
+                //    border_col = table->BorderOuterColor;
             }
         }
 
@@ -9151,10 +9174,10 @@ void    ImGui::TableEndRow(ImGuiTable* table)
     const bool unfreeze_rows = (table->CurrentRow + 1 == table->FreezeRowsCount && table->FreezeRowsCount > 0);
 
     // Draw bottom border (always strong)
-    const bool draw_separating_border = unfreeze_rows || (table->RowFlags & ImGuiTableRowFlags_Headers);
+    const bool draw_separating_border = unfreeze_rows;// || (table->RowFlags & ImGuiTableRowFlags_Headers);
     if (draw_separating_border)
         if (bg_y2 >= table->BackgroundClipRect.Min.y && bg_y2 < table->BackgroundClipRect.Max.y)
-            window->DrawList->AddLine(ImVec2(table->BorderX1, bg_y2), ImVec2(table->BorderX2, bg_y2), table->BorderOuterColor);
+            window->DrawList->AddLine(ImVec2(table->BorderX1, bg_y2), ImVec2(table->BorderX2, bg_y2), table->BorderColorStrong);
 
     // End frozen rows (when we are past the last frozen row line, teleport cursor and alter clipping rectangle)
     // We need to do that in TableEndRow() instead of TableBeginRow() so the list clipper can mark end of row and get the new cursor position.
@@ -9461,7 +9484,7 @@ void    ImGui::TableAutoHeaders()
 
         const char* name = TableGetColumnName(column_n);
 
-        // FIXME-TABLE: Test custom user elements
+        // [DEBUG] Test custom user elements
 #if 0
         if (column_n < 2)
         {

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -7892,6 +7892,13 @@ bool    ImGui::BeginTableEx(const char* name, ImGuiID id, int columns_count, ImG
         PushID(instance_id);
     }
 
+    // Backup a copy of host window members we will modify
+    ImGuiWindow* inner_window = table->InnerWindow;
+    table->HostClipRect = inner_window->ClipRect;
+    table->HostSkipItems = inner_window->SkipItems;
+    table->HostWorkRect = inner_window->WorkRect;
+    table->HostCursorMaxPos = inner_window->DC.CursorMaxPos;
+
     // Borders
     // - None               ........Content..... Pad .....Content........
     // - VOuter             | Pad ..Content..... Pad .....Content.. Pad |       // FIXME-TABLE: Not handled properly
@@ -7899,7 +7906,6 @@ bool    ImGui::BeginTableEx(const char* name, ImGuiID id, int columns_count, ImG
     // - VOuter+VInner      | Pad ..Content.. Pad | Pad ..Content.. Pad |
 
     const bool has_cell_padding_x = (flags & ImGuiTableFlags_BordersVOuter) != 0;
-    ImGuiWindow* inner_window = table->InnerWindow;
     table->CellPaddingX1 = has_cell_padding_x ? g.Style.CellPadding.x + 1.0f : 0.0f;
     table->CellPaddingX2 = has_cell_padding_x ? g.Style.CellPadding.x : 0.0f;
     table->CellPaddingY = g.Style.CellPadding.y;
@@ -7909,7 +7915,6 @@ bool    ImGui::BeginTableEx(const char* name, ImGuiID id, int columns_count, ImG
     table->CurrentRow = -1;
     table->RowBgColorCounter = 0;
     table->LastRowFlags = ImGuiTableRowFlags_None;
-    table->HostClipRect = inner_window->ClipRect;
     table->InnerClipRect = (inner_window == outer_window) ? table->WorkRect : inner_window->ClipRect;
     table->InnerClipRect.ClipWith(table->WorkRect);     // We need this to honor inner_width
     table->InnerClipRect.ClipWith(table->HostClipRect);
@@ -7965,11 +7970,6 @@ bool    ImGui::BeginTableEx(const char* name, ImGuiID id, int columns_count, ImG
     // Load settings
     if (table->IsSettingsRequestLoad)
         TableLoadSettings(table);
-
-    // Grab a copy of window fields we will modify
-    table->BackupSkipItems = inner_window->SkipItems;
-    table->BackupWorkRect = inner_window->WorkRect;
-    table->BackupCursorMaxPos = inner_window->DC.CursorMaxPos;
 
     // Disable output until user calls TableNextRow() or TableNextCell() leading to the TableUpdateLayout() call..
     // This is not strictly necessary but will reduce cases were misleading "out of table" output will be confusing to the user.
@@ -8416,7 +8416,7 @@ void    ImGui::TableUpdateLayout(ImGuiTable* table)
         }
 
         // Don't decrement auto-fit counters until container window got a chance to submit its items
-        if (table->BackupSkipItems == false)
+        if (table->HostSkipItems == false)
         {
             column->AutoFitQueue >>= 1;
             column->CannotSkipItemsQueue >>= 1;
@@ -8556,8 +8556,8 @@ void    ImGui::EndTable()
         TableEndRow(table);
 
     // Finalize table height
-    inner_window->SkipItems = table->BackupSkipItems;
-    inner_window->DC.CursorMaxPos = table->BackupCursorMaxPos;
+    inner_window->SkipItems = table->HostSkipItems;
+    inner_window->DC.CursorMaxPos = table->HostCursorMaxPos;
     if (inner_window != outer_window)
     {
         table->OuterRect.Max.y = ImMax(table->OuterRect.Max.y, inner_window->Pos.y + inner_window->Size.y);
@@ -8630,8 +8630,8 @@ void    ImGui::EndTable()
     }
 
     // Layout in outer window
-    inner_window->WorkRect = table->BackupWorkRect;
-    inner_window->SkipItems = table->BackupSkipItems;
+    inner_window->WorkRect = table->HostWorkRect;
+    inner_window->SkipItems = table->HostSkipItems;
     outer_window->DC.CursorPos = table->OuterRect.Min;
     outer_window->DC.ColumnsOffset.x = 0.0f;
     if (inner_window != outer_window)
@@ -9254,7 +9254,7 @@ void    ImGui::TableBeginCell(ImGuiTable* table, int column_no)
     // FIXME-COLUMNS: Setup baseline, preserve across columns (how can we obtain first line baseline tho..)
     // window->DC.CurrLineTextBaseOffset = ImMax(window->DC.CurrLineTextBaseOffset, g.Style.FramePadding.y);
 
-    window->SkipItems = column->IsClipped ? true : table->BackupSkipItems;
+    window->SkipItems = column->IsClipped ? true : table->HostSkipItems;
     if (table->Flags & ImGuiTableFlags_NoClipX)
     {
         table->DrawSplitter.SetCurrentChannel(window->DrawList, 1);
@@ -9488,15 +9488,23 @@ void    ImGui::TableAutoHeaders()
 
     ImGuiTable* table = g.CurrentTable;
     IM_ASSERT(table != NULL && "Need to call TableAutoHeaders() after BeginTable()!");
+    const int columns_count = table->ColumnsCount;
 
-    TableNextRow(ImGuiTableRowFlags_Headers, GetTextLineHeight() + g.Style.CellPadding.y * 2.0f);
+    // Calculate row height (for the unlikely case that labels may be are multi-line)
+    float row_height = GetTextLineHeight();
+    for (int column_n = 0; column_n < columns_count; column_n++)
+        if (TableGetColumnIsVisible(column_n))
+            row_height = ImMax(row_height, CalcTextSize(TableGetColumnName(column_n)).y);
+    row_height += g.Style.CellPadding.y * 2.0f;
+
+    // Open row
+    TableNextRow(ImGuiTableRowFlags_Headers, row_height);
     if (window->SkipItems)
         return;
 
     // This for loop is constructed to not make use of internal functions,
     // as this is intended to be a base template to copy and build from.
     int open_context_popup = INT_MAX;
-    const int columns_count = table->ColumnsCount;
     for (int column_n = 0; column_n < columns_count; column_n++)
     {
         if (!TableSetColumnIndex(column_n))
@@ -9533,7 +9541,7 @@ void    ImGui::TableAutoHeaders()
 
     // FIXME-TABLE: This is not user-land code any more... 
     // FIXME-TABLE: Need to explain why this is here!
-    window->SkipItems = table->BackupSkipItems;
+    window->SkipItems = table->HostSkipItems;
 
     // Allow opening popup from the right-most section after the last column
     // FIXME-TABLE: This is not user-land code any more... perhaps instead we should expose hovered column.
@@ -9578,6 +9586,7 @@ void    ImGui::TableAutoHeaders()
 // Emit a column header (text + optional sort order)
 // We cpu-clip text here so that all columns headers can be merged into a same draw call.
 // FIXME-TABLE: Should hold a selection state.
+// FIXME-TABLE: Style confusion between CellPadding.y and FramePadding.y
 void    ImGui::TableHeader(const char* label)
 {
     ImGuiContext& g = *GImGui;
@@ -9591,19 +9600,21 @@ void    ImGui::TableHeader(const char* label)
     const int column_n = table->CurrentColumn;
     ImGuiTableColumn* column = &table->Columns[column_n];
 
-    float row_height = GetTextLineHeight();
-    ImRect cell_r = TableGetCellRect();
-    //GetForegroundDrawList()->AddRect(cell_r.Min, cell_r.Max, IM_COL32(255, 0, 0, 255)); // [DEBUG]
-    ImRect work_r = cell_r;
-    work_r.Min.x = window->DC.CursorPos.x;
-    work_r.Max.y = work_r.Min.y + row_height;
-
     // Label
     if (label == NULL)
         label = "";
     const char* label_end = FindRenderedTextEnd(label);
     ImVec2 label_size = CalcTextSize(label, label_end, true);
     ImVec2 label_pos = window->DC.CursorPos;
+
+    // If we already got a row height, there's use that.
+    ImRect cell_r = TableGetCellRect();
+    float label_height = ImMax(label_size.y, cell_r.GetHeight() - g.Style.CellPadding.y * 2.0f);
+
+    //GetForegroundDrawList()->AddRect(cell_r.Min, cell_r.Max, IM_COL32(255, 0, 0, 255)); // [DEBUG]
+    ImRect work_r = cell_r;
+    work_r.Min.x = window->DC.CursorPos.x;
+    work_r.Max.y = work_r.Min.y + label_height;
     float ellipsis_max = work_r.Max.x;
 
     // Selectable
@@ -9614,7 +9625,7 @@ void    ImGui::TableHeader(const char* label)
 
     // Keep header highlighted when context menu is open. (FIXME-TABLE: however we cannot assume the ID of said popup if it has been created by the user...)
     const bool selected = (table->IsContextPopupOpen && table->ContextPopupColumn == column_n && table->InstanceInteracted == table->InstanceNo);
-    const bool pressed = Selectable("", selected, ImGuiSelectableFlags_DrawHoveredWhenHeld, ImVec2(0.0f, row_height));
+    const bool pressed = Selectable("", selected, ImGuiSelectableFlags_DrawHoveredWhenHeld, ImVec2(0.0f, label_height));
     const bool held = IsItemActive();
     if (held)
         table->HeldHeaderColumn = (ImS8)column_n;
@@ -9676,7 +9687,7 @@ void    ImGui::TableHeader(const char* label)
     // Render clipped label
     // Clipping here ensure that in the majority of situations, all our header cells will be merged into a single draw call.
     //window->DrawList->AddCircleFilled(ImVec2(ellipsis_max, label_pos.y), 40, IM_COL32_WHITE);
-    RenderTextEllipsis(window->DrawList, label_pos, ImVec2(ellipsis_max, label_pos.y + row_height + g.Style.FramePadding.y), ellipsis_max, ellipsis_max, label, label_end, &label_size);
+    RenderTextEllipsis(window->DrawList, label_pos, ImVec2(ellipsis_max, label_pos.y + label_height + g.Style.FramePadding.y), ellipsis_max, ellipsis_max, label, label_end, &label_size);
 
     // We feed our unclipped width to the column without writing on CursorMaxPos, so that column is still considering for merging.
     // FIXME-TABLE: Clarify policies of how label width and potential decorations (arrows) fit into auto-resize of the column
@@ -9726,7 +9737,7 @@ void ImGui::TableSortSpecsClickColumn(ImGuiTable* table, ImGuiTableColumn* click
 }
 
 // Return NULL if no sort specs.
-// Return ->WantSort == true when the specs have changed since the last query.
+// You can sort your data again when 'SpecsChanged == true'.It will be true with sorting specs have changed since last call, or the first time.
 const ImGuiTableSortSpecs* ImGui::TableGetSortSpecs()
 {
     ImGuiContext& g = *GImGui;

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -7728,20 +7728,22 @@ void ImGui::Columns(int columns_count, const char* id, bool border)
 //    - TableBeginUpdateColumns()               - apply resize/order requests, lock columns active state, order
 // - TableSetupColumn()                         user submit columns details (optional)
 // - TableAutoHeaders() or TableHeader()        user submit a headers row (optional)
-//    - TableSortSpecsClickColumn()
+//    - TableSortSpecsClickColumn()             - when clicked: alter sort order and sort direction
 // - TableGetSortSpecs()                        user queries updated sort specs (optional)
 // - TableNextRow() / TableNextCell()           user begin into the first row, also automatically called by TableAutoHeaders()
-//    - TableUpdateLayout()                     - called by the FIRST call to TableNextRow()
-//      - TableUpdateDrawChannels()             - setup ImDrawList channels
-//      - TableUpdateBorders()                  - detect hovering columns for resize, ahead of contents submission
-//      - TableDrawContextMenu()                - draw right-click context menu
+//    - TableUpdateLayout()                     - called by the FIRST call to TableNextRow()!
+//      - TableUpdateDrawChannels()               - setup ImDrawList channels
+//      - TableUpdateBorders()                    - detect hovering columns for resize, ahead of contents submission
+//      - TableDrawContextMenu()                  - draw right-click context menu
+//    - TableEndCell()                          - close existing cell if not the first time
+//    - TableBeginCell()                        - enter into current cell
 // - [...]                                      user emit contents
 // - EndTable()                                 user ends the table
 //    - TableDrawBorders()                      - draw outer borders, inner vertical borders
 //    - TableDrawMergeChannels()                - merge draw channels if clipping isn't required
 //    - TableSetColumnWidth()                   - apply resizing width
-//      - TableUpdateColumnsWeightFromWidth()
-//      - EndChild()                            - (if ScrollX/ScrollY is set)
+//      - TableUpdateColumnsWeightFromWidth()     - recompute columns weights (of weighted columns) from their respective width
+//      - EndChild()                              - (if ScrollX/ScrollY is set)
 //-----------------------------------------------------------------------------
 
 // Configuration
@@ -7871,7 +7873,7 @@ bool    ImGui::BeginTableEx(const char* name, ImGuiID id, int columns_count, ImG
             override_content_size.y = FLT_MIN;
 
         // Ensure specified width (when not specified, Stretched columns will act as if the width == OuterWidth and never lead to any scrolling)
-        // We don't handle inner_width < 0.0f, we could potentially use it to right-align based on the right side of the child window work rect, 
+        // We don't handle inner_width < 0.0f, we could potentially use it to right-align based on the right side of the child window work rect,
         // which would require knowing ahead if we are going to have decoration taking horizontal spaces (typically a vertical scrollbar).
         if (inner_width != 0.0f)
             override_content_size.x = inner_width;
@@ -7975,7 +7977,7 @@ bool    ImGui::BeginTableEx(const char* name, ImGuiID id, int columns_count, ImG
     // This is not strictly necessary but will reduce cases were misleading "out of table" output will be confusing to the user.
     // Because we cannot safely assert in EndTable() when no rows have been created, this seems like our best option.
     inner_window->SkipItems = true;
-    
+
     // Update/lock which columns will be Active for the frame
     TableBeginUpdateColumns(table);
 
@@ -7987,7 +7989,7 @@ void ImGui::TableBeginUpdateColumns(ImGuiTable* table)
     // Handle resizing request
     // (We process this at the first TableBegin of the frame)
     // FIXME-TABLE: Preserve contents width _while resizing down_ until releasing.
-    // FIXME-TABLE: Contains columns if our work area doesn't allow for scrolling. 
+    // FIXME-TABLE: Contains columns if our work area doesn't allow for scrolling.
     if (table->InstanceNo == 0)
     {
         if (table->ResizedColumn != -1 && table->ResizedColumnNextWidth != FLT_MAX)
@@ -8185,7 +8187,7 @@ static float TableGetMinColumnWidth()
 
 // Layout columns for the frame
 // Runs on the first call to TableNextRow(), to give a chance for TableSetupColumn() to be called first.
-// FIXME-TABLE: Our width (and therefore our WorkRect) will be minimal in the first frame for WidthAlwaysAutoResize columns, 
+// FIXME-TABLE: Our width (and therefore our WorkRect) will be minimal in the first frame for WidthAlwaysAutoResize columns,
 // increase feedback side-effect with widgets relying on WorkRect.Max.x. Maybe provide a default distribution for WidthAlwaysAutoResize columns?
 void    ImGui::TableUpdateLayout(ImGuiTable* table)
 {
@@ -8316,7 +8318,7 @@ void    ImGui::TableUpdateLayout(ImGuiTable* table)
             table->Columns[g.ShrinkWidthBuffer.Data[n].Index].WidthGiven = ImMax(g.ShrinkWidthBuffer.Data[n].Width, min_column_size);
         // FIXME: Need to alter table->ColumnsTotalWidth
     }
-    else 
+    else
 #endif
 
     // Redistribute remainder width due to rounding (remainder width is < 1.0f * number of Stretch column)
@@ -8360,7 +8362,7 @@ void    ImGui::TableUpdateLayout(ImGuiTable* table)
             column->ClipRect.Max.x = offset_x;
             column->ClipRect.Max.y = FLT_MAX;
             column->ClipRect.ClipWithFull(host_clip_rect);
-            column->IsClipped = true;
+            column->IsClipped = column->SkipItems = true;
             continue;
         }
 
@@ -8389,8 +8391,9 @@ void    ImGui::TableUpdateLayout(ImGuiTable* table)
         column->ClipRect.Max.x = column->MaxX;// -1.0f;
         column->ClipRect.Max.y = FLT_MAX;
         column->ClipRect.ClipWithFull(host_clip_rect);
-        
+
         column->IsClipped = (column->ClipRect.Max.x <= column->ClipRect.Min.x) && (column->AutoFitQueue & 1) == 0 && (column->CannotSkipItemsQueue & 1) == 0;
+        column->SkipItems = column->IsClipped || table->HostSkipItems;
         if (column->IsClipped)
         {
             // Columns with the _WidthAlwaysAutoResize sizing policy will never be updated then.
@@ -8440,7 +8443,7 @@ void    ImGui::TableUpdateLayout(ImGuiTable* table)
     // Borders
     if (table->Flags & ImGuiTableFlags_Resizable)
         TableUpdateBorders(table);
-    
+
     // Reset fields after we used them in TableSetupResize()
     table->LastFirstRowHeight = 0.0f;
     table->IsLayoutLocked = true;
@@ -8495,7 +8498,7 @@ void    ImGui::TableUpdateBorders(ImGuiTable* table)
         const int column_n = table->DisplayOrder[order_n];
         ImGuiTableColumn* column = &table->Columns[column_n];
 
-        // Detect hovered column: 
+        // Detect hovered column:
         // - we perform an unusually low-level check here.. not using IsMouseHoveringRect() to avoid touch padding.
         // - we don't care about the full set of IsItemHovered() feature either.
         if (mouse_x_hover_body >= column->MinX && mouse_x_hover_body < column->MaxX)
@@ -8536,7 +8539,7 @@ void    ImGui::EndTable()
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
     IM_ASSERT(table != NULL && "Only call EndTable() is BeginTable() returns true!");
-    
+
     // This assert would be very useful to catch a common error... unfortunately it would probably trigger in some cases,
     // and for consistency user may sometimes output empty tables (and still benefit from e.g. outer border)
     //IM_ASSERT(table->IsLayoutLocked && "Table unused: never called TableNextRow(), is that the intent?");
@@ -8576,7 +8579,7 @@ void    ImGui::EndTable()
     for (int column_n = 0; column_n < table->ColumnsCount; column_n++)
     {
         ImGuiTableColumn* column = &table->Columns[column_n];
-        
+
         // Store content width (for both Headers and Rows)
         //float ref_x = column->MinX;
         float ref_x_rows = column->StartXRows - table->CellPaddingX1;
@@ -8726,7 +8729,7 @@ void ImGui::TableDrawBorders(ImGuiTable* table)
     if (table->Flags & ImGuiTableFlags_BordersOuter)
     {
         // Display outer border offset by 1 which is a simple way to display it without adding an extra draw call
-        // (Without the offset, in outer_window it would be rendered behind cells, because child windows are above their parent. 
+        // (Without the offset, in outer_window it would be rendered behind cells, because child windows are above their parent.
         // In inner_window, it won't reach out over scrollbars. Another weird solution would be to display part of it in inner window,
         // and the part that's over scrollbars in the outer window..)
         // Either solution currently won't allow us to use a larger border size: the border would clipped.
@@ -8808,7 +8811,7 @@ void ImGui::TableSetColumnWidth(ImGuiTable* table, ImGuiTableColumn* column_0, f
     // - F1 F2 W3  resize from W3|          --> ok: no-op (disabled by Resize Rule 1)
     // - W1 W2 W3  resize from W1| or W2|   --> FIXME
     // - W1 W2 W3  resize from W3|          --> ok: no-op (disabled by Resize Rule 1)
-    // - W1 F2 F3  resize from F3|          --> ok: no-op (disabled by Resize Rule 1) 
+    // - W1 F2 F3  resize from F3|          --> ok: no-op (disabled by Resize Rule 1)
     // - W1 F2     resize from F2|          --> ok: no-op (disabled by Resize Rule 1)
     // - W1 W2 F3  resize from W1| or W2|   --> ok
     // - W1 F2 W3  resize from W1| or F2|   --> FIXME
@@ -8845,7 +8848,7 @@ void ImGui::TableSetColumnWidth(ImGuiTable* table, ImGuiTableColumn* column_0, f
         {
             float off = (column_0->WidthGiven - column_0_width);
             float column_1_width = column_1->WidthGiven + off;
-            column_1->WidthRequested = ImMax(min_width, column_1_width); 
+            column_1->WidthRequested = ImMax(min_width, column_1_width);
             return;
         }
 
@@ -8873,7 +8876,7 @@ void ImGui::TableSetColumnWidth(ImGuiTable* table, ImGuiTableColumn* column_0, f
 // At the end of the operation our 1-4 groups will each have a ImDrawCmd using the same ClipRect, and they will be merged by the DrawSplitter.Merge() call.
 //
 // Column channels will not be merged into one of the 1-4 groups in the following cases:
-// - The contents stray off its clipping rectangle (we only compare the MaxX value, not the MinX value). 
+// - The contents stray off its clipping rectangle (we only compare the MaxX value, not the MinX value).
 //   Direct ImDrawList calls won't be noticed so if you use them make sure the ImGui:: bounds matches, by e.g. calling SetCursorScreenPos().
 // - The channel uses more than one draw command itself (we drop all our merging stuff here.. we could do better but it's going to be rare)
 //
@@ -8932,10 +8935,10 @@ void    ImGui::TableDrawMergeChannels(ImGuiTable* table)
             merge_set_clip_rect[dst_merge_set_n].Add(src_channel->_CmdBuffer[0].ClipRect);
 
             // If we end with a single set and hosted by the outer window, we'll attempt to merge our draw command with
-            // the existing outer window command. But we can only do so if our columns all fit within the expected clip rect, 
+            // the existing outer window command. But we can only do so if our columns all fit within the expected clip rect,
             // otherwise clipping will be incorrect when ScrollX is disabled.
             // FIXME-TABLE FIXME-WORKRECT: We are wasting a merge opportunity on tables without scrolling if column don't fit within host clip rect, solely because of the half-padding difference between window->WorkRect and window->InnerClipRect
-            
+
             // 2019/10/22: (1) This is breaking table_2_draw_calls but I cannot seem to repro what it is attempting to fix...
             // cf git fce2e8dc "Fixed issue with clipping when outerwindow==innerwindow / support ScrollH without ScrollV."
             // 2019/10/22: (2) Clamping code in TableUpdateLayout() seemingly made this not necessary...
@@ -9240,9 +9243,10 @@ void    ImGui::TableBeginCell(ImGuiTable* table, int column_no)
     const float start_x = (table->RowFlags & ImGuiTableRowFlags_Headers) ? column->StartXHeaders : column->StartXRows;
 
     window->DC.LastItemId = 0;
-    window->DC.CursorPos = ImVec2(start_x, table->RowPosY1 + table->CellPaddingY);
+    window->DC.CursorPos.x = start_x;
+    window->DC.CursorPos.y = table->RowPosY1 + table->CellPaddingY;
     window->DC.CursorMaxPos.x = window->DC.CursorPos.x;
-    window->DC.ColumnsOffset.x = start_x - window->Pos.x - window->DC.Indent.x; // FIXME-WORKRECT // FIXME-TABLE: Recurse
+    window->DC.ColumnsOffset.x = start_x - window->Pos.x - window->DC.Indent.x; // FIXME-WORKRECT
     window->DC.CurrLineTextBaseOffset = table->RowTextBaseline;
 
     window->WorkRect.Min.y = window->DC.CursorPos.y;
@@ -9253,10 +9257,7 @@ void    ImGui::TableBeginCell(ImGuiTable* table, int column_no)
     if (!column->IsActive)
         window->DC.CursorPos.y = ImMax(window->DC.CursorPos.y, table->RowPosY2);
 
-    // FIXME-COLUMNS: Setup baseline, preserve across columns (how can we obtain first line baseline tho..)
-    // window->DC.CurrLineTextBaseOffset = ImMax(window->DC.CurrLineTextBaseOffset, g.Style.FramePadding.y);
-
-    window->SkipItems = column->IsClipped ? true : table->HostSkipItems;
+    window->SkipItems = column->SkipItems;
     if (table->Flags & ImGuiTableFlags_NoClipX)
     {
         table->DrawSplitter.SetCurrentChannel(window->DrawList, 1);
@@ -9275,7 +9276,7 @@ void    ImGui::TableBeginCell(ImGuiTable* table, int column_no)
     }
 }
 
-// [Internal] Called by TableNextRow()TableNextCell()!
+// [Internal] Called by TableNextRow()/TableNextCell()!
 void    ImGui::TableEndCell(ImGuiTable* table)
 {
     ImGuiTableColumn* column = &table->Columns[table->CurrentColumn];
@@ -9386,7 +9387,7 @@ const char* ImGui::TableGetColumnName(ImGuiTable* table, int column_no)
 
 void    ImGui::TableSetColumnAutofit(ImGuiTable* table, int column_no)
 {
-    // Disable clipping then auto-fit, will take 2 frames 
+    // Disable clipping then auto-fit, will take 2 frames
     // (we don't take a shortcut for unclipped columns to reduce inconsistencies when e.g. resizing multiple columns)
     ImGuiTableColumn* column = &table->Columns[column_no];
     column->CannotSkipItemsQueue = (1 << 0);
@@ -9738,7 +9739,8 @@ void ImGui::TableSortSpecsClickColumn(ImGuiTable* table, ImGuiTableColumn* click
 }
 
 // Return NULL if no sort specs.
-// You can sort your data again when 'SpecsChanged == true'.It will be true with sorting specs have changed since last call, or the first time.
+// You can sort your data again when 'SpecsChanged == true'. It will be true with sorting specs have changed since last call, or the first time.
+// Lifetime: don't hold on this pointer over multiple frames or past any subsequent call to BeginTable()!
 const ImGuiTableSortSpecs* ImGui::TableGetSortSpecs()
 {
     ImGuiContext& g = *GImGui;
@@ -9917,13 +9919,13 @@ void ImGui::TableSaveSettings(ImGuiTable* table)
         table->SettingsOffset = g.SettingsTables.offset_from_ptr(settings);
     }
     settings->ColumnsCount = (ImS8)table->ColumnsCount;
-    
+
     // Serialize ImGuiTableSettings/ImGuiTableColumnSettings --> ImGuiTable/ImGuiTableColumn
     IM_ASSERT(settings->ID == table->ID);
     IM_ASSERT(settings->ColumnsCount == table->ColumnsCount && settings->ColumnsCountMax >= settings->ColumnsCount);
     ImGuiTableColumn* column = table->Columns.Data;
     ImGuiTableColumnSettings* column_settings = settings->GetColumnSettings();
-    
+
     // FIXME-TABLE: Logic to avoid saving default widths?
     settings->SaveFlags = ImGuiTableFlags_Resizable;
     for (int n = 0; n < table->ColumnsCount; n++, column++, column_settings++)
@@ -9939,7 +9941,7 @@ void ImGui::TableSaveSettings(ImGuiTable* table)
         // FIXME-TABLE: We don't have logic to easily compare SortOrder to DefaultSortOrder yet.
         if (column->IndexDisplayOrder != n)
             settings->SaveFlags |= ImGuiTableFlags_Reorderable;;
-        if (column_settings->SortOrder != -1)   
+        if (column_settings->SortOrder != -1)
             settings->SaveFlags |= ImGuiTableFlags_Sortable;
         if (column_settings->Visible != ((column->Flags & ImGuiTableColumnFlags_DefaultHide) == 0))
             settings->SaveFlags |= ImGuiTableFlags_Hideable;
@@ -10031,7 +10033,7 @@ void    ImGui::TableSettingsHandler_WriteAll(ImGuiContext* ctx, ImGuiSettingsHan
     {
         if (settings->ID == 0) // Skip ditched settings
             continue;
-        
+
         // TableSaveSettings() may clear some of those flags when we establish that the data can be stripped (e.g. Order was unchanged)
         const bool save_size    = (settings->SaveFlags & ImGuiTableFlags_Resizable) != 0;
         const bool save_visible = (settings->SaveFlags & ImGuiTableFlags_Hideable) != 0;
@@ -10055,7 +10057,7 @@ void    ImGui::TableSettingsHandler_WriteAll(ImGuiContext* ctx, ImGuiSettingsHan
             if (save_order)                             buf->appendf(" Order=%d", column->DisplayOrder);
             if (save_sort && column->SortOrder != -1)   buf->appendf(" Sort=%d%c", column->SortOrder, (column->SortDirection == ImGuiSortDirection_Ascending) ? 'v' : '^');
             buf->append("\n");
-        }       
+        }
         buf->append("\n");
     }
 }

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -7818,9 +7818,8 @@ bool    ImGui::BeginTable(const char* str_id, int columns_count, ImGuiTableFlags
     ImVec2 actual_outer_size = CalcItemSize(outer_size, ImMax(avail_size.x, 1.0f), use_child_window ? ImMax(avail_size.y, 1.0f) : 0.0f);
     ImRect outer_rect(outer_window->DC.CursorPos, outer_window->DC.CursorPos + actual_outer_size);
 
-    // If an outer size is specified ahead we will be able to early out when not visible,
-    // The exact rules here can evolve.
-    if (use_child_window && IsClippedEx(outer_rect, id, false))
+    // If an outer size is specified ahead we will be able to early out when not visible. Exact clipping rules may evolve.
+    if (use_child_window && IsClippedEx(outer_rect, 0, false))
     {
         ItemSize(outer_rect);
         return false;
@@ -7833,9 +7832,16 @@ bool    ImGui::BeginTable(const char* str_id, int columns_count, ImGuiTableFlags
     // Acquire storage for the table
     ImGuiTable* table = g.Tables.GetOrAddByKey(id);
     const ImGuiTableFlags table_last_flags = table->Flags;
+    const int instance_no = (table->LastFrameActive != g.FrameCount) ? 0 : table->InstanceNo + 1;
+    const ImGuiID instance_id = id + instance_no;
+    if (instance_no > 0)
+        IM_ASSERT(table->ColumnsCount == columns_count && "BeginTable(): Cannot change columns count mid-frame while preserving same ID");
+
+    // Initialize
     table->ID = id;
     table->Flags = flags;
     table->IsFirstFrame = (table->LastFrameActive == -1);
+    table->InstanceNo = (ImS16)instance_no;
     table->LastFrameActive = g.FrameCount;
     table->OuterWindow = table->InnerWindow = outer_window;
     table->ColumnsCount = columns_count;
@@ -7863,7 +7869,7 @@ bool    ImGui::BeginTable(const char* str_id, int columns_count, ImGuiTableFlags
 
         // Create scrolling region (without border = zero window padding)
         ImGuiWindowFlags child_flags = (flags & ImGuiTableFlags_ScrollX) ? ImGuiWindowFlags_HorizontalScrollbar : ImGuiWindowFlags_None;
-        BeginChildEx(str_id, id, table->OuterRect.GetSize(), false, child_flags);
+        BeginChildEx(str_id, instance_id, table->OuterRect.GetSize(), false, child_flags);
         table->InnerWindow = g.CurrentWindow;
         table->WorkRect = table->InnerWindow->WorkRect;
         table->OuterRect = table->InnerWindow->Rect();
@@ -7871,7 +7877,7 @@ bool    ImGui::BeginTable(const char* str_id, int columns_count, ImGuiTableFlags
     else
     {
         // WorkRect.Max will grow as we append contents.
-        PushID(id);
+        PushID(instance_id);
     }
 
     const bool has_cell_padding_x = (flags & (ImGuiTableFlags_BordersOuter | ImGuiTableFlags_BordersV)) != 0;
@@ -7904,7 +7910,6 @@ bool    ImGui::BeginTable(const char* str_id, int columns_count, ImGuiTableFlags
     table->HoveredColumnBody = -1;
     table->HoveredColumnBorder = -1;
     table->RightMostActiveColumn = -1;
-    table->LeftMostStretchedColumnDisplayOrder = -1;
     table->IsFirstFrame = false;
 
     // FIXME-TABLE FIXME-STYLE: Using opaque colors facilitate overlapping elements of the grid
@@ -7951,18 +7956,36 @@ bool    ImGui::BeginTable(const char* str_id, int columns_count, ImGuiTableFlags
     if (table->IsFirstFrame || table->IsSettingsRequestLoad)
         TableLoadSettings(table);
 
+    // Handle resizing request
+    // (We process this at the first beginning of the frame)
+    // FIXME-TABLE: Preserve contents width _while resizing down_ until releasing.
+    // FIXME-TABLE: Contains columns if our work area doesn't allow for scrolling. 
+    if (table->InstanceNo == 0)
+    {
+        if (table->ResizedColumn != -1 && table->ResizedColumnNextWidth != FLT_MAX)
+            TableSetColumnWidth(table, &table->Columns[table->ResizedColumn], table->ResizedColumnNextWidth);
+        table->ResizedColumnNextWidth = FLT_MAX;
+        table->ResizedColumn = -1;
+    }
+
     // Handle reordering request
     // Note: we don't clear ReorderColumn after handling the request.
-    if (table->ReorderColumn != -1 && table->ReorderColumnDir != 0)
+    if (table->InstanceNo == 0)
     {
-        IM_ASSERT(table->ReorderColumnDir == -1 || table->ReorderColumnDir == +1);
-        IM_ASSERT(table->Flags & ImGuiTableFlags_Reorderable);
-        ImGuiTableColumn* dragged_column = &table->Columns[table->ReorderColumn];
-        ImGuiTableColumn* target_column = &table->Columns[(table->ReorderColumnDir == -1) ? dragged_column->PrevActiveColumn : dragged_column->NextActiveColumn];
-        ImSwap(table->DisplayOrder[dragged_column->IndexDisplayOrder], table->DisplayOrder[target_column->IndexDisplayOrder]);
-        ImSwap(dragged_column->IndexDisplayOrder, target_column->IndexDisplayOrder);
-        table->ReorderColumnDir = 0;
-        table->IsSettingsDirty = true;
+        if (table->HeadHeaderColumn == -1 && table->ReorderColumn != -1)
+            table->ReorderColumn = -1;
+        table->HeadHeaderColumn = -1;
+        if (table->ReorderColumn != -1 && table->ReorderColumnDir != 0)
+        {
+            IM_ASSERT(table->ReorderColumnDir == -1 || table->ReorderColumnDir == +1);
+            IM_ASSERT(table->Flags & ImGuiTableFlags_Reorderable);
+            ImGuiTableColumn* dragged_column = &table->Columns[table->ReorderColumn];
+            ImGuiTableColumn* target_column = &table->Columns[(table->ReorderColumnDir == -1) ? dragged_column->PrevActiveColumn : dragged_column->NextActiveColumn];
+            ImSwap(table->DisplayOrder[dragged_column->IndexDisplayOrder], table->DisplayOrder[target_column->IndexDisplayOrder]);
+            ImSwap(dragged_column->IndexDisplayOrder, target_column->IndexDisplayOrder);
+            table->ReorderColumnDir = 0;
+            table->IsSettingsDirty = true;
+        }
     }
 
     // Handle display order reset request
@@ -8373,7 +8396,7 @@ void    ImGui::TableUpdateLayout(ImGuiTable* table)
     table->IsUsingHeaders = false;
 
     // Context menu
-    if (table->IsContextPopupOpen)
+    if (table->IsContextPopupOpen && table->InstanceNo == table->InstanceInteracted)
     {
         if (BeginPopup("##TableContextMenu"))
         {
@@ -8423,7 +8446,7 @@ void    ImGui::TableUpdateBorders(ImGuiTable* table)
         if (column->Flags & (ImGuiTableColumnFlags_NoResize | ImGuiTableColumnFlags_NoDirectResize_))
             continue;
 
-        ImGuiID column_id = table->ID + (ImGuiID)column_n;
+        ImGuiID column_id = table->ID + (table->InstanceNo * table->ColumnsCount) + column_n;
         ImRect hit_rect(column->MaxX - hit_half_width, hit_y1, column->MaxX + hit_half_width, hit_y2);
         //GetForegroundDrawList()->AddRect(hit_rect.Min, hit_rect.Max, IM_COL32(255, 0, 0, 100));
         KeepAliveID(column_id);
@@ -8431,7 +8454,10 @@ void    ImGui::TableUpdateBorders(ImGuiTable* table)
         bool hovered = false, held = false;
         ButtonBehavior(hit_rect, column_id, &hovered, &held, ImGuiButtonFlags_FlattenChildren | ImGuiButtonFlags_AllowItemOverlap);
         if (held)
+        {
             table->ResizedColumn = (ImS8)column_n;
+            table->InstanceInteracted = table->InstanceNo;
+        }
         if ((hovered && g.HoveredIdTimer > TABLE_RESIZE_SEPARATOR_FEEDBACK_TIMER) || held)
         {
             table->HoveredColumnBorder = (ImS8)column_n;
@@ -8521,14 +8547,12 @@ void    ImGui::EndTable()
     }
 
     // Apply resizing/dragging at the end of the frame
-    // FIXME-TABLE: Preserve contents width _while resizing down_ until releasing.
-    // FIXME-TABLE: Contains columns if our work area doesn't allow for scrolling. 
     if (table->ResizedColumn != -1)
     {
         ImGuiTableColumn* column = &table->Columns[table->ResizedColumn];
         const float new_x2 = (g.IO.MousePos.x - g.ActiveIdClickOffset.x + TABLE_RESIZE_SEPARATOR_HALF_THICKNESS);
         const float new_width = ImFloor(new_x2 - column->MinX);
-        TableSetColumnWidth(table, column, new_width);
+        table->ResizedColumnNextWidth = new_width;
     }
 
     // Layout in outer window
@@ -8600,7 +8624,7 @@ void ImGui::TableDrawBorders(ImGuiTable* table)
             const int column_n = table->DisplayOrder[order_n];
             ImGuiTableColumn* column = &table->Columns[column_n];
             const bool is_hovered = (table->HoveredColumnBorder == column_n);
-            const bool is_resized = (table->ResizedColumn == column_n);
+            const bool is_resized = (table->ResizedColumn == column_n) && (table->InstanceInteracted == table->InstanceNo);
             const bool draw_right_border = (column->MaxX <= table->InnerClipRect.Max.x) || (is_resized || is_hovered);
             if (draw_right_border && column->MaxX > column->ClipRect.Min.x) // FIXME-TABLE FIXME-STYLE: Assume BorderSize==1, this is problematic if we want to increase the border size..
             {
@@ -9384,7 +9408,7 @@ void    ImGui::TableAutoHeaders()
         // [DEBUG]
         //if (g.IO.KeyCtrl) { static char buf[32]; name = buf; ImGuiTableColumn* c = &table->Columns[column_n]; if (c->Flags & ImGuiTableColumnFlags_WidthStretch) ImFormatString(buf, 32, "%.3f>%.1f", c->ResizeWeight, c->WidthGiven); else ImFormatString(buf, 32, "%.1f", c->WidthGiven); }
 
-        PushID(column_n); // Allow unnamed labels (generally accidental, but let's behave nicely with them)
+        PushID(table->InstanceNo * table->ColumnsCount + column_n); // Allow unnamed labels (generally accidental, but let's behave nicely with them)
         TableHeader(name);
         PopID();
 
@@ -9427,6 +9451,7 @@ void    ImGui::TableAutoHeaders()
     {
         table->IsContextPopupOpen = true;
         table->ContextPopupColumn = (ImS8)open_context_popup;
+        table->InstanceInteracted = table->InstanceNo;
         OpenPopup("##TableContextMenu");
     }
 }
@@ -9467,9 +9492,11 @@ void    ImGui::TableHeader(const char* label)
     //window->DC.CursorPos.x = column->MinX + table->CellPadding.x;
 
     // Keep header highlighted when context menu is open. (FIXME-TABLE: however we cannot assume the ID of said popup if it has been created by the user...)
-    const bool selected = (table->IsContextPopupOpen && table->ContextPopupColumn == column_n);
+    const bool selected = (table->IsContextPopupOpen && table->ContextPopupColumn == column_n && table->InstanceInteracted == table->InstanceNo);
     const bool pressed = Selectable("", selected, ImGuiSelectableFlags_DrawHoveredWhenHeld, ImVec2(0.0f, row_height));
     const bool held = IsItemActive();
+    if (held)
+        table->HeadHeaderColumn = (ImS8)column_n;
     window->DC.CursorPos.y -= g.Style.ItemSpacing.y * 0.5f;
 
     // Drag and drop: re-order columns. Frozen columns are not reorderable.
@@ -9478,6 +9505,7 @@ void    ImGui::TableHeader(const char* label)
     {
         // While moving a column it will jump on the other side of the mouse, so we also test for MouseDelta.x
         table->ReorderColumn = (ImS8)column_n;
+        table->InstanceInteracted = table->InstanceNo;
         if (g.IO.MouseDelta.x < 0.0f && g.IO.MousePos.x < cell_r.Min.x)
             if (column->PrevActiveColumn != -1 && (column->IndexWithinActiveSet < table->FreezeColumnsRequest) == (table->Columns[column->PrevActiveColumn].IndexWithinActiveSet < table->FreezeColumnsRequest))
                 table->ReorderColumnDir = -1;
@@ -9523,8 +9551,6 @@ void    ImGui::TableHeader(const char* label)
         if (pressed && table->ReorderColumn != column_n)
             TableSortSpecsClickColumn(table, column, g.IO.KeyShift);
     }
-    if (!held && table->ReorderColumn == column_n)
-        table->ReorderColumn = -1;
 
     // Render clipped label
     // Clipping here ensure that in the majority of situations, all our header cells will be merged into a single draw call.

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -7724,7 +7724,7 @@ void ImGui::Columns(int columns_count, const char* id, bool border)
 // Typical call flow: (root level is public API):
 // - BeginTable()                               user begin into a table
 //    - BeginChild()                            - (if ScrollX/ScrollY is set)
-//    - TableBeginInitVisibility()              - lock columns visibility
+//    - TableBeginUpdateColumns()               - apply resize/order requests, lock columns active state, order
 // - TableSetupColumn()                         user submit columns details (optional)
 // - TableAutoHeaders() or TableHeader()        user submit a headers row (optional)
 //    - TableSortSpecsClickColumn()
@@ -7966,8 +7966,26 @@ bool    ImGui::BeginTableEx(const char* name, ImGuiID id, int columns_count, ImG
     if (table->IsFirstFrame || table->IsSettingsRequestLoad)
         TableLoadSettings(table);
 
+    // Grab a copy of window fields we will modify
+    table->BackupSkipItems = inner_window->SkipItems;
+    table->BackupWorkRect = inner_window->WorkRect;
+    table->BackupCursorMaxPos = inner_window->DC.CursorMaxPos;
+
+    // Disable output until user calls TableNextRow() or TableNextCell() leading to the TableUpdateLayout() call..
+    // This is not strictly necessary but will reduce cases were misleading "out of table" output will be confusing to the user.
+    // Because we cannot safely assert in EndTable() when no rows have been created, this seems like our best option.
+    inner_window->SkipItems = true;
+    
+    // Update/lock which columns will be Active for the frame
+    TableBeginUpdateColumns(table);
+
+    return true;
+}
+
+void ImGui::TableBeginUpdateColumns(ImGuiTable* table)
+{
     // Handle resizing request
-    // (We process this at the first beginning of the frame)
+    // (We process this at the first TableBegin of the frame)
     // FIXME-TABLE: Preserve contents width _while resizing down_ until releasing.
     // FIXME-TABLE: Contains columns if our work area doesn't allow for scrolling. 
     if (table->InstanceNo == 0)
@@ -8001,29 +8019,12 @@ bool    ImGui::BeginTableEx(const char* name, ImGuiID id, int columns_count, ImG
     // Handle display order reset request
     if (table->IsResetDisplayOrderRequest)
     {
-        for (int n = 0; n < columns_count; n++)
+        for (int n = 0; n < table->ColumnsCount; n++)
             table->DisplayOrder[n] = table->Columns[n].IndexDisplayOrder = (ImU8)n;
         table->IsResetDisplayOrderRequest = false;
         table->IsSettingsDirty = true;
     }
 
-    TableBeginInitVisibility(table);
-
-    // Grab a copy of window fields we will modify
-    table->BackupSkipItems = inner_window->SkipItems;
-    table->BackupWorkRect = inner_window->WorkRect;
-    table->BackupCursorMaxPos = inner_window->DC.CursorMaxPos;
-
-    if (flags & ImGuiTableFlags_NoClipX)
-        table->DrawSplitter.SetCurrentChannel(inner_window->DrawList, 1);
-    else
-        inner_window->DrawList->PushClipRect(inner_window->ClipRect.Min, inner_window->ClipRect.Max, false);
-
-    return true;
-}
-
-void ImGui::TableBeginInitVisibility(ImGuiTable* table)
-{
     // Setup and lock Active state and order
     table->ColumnsActiveCount = 0;
     table->IsDefaultDisplayOrder = true;
@@ -8436,6 +8437,13 @@ void    ImGui::TableUpdateLayout(ImGuiTable* table)
             table->IsContextPopupOpen = false;
         }
     }
+
+    // Initial state
+    ImGuiWindow* inner_window = table->InnerWindow;
+    if (table->Flags & ImGuiTableFlags_NoClipX)
+        table->DrawSplitter.SetCurrentChannel(inner_window->DrawList, 1);
+    else
+        inner_window->DrawList->PushClipRect(inner_window->ClipRect.Min, inner_window->ClipRect.Max, false);
 }
 
 // Process interaction on resizing borders. Actual size change will be applied in EndTable()
@@ -8506,6 +8514,15 @@ void    ImGui::EndTable()
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
     IM_ASSERT(table != NULL && "Only call EndTable() is BeginTable() returns true!");
+    
+    // This assert would be very useful to catch a common error... unfortunately it would probably trigger in some cases,
+    // and for consistency user may sometimes output empty tables (and still benefit from e.g. outer border)
+    //IM_ASSERT(table->IsLayoutLocked && "Table unused: never called TableNextRow(), is that the intent?");
+
+    // If the user never got to call TableNextRow() or TableNextCell(), we call layout ourselves to ensure all our
+    // code paths are consistent (instead of just hoping that TableBegin/TableEnd will work), get borders drawn, etc.
+    if (!table->IsLayoutLocked)
+        TableUpdateLayout(table);
 
     const ImGuiTableFlags flags = table->Flags;
     ImGuiWindow* inner_window = table->InnerWindow;
@@ -9419,23 +9436,23 @@ void    ImGui::TableDrawContextMenu(ImGuiTable* table, int selected_column_n)
 }
 
 // This is a helper to output TableHeader() calls based on the column names declared in TableSetupColumn().
-// The intent is that advanced users would not need to use this helper and may create their own.
+// The intent is that advanced users willing to create customized headers would not need to use this helper and may create their own.
+// However presently this function uses too many internal structures/calls.
 void    ImGui::TableAutoHeaders()
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
-    if (window->SkipItems)
-        return;
 
     ImGuiTable* table = g.CurrentTable;
     IM_ASSERT(table != NULL && "Need to call TableAutoHeaders() after BeginTable()!");
-    IM_ASSERT(table->CurrentRow == -1);
 
-    int open_context_popup = INT_MAX;
+    TableNextRow(ImGuiTableRowFlags_Headers, GetTextLineHeight());
+    if (window->SkipItems)
+        return;
 
     // This for loop is constructed to not make use of internal functions,
     // as this is intended to be a base template to copy and build from.
-    TableNextRow(ImGuiTableRowFlags_Headers, GetTextLineHeight());
+    int open_context_popup = INT_MAX;
     const int columns_count = table->ColumnsCount;
     for (int column_n = 0; column_n < columns_count; column_n++)
     {
@@ -9448,7 +9465,7 @@ void    ImGui::TableAutoHeaders()
 #if 0
         if (column_n < 2)
         {
-            static bool b[10] = {};
+            static bool b[2] = {};
             PushID(column_n);
             PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
             Checkbox("##", &b[column_n]);
@@ -9461,7 +9478,8 @@ void    ImGui::TableAutoHeaders()
         // [DEBUG]
         //if (g.IO.KeyCtrl) { static char buf[32]; name = buf; ImGuiTableColumn* c = &table->Columns[column_n]; if (c->Flags & ImGuiTableColumnFlags_WidthStretch) ImFormatString(buf, 32, "%.3f>%.1f", c->ResizeWeight, c->WidthGiven); else ImFormatString(buf, 32, "%.1f", c->WidthGiven); }
 
-        PushID(table->InstanceNo * table->ColumnsCount + column_n); // Allow unnamed labels (generally accidental, but let's behave nicely with them)
+        // Push an id to allow unnamed labels (generally accidental, but let's behave nicely with them)
+        PushID(table->InstanceNo * table->ColumnsCount + column_n);
         TableHeader(name);
         PopID();
 
@@ -9471,15 +9489,19 @@ void    ImGui::TableAutoHeaders()
     }
 
     // FIXME-TABLE: This is not user-land code any more... 
+    // FIXME-TABLE: Need to explain why this is here!
     window->SkipItems = table->BackupSkipItems;
 
     // Allow opening popup from the right-most section after the last column
     // FIXME-TABLE: This is not user-land code any more... perhaps instead we should expose hovered column.
     // and allow some sort of row-centric IsItemHovered() for full flexibility?
-    const float unused_x1 = (table->RightMostActiveColumn != -1) ? table->Columns[table->RightMostActiveColumn].MaxX : table->WorkRect.Min.x;
+    float unused_x1 = table->WorkRect.Min.x;
+    if (table->RightMostActiveColumn != -1)
+        unused_x1 = ImMax(unused_x1, table->Columns[table->RightMostActiveColumn].MaxX);
     if (unused_x1 < table->WorkRect.Max.x)
     {
-        // FIXME: We inherit ClipRect/SkipItem from last submitted column (active or not), let's override
+        // FIXME: We inherit ClipRect/SkipItem from last submitted column (active or not), let's temporarily override it.
+        // Because we don't perform any rendering here we just overwrite window->ClipRect used by logic.
         window->ClipRect = table->InnerClipRect;
 
         ImVec2 backup_cursor_max_pos = window->DC.CursorMaxPos;
@@ -9499,7 +9521,7 @@ void    ImGui::TableAutoHeaders()
         window->ClipRect = window->DrawList->_ClipRectStack.back();
     }
 
-    // Context Menu
+    // Open Context Menu
     if (open_context_popup != INT_MAX)
         if (table->Flags & (ImGuiTableFlags_Resizable | ImGuiTableFlags_Reorderable | ImGuiTableFlags_Hideable))
         {

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -9079,7 +9079,7 @@ void    ImGui::TableSetupColumn(const char* label, ImGuiTableColumnFlags flags, 
 }
 
 // Starts into the first cell of a new row
-void    ImGui::TableNextRow(ImGuiTableRowFlags row_flags, float min_row_height)
+void    ImGui::TableNextRow(ImGuiTableRowFlags row_flags, float row_min_height)
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
@@ -9091,12 +9091,13 @@ void    ImGui::TableNextRow(ImGuiTableRowFlags row_flags, float min_row_height)
 
     table->LastRowFlags = table->RowFlags;
     table->RowFlags = row_flags;
+    table->RowMinHeight = row_min_height;
     TableBeginRow(table);
 
     // We honor min_row_height requested by user, but cannot guarantee per-row maximum height,
     // because that would essentially require a unique clipping rectangle per-cell.
     table->RowPosY2 += table->CellPaddingY * 2.0f;
-    table->RowPosY2 = ImMax(table->RowPosY2, table->RowPosY1 + min_row_height);
+    table->RowPosY2 = ImMax(table->RowPosY2, table->RowPosY1 + row_min_height);
 
     TableBeginCell(table, 0);
 }
@@ -9597,6 +9598,7 @@ void    ImGui::TableAutoHeaders()
 
 // Emit a column header (text + optional sort order)
 // We cpu-clip text here so that all columns headers can be merged into a same draw call.
+// Note that because of how we cpu-clip and display sorting indicators, you _cannot_ use SameLine() after a TableHeader()
 // FIXME-TABLE: Should hold a selection state.
 // FIXME-TABLE: Style confusion between CellPadding.y and FramePadding.y
 void    ImGui::TableHeader(const char* label)
@@ -9621,7 +9623,7 @@ void    ImGui::TableHeader(const char* label)
 
     // If we already got a row height, there's use that.
     ImRect cell_r = TableGetCellRect();
-    float label_height = ImMax(label_size.y, cell_r.GetHeight() - g.Style.CellPadding.y * 2.0f);
+    float label_height = ImMax(label_size.y, table->RowMinHeight - g.Style.CellPadding.y * 2.0f);
 
     //GetForegroundDrawList()->AddRect(cell_r.Min, cell_r.Max, IM_COL32(255, 0, 0, 255)); // [DEBUG]
     ImRect work_r = cell_r;

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -9639,7 +9639,7 @@ void    ImGui::TableHeader(const char* label)
 
     // Keep header highlighted when context menu is open. (FIXME-TABLE: however we cannot assume the ID of said popup if it has been created by the user...)
     const bool selected = (table->IsContextPopupOpen && table->ContextPopupColumn == column_n && table->InstanceInteracted == table->InstanceNo);
-    const bool pressed = Selectable("", selected, ImGuiSelectableFlags_DrawHoveredWhenHeld, ImVec2(0.0f, label_height));
+    const bool pressed = Selectable("", selected, ImGuiSelectableFlags_DrawHoveredWhenHeld | ImGuiSelectableFlags_DontClosePopups, ImVec2(0.0f, label_height));
     const bool held = IsItemActive();
     if (held)
         table->HeldHeaderColumn = (ImS8)column_n;

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -7766,6 +7766,7 @@ inline ImGuiTableFlags TableFixFlags(ImGuiTableFlags flags)
         flags |= ImGuiTableFlags_BordersV;
 
     // Adjust flags: disable top rows freezing if there's no scrolling
+    // In theory we could want to assert if ScrollFreeze was set without the corresponding scroll flag, but that would hinder demos.
     if ((flags & ImGuiTableFlags_ScrollX) == 0)
         flags &= ~ImGuiTableFlags_ScrollFreezeColumnsMask_;
     if ((flags & ImGuiTableFlags_ScrollY) == 0)
@@ -7814,6 +7815,8 @@ bool    ImGui::BeginTableEx(const char* name, ImGuiID id, int columns_count, ImG
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* outer_window = GetCurrentWindow();
+
+    // Sanity checks
     IM_ASSERT(columns_count > 0 && columns_count < IMGUI_TABLE_MAX_COLUMNS && "Only 0..63 columns allowed!");
     if (flags & ImGuiTableFlags_ScrollX)
         IM_ASSERT(inner_width >= 0.0f);
@@ -8500,7 +8503,7 @@ void    ImGui::EndTable()
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
-    IM_ASSERT(table != NULL);
+    IM_ASSERT(table != NULL && "Only call EndTable() is BeginTable() returns true!");
 
     const ImGuiTableFlags flags = table->Flags;
     ImGuiWindow* inner_window = table->InnerWindow;
@@ -8952,8 +8955,8 @@ void    ImGui::TableSetupColumn(const char* label, ImGuiTableColumnFlags flags, 
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
-    IM_ASSERT(table != NULL && "Can only call TableSetupColumn() after BeginTable()!");
-    IM_ASSERT(!table->IsLayoutLocked && "Can only call TableSetupColumn() before first row!");
+    IM_ASSERT(table != NULL && "Need to call TableSetupColumn() after BeginTable()!");
+    IM_ASSERT(!table->IsLayoutLocked && "Need to call call TableSetupColumn() before first row!");
     IM_ASSERT(table->DeclColumnsCount >= 0 && table->DeclColumnsCount < table->ColumnsCount && "Called TableSetupColumn() too many times!");
 
     ImGuiTableColumn* column = &table->Columns[table->DeclColumnsCount];
@@ -9165,7 +9168,8 @@ void    ImGui::TableEndRow(ImGuiTable* table)
     table->IsInsideRow = false;
 }
 
-// [Internal] This is called a lot, so we need to be mindful of unnecessary overhead!
+// [Internal] Called by TableNextRow()TableNextCell()!
+// This is called a lot, so we need to be mindful of unnecessary overhead.
 void    ImGui::TableBeginCell(ImGuiTable* table, int column_no)
 {
     table->CurrentColumn = column_no;
@@ -9210,7 +9214,7 @@ void    ImGui::TableBeginCell(ImGuiTable* table, int column_no)
     }
 }
 
-// [Internal]
+// [Internal] Called by TableNextRow()TableNextCell()!
 void    ImGui::TableEndCell(ImGuiTable* table)
 {
     ImGuiTableColumn* column = &table->Columns[table->CurrentColumn];
@@ -9344,6 +9348,7 @@ void    ImGui::PopTableBackground()
     PopClipRect();
 }
 
+// Output context menu into current window (generally a popup)
 // FIXME-TABLE: Ideally this should be writable by the user. Full programmatic access to that data?
 void    ImGui::TableDrawContextMenu(ImGuiTable* table, int selected_column_n)
 {
@@ -9411,7 +9416,7 @@ void    ImGui::TableDrawContextMenu(ImGuiTable* table, int selected_column_n)
     }
 }
 
-// This is a helper to output headers based on the column names declared in TableSetupColumn()
+// This is a helper to output TableHeader() calls based on the column names declared in TableSetupColumn().
 // The intent is that advanced users would not need to use this helper and may create their own.
 void    ImGui::TableAutoHeaders()
 {
@@ -9421,7 +9426,8 @@ void    ImGui::TableAutoHeaders()
         return;
 
     ImGuiTable* table = g.CurrentTable;
-    IM_ASSERT(table && table->CurrentRow == -1);
+    IM_ASSERT(table != NULL && "Need to call TableAutoHeaders() after BeginTable()!");
+    IM_ASSERT(table->CurrentRow == -1);
 
     int open_context_popup = INT_MAX;
 
@@ -9512,6 +9518,7 @@ void    ImGui::TableHeader(const char* label)
         return;
 
     ImGuiTable* table = g.CurrentTable;
+    IM_ASSERT(table != NULL && "Need to call TableAutoHeaders() after BeginTable()!");
     IM_ASSERT(table->CurrentColumn != -1);
     const int column_n = table->CurrentColumn;
     ImGuiTableColumn* column = &table->Columns[column_n];

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -9109,6 +9109,7 @@ void    ImGui::TableBeginRow(ImGuiTable* table)
 
     table->RowPosY1 = table->RowPosY2 = next_y1;
     table->RowTextBaseline = 0.0f;
+    window->DC.PrevLineTextBaseOffset = 0.0f;
     window->DC.CursorMaxPos.y = next_y1;
 
     // Making the header BG color non-transparent will allow us to overlay it multiple times when handling smooth dragging.
@@ -9229,6 +9230,7 @@ void    ImGui::TableEndRow(ImGuiTable* table)
 
 // [Internal] Called by TableNextRow()TableNextCell()!
 // This is called a lot, so we need to be mindful of unnecessary overhead.
+// FIXME-TABLE FIXME-OPT: Could probably shortcut some things for non-active or clipped columns.
 void    ImGui::TableBeginCell(ImGuiTable* table, int column_no)
 {
     table->CurrentColumn = column_no;
@@ -9499,7 +9501,7 @@ void    ImGui::TableAutoHeaders()
 
     // Open row
     TableNextRow(ImGuiTableRowFlags_Headers, row_height);
-    if (window->SkipItems)
+    if (table->HostSkipItems) // Merely an optimization
         return;
 
     // This for loop is constructed to not make use of internal functions,
@@ -9539,8 +9541,7 @@ void    ImGui::TableAutoHeaders()
             open_context_popup = column_n;
     }
 
-    // FIXME-TABLE: This is not user-land code any more... 
-    // FIXME-TABLE: Need to explain why this is here!
+    // FIXME-TABLE: This is not user-land code any more + need to explain WHY this is here!
     window->SkipItems = table->HostSkipItems;
 
     // Allow opening popup from the right-most section after the last column

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -7725,13 +7725,13 @@ void ImGui::Columns(int columns_count, const char* id, bool border)
 // - BeginTable()                               user begin into a table
 //    - BeginChild()                            - (if ScrollX/ScrollY is set)
 //    - TableBeginInitVisibility()              - lock columns visibility
-//    - TableBeginInitDrawChannels()            - setup ImDrawList channels
 // - TableSetupColumn()                         user submit columns details (optional)
 // - TableAutoHeaders() or TableHeader()        user submit a headers row (optional)
 //    - TableSortSpecsClickColumn()
 // - TableGetSortSpecs()                        user queries updated sort specs (optional)
 // - TableNextRow() / TableNextCell()           user begin into the first row, also automatically called by TableAutoHeaders()
 //    - TableUpdateLayout()                     - called by the FIRST call to TableNextRow()
+//      - TableUpdateDrawChannels()             - setup ImDrawList channels
 //      - TableUpdateBorders()                  - detect hovering columns for resize, ahead of contents submission
 //      - TableDrawContextMenu()                - draw right-click context menu
 // - [...]                                      user emit contents
@@ -7998,7 +7998,6 @@ bool    ImGui::BeginTable(const char* str_id, int columns_count, ImGuiTableFlags
     }
 
     TableBeginInitVisibility(table);
-    TableBeginInitDrawChannels(table);
 
     // Grab a copy of window fields we will modify
     table->BackupSkipItems = inner_window->SkipItems;
@@ -8038,7 +8037,7 @@ void ImGui::TableBeginInitVisibility(ImGuiTable* table)
         }
         if (column->SortOrder > 0 && !(table->Flags & ImGuiTableFlags_MultiSortable))
             table->IsSortSpecsDirty = true;
-        if (column->AutoFitFrames > 0)
+        if (column->AutoFitQueue != 0x00)
             want_column_auto_fit = true;
 
         ImU64 index_mask = (ImU64)1 << column_n;
@@ -8065,6 +8064,7 @@ void ImGui::TableBeginInitVisibility(ImGuiTable* table)
         }
         IM_ASSERT(column->IndexWithinActiveSet <= column->IndexDisplayOrder);
     }
+    table->VisibleMaskByIndex = table->ActiveMaskByIndex; // Columns will be masked out by TableUpdateLayout() when Clipped
     table->RightMostActiveColumn = (ImS8)(last_active_column ? table->Columns.index_from_ptr(last_active_column) : -1);
 
     // Disable child window clipping while fitting columns. This is not strictly necessary but makes it possible to avoid
@@ -8073,7 +8073,7 @@ void ImGui::TableBeginInitVisibility(ImGuiTable* table)
         table->InnerWindow->SkipItems = false;
 }
 
-void ImGui::TableBeginInitDrawChannels(ImGuiTable* table)
+void ImGui::TableUpdateDrawChannels(ImGuiTable* table)
 {
     // Allocate draw channels.
     // - We allocate them following the storage order instead of the display order so reordering won't needlessly increase overall dormant memory cost
@@ -8088,7 +8088,7 @@ void ImGui::TableBeginInitDrawChannels(ImGuiTable* table)
     const int freeze_row_multiplier = (table->FreezeRowsCount > 0) ? 2 : 1;
     const int channels_for_row = (table->Flags & ImGuiTableFlags_NoClipX) ? 1 : table->ColumnsActiveCount;
     const int channels_for_background = 1;
-    const int channels_for_dummy = (table->ColumnsActiveCount < table->ColumnsCount) ? +1 : 0;
+    const int channels_for_dummy = (table->ColumnsActiveCount < table->ColumnsCount || table->VisibleMaskByIndex != table->ActiveMaskByIndex) ? +1 : 0;
     const int channels_total = channels_for_background + (channels_for_row * freeze_row_multiplier) + channels_for_dummy;
     table->DrawSplitter.Split(table->InnerWindow->DrawList, channels_total);
     table->DummyDrawChannel = channels_for_dummy ? (ImS8)(channels_total - 1) : -1;
@@ -8097,7 +8097,7 @@ void ImGui::TableBeginInitDrawChannels(ImGuiTable* table)
     for (int column_n = 0; column_n < table->ColumnsCount; column_n++)
     {
         ImGuiTableColumn* column = &table->Columns[column_n];
-        if (column->IsActive)
+        if (!column->IsClipped)
         {
             column->DrawChannelRowsBeforeFreeze = (ImS8)(draw_channel_current);
             column->DrawChannelRowsAfterFreeze = (ImS8)(draw_channel_current + (table->FreezeRowsCount > 0 ? channels_for_row : 0));
@@ -8194,7 +8194,7 @@ void    ImGui::TableUpdateLayout(ImGuiTable* table)
         {
             // Latch initial size for fixed columns
             count_fixed += 1;
-            const bool init_size = (column->AutoFitFrames > 0) || (column->Flags & ImGuiTableColumnFlags_WidthAlwaysAutoResize);
+            const bool init_size = (column->AutoFitQueue != 0x00) || (column->Flags & ImGuiTableColumnFlags_WidthAlwaysAutoResize);
             if (init_size)
             {
                 // Combine width from regular rows + width from headers unless requested not to
@@ -8206,7 +8206,7 @@ void    ImGui::TableUpdateLayout(ImGuiTable* table)
                 // FIXME-TABLE: Increase minimum size during init frame so avoid biasing auto-fitting widgets (e.g. TextWrapped) too much.
                 // Otherwise what tends to happen is that TextWrapped would output a very large height (= first frame scrollbar display very off + clipper would skip lots of items)
                 // This is merely making the side-effect less extreme, but doesn't properly fixes it.
-                if (column->AutoFitFrames > 1 && table->IsFirstFrame)
+                if (column->AutoFitQueue > 0x01 && table->IsFirstFrame)
                     column->WidthRequested = ImMax(column->WidthRequested, min_column_width * 4.0f);
             }
             width_fixed += column->WidthRequested;
@@ -8219,10 +8219,6 @@ void    ImGui::TableUpdateLayout(ImGuiTable* table)
             if (table->LeftMostStretchedColumnDisplayOrder == -1)
                 table->LeftMostStretchedColumnDisplayOrder = (ImS8)column->IndexDisplayOrder;
         }
-
-        // Don't increment auto-fit until container window got a chance to submit its items
-        if (column->AutoFitFrames > 0 && table->BackupSkipItems == false)
-            column->AutoFitFrames--;
     }
 
     // Layout
@@ -8338,6 +8334,7 @@ void    ImGui::TableUpdateLayout(ImGuiTable* table)
             column->ClipRect.Max.x = offset_x;
             column->ClipRect.Max.y = FLT_MAX;
             column->ClipRect.ClipWithFull(host_clip_rect);
+            column->IsClipped = true;
             continue;
         }
 
@@ -8353,27 +8350,44 @@ void    ImGui::TableUpdateLayout(ImGuiTable* table)
         column->MinX = offset_x;
         column->MaxX = column->MinX + column->WidthGiven;
 
-        const float initial_max_pos_x = column->MinX + table->CellPaddingX1;
-        column->ContentMaxPosRowsFrozen = column->ContentMaxPosRowsUnfrozen = initial_max_pos_x;
-        column->ContentMaxPosHeadersUsed = column->ContentMaxPosHeadersDesired = initial_max_pos_x;
-
-        // Starting cursor position
-        column->StartXRows = column->StartXHeaders = column->MinX + table->CellPaddingX1;
-
-        // Alignment
-        // FIXME-TABLE: This align based on the whole column width, not per-cell, and therefore isn't useful in many cases.
-        // (To be able to honor this we might be able to store a log of cells width, per row, for visible rows, but nav/programmatic scroll would have visible artifacts.)
-        //if (column->Flags & ImGuiTableColumnFlags_AlignRight)
-        //    column->StartXRows = ImMax(column->StartXRows, column->MaxX - column->WidthContent[0]);
-        //else if (column->Flags & ImGuiTableColumnFlags_AlignCenter)
-        //    column->StartXRows = ImLerp(column->StartXRows, ImMax(column->StartXRows, column->MaxX - column->WidthContent[0]), 0.5f);
-
         //// A one pixel padding on the right side makes clipping more noticeable and contents look less cramped.
         column->ClipRect.Min.x = column->MinX;
         column->ClipRect.Min.y = work_rect.Min.y;
         column->ClipRect.Max.x = column->MaxX;// -1.0f;
         column->ClipRect.Max.y = FLT_MAX;
         column->ClipRect.ClipWithFull(host_clip_rect);
+        
+        column->IsClipped = (column->ClipRect.Max.x <= column->ClipRect.Min.x) && (column->AutoFitQueue & 1) == 0 && (column->CannotSkipItemsQueue & 1) == 0;
+        if (column->IsClipped)
+        {
+            // Columns with the _WidthAlwaysAutoResize sizing policy will never be updated then.
+            table->VisibleMaskByIndex &= ~((ImU64)1 << column_n);
+        }
+        else
+        {
+            // Starting cursor position
+            column->StartXRows = column->StartXHeaders = column->MinX + table->CellPaddingX1;
+
+            // Alignment
+            // FIXME-TABLE: This align based on the whole column width, not per-cell, and therefore isn't useful in many cases.
+            // (To be able to honor this we might be able to store a log of cells width, per row, for visible rows, but nav/programmatic scroll would have visible artifacts.)
+            //if (column->Flags & ImGuiTableColumnFlags_AlignRight)
+            //    column->StartXRows = ImMax(column->StartXRows, column->MaxX - column->WidthContent[0]);
+            //else if (column->Flags & ImGuiTableColumnFlags_AlignCenter)
+            //    column->StartXRows = ImLerp(column->StartXRows, ImMax(column->StartXRows, column->MaxX - column->WidthContent[0]), 0.5f);
+
+            // Reset content width variables
+            const float initial_max_pos_x = column->MinX + table->CellPaddingX1;
+            column->ContentMaxPosRowsFrozen = column->ContentMaxPosRowsUnfrozen = initial_max_pos_x;
+            column->ContentMaxPosHeadersUsed = column->ContentMaxPosHeadersDesired = initial_max_pos_x;
+        }
+
+        // Don't decrement auto-fit counters until container window got a chance to submit its items
+        if (table->BackupSkipItems == false)
+        {
+            column->AutoFitQueue >>= 1;
+            column->CannotSkipItemsQueue >>= 1;
+        }
 
         if (active_n < table->FreezeColumnsCount)
             host_clip_rect.Min.x = ImMax(host_clip_rect.Min.x, column->MaxX + 2.0f);
@@ -8386,6 +8400,9 @@ void    ImGui::TableUpdateLayout(ImGuiTable* table)
     // This will hide the resizing option from the context menu.
     if (count_resizable == 0 && (table->Flags & ImGuiTableFlags_Resizable))
         table->Flags &= ~ImGuiTableFlags_Resizable;
+
+    // Allocate draw channels
+    TableUpdateDrawChannels(table);
 
     // Borders
     if (table->Flags & ImGuiTableFlags_Resizable)
@@ -8727,7 +8744,7 @@ void ImGui::TableSetColumnWidth(ImGuiTable* table, ImGuiTableColumn* column_0, f
     // - W1 F2 F3  resize from F2|          --> FIXME should resize F2, F3 and not have effect on W1 (Stretch columns are _before_ the Fixed column).
 
     // Rules:
-    // - [Resize Rule 1] Can't resize from right of right-most visible column if there is any Stretch column. Implemented in TableSetupLayout().
+    // - [Resize Rule 1] Can't resize from right of right-most visible column if there is any Stretch column. Implemented in TableUpdateLayout().
     // - [Resize Rule 2] Resizing from right-side of a Stretch column before a fixed column froward sizing to left-side of fixed column.
     // - [Resize Rule 3] If we are are followed by a fixed column and we have a Stretch column before, we need to ensure that our left border won't move.
 
@@ -8848,7 +8865,7 @@ void    ImGui::TableDrawMergeChannels(ImGuiTable* table)
             
             // 2019/10/22: (1) This is breaking table_2_draw_calls but I cannot seem to repro what it is attempting to fix...
             // cf git fce2e8dc "Fixed issue with clipping when outerwindow==innerwindow / support ScrollH without ScrollV."
-            // 2019/10/22: (2) Clamping code in TableSetupLayout() seemingly made this not necessary...
+            // 2019/10/22: (2) Clamping code in TableUpdateLayout() seemingly made this not necessary...
 #if 0
             if (column->MinX < table->InnerClipRect.Min.x || column->MaxX > table->InnerClipRect.Max.x)
                 merge_set_all_fit_within_inner_rect = false;
@@ -8949,7 +8966,7 @@ void    ImGui::TableSetupColumn(const char* label, ImGuiTableColumnFlags flags, 
         if ((flags & ImGuiTableColumnFlags_WidthFixed) && init_width_or_weight > 0.0f)
         {
             column->WidthRequested = init_width_or_weight;
-            column->AutoFitFrames = 0;
+            column->AutoFitQueue = 0x00;
         }
         if (flags & ImGuiTableColumnFlags_WidthStretch)
         {
@@ -9162,7 +9179,7 @@ void    ImGui::TableBeginCell(ImGuiTable* table, int column_no)
     // FIXME-COLUMNS: Setup baseline, preserve across columns (how can we obtain first line baseline tho..)
     // window->DC.CurrLineTextBaseOffset = ImMax(window->DC.CurrLineTextBaseOffset, g.Style.FramePadding.y);
 
-    window->SkipItems = column->IsActive ? table->BackupSkipItems : true;
+    window->SkipItems = column->IsClipped ? true : table->BackupSkipItems;
     if (table->Flags & ImGuiTableFlags_NoClipX)
     {
         table->DrawSplitter.SetCurrentChannel(window->DrawList, 1);
@@ -9218,8 +9235,8 @@ bool    ImGui::TableNextCell()
         TableNextRow();
     }
 
-    ImGuiTableColumn* column = &table->Columns[table->CurrentColumn];
-    return column->IsActive;
+    int column_n = table->CurrentColumn;
+    return (table->VisibleMaskByIndex & ((ImU64)1 << column_n)) != 0;
 }
 
 const char*   ImGui::TableGetColumnName(int column_n)
@@ -9241,7 +9258,7 @@ bool    ImGui::TableGetColumnIsVisible(int column_n)
         return false;
     if (column_n < 0)
         column_n = table->CurrentColumn;
-    return (table->ActiveMaskByIndex & ((ImU64)1 << column_n)) != 0;
+    return (table->VisibleMaskByIndex & ((ImU64)1 << column_n)) != 0;
 }
 
 int     ImGui::TableGetColumnIndex()
@@ -9268,7 +9285,7 @@ bool    ImGui::TableSetColumnIndex(int column_idx)
         TableBeginCell(table, column_idx);
     }
 
-    return (table->ActiveMaskByIndex & ((ImU64)1 << column_idx)) != 0;
+    return (table->VisibleMaskByIndex & ((ImU64)1 << column_idx)) != 0;
 }
 
 ImRect  ImGui::TableGetCellRect()
@@ -9285,6 +9302,15 @@ const char* ImGui::TableGetColumnName(ImGuiTable* table, int column_no)
     if (column->NameOffset == -1)
         return NULL;
     return &table->ColumnsNames.Buf[column->NameOffset];
+}
+
+void    ImGui::TableSetColumnAutofit(ImGuiTable* table, int column_no)
+{
+    // Disable clipping then auto-fit, will take 2 frames 
+    // (we don't take a shortcut for unclipped columns to reduce inconsistencies when e.g. resizing multiple columns)
+    ImGuiTableColumn* column = &table->Columns[column_no];
+    column->CannotSkipItemsQueue = (1 << 0);
+    column->AutoFitQueue = (1 << 1);
 }
 
 void    ImGui::PushTableBackground()
@@ -9324,7 +9350,7 @@ void    ImGui::TableDrawContextMenu(ImGuiTable* table, int selected_column_n)
         {
             const bool can_resize = !(selected_column->Flags & (ImGuiTableColumnFlags_NoResize | ImGuiTableColumnFlags_WidthStretch)) && selected_column->IsActive;
             if (MenuItem("Size column to fit", NULL, false, can_resize))
-                selected_column->AutoFitFrames = 1;
+                TableSetColumnAutofit(table, selected_column_n);
         }
 
         if (MenuItem("Size all columns to fit", NULL))
@@ -9333,7 +9359,7 @@ void    ImGui::TableDrawContextMenu(ImGuiTable* table, int selected_column_n)
             {
                 ImGuiTableColumn* column = &table->Columns[column_n];
                 if (column->IsActive)
-                    column->AutoFitFrames = 1;
+                    TableSetColumnAutofit(table, column_n);
             }
         }
         want_separator = true;

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -8006,12 +8006,26 @@ void ImGui::TableBeginUpdateColumns(ImGuiTable* table)
         table->HeldHeaderColumn = -1;
         if (table->ReorderColumn != -1 && table->ReorderColumnDir != 0)
         {
-            IM_ASSERT(table->ReorderColumnDir == -1 || table->ReorderColumnDir == +1);
+            // We need to handle reordering across hidden columns.
+            // In the configuration below, moving C to the right of E will lead to:
+            //    ... C [D] E  --->  ... [D] E  C   (Column name/index)
+            //    ... 2  3  4        ...  2  3  4   (Display order)
+            const int reorder_dir = table->ReorderColumnDir;
+            IM_ASSERT(reorder_dir == -1 || reorder_dir == +1);
             IM_ASSERT(table->Flags & ImGuiTableFlags_Reorderable);
-            ImGuiTableColumn* dragged_column = &table->Columns[table->ReorderColumn];
-            ImGuiTableColumn* target_column = &table->Columns[(table->ReorderColumnDir == -1) ? dragged_column->PrevActiveColumn : dragged_column->NextActiveColumn];
-            ImSwap(table->DisplayOrder[dragged_column->IndexDisplayOrder], table->DisplayOrder[target_column->IndexDisplayOrder]);
-            ImSwap(dragged_column->IndexDisplayOrder, target_column->IndexDisplayOrder);
+            ImGuiTableColumn* src_column = &table->Columns[table->ReorderColumn];
+            ImGuiTableColumn* dst_column = &table->Columns[(reorder_dir == -1) ? src_column->PrevActiveColumn : src_column->NextActiveColumn];
+            IM_UNUSED(dst_column);
+            const int src_order = src_column->IndexDisplayOrder;
+            const int dst_order = dst_column->IndexDisplayOrder;
+            src_column->IndexDisplayOrder = (ImS8)dst_order;
+            for (int order_n = src_order + reorder_dir; order_n != dst_order + reorder_dir; order_n += reorder_dir)
+                table->Columns[table->DisplayOrder[order_n]].IndexDisplayOrder -= (ImS8)reorder_dir;
+            IM_ASSERT(dst_column->IndexDisplayOrder == dst_order - reorder_dir);
+
+            // Display order is stored in both columns->IndexDisplayOrder and table->DisplayOrder[], rebuild the later from the former.
+            for (int column_n = 0; column_n < table->ColumnsCount; column_n++)
+                table->DisplayOrder[table->Columns[column_n].IndexDisplayOrder] = (ImS8)column_n;
             table->ReorderColumnDir = 0;
             table->IsSettingsDirty = true;
         }
@@ -8350,14 +8364,21 @@ void    ImGui::TableUpdateLayout(ImGuiTable* table)
             continue;
         }
 
-        // If horizontal scrolling if disabled, we apply a final lossless shrinking of columns in order to make sure they are all visible.
-        // Because of this we also know that all of the columns will always fit in table->WorkRect and therefore in table->InnerRect (because ScrollX is off)
-        if (!(table->Flags & ImGuiTableFlags_ScrollX))
+        float max_x = FLT_MAX;
+        if (table->Flags & ImGuiTableFlags_ScrollX)
         {
-            float max_x = table->WorkRect.Max.x - (table->ColumnsActiveCount - (column->IndexWithinActiveSet + 1)) * min_column_width;
-            if (offset_x + column->WidthGiven > max_x)
-                column->WidthGiven = ImMax(max_x - offset_x, min_column_width);
+            // Frozen columns can't reach beyond visible width else scrolling will naturally break.
+            if (order_n < table->FreezeColumnsRequest)
+                max_x = table->InnerClipRect.Max.x - (table->FreezeColumnsRequest - order_n) * min_column_width;
         }
+        else
+        {
+            // If horizontal scrolling if disabled, we apply a final lossless shrinking of columns in order to make sure they are all visible.
+            // Because of this we also know that all of the columns will always fit in table->WorkRect and therefore in table->InnerRect (because ScrollX is off)
+            max_x = table->WorkRect.Max.x - (table->ColumnsActiveCount - (column->IndexWithinActiveSet + 1)) * min_column_width;
+        }
+        if (offset_x + column->WidthGiven > max_x)
+            column->WidthGiven = ImMax(max_x - offset_x, min_column_width);
 
         column->MinX = offset_x;
         column->MaxX = column->MinX + column->WidthGiven;

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -8384,7 +8384,8 @@ void    ImGui::TableUpdateLayout(ImGuiTable* table)
         {
             // If horizontal scrolling if disabled, we apply a final lossless shrinking of columns in order to make sure they are all visible.
             // Because of this we also know that all of the columns will always fit in table->WorkRect and therefore in table->InnerRect (because ScrollX is off)
-            max_x = table->WorkRect.Max.x - (table->ColumnsActiveCount - (column->IndexWithinActiveSet + 1)) * min_column_width;
+            if (!(table->Flags & ImGuiTableFlags_NoKeepColumnsVisible))
+                max_x = table->WorkRect.Max.x - (table->ColumnsActiveCount - (column->IndexWithinActiveSet + 1)) * min_column_width;
         }
         if (offset_x + column->WidthGiven > max_x)
             column->WidthGiven = ImMax(max_x - offset_x, min_column_width);

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -8245,7 +8245,9 @@ void    ImGui::TableUpdateLayout(ImGuiTable* table)
         else
         {
             IM_ASSERT(column->Flags & ImGuiTableColumnFlags_WidthStretch);
-            IM_ASSERT(column->ResizeWeight > 0.0f);
+            const int init_size = (column->ResizeWeight < 0.0f);
+            if (init_size)
+                column->ResizeWeight = 1.0f;
             total_weights += column->ResizeWeight;
             if (table->LeftMostStretchedColumnDisplayOrder == -1)
                 table->LeftMostStretchedColumnDisplayOrder = (ImS8)column->IndexDisplayOrder;
@@ -9038,7 +9040,8 @@ void    ImGui::TableSetupColumn(const char* label, ImGuiTableColumnFlags flags, 
     flags = column->Flags;
 
     // Initialize defaults
-    if (table->IsInitializing && !table->IsSettingsLoaded)
+    // FIXME-TABLE: We don't restore widths/weight so let's avoid using IsSettingsLoaded for now
+    if (table->IsInitializing && column->WidthRequested < 0.0f && column->ResizeWeight < 0.0f)// && !table->IsSettingsLoaded)
     {
         // Init width or weight
         // Disable auto-fit if a default fixed width has been specified
@@ -9056,7 +9059,9 @@ void    ImGui::TableSetupColumn(const char* label, ImGuiTableColumnFlags flags, 
         {
             column->ResizeWeight = 1.0f;
         }
-
+    }
+    if (table->IsInitializing && !table->IsSettingsLoaded)
+    {
         // Init default visibility/sort state
         if (flags & ImGuiTableColumnFlags_DefaultHide)
             column->IsActive = column->NextIsActive = false;

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -7927,13 +7927,9 @@ bool    ImGui::BeginTableEx(const char* name, ImGuiID id, int columns_count, ImG
     table->HoveredColumnBorder = -1;
     table->RightMostActiveColumn = -1;
 
-    // FIXME-TABLE FIXME-STYLE: Using opaque colors facilitate overlapping elements of the grid
-    //table->BorderOuterColor = GetColorU32(ImGuiCol_Separator, 1.00f);
-    //table->BorderInnerColor = GetColorU32(ImGuiCol_Separator, 0.60f);
-    table->BorderColorStrong = GetColorU32(ImVec4(0.31f, 0.31f, 0.35f, 1.00f));
-    table->BorderColorLight = GetColorU32(ImVec4(0.23f, 0.23f, 0.25f, 1.00f));
-    //table->BorderOuterColor = IM_COL32(255, 0, 0, 255);
-    //table->BorderInnerColor = IM_COL32(255, 255, 0, 255);
+    // Using opaque colors facilitate overlapping elements of the grid
+    table->BorderColorStrong = GetColorU32(ImGuiCol_TableBorderStrong);
+    table->BorderColorLight = GetColorU32(ImGuiCol_TableBorderLight);
     table->BorderX1 = table->InnerClipRect.Min.x;// +((table->Flags & ImGuiTableFlags_BordersOuter) ? 0.0f : -1.0f);
     table->BorderX2 = table->InnerClipRect.Max.x;// +((table->Flags & ImGuiTableFlags_BordersOuter) ? 0.0f : +1.0f);
 

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -7721,6 +7721,7 @@ void ImGui::Columns(int columns_count, const char* id, bool border)
 // [SECTION] Widgets: BeginTable, EndTable, etc.
 //-----------------------------------------------------------------------------
 
+//-----------------------------------------------------------------------------
 // Typical call flow: (root level is public API):
 // - BeginTable()                               user begin into a table
 //    - BeginChild()                            - (if ScrollX/ScrollY is set)
@@ -7741,6 +7742,7 @@ void ImGui::Columns(int columns_count, const char* id, bool border)
 //    - TableSetColumnWidth()                   - apply resizing width
 //      - TableUpdateColumnsWeightFromWidth()
 //      - EndChild()                            - (if ScrollX/ScrollY is set)
+//-----------------------------------------------------------------------------
 
 // Configuration
 static const float TABLE_RESIZE_SEPARATOR_HALF_THICKNESS = 4.0f;    // Extend outside inner borders.
@@ -7850,12 +7852,12 @@ bool    ImGui::BeginTableEx(const char* name, ImGuiID id, int columns_count, ImG
     // Initialize
     table->ID = id;
     table->Flags = flags;
-    table->IsFirstFrame = (table->LastFrameActive == -1);
     table->InstanceNo = (ImS16)instance_no;
     table->LastFrameActive = g.FrameCount;
     table->OuterWindow = table->InnerWindow = outer_window;
     table->ColumnsCount = columns_count;
     table->ColumnsNames.Buf.resize(0);
+    table->IsInitializing = false;
     table->IsLayoutLocked = false;
     table->InnerWidth = inner_width;
     table->OuterRect = outer_rect;
@@ -7916,11 +7918,9 @@ bool    ImGui::BeginTableEx(const char* name, ImGuiID id, int columns_count, ImG
     table->FreezeColumnsCount = (inner_window->Scroll.x != 0.0f) ? table->FreezeColumnsRequest : 0;
     table->IsFreezeRowsPassed = (table->FreezeRowsCount == 0);
     table->DeclColumnsCount = 0;
-    table->LastResizedColumn = table->ResizedColumn;
     table->HoveredColumnBody = -1;
     table->HoveredColumnBorder = -1;
     table->RightMostActiveColumn = -1;
-    table->IsFirstFrame = false;
 
     // FIXME-TABLE FIXME-STYLE: Using opaque colors facilitate overlapping elements of the grid
     //table->BorderOuterColor = GetColorU32(ImGuiCol_Separator, 1.00f);
@@ -7949,8 +7949,7 @@ bool    ImGui::BeginTableEx(const char* name, ImGuiID id, int columns_count, ImG
     // Setup default columns state
     if (table->Columns.Size == 0)
     {
-        table->IsFirstFrame = true;
-        table->IsSortSpecsDirty = true;
+        table->IsInitializing = table->IsSettingsRequestLoad = table->IsSortSpecsDirty = true;
         table->Columns.reserve(columns_count);
         table->DisplayOrder.reserve(columns_count);
         for (int n = 0; n < columns_count; n++)
@@ -7963,7 +7962,7 @@ bool    ImGui::BeginTableEx(const char* name, ImGuiID id, int columns_count, ImG
     }
 
     // Load settings
-    if (table->IsFirstFrame || table->IsSettingsRequestLoad)
+    if (table->IsSettingsRequestLoad)
         TableLoadSettings(table);
 
     // Grab a copy of window fields we will modify
@@ -7992,6 +7991,7 @@ void ImGui::TableBeginUpdateColumns(ImGuiTable* table)
     {
         if (table->ResizedColumn != -1 && table->ResizedColumnNextWidth != FLT_MAX)
             TableSetColumnWidth(table, &table->Columns[table->ResizedColumn], table->ResizedColumnNextWidth);
+        table->LastResizedColumn = table->ResizedColumn;
         table->ResizedColumnNextWidth = FLT_MAX;
         table->ResizedColumn = -1;
     }
@@ -8000,9 +8000,9 @@ void ImGui::TableBeginUpdateColumns(ImGuiTable* table)
     // Note: we don't clear ReorderColumn after handling the request.
     if (table->InstanceNo == 0)
     {
-        if (table->HeadHeaderColumn == -1 && table->ReorderColumn != -1)
+        if (table->HeldHeaderColumn == -1 && table->ReorderColumn != -1)
             table->ReorderColumn = -1;
-        table->HeadHeaderColumn = -1;
+        table->HeldHeaderColumn = -1;
         if (table->ReorderColumn != -1 && table->ReorderColumnDir != 0)
         {
             IM_ASSERT(table->ReorderColumnDir == -1 || table->ReorderColumnDir == +1);
@@ -8214,10 +8214,10 @@ void    ImGui::TableUpdateLayout(ImGuiTable* table)
                     width_request = ImMax(width_request, (float)column->ContentWidthHeadersDesired);
                 column->WidthRequested = ImMax(width_request + padding_auto_x, min_column_width);
 
-                // FIXME-TABLE: Increase minimum size during init frame so avoid biasing auto-fitting widgets (e.g. TextWrapped) too much.
+                // FIXME-TABLE: Increase minimum size during init frame to avoid biasing auto-fitting widgets (e.g. TextWrapped) too much.
                 // Otherwise what tends to happen is that TextWrapped would output a very large height (= first frame scrollbar display very off + clipper would skip lots of items)
                 // This is merely making the side-effect less extreme, but doesn't properly fixes it.
-                if (column->AutoFitQueue > 0x01 && table->IsFirstFrame)
+                if (column->AutoFitQueue > 0x01 && table->IsInitializing)
                     column->WidthRequested = ImMax(column->WidthRequested, min_column_width * 4.0f);
             }
             width_fixed += column->WidthRequested;
@@ -8589,7 +8589,7 @@ void    ImGui::EndTable()
     {
         inner_window->Scroll.x = 0.0f;
     }
-    else if (table->LastResizedColumn != -1 && table->ResizedColumn == -1 && inner_window->ScrollbarX)
+    else if (table->LastResizedColumn != -1 && table->ResizedColumn == -1 && inner_window->ScrollbarX && table->InstanceInteracted == table->InstanceNo)
     {
         ImGuiTableColumn* column = &table->Columns[table->LastResizedColumn];
         if (column->MaxX < table->InnerClipRect.Min.x)
@@ -8993,7 +8993,7 @@ void    ImGui::TableSetupColumn(const char* label, ImGuiTableColumnFlags flags, 
     flags = column->Flags;
 
     // Initialize defaults
-    if (table->IsFirstFrame && !table->IsSettingsLoaded)
+    if (table->IsInitializing && !table->IsSettingsLoaded)
     {
         // Init width or weight
         // Disable auto-fit if a default fixed width has been specified
@@ -9573,7 +9573,7 @@ void    ImGui::TableHeader(const char* label)
     const bool pressed = Selectable("", selected, ImGuiSelectableFlags_DrawHoveredWhenHeld, ImVec2(0.0f, row_height));
     const bool held = IsItemActive();
     if (held)
-        table->HeadHeaderColumn = (ImS8)column_n;
+        table->HeldHeaderColumn = (ImS8)column_n;
     window->DC.CursorPos.y -= g.Style.ItemSpacing.y * 0.5f;
 
     // Drag and drop: re-order columns. Frozen columns are not reorderable.
@@ -9783,7 +9783,7 @@ void ImGui::TableSortSpecsSanitize(ImGuiTable* table)
     }
 
     // Fallback default sort order (if no column has the ImGuiTableColumnFlags_DefaultSort flag)
-    if (sort_order_count == 0 && table->IsFirstFrame)
+    if (sort_order_count == 0 && table->IsInitializing)
         for (int column_n = 0; column_n < table->ColumnsCount; column_n++)
         {
             ImGuiTableColumn* column = &table->Columns[column_n];

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -7806,12 +7806,17 @@ inline ImGuiTableFlags TableFixFlags(ImGuiTableFlags flags)
 // Even if not really useful, we allow 'inner_scroll_width < outer_size.x' for consistency and to facilitate understanding of what the value does.
 bool    ImGui::BeginTable(const char* str_id, int columns_count, ImGuiTableFlags flags, const ImVec2& outer_size, float inner_width)
 {
+    ImGuiID id = GetID(str_id);
+    return BeginTableEx(str_id, id, columns_count, flags, outer_size, inner_width);
+}
+
+bool    ImGui::BeginTableEx(const char* name, ImGuiID id, int columns_count, ImGuiTableFlags flags, const ImVec2& outer_size, float inner_width)
+{
     ImGuiContext& g = *GImGui;
     ImGuiWindow* outer_window = GetCurrentWindow();
     IM_ASSERT(columns_count > 0 && columns_count < IMGUI_TABLE_MAX_COLUMNS && "Only 0..63 columns allowed!");
     if (flags & ImGuiTableFlags_ScrollX)
         IM_ASSERT(inner_width >= 0.0f);
-    ImGuiID id = GetID(str_id);
 
     const bool use_child_window = (flags & (ImGuiTableFlags_ScrollX | ImGuiTableFlags_ScrollY)) != 0;
     const ImVec2 avail_size = GetContentRegionAvail();
@@ -7869,7 +7874,7 @@ bool    ImGui::BeginTable(const char* str_id, int columns_count, ImGuiTableFlags
 
         // Create scrolling region (without border = zero window padding)
         ImGuiWindowFlags child_flags = (flags & ImGuiTableFlags_ScrollX) ? ImGuiWindowFlags_HorizontalScrollbar : ImGuiWindowFlags_None;
-        BeginChildEx(str_id, instance_id, table->OuterRect.GetSize(), false, child_flags);
+        BeginChildEx(name, instance_id, table->OuterRect.GetSize(), false, child_flags);
         table->InnerWindow = g.CurrentWindow;
         table->WorkRect = table->InnerWindow->WorkRect;
         table->OuterRect = table->InnerWindow->Rect();
@@ -8470,7 +8475,14 @@ void    ImGui::TableUpdateBorders(ImGuiTable* table)
         KeepAliveID(column_id);
 
         bool hovered = false, held = false;
-        ButtonBehavior(hit_rect, column_id, &hovered, &held, ImGuiButtonFlags_FlattenChildren | ImGuiButtonFlags_AllowItemOverlap);
+        bool pressed = ButtonBehavior(hit_rect, column_id, &hovered, &held, ImGuiButtonFlags_FlattenChildren | ImGuiButtonFlags_AllowItemOverlap | ImGuiButtonFlags_PressedOnClick | ImGuiButtonFlags_PressedOnDoubleClick);
+        if (pressed && IsMouseDoubleClicked(0) && !(column->Flags & ImGuiTableColumnFlags_WidthStretch))
+        {
+            // FIXME-TABLE: Double-clicking on column edge could auto-fit weighted column?
+            TableSetColumnAutofit(table, column_n);
+            ClearActiveID();
+            held = hovered = false;
+        }
         if (held)
         {
             table->ResizedColumn = (ImS8)column_n;

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -7815,6 +7815,8 @@ bool    ImGui::BeginTableEx(const char* name, ImGuiID id, int columns_count, ImG
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* outer_window = GetCurrentWindow();
+    if (outer_window->SkipItems) // Consistent with other tables + beneficial side effect that assert on miscalling EndTable() will be more visible.
+        return false;
 
     // Sanity checks
     IM_ASSERT(columns_count > 0 && columns_count < IMGUI_TABLE_MAX_COLUMNS && "Only 0..63 columns allowed!");
@@ -9499,12 +9501,13 @@ void    ImGui::TableAutoHeaders()
 
     // Context Menu
     if (open_context_popup != INT_MAX)
-    {
-        table->IsContextPopupOpen = true;
-        table->ContextPopupColumn = (ImS8)open_context_popup;
-        table->InstanceInteracted = table->InstanceNo;
-        OpenPopup("##TableContextMenu");
-    }
+        if (table->Flags & (ImGuiTableFlags_Resizable | ImGuiTableFlags_Reorderable | ImGuiTableFlags_Hideable))
+        {
+            table->IsContextPopupOpen = true;
+            table->ContextPopupColumn = (ImS8)open_context_popup;
+            table->InstanceInteracted = table->InstanceNo;
+            OpenPopup("##TableContextMenu");
+        }
 }
 
 // Emit a column header (text + optional sort order)


### PR DESCRIPTION
I found a minor issue in the demo window in tables branch. The sorting order is reversed:
![sorting](https://user-images.githubusercontent.com/45316015/74485415-f9cbfb80-4eba-11ea-82af-c5ce22cd24d4.jpg)

It was caused by subtracting rhs from lhs in the comparison function, instead of the opposite, as seen in diff.