### PR TITLE
UpdateMouseWheel now gives the axis with the dominant movement preced…

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -3593,7 +3593,7 @@ void ImGui::UpdateMouseWheel()
     // If a child window has the ImGuiWindowFlags_NoScrollWithMouse flag, we give a chance to scroll its parent
 
     // Vertical Mouse Wheel scrolling
-    const float wheel_y = (g.IO.MouseWheel != 0.0f && !g.IO.KeyShift) ? g.IO.MouseWheel : 0.0f;
+    const float wheel_y = (g.IO.MouseWheel != 0.0f && ImFabs(g.IO.MouseWheelH) < ImFabs(g.IO.MouseWheel) && !g.IO.KeyShift) ? g.IO.MouseWheel : 0.0f;
     if (wheel_y != 0.0f && !g.IO.KeyCtrl)
     {
         StartLockWheelingWindow(window);


### PR DESCRIPTION
When using a touchpad gesture to perform mouse wheel scrolling, it is almost impossible to do horizontal scrolling as movement axes are not cleanly separated as for real mouse wheels. So for most of the horizontal movements `g.IO.MouseWheel != 0.0f` is still valid, and this leads to a marginal Y movement "capturing" the event and without a current window that is Y-scrollable the window will be replaced with its parent possibly up to the root. This leads to scrolling only sometimes erratically happening, when the user manages to do a straight x-only movement giving a sticky feeling.

This suggestion adds a small test for the axis of major movement and skips the vertical mouse wheel scrolling block in case of dominant X axis movement. The result is, that now in the demo window horizontal scrolling with touchpad gestures works as expected (e.g. in the "Fizz Buzz" scroller).