### PR TITLE
Internal: Fix: Read back hexadecimal format properly in slider behavi…

### DIFF
--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -1907,18 +1907,22 @@ static const char* ImAtoi(const char* src, TYPE* output)
 template<typename TYPE, typename SIGNEDTYPE>
 TYPE ImGui::RoundScalarWithFormatT(const char* format, ImGuiDataType data_type, TYPE v)
 {
-    const char* fmt_start = ImParseFormatFindStart(format);
-    if (fmt_start[0] != '%' || fmt_start[1] == '%') // Don't apply if the value is not visible in the format string
+    char fmt_buf[32];
+    format = ImParseFormatTrimDecorations(format, fmt_buf, IM_ARRAYSIZE(fmt_buf));
+    if (format[0] != '%' || format[1] == '%') // Don't apply if the value is not visible in the format string
         return v;
     char v_str[64];
-    ImFormatString(v_str, IM_ARRAYSIZE(v_str), fmt_start, v);
-    const char* p = v_str;
-    while (*p == ' ')
-        p++;
-    if (data_type == ImGuiDataType_Float || data_type == ImGuiDataType_Double)
-        v = (TYPE)ImAtof(p);
-    else
-        ImAtoi(p, (SIGNEDTYPE*)&v);
+    ImFormatString(v_str, IM_ARRAYSIZE(v_str), format, v);
+    if (sscanf(v_str, format, (SIGNEDTYPE*)&v) == 0)
+    {
+        const char* p = v_str;
+        while (*p == ' ')
+            p++;
+        if (data_type == ImGuiDataType_Float || data_type == ImGuiDataType_Double)
+            v = (TYPE)ImAtof(p);
+        else
+            ImAtoi(p, (SIGNEDTYPE*)&v);
+    }
     return v;
 }
 


### PR DESCRIPTION
If used with an hexadecimal format, `ImGui::Slider*` functions would break when coming across values including letters.

E.g.
```c++
static int n = 0;`
ImGui::SliderInt("foobar", &n, 0, 0x20, "0x%02X");
```

![slider_issue](https://user-images.githubusercontent.com/11278694/79574378-57014a80-80c0-11ea-8781-9df3508c651c.gif)

It is caused by `ImAtoi()` which assumes the given string is a decimal number. So instead we use `scanf()` by feeding it back the given format (and in case it fails we fallback to the previous method).