### PR TITLE
Docking: Fix DockBuilderRemoveNode() may cause read access violation. (#3111)

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -14183,6 +14183,12 @@ void ImGui::DockBuilderRemoveNode(ImGuiID node_id)
         return;
     DockBuilderRemoveNodeDockedWindows(node_id, true);
     DockBuilderRemoveNodeChildNodes(node_id);
+
+    // Check is node_id still available (#3111)
+    node = DockContextFindNodeByID(ctx, node_id);
+    if (node == NULL)
+        return;
+
     if (node->IsCentralNode() && node->ParentNode)
         node->ParentNode->LocalFlags |= ImGuiDockNodeFlags_CentralNode;
     DockContextRemoveNode(ctx, node, true);


### PR DESCRIPTION
This PR fixes the issue #3111.

Added NULL check for node before accessing ParentNode in DockBuilderRemoveNode(), as @ocornut suggested in #3111. (https://github.com/ocornut/imgui/issues/3111#issuecomment-611485445)