### PR TITLE
Update ImeSetInputScreenPosFn to pass the line_height.

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -1466,7 +1466,7 @@ struct ImGuiIO
 
     // Optional: Notify OS Input Method Editor of the screen position of your cursor for text input position (e.g. when using Japanese/Chinese IME on Windows)
     // (default to use native imm32 api on Windows)
-    void        (*ImeSetInputScreenPosFn)(int x, int y);
+    void        (*ImeSetInputScreenPosFn)(float x, float y, float line_height);
     void*       ImeWindowHandle;                // = NULL           // (Windows) Set this to your HWND to get automatic IME cursor positioning.
 
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -1194,7 +1194,9 @@ struct ImGuiContext
 
     // Platform support
     ImVec2                  PlatformImePos;                     // Cursor position request & last passed to the OS Input Method Editor
+    float                   PlatformImeLineHeight;              // Text input line height that can be passed to the OS Input Method Editor
     ImVec2                  PlatformImeLastPos;
+    float                   PlatformImeLastLineHeight;
 
     // Settings
     bool                    SettingsLoaded;

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -4179,7 +4179,10 @@ bool ImGui::InputTextEx(const char* label, const char* hint, char* buf, int buf_
 
             // Notify OS of text input position for advanced IME (-1 x offset so that Windows IME can cover our cursor. Bit of an extra nicety.)
             if (!is_readonly)
+            {
                 g.PlatformImePos = ImVec2(cursor_screen_pos.x - 1.0f, cursor_screen_pos.y - g.FontSize);
+                g.PlatformImeLineHeight = g.FontSize;
+            }
         }
     }
     else


### PR DESCRIPTION
This PR is to continue the discussion in https://github.com/ocornut/imgui/pull/3108#issuecomment-611435871

As of now, I only cherry-picked the commit into this PR. I think changing
it from Vec2 to Vec4 would be nicer, but we need to have a good definition
of what that rectangle is (the cursor shape? the next char? the existing chars
with proposed text (markedText)?).

I don't have a Windows to continue the discussion on changing the
defaultImpl to use poll. I think it would be interesting to do that, and is
probably the right change, but don't have full context yet.