### PR TITLE
Backends: Include imgui.h in implementation headers.

### DIFF
--- a/examples/imgui_impl_allegro5.h
+++ b/examples/imgui_impl_allegro5.h
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include "imgui.h"
+
 struct ALLEGRO_DISPLAY;
 union ALLEGRO_EVENT;
 

--- a/examples/imgui_impl_dx10.h
+++ b/examples/imgui_impl_dx10.h
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include "imgui.h"
+
 struct ID3D10Device;
 
 IMGUI_IMPL_API bool     ImGui_ImplDX10_Init(ID3D10Device* device);

--- a/examples/imgui_impl_dx11.h
+++ b/examples/imgui_impl_dx11.h
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include "imgui.h"
+
 struct ID3D11Device;
 struct ID3D11DeviceContext;
 

--- a/examples/imgui_impl_dx12.h
+++ b/examples/imgui_impl_dx12.h
@@ -13,6 +13,8 @@
 
 #pragma once
 
+#include "imgui.h"
+
 enum DXGI_FORMAT;
 struct ID3D12Device;
 struct ID3D12DescriptorHeap;

--- a/examples/imgui_impl_dx9.h
+++ b/examples/imgui_impl_dx9.h
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include "imgui.h"
+
 struct IDirect3DDevice9;
 
 IMGUI_IMPL_API bool     ImGui_ImplDX9_Init(IDirect3DDevice9* device);

--- a/examples/imgui_impl_glfw.h
+++ b/examples/imgui_impl_glfw.h
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include "imgui.h"
+
 struct GLFWwindow;
 
 IMGUI_IMPL_API bool     ImGui_ImplGlfw_InitForOpenGL(GLFWwindow* window, bool install_callbacks);

--- a/examples/imgui_impl_glut.h
+++ b/examples/imgui_impl_glut.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "imgui.h"
+
 IMGUI_IMPL_API bool     ImGui_ImplGLUT_Init();
 IMGUI_IMPL_API void     ImGui_ImplGLUT_InstallFuncs();
 IMGUI_IMPL_API void     ImGui_ImplGLUT_Shutdown();

--- a/examples/imgui_impl_marmalade.h
+++ b/examples/imgui_impl_marmalade.h
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include "imgui.h"
+
 IMGUI_IMPL_API bool     ImGui_Marmalade_Init(bool install_callbacks);
 IMGUI_IMPL_API void     ImGui_Marmalade_Shutdown();
 IMGUI_IMPL_API void     ImGui_Marmalade_NewFrame();

--- a/examples/imgui_impl_metal.h
+++ b/examples/imgui_impl_metal.h
@@ -9,6 +9,8 @@
 // If you are new to dear imgui, read examples/README.txt and read the documentation at the top of imgui.cpp.
 // https://github.com/ocornut/imgui
 
+#include "imgui.h"
+
 @class MTLRenderPassDescriptor;
 @protocol MTLDevice, MTLCommandBuffer, MTLRenderCommandEncoder;
 

--- a/examples/imgui_impl_opengl2.h
+++ b/examples/imgui_impl_opengl2.h
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include "imgui.h"
+
 IMGUI_IMPL_API bool     ImGui_ImplOpenGL2_Init();
 IMGUI_IMPL_API void     ImGui_ImplOpenGL2_Shutdown();
 IMGUI_IMPL_API void     ImGui_ImplOpenGL2_NewFrame();

--- a/examples/imgui_impl_opengl3.h
+++ b/examples/imgui_impl_opengl3.h
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include "imgui.h"
+
 // Backend API
 IMGUI_IMPL_API bool     ImGui_ImplOpenGL3_Init(const char* glsl_version = NULL);
 IMGUI_IMPL_API void     ImGui_ImplOpenGL3_Shutdown();

--- a/examples/imgui_impl_osx.h
+++ b/examples/imgui_impl_osx.h
@@ -8,6 +8,8 @@
 // Issues:
 //  [ ] Platform: Keys are all generally very broken. Best using [event keycode] and not [event characters]..
 
+#include "imgui.h"
+
 @class NSEvent;
 @class NSView;
 

--- a/examples/imgui_impl_sdl.h
+++ b/examples/imgui_impl_sdl.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include "imgui.h"
+
 struct SDL_Window;
 typedef union SDL_Event SDL_Event;
 

--- a/examples/imgui_impl_vulkan.h
+++ b/examples/imgui_impl_vulkan.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include "imgui.h"
 #include <vulkan/vulkan.h>
 
 // Initialization data, for ImGui_ImplVulkan_Init()

--- a/examples/imgui_impl_win32.h
+++ b/examples/imgui_impl_win32.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include "imgui.h"
+
 IMGUI_IMPL_API bool     ImGui_ImplWin32_Init(void* hwnd);
 IMGUI_IMPL_API void     ImGui_ImplWin32_Shutdown();
 IMGUI_IMPL_API void     ImGui_ImplWin32_NewFrame();


### PR DESCRIPTION
Currently, the implementation headers don't include the `imgui.h` header.
Which means that the compilation will fail if the implementation header
was included before the `imgui.h` header in the compilation unit. For
instance, a compilation unit with the following will work:

```c
#include "imgui.h"
#include "imgui_impl_glfw.h"
#include "imgui_impl_opengl3.h"
```

But a compilation unit with the following will fail because `IMGUI_IMPL_API`
and possibly other symbols will not be defined:

```c
#include "imgui_impl_glfw.h"
#include "imgui_impl_opengl3.h"
#include "imgui.h"
```

This patch includes `imgui.h` in the implementation headers to make
inclusions order-invariant, which is a recommended practice.