### PR TITLE
Support older 2.x series of glbinding as loader for OpenGL3

### DIFF
--- a/examples/example_glfw_opengl3/Makefile
+++ b/examples/example_glfw_opengl3/Makefile
@@ -42,8 +42,11 @@ CXXFLAGS += -I../libs/gl3w -DIMGUI_IMPL_OPENGL_LOADER_GL3W
 # CXXFLAGS += -I../libs/glad/include -DIMGUI_IMPL_OPENGL_LOADER_GLAD
 
 ## Using OpenGL loader: glbinding
-## (This assumes a system-wide installation)
-# CXXFLAGS += -lglbinding -DIMGUI_IMPL_OPENGL_LOADER_GLBINDING
+## This assumes a system-wide installation
+## of either version 3.0.0 (or newer)
+# CXXFLAGS += -lglbinding -DIMGUI_IMPL_OPENGL_LOADER_GLBINDING3
+## or the older version 2.x
+# CXXFLAGS += -lglbinding -DIMGUI_IMPL_OPENGL_LOADER_GLBINDING2
 
 ##---------------------------------------------------------------------
 ## BUILD FLAGS PER PLATFORM

--- a/examples/example_glfw_opengl3/main.cpp
+++ b/examples/example_glfw_opengl3/main.cpp
@@ -17,9 +17,13 @@
 #include <GL/glew.h>    // Initialize with glewInit()
 #elif defined(IMGUI_IMPL_OPENGL_LOADER_GLAD)
 #include <glad/glad.h>  // Initialize with gladLoadGL()
-#elif defined(IMGUI_IMPL_OPENGL_LOADER_GLBINDING)
+#elif defined(IMGUI_IMPL_OPENGL_LOADER_GLBINDING2) || defined(IMGUI_IMPL_OPENGL_LOADER_GLBINDING3)
 #define GLFW_INCLUDE_NONE         // GLFW including OpenGL headers causes ambiguity or multiple definition errors.
+#if defined(IMGUI_IMPL_OPENGL_LOADER_GLBINDING2)
+#include <glbinding/Binding.h>    // Initialize with glbinding::Binding::initialize()
+#else
 #include <glbinding/glbinding.h>  // Initialize with glbinding::initialize()
+#endif
 #include <glbinding/gl/gl.h>
 using namespace gl;
 #else
@@ -79,7 +83,10 @@ int main(int, char**)
     bool err = glewInit() != GLEW_OK;
 #elif defined(IMGUI_IMPL_OPENGL_LOADER_GLAD)
     bool err = gladLoadGL() == 0;
-#elif defined(IMGUI_IMPL_OPENGL_LOADER_GLBINDING)
+#elif defined(IMGUI_IMPL_OPENGL_LOADER_GLBINDING2)
+    bool err = false;
+    glbinding::Binding::initialize();
+#elif defined(IMGUI_IMPL_OPENGL_LOADER_GLBINDING3)
     bool err = false;
     glbinding::initialize([](const char* name) { return (glbinding::ProcAddress)glfwGetProcAddress(name); });
 #else

--- a/examples/example_sdl_opengl3/Makefile
+++ b/examples/example_sdl_opengl3/Makefile
@@ -42,8 +42,11 @@ CXXFLAGS += -I../libs/gl3w -DIMGUI_IMPL_OPENGL_LOADER_GL3W
 # CXXFLAGS += -I../libs/glad/include -DIMGUI_IMPL_OPENGL_LOADER_GLAD
 
 ## Using OpenGL loader: glbinding
-## (This assumes a system-wide installation)
-# CXXFLAGS += -lglbinding -DIMGUI_IMPL_OPENGL_LOADER_GLBINDING
+## This assumes a system-wide installation
+## of either version 3.0.0 (or newer)
+# CXXFLAGS += -lglbinding -DIMGUI_IMPL_OPENGL_LOADER_GLBINDING3
+## or the older version 2.x
+# CXXFLAGS += -lglbinding -DIMGUI_IMPL_OPENGL_LOADER_GLBINDING2
 
 ##---------------------------------------------------------------------
 ## BUILD FLAGS PER PLATFORM

--- a/examples/example_sdl_opengl3/main.cpp
+++ b/examples/example_sdl_opengl3/main.cpp
@@ -19,8 +19,12 @@
 #include <GL/glew.h>    // Initialize with glewInit()
 #elif defined(IMGUI_IMPL_OPENGL_LOADER_GLAD)
 #include <glad/glad.h>  // Initialize with gladLoadGL()
-#elif defined(IMGUI_IMPL_OPENGL_LOADER_GLBINDING)
+#elif defined(IMGUI_IMPL_OPENGL_LOADER_GLBINDING2) || defined(IMGUI_IMPL_OPENGL_LOADER_GLBINDING3)
+#if defined(IMGUI_IMPL_OPENGL_LOADER_GLBINDING2)
+#include <glbinding/Binding.h>    // Initialize with glbinding::Binding::initialize()
+#else
 #include <glbinding/glbinding.h>  // Initialize with glbinding::initialize()
+#endif
 #include <glbinding/gl/gl.h>
 using namespace gl;
 #else
@@ -73,7 +77,10 @@ int main(int, char**)
     bool err = glewInit() != GLEW_OK;
 #elif defined(IMGUI_IMPL_OPENGL_LOADER_GLAD)
     bool err = gladLoadGL() == 0;
-#elif defined(IMGUI_IMPL_OPENGL_LOADER_GLBINDING)
+#elif defined(IMGUI_IMPL_OPENGL_LOADER_GLBINDING2)
+    bool err = false;
+    glbinding::Binding::initialize();
+#elif defined(IMGUI_IMPL_OPENGL_LOADER_GLBINDING3)
     bool err = false;
     glbinding::initialize([](const char* name) { return (glbinding::ProcAddress)SDL_GL_GetProcAddress(name); });
 #else

--- a/examples/imgui_impl_opengl3.cpp
+++ b/examples/imgui_impl_opengl3.cpp
@@ -86,14 +86,16 @@
 #undef IMGUI_IMPL_OPENGL_LOADER_GL3W
 #undef IMGUI_IMPL_OPENGL_LOADER_GLEW
 #undef IMGUI_IMPL_OPENGL_LOADER_GLAD
-#undef IMGUI_IMPL_OPENGL_LOADER_GLBINDING
+#undef IMGUI_IMPL_OPENGL_LOADER_GLBINDING2
+#undef IMGUI_IMPL_OPENGL_LOADER_GLBINDING3
 #undef IMGUI_IMPL_OPENGL_LOADER_CUSTOM
 #elif defined(__EMSCRIPTEN__)
 #define IMGUI_IMPL_OPENGL_ES2           // Emscripten    -> GL ES 2, "#version 100"
 #undef IMGUI_IMPL_OPENGL_LOADER_GL3W
 #undef IMGUI_IMPL_OPENGL_LOADER_GLEW
 #undef IMGUI_IMPL_OPENGL_LOADER_GLAD
-#undef IMGUI_IMPL_OPENGL_LOADER_GLBINDING
+#undef IMGUI_IMPL_OPENGL_LOADER_GLBINDING2
+#undef IMGUI_IMPL_OPENGL_LOADER_GLBINDING3
 #undef IMGUI_IMPL_OPENGL_LOADER_CUSTOM
 #endif
 #endif
@@ -118,9 +120,13 @@
 #include <GL/glew.h>    // Needs to be initialized with glewInit() in user's code
 #elif defined(IMGUI_IMPL_OPENGL_LOADER_GLAD)
 #include <glad/glad.h>  // Needs to be initialized with gladLoadGL() in user's code
-#elif defined(IMGUI_IMPL_OPENGL_LOADER_GLBINDING)
+#elif defined(IMGUI_IMPL_OPENGL_LOADER_GLBINDING2) || defined(IMGUI_IMPL_OPENGL_LOADER_GLBINDING3)
 #include <glbinding/gl/gl.h>  // Initialize with glbinding::initialize()
+#if defined(IMGUI_IMPL_OPENGL_LOADER_GLBINDING2)
+#include <glbinding/Binding.h>
+#else
 #include <glbinding/glbinding.h>
+#endif
 using namespace gl;
 #else
 #include IMGUI_IMPL_OPENGL_LOADER_CUSTOM
@@ -193,8 +199,10 @@ bool    ImGui_ImplOpenGL3_Init(const char* glsl_version)
     gl_loader = "GLEW";
 #elif defined(IMGUI_IMPL_OPENGL_LOADER_GLAD)
     gl_loader = "GLAD";
-#elif defined(IMGUI_IMPL_OPENGL_LOADER_GLBINDING)
-    gl_loader = "glbinding";
+#elif defined(IMGUI_IMPL_OPENGL_LOADER_GLBINDING2)
+    gl_loader = "glbinding2";
+#elif defined(IMGUI_IMPL_OPENGL_LOADER_GLBINDING3)
+    gl_loader = "glbinding3";
 #else // IMGUI_IMPL_OPENGL_LOADER_CUSTOM
     gl_loader = "Custom";
 #endif

--- a/examples/imgui_impl_opengl3.h
+++ b/examples/imgui_impl_opengl3.h
@@ -46,7 +46,8 @@ IMGUI_IMPL_API void     ImGui_ImplOpenGL3_DestroyDeviceObjects();
 #if !defined(IMGUI_IMPL_OPENGL_LOADER_GL3W) \
  && !defined(IMGUI_IMPL_OPENGL_LOADER_GLEW) \
  && !defined(IMGUI_IMPL_OPENGL_LOADER_GLAD) \
- && !defined(IMGUI_IMPL_OPENGL_LOADER_GLBINDING) \
+ && !defined(IMGUI_IMPL_OPENGL_LOADER_GLBINDING2) \
+ && !defined(IMGUI_IMPL_OPENGL_LOADER_GLBINDING3) \
  && !defined(IMGUI_IMPL_OPENGL_LOADER_CUSTOM)
     #if defined(__has_include)
         #if __has_include(<GL/glew.h>)
@@ -55,8 +56,10 @@ IMGUI_IMPL_API void     ImGui_ImplOpenGL3_DestroyDeviceObjects();
             #define IMGUI_IMPL_OPENGL_LOADER_GLAD
         #elif __has_include(<GL/gl3w.h>)
             #define IMGUI_IMPL_OPENGL_LOADER_GL3W
-        #elif __has_include(<glbinding/gl/gl.h>)
-            #define IMGUI_IMPL_OPENGL_LOADER_GLBINDING
+        #elif __has_include(<glbinding/glbinding.h>)
+            #define IMGUI_IMPL_OPENGL_LOADER_GLBINDING3
+        #elif __has_include(<glbinding/Binding.h>)
+            #define IMGUI_IMPL_OPENGL_LOADER_GLBINDING2
         #else
             #error "Cannot detect OpenGL loader!"
         #endif


### PR DESCRIPTION
For the moment I have only the older 2.x series available on my system
which uses slightly different header filenames and initialisation, so
as a slight variation of the 3.x series support recently implemented
here the glue needed to make 2.x series work.

I would hope a potential 4.x will not change filenames and such, so the
existing flag isn't rebranded to 3 which also avoids breaking compat.

References: #2870, 5e2329b98e6562c9e7883e92dcf878e969d81878

No worries if you conclude that you don't want to support/include this, I am pushing the PR mostly at the off chance of it helping someone. That might already be achieved with the references. :grin: