### PR TITLE
Fix for ImDrawListSplitter::Merge - corrupted data in buffer (64k+ vertices) with 16-bits indices #3129

### DIFF
--- a/examples/example_win32_directx11/main.cpp
+++ b/examples/example_win32_directx11/main.cpp
@@ -22,75 +22,6 @@ void CreateRenderTarget();
 void CleanupRenderTarget();
 LRESULT WINAPI WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
 
-#include <random>
-void ShowBackendCheckerWindow(bool* p_open)
-{
-    if (!ImGui::Begin("Dear ImGui Backend Checker", p_open))
-    {
-        ImGui::End();
-        return;
-    }
-
-    ImGuiIO& io = ImGui::GetIO();
-    ImGui::Text("Dear ImGui %s Backend Checker", ImGui::GetVersion());
-    ImGui::Text("io.BackendPlatformName: %s", io.BackendPlatformName ? io.BackendPlatformName : "NULL");
-    ImGui::Text("io.BackendRendererName: %s", io.BackendRendererName ? io.BackendRendererName : "NULL");
-    ImGui::Text("RendererHasVtxOffset: %s", ((io.BackendFlags & ImGuiBackendFlags_RendererHasVtxOffset) != 0) ? "True" : "False");
-    ImGui::Text("sizeof(ImDrawIdx): %d", sizeof(ImDrawIdx));
-    ImGui::Separator();
-
-    //if (ImGui::TreeNode("0001: Renderer: Large Mesh Support"))
-    {
-        ImDrawList* draw_list = ImGui::GetWindowDrawList();
-        {
-            static int vtx_count = 64722;// 60000;
-            ImGui::SliderInt("VtxCount##1", &vtx_count, 0, 100000);
-
-            static int map[100000 / 4];
-            for (int n = 0; n < vtx_count / 4; n++)
-                map[n] = n;
-            std::srand(13);
-            std::random_shuffle(std::begin(map), std::end(map), [](auto n) { return std::rand() % n; });
-
-            ImDrawListSplitter splitter;
-            splitter.Split(draw_list, 100000 / 4);
-
-            ImVec2 p = ImGui::GetCursorScreenPos();
-            for (int n = 0; n < vtx_count / 4; n++)
-            {
-                splitter.SetCurrentChannel(draw_list, map[n]);
-
-                float off_x = (float)(n % 100) * 3.0f;
-                float off_y = (float)(n % 100) * 1.0f;
-                ImU32 col = IM_COL32(((n * 17) & 255), ((n * 59) & 255), ((n * 83) & 255), 255);
-                draw_list->AddRectFilled(ImVec2(p.x + off_x, p.y + off_y), ImVec2(p.x + off_x + 50, p.y + off_y + 50), col);
-            }
-
-            splitter.Merge(draw_list);
-
-            ImGui::Dummy(ImVec2(300 + 50, 100 + 50));
-            ImGui::Text("VtxBuffer.Size = %d", draw_list->VtxBuffer.Size);
-        }
-        {
-            static int vtx_count = 60000;
-            ImGui::SliderInt("VtxCount##2", &vtx_count, 0, 100000);
-            ImVec2 p = ImGui::GetCursorScreenPos();
-            for (int n = 0; n < vtx_count / (10 * 4); n++)
-            {
-                float off_x = (float)(n % 100) * 3.0f;
-                float off_y = (float)(n % 100) * 1.0f;
-                ImU32 col = IM_COL32(((n * 17) & 255), ((n * 59) & 255), ((n * 83) & 255), 255);
-                draw_list->AddText(ImVec2(p.x + off_x, p.y + off_y), col, "ABCDEFGHIJ");
-            }
-            ImGui::Dummy(ImVec2(300 + 50, 100 + 20));
-            ImGui::Text("VtxBuffer.Size = %d", draw_list->VtxBuffer.Size);
-        }
-        //ImGui::TreePop();
-    }
-
-    ImGui::End();
-}
-
 // Main code
 int main(int, char**)
 {
@@ -167,10 +98,6 @@ int main(int, char**)
         ImGui_ImplDX11_NewFrame();
         ImGui_ImplWin32_NewFrame();
         ImGui::NewFrame();
-
-        static bool show_check_window = true;
-        if (show_check_window)
-            ShowBackendCheckerWindow(&show_check_window);
 
         // 1. Show the big demo window (Most of the sample code is in ImGui::ShowDemoWindow()! You can browse its code to learn more about Dear ImGui!).
         if (show_demo_window)

--- a/examples/example_win32_directx11/main.cpp
+++ b/examples/example_win32_directx11/main.cpp
@@ -22,6 +22,75 @@ void CreateRenderTarget();
 void CleanupRenderTarget();
 LRESULT WINAPI WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
 
+#include <random>
+void ShowBackendCheckerWindow(bool* p_open)
+{
+    if (!ImGui::Begin("Dear ImGui Backend Checker", p_open))
+    {
+        ImGui::End();
+        return;
+    }
+
+    ImGuiIO& io = ImGui::GetIO();
+    ImGui::Text("Dear ImGui %s Backend Checker", ImGui::GetVersion());
+    ImGui::Text("io.BackendPlatformName: %s", io.BackendPlatformName ? io.BackendPlatformName : "NULL");
+    ImGui::Text("io.BackendRendererName: %s", io.BackendRendererName ? io.BackendRendererName : "NULL");
+    ImGui::Text("RendererHasVtxOffset: %s", ((io.BackendFlags & ImGuiBackendFlags_RendererHasVtxOffset) != 0) ? "True" : "False");
+    ImGui::Text("sizeof(ImDrawIdx): %d", sizeof(ImDrawIdx));
+    ImGui::Separator();
+
+    //if (ImGui::TreeNode("0001: Renderer: Large Mesh Support"))
+    {
+        ImDrawList* draw_list = ImGui::GetWindowDrawList();
+        {
+            static int vtx_count = 64722;// 60000;
+            ImGui::SliderInt("VtxCount##1", &vtx_count, 0, 100000);
+
+            static int map[100000 / 4];
+            for (int n = 0; n < vtx_count / 4; n++)
+                map[n] = n;
+            std::srand(13);
+            std::random_shuffle(std::begin(map), std::end(map), [](auto n) { return std::rand() % n; });
+
+            ImDrawListSplitter splitter;
+            splitter.Split(draw_list, 100000 / 4);
+
+            ImVec2 p = ImGui::GetCursorScreenPos();
+            for (int n = 0; n < vtx_count / 4; n++)
+            {
+                splitter.SetCurrentChannel(draw_list, map[n]);
+
+                float off_x = (float)(n % 100) * 3.0f;
+                float off_y = (float)(n % 100) * 1.0f;
+                ImU32 col = IM_COL32(((n * 17) & 255), ((n * 59) & 255), ((n * 83) & 255), 255);
+                draw_list->AddRectFilled(ImVec2(p.x + off_x, p.y + off_y), ImVec2(p.x + off_x + 50, p.y + off_y + 50), col);
+            }
+
+            splitter.Merge(draw_list);
+
+            ImGui::Dummy(ImVec2(300 + 50, 100 + 50));
+            ImGui::Text("VtxBuffer.Size = %d", draw_list->VtxBuffer.Size);
+        }
+        {
+            static int vtx_count = 60000;
+            ImGui::SliderInt("VtxCount##2", &vtx_count, 0, 100000);
+            ImVec2 p = ImGui::GetCursorScreenPos();
+            for (int n = 0; n < vtx_count / (10 * 4); n++)
+            {
+                float off_x = (float)(n % 100) * 3.0f;
+                float off_y = (float)(n % 100) * 1.0f;
+                ImU32 col = IM_COL32(((n * 17) & 255), ((n * 59) & 255), ((n * 83) & 255), 255);
+                draw_list->AddText(ImVec2(p.x + off_x, p.y + off_y), col, "ABCDEFGHIJ");
+            }
+            ImGui::Dummy(ImVec2(300 + 50, 100 + 20));
+            ImGui::Text("VtxBuffer.Size = %d", draw_list->VtxBuffer.Size);
+        }
+        //ImGui::TreePop();
+    }
+
+    ImGui::End();
+}
+
 // Main code
 int main(int, char**)
 {
@@ -98,6 +167,10 @@ int main(int, char**)
         ImGui_ImplDX11_NewFrame();
         ImGui_ImplWin32_NewFrame();
         ImGui::NewFrame();
+
+        static bool show_check_window = true;
+        if (show_check_window)
+            ShowBackendCheckerWindow(&show_check_window);
 
         // 1. Show the big demo window (Most of the sample code is in ImGui::ShowDemoWindow()! You can browse its code to learn more about Dear ImGui!).
         if (show_demo_window)

--- a/imgui.h
+++ b/imgui.h
@@ -2068,6 +2068,7 @@ struct ImDrawList
     inline    void  PrimVtx(const ImVec2& pos, const ImVec2& uv, ImU32 col)     { PrimWriteIdx((ImDrawIdx)_VtxCurrentIdx); PrimWriteVtx(pos, uv, col); }
     IMGUI_API void  UpdateClipRect();
     IMGUI_API void  UpdateTextureID();
+    IMGUI_API void  UpdateStaleDrawCmd();
 };
 
 // All draw data to render a Dear ImGui frame

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -1423,11 +1423,11 @@ void ImDrawListSplitter::SetCurrentChannel(ImDrawList* draw_list, int idx)
     memcpy(&draw_list->CmdBuffer, &_Channels.Data[idx]._CmdBuffer, sizeof(draw_list->CmdBuffer));
     memcpy(&draw_list->IdxBuffer, &_Channels.Data[idx]._IdxBuffer, sizeof(draw_list->IdxBuffer));
     draw_list->_IdxWritePtr = draw_list->IdxBuffer.Data + draw_list->IdxBuffer.Size;
-    // If the vertex offset or clip rect changed then we need a new draw call (FIXME: What about user callbacks?)
+    // If the vertex offset, texture ID or clip rect changed then we need a new draw call (FIXME: What about user callbacks?)
     if (draw_list->CmdBuffer.Size > 0)
     {
         ImDrawCmd* new_curr_cmd = &draw_list->CmdBuffer.Data[draw_list->CmdBuffer.Size - 1]; // The "new" current command
-        if ((new_curr_cmd->VtxOffset != draw_list->_VtxCurrentOffset) || (old_curr_cmd && (memcmp(&new_curr_cmd->ClipRect, &old_curr_cmd->ClipRect, sizeof(ImVec4)) != 0)))
+        if ((new_curr_cmd->VtxOffset != draw_list->_VtxCurrentOffset) || (new_curr_cmd->TextureId != (draw_list->_TextureIdStack.Size ? draw_list->_TextureIdStack.Data[draw_list->_TextureIdStack.Size - 1] : (ImTextureID)NULL)) || (old_curr_cmd && (memcmp(&new_curr_cmd->ClipRect, &old_curr_cmd->ClipRect, sizeof(ImVec4)) != 0)))
             draw_list->AddDrawCmd();
     }
 }

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -1423,11 +1423,11 @@ void ImDrawListSplitter::SetCurrentChannel(ImDrawList* draw_list, int idx)
     memcpy(&draw_list->CmdBuffer, &_Channels.Data[idx]._CmdBuffer, sizeof(draw_list->CmdBuffer));
     memcpy(&draw_list->IdxBuffer, &_Channels.Data[idx]._IdxBuffer, sizeof(draw_list->IdxBuffer));
     draw_list->_IdxWritePtr = draw_list->IdxBuffer.Data + draw_list->IdxBuffer.Size;
-    // If the vertex offset, texture ID or clip rect changed then we need a new draw call (FIXME: What about user callbacks?)
+    // If the vertex offset, texture ID or clip rect changed then we need a new draw call
     if (draw_list->CmdBuffer.Size > 0)
     {
         ImDrawCmd* new_curr_cmd = &draw_list->CmdBuffer.Data[draw_list->CmdBuffer.Size - 1]; // The "new" current command
-        if ((new_curr_cmd->VtxOffset != draw_list->_VtxCurrentOffset) || (new_curr_cmd->TextureId != (draw_list->_TextureIdStack.Size ? draw_list->_TextureIdStack.Data[draw_list->_TextureIdStack.Size - 1] : (ImTextureID)NULL)) || (old_curr_cmd && (memcmp(&new_curr_cmd->ClipRect, &old_curr_cmd->ClipRect, sizeof(ImVec4)) != 0)))
+        if ((new_curr_cmd->VtxOffset != draw_list->_VtxCurrentOffset) || (new_curr_cmd->TextureId != (draw_list->_TextureIdStack.Size ? draw_list->_TextureIdStack.Data[draw_list->_TextureIdStack.Size - 1] : (ImTextureID)NULL)) || (old_curr_cmd && (memcmp(&new_curr_cmd->ClipRect, &old_curr_cmd->ClipRect, sizeof(ImVec4)) != 0)) || new_curr_cmd->UserCallback)
             draw_list->AddDrawCmd();
     }
 }

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -7553,7 +7553,7 @@ void ImGui::PushColumnsBackground()
     int cmd_size = window->DrawList->CmdBuffer.Size;
     PushClipRect(columns->HostClipRect.Min, columns->HostClipRect.Max, false);
     IM_UNUSED(cmd_size);
-    IM_ASSERT(cmd_size == window->DrawList->CmdBuffer.Size); // Being in channel 0 this should not have created an ImDrawCmd
+    IM_ASSERT(cmd_size >= window->DrawList->CmdBuffer.Size); // Being in channel 0 this should not have created an ImDrawCmd
 }
 
 void ImGui::PopColumnsBackground()


### PR DESCRIPTION
This is fix for ImDrawListSplitter::Merge - corrupted data in buffer (64k+ vertices) with 16-bits indices #3129

Thanks for @ShironekoBen for finding underlying issue and making initial patch.

Basically issue was caused by draw commands cached while making channel split and when switching channels, they internal state (texture ID, clip rect and vertex offset) may no longer match on in ImDrawList.

Another partial fix will be to not create draw commands while preparing split since check now is always present in SetCurrentChannel. Fill will be partial because on heavy use of vertices we can still hit state when draw command is stale.

Pre-allocating single draw command on split may no longer be necessary since SetCurrentChannel always check for validity after switch. Also for sparse channel splits there are a lot of unused draw commands allocated, just to be discarded on merge.
This is a case for Node Editor where each node has few assigned channels, where most of them are empty (one for selection, one for highlights, one for background, etc) most of the time. So maybe this change can also be considered.

![image](https://user-images.githubusercontent.com/1197433/80279480-4410fa80-86fe-11ea-8941-48f3d3694290.png)

Introduction of channel merging based on bounding boxes may further reduce number of generated draw commands. They number can quickly explode when 16-bit indices are used with large meshes:
![image](https://user-images.githubusercontent.com/1197433/80279559-cb5e6e00-86fe-11ea-89b1-66858373ea1b.png)

Code used for testing:
https://gist.github.com/thedmd/e384a83c0fe9e82ec0f69c869510ad44

Repro on non-patched ImGui copy:
 * Copy&paste above gist
 * Invoke `TestSplitterBug()`
