### PR TITLE
add meson for system installation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,39 @@
+project(
+  'Dear ImGui',
+  'cpp',
+  meson_version : '>= 0.46.0',
+  default_options : ['default_library=both'],
+  license : 'MIT',
+  version : '1.75',
+)
+
+dearimgui_inc = include_directories('.')
+dearimgui_src = files(
+  'imgui.cpp',
+  'imgui_draw.cpp',
+  'imgui_widgets.cpp',
+)
+
+dearimgui_lib = library(
+  'dearimgui',
+  dearimgui_src,
+  include_directories : dearimgui_inc,
+  install : true,
+  version : meson.project_version(),
+  soversion : '0',
+)
+
+install_headers('imgui.h')
+
+pkgconfig = import('pkgconfig')
+pkgconfig.generate(
+  dearimgui_lib,
+  name : 'dearimgui',
+  description : 'Immediate mode graphical user interface',
+  version : meson.project_version(),
+)
+
+dearimgui_dep = declare_dependency(
+  link_with : dearimgui_lib,
+  include_directories : dearimgui_inc,
+)


### PR DESCRIPTION
This is a little bit similar to #3027, just way simpler and with a slightly different scope. But let's start from zero:

I'm currently looking into building a Debian package of a project that uses ImGui. Naturally on Unix, we don't want stuff statically linked or programs providing sources for their dependencies if possible.
The solution to this is to pack ImGui, but for this we need a build system. I _could_ just add a patch inside Debian, but I rather avoid it since the maintainers for Fedora etc have the same problem. 
So let's add a build system (which one doesn't really matter, I just think meson is pretty clean compared to CMake or worse autotools), that builds a dynamic library and adds a pkg-config entry.
Projects then can simply link against the library using pkg-config. However, some people might still want to link statically against it in release binaries, that's why we should also build a static library.
For developers, we also want to install the header, and add a simple dependency variable in meson since it's basically free.

Looking at #3027, there are some things I didn't do, but that doesn't mean that they aren't possible. Meson supports a full test suite, with which the examples could be compiled and tested, however I don't think that converting the current system to meson is an advantage.

I didn't write anything about this in the Readme, there should be a note somewhere, but I don't really know where I should put it. If you have any question about the code, just let me know.