### PR TITLE
Use __NEWLIB__ instead of __SWITCH__ and __CYGWIN__ for alloca.h-detection

### DIFF
--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -36,7 +36,7 @@ Index of this file:
 
 #include <stdio.h>      // vsnprintf, sscanf, printf
 #if !defined(alloca)
-#if defined(__GLIBC__) || defined(__sun) || defined(__CYGWIN__) || defined(__APPLE__) || defined(__NEWLIB__)
+#if defined(__GLIBC__) || defined(__sun) || defined(__APPLE__) || defined(__NEWLIB__)
 #include <alloca.h>     // alloca (glibc uses <alloca.h>. Note that Cygwin may have _WIN32 defined, so the order matters here)
 #elif defined(_WIN32)
 #include <malloc.h>     // alloca

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -36,7 +36,7 @@ Index of this file:
 
 #include <stdio.h>      // vsnprintf, sscanf, printf
 #if !defined(alloca)
-#if defined(__GLIBC__) || defined(__sun) || defined(__CYGWIN__) || defined(__APPLE__) || defined(__SWITCH__)
+#if defined(__GLIBC__) || defined(__sun) || defined(__CYGWIN__) || defined(__APPLE__) || defined(__NEWLIB__)
 #include <alloca.h>     // alloca (glibc uses <alloca.h>. Note that Cygwin may have _WIN32 defined, so the order matters here)
 #elif defined(_WIN32)
 #include <malloc.h>     // alloca


### PR DESCRIPTION
devkitPro uses the newlib libc for some (all?) of its platforms, so by using `__NEWLIB__` instead of `__SWITCH__`, Dear ImGui theoretically gains support for the GameCube, Wii, and Wii U, along with any other platform that uses newlib.

This was tested on the Switch by @dos1 in #2595, and I verified that `__NEWLIB__` is defined on the Wii U.