### PR TITLE
Allow window size constraints to be applied to only the minimum or maximum sizes...

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -4928,8 +4928,10 @@ static ImVec2 CalcWindowSizeAfterConstraint(ImGuiWindow* window, ImVec2 new_size
     {
         // Using -1,-1 on either X/Y axis to preserve the current size.
         ImRect cr = g.NextWindowData.SizeConstraintRect;
-        new_size.x = (cr.Min.x >= 0 && cr.Max.x >= 0) ? ImClamp(new_size.x, cr.Min.x, cr.Max.x) : window->SizeFull.x;
-        new_size.y = (cr.Min.y >= 0 && cr.Max.y >= 0) ? ImClamp(new_size.y, cr.Min.y, cr.Max.y) : window->SizeFull.y;
+        new_size.x = cr.Min.x >= 0 ? ImMax(new_size.x, cr.Min.x) : window->SizeFull.x;
+        new_size.y = cr.Min.y >= 0 ? ImMax(new_size.y, cr.Min.y) : window->SizeFull.y;
+        new_size.x = cr.Max.x >= 0 ? ImMin(new_size.x, cr.Max.x) : new_size.x;
+        new_size.y = cr.Max.y >= 0 ? ImMin(new_size.y, cr.Max.y) : new_size.y;
         if (g.NextWindowData.SizeCallback)
         {
             ImGuiSizeCallbackData data;


### PR DESCRIPTION
... without using unintuitive arguments.

This change is related to the function 
`void SetNextWindowSizeConstraints(const ImVec2& size_min, const ImVec2& size_max, ImGuiSizeCallback custom_callback = NULL, void* custom_callback_data = NULL);`

The comment on that function reads
`// set next window size limits. use -1,-1 on either X/Y axis to preserve the current size. Sizes will be rounded down. Use callback to apply non-trivial programmatic constraints.`

Intuitively, I would think this means I could do something like `SetNextWindowSizeConstraints(ImVec2(500, -1), ImVec2(-1, -1))` if I wanted to have a window that could never be less than 500 pixels wide, but was otherwise unrestricted in its sizing. In practice, this call will do nothing, since *both* the minimum and maximum for a given dimension must be >= 0.

If I actually wanted the minimum size to be 500 pixels with no restriction on maximum size, I'd have to do something like `SetNextWindowSizeConstraints(ImVec2(500, -1), ImVec2(INFINITY, -1))` which seems unintuitive to me.

This change allows using the API like the first example. 

Potentially related question: What is the passed-in value of `new_size` to `CalcWindowSizeAfterConstraint` intended to be, compared to `window->SizeFull`? This PR attempts to keep the same behavior as the existing code, but I would think that the false condition of the ternary should be `new_size` instead of `window->SizeFull`.