### PR TITLE
Add a CMakeLists.txt for the example_emscipten example

### DIFF
--- a/examples/example_emscripten/CMakeLists.txt
+++ b/examples/example_emscripten/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.0)
+project(example_emscripten)
+
+find_package(OpenGL REQUIRED)
+find_package(Threads REQUIRED)
+
+set(IMGUI_SRCS imgui/imgui.cpp
+    ../../imgui_demo.cpp 
+    ../../imgui_draw.cpp 
+    ../../imgui_widgets.cpp
+    ../imgui_impl_sdl.cpp
+    ../imgui_impl_opengl3.cpp
+    )
+
+set(INCS ${CMAKE_CURRENT_LIST_DIR} 
+    ../..
+    ..
+    )
+
+set(LIBS ${OPENGL_opengl_LIBRARY} 
+    ${OPENGL_glx_LIBRARY}
+    ${CMAKE_DL_LIBS}
+    SDL2-mt
+    Threads::Threads
+    )
+
+set(PROJ_SRCS main.cpp)
+
+add_executable(${PROJECT_NAME} ${PROJ_SRCS} ${IMGUI_SRCS})
+
+set_target_properties(${PROJECT_NAME} PROPERTIES 
+    SUFFIX .html 
+    COMPILE_FLAGS "-DEMSCRIPTEN -s USE_SDL=2" 
+    LINK_FLAGS 
+        "-s WASM=1 -s USE_PTHREADS=1 -s ALLOW_MEMORY_GROWTH=1 -s DISABLE_EXCEPTION_CATCHING=1 -s NO_EXIT_RUNTIME=0 -s ASSERTIONS=1 -Wl,--shared-memory,--no-check-features"
+    )
+
+target_include_directories(${PROJECT_NAME} PUBLIC ${INCS})
+
+target_link_libraries(${PROJECT_NAME} PUBLIC ${LIBS})

--- a/examples/example_emscripten/CMakeLists.txt
+++ b/examples/example_emscripten/CMakeLists.txt
@@ -4,7 +4,7 @@ project(example_emscripten)
 find_package(OpenGL REQUIRED)
 find_package(Threads REQUIRED)
 
-set(IMGUI_SRCS imgui/imgui.cpp
+set(IMGUI_SRCS ../../imgui.cpp
     ../../imgui_demo.cpp 
     ../../imgui_draw.cpp 
     ../../imgui_widgets.cpp

--- a/examples/example_emscripten/README.md
+++ b/examples/example_emscripten/README.md
@@ -10,3 +10,12 @@
 - Note that Emscripten 1.39.0 (October 2019) obsoleted the `BINARYEN_TRAP_MODE=clamp` compilation flag which was required with version older than 1.39.0 to avoid rendering artefacts. See [#2877](https://github.com/ocornut/imgui/issues/2877) for details. If you use an older version, uncomment this line in the Makefile:
 
 `#EMS += -s BINARYEN_TRAP_MODE=clamp`
+
+## How to build using CMake
+- As above, you need to install the Emscripten toolchain.
+
+- Then build using emcmake which is distributed by the Emscripten toolchain.
+```
+emcmake cmake -B bin
+cmake --build bin
+```


### PR DESCRIPTION
Hello

Since many projects use CMake and emscripten provides both emcmake and a cmake toolchain file, I thought it might be useful to provide a CMakeLists.txt example for use with emscripten.
