### PR TITLE
Fix window resizing in SDL+DX11 example

### DIFF
--- a/examples/example_sdl_directx11/main.cpp
+++ b/examples/example_sdl_directx11/main.cpp
@@ -101,6 +101,15 @@ int main(int, char**)
                 done = true;
             if (event.type == SDL_WINDOWEVENT && event.window.event == SDL_WINDOWEVENT_CLOSE && event.window.windowID == SDL_GetWindowID(window))
                 done = true;
+            if (event.type == SDL_WINDOWEVENT && event.window.event == SDL_WINDOWEVENT_RESIZED)
+            {                
+                g_pd3dDeviceContext->OMSetRenderTargets(0, 0, 0);
+                // Release all outstanding references to the swap chain's buffers.
+                g_mainRenderTargetView->Release();
+
+                g_pSwapChain->ResizeBuffers(0, 0, 0, DXGI_FORMAT_UNKNOWN, 0);
+                CreateRenderTarget();
+            }
         }
 
         // Start the Dear ImGui frame


### PR DESCRIPTION
Make the dx11 example implementation resize the window in a sane way, i.e. not the stretching/scaling the initial render to fit the new window size (current behaviour).

This is what happens if I resize initial window currently: mouse doesn't hit detect on the controls properly (mouse not shown, but it's actually hovering in the blue), scaling makes it unreadable.
![image](https://user-images.githubusercontent.com/54322500/76448172-d31db980-63c1-11ea-9d64-71910adab816.png)

with the new code:

![image](https://user-images.githubusercontent.com/54322500/76448393-28f26180-63c2-11ea-87c7-3770ec6008b8.png).
