### PR TITLE
[vulkan] Allow the user to specify custom Vulkan proc addresses.

### DIFF
--- a/examples/imgui_impl_vulkan.h
+++ b/examples/imgui_impl_vulkan.h
@@ -40,6 +40,8 @@ struct ImGui_ImplVulkan_InitInfo
     VkSampleCountFlagBits        MSAASamples;   // >= VK_SAMPLE_COUNT_1_BIT
     const VkAllocationCallbacks* Allocator;
     void                (*CheckVkResultFn)(VkResult err);
+    // Optional. When nullptr and VK_NO_PROTOTYPES undefined, procs will be resolved statically.
+    PFN_vkVoidFunction  (*GetVulkanProcAddressFn)(const char* proc_name);
 };
 
 // Called by user code


### PR DESCRIPTION
Some Vulkan applications don't link against libVulkan. Instead, proc addresses
for Vulkan functions are resolved dynamically at runtime. When this is done, all
translation units are compiled with `VK_NO_PROTOTYPES` defined somewhere and each
Vulkan API callsite looking at a dispatch table. This scheme was incompatible
with the working of imgui_impl_vulkan as specifying `VK_NO_PROTOTYPES` would cause
compile failures. Now specifying
`ImGui_ImplVulkan_InitInfo::GetVulkanProcAddressFn` will delegate proc address
resolution responsibilities to the caller. If the caller does not specify this
callback and has not compiled the imgui_impl_vulkan.cpp translation unit with
`VK_NO_PROTOTYPES`, the proc address table is populated with static addresses as
before. So existing users should not have to change anything.