### PR TITLE
Request monitor update when dpi awarness is enabled

### DIFF
--- a/examples/imgui_impl_win32.cpp
+++ b/examples/imgui_impl_win32.cpp
@@ -473,6 +473,9 @@ typedef DPI_AWARENESS_CONTEXT(WINAPI* PFN_SetThreadDpiAwarenessContext)(DPI_AWAR
 // Helper function to enable DPI awareness without setting up a manifest
 void ImGui_ImplWin32_EnableDpiAwareness()
 {
+    // Make sure monitors are up to date with the correct scaling
+    g_WantUpdateMonitors = true;
+
     // if (IsWindows10OrGreater()) // This needs a manifest to succeed. Instead we try to grab the function pointer!
     {
         static HINSTANCE user32_dll = ::LoadLibraryA("user32.dll"); // Reference counted per-process


### PR DESCRIPTION
I noticed that my windows were increasing in size when I dragged them out of the main application. The issue what that I was calling ``ImGui_ImplWin32_EnableDpiAwareness`` after ``ImGui_ImplWin32_Init``. While the easy solution is to just call it first (which I do now), this seemed like a good way to make the function just act as expected without having to issue and error or assert or otherwise notify users of the problem.