### PR TITLE
Skip rendering first vulkan frame when elements off screen

### DIFF
--- a/examples/imgui_impl_vulkan.cpp
+++ b/examples/imgui_impl_vulkan.cpp
@@ -313,6 +313,9 @@ static void ImGui_ImplVulkan_SetupRenderState(ImDrawData* draw_data, VkCommandBu
 // (this used to be set in io.RenderDrawListsFn and called by ImGui::Render(), but you can now call this directly from your main loop)
 void ImGui_ImplVulkan_RenderDrawData(ImDrawData* draw_data, VkCommandBuffer command_buffer)
 {
+    // Avoid rendering when GUI elements off screen first frame. Causes memory allocation error when multiplying by 0
+    if(draw_data->TotalIdxCount == 0 || draw_data->TotalVtxCount == 0) return;
+
     // Avoid rendering when minimized, scale coordinates for retina displays (screen coordinates != framebuffer coordinates)
     int fb_width = (int)(draw_data->DisplaySize.x * draw_data->FramebufferScale.x);
     int fb_height = (int)(draw_data->DisplaySize.y * draw_data->FramebufferScale.y);


### PR DESCRIPTION
Apologies as I'm rather new to imgui. I ran into this trying my first integration. There is probably a better solution than this work around but I don't know the depths of imgui yet. I'm hoping this PR gets the conversation started and towards the correct fix.

There's a bug with `imgui_impl_vulkan` where if the GUI elements are initially off screen on the first frame, the `TotalIdxCount` and `TotalVtxCount` are `0`. When this happens later on we try and allocate a vulkan buffer with size 0, which Vulkan gives us an error code -2, `VK_ERROR_OUT_OF_DEVICE_MEMORY`. (terrible error since size 0 isn't out of memory, it's invalid). 

Interestingly if we just skip rendering frames where the vertex count is 0 `GetDrawData` has vertices again. It looks like imgui repositions off screen elements back into the viewable area? This leads me to the belief that there may be a bug within `GetDrawData` and this hack is covering it up.

We can easily reproduce the behavior by placing this ini alongside a built Vulkan example. The `check_vk_result` on line 355/356 fails because of the 0 size passed into `vkMapMemory`

```
[Window][Debug##Default]
Pos=60,60
Size=400,400
Collapsed=0

[Window][Hello, world!]
Pos=45,56
Size=345,169
Collapsed=0

[Window][Dear ImGui Demo]
Pos=516,129
Size=550,680
Collapsed=0
```