### PR TITLE
Fix wrong comment in ImGuiCond_

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -1265,7 +1265,7 @@ enum ImGuiMouseCursor_
 enum ImGuiCond_
 {
     ImGuiCond_Always        = 1 << 0,   // Set the variable
-    ImGuiCond_Once          = 1 << 1,   // Set the variable once per runtime session (only the first call with succeed)
+    ImGuiCond_Once          = 1 << 1,   // Set the variable once per runtime session (only the first call will succeed)
     ImGuiCond_FirstUseEver  = 1 << 2,   // Set the variable if the object/window has no persistently saved data (no entry in .ini file)
     ImGuiCond_Appearing     = 1 << 3    // Set the variable if the object/window is appearing after being hidden/inactive (or the first time)
 };


### PR DESCRIPTION
It's a very minor nitpick, but since code explicitly serves as a documentation for the project, I think it does make sense to fix such.

This PR fixes a simple error in the comment for `ImGuiCond_Once`.