### PR TITLE
Fix imgui_impl_opengl3 on MacOS

### DIFF
--- a/examples/imgui_impl_opengl3.cpp
+++ b/examples/imgui_impl_opengl3.cpp
@@ -184,6 +184,9 @@ bool    ImGui_ImplOpenGL3_Init(const char* glsl_version)
 #elif defined(IMGUI_IMPL_OPENGL_ES3)
     if (glsl_version == NULL)
         glsl_version = "#version 300 es";
+#elif defined(__APPLE__)
+    if (glsl_version == NULL)
+        glsl_version = "#version 330";
 #else
     if (glsl_version == NULL)
         glsl_version = "#version 130";

--- a/examples/imgui_impl_opengl3.cpp
+++ b/examples/imgui_impl_opengl3.cpp
@@ -186,7 +186,7 @@ bool    ImGui_ImplOpenGL3_Init(const char* glsl_version)
         glsl_version = "#version 300 es";
 #elif defined(__APPLE__)
     if (glsl_version == NULL)
-        glsl_version = "#version 330";
+        glsl_version = "#version 150";
 #else
     if (glsl_version == NULL)
         glsl_version = "#version 130";


### PR DESCRIPTION
GLSL version '130' is not supported on MacOS.

Output without this patch:
```
ERROR: ImGui_ImplOpenGL3_CreateDeviceObjects: failed to compile vertex shader!
ERROR: 0:1: '' :  version '130' is not supported
ERROR: 0:2: '' :  #version required and missing.

ERROR: ImGui_ImplOpenGL3_CreateDeviceObjects: failed to compile fragment shader!
ERROR: 0:1: '' :  version '130' is not supported
ERROR: 0:2: '' :  #version required and missing.

ERROR: ImGui_ImplOpenGL3_CreateDeviceObjects: failed to link shader program! (with GLSL '#version 130
')
ERROR: One or more attached shaders not successfully compiled
```