### PR TITLE
Fix multiple macro definitions of GLFW_INCLUDE_NONE

### DIFF
--- a/examples/imgui_impl_opengl3.cpp
+++ b/examples/imgui_impl_opengl3.cpp
@@ -121,12 +121,16 @@
 #elif defined(IMGUI_IMPL_OPENGL_LOADER_GLAD)
 #include <glad/glad.h>          // Needs to be initialized with gladLoadGL() in user's code.
 #elif defined(IMGUI_IMPL_OPENGL_LOADER_GLBINDING2)
+#ifndef GLFW_INCLUDE_NONE
 #define GLFW_INCLUDE_NONE       // GLFW including OpenGL headers causes ambiguity or multiple definition errors.
+#endif
 #include <glbinding/Binding.h>  // Needs to be initialized with glbinding::Binding::initialize() in user's code.
 #include <glbinding/gl/gl.h>
 using namespace gl;
 #elif defined(IMGUI_IMPL_OPENGL_LOADER_GLBINDING3)
+#ifndef GLFW_INCLUDE_NONE
 #define GLFW_INCLUDE_NONE       // GLFW including OpenGL headers causes ambiguity or multiple definition errors.
+#endif
 #include <glbinding/glbinding.h>// Needs to be initialized with glbinding::initialize() in user's code.
 #include <glbinding/gl/gl.h>
 using namespace gl;


### PR DESCRIPTION
It can be common to set this define in the visual studio project properties when working with GLFW and glbinding. These defines trigger [C4005](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4005) unless they are wrapped with #ifndefs. 
