### PR TITLE
remove false comment in imgui_demo

### DIFF
--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -13,7 +13,6 @@
 // will want to refer to and call. Have the ImGui::ShowDemoWindow() function wired in an always-available debug menu of
 // your game/app! Removing this file from your project is hindering access to documentation for everyone in your team,
 // likely leading you to poorer usage of the library.
-// Everything in this file will be stripped out by the linker if you don't call ImGui::ShowDemoWindow().
 // If you want to link core Dear ImGui in your shipped builds but want a thorough guarantee that the demo will not be linked,
 // you can setup your imconfig.h with #define IMGUI_DISABLE_DEMO_WINDOWS and those functions will be empty.
 // In other situation, whenever you have Dear ImGui available you probably want this to be available for reference.


### PR DESCRIPTION
I don't mind leaving the demo functions in, but this statement is untrue. I have had the imgui_demo code show up unused in several of my release builds and have seen it even in commercial games like Quake Champions. I think since the functions are not static, the compiler cannot tell if they are used externally and leaves them in.
