### PR TITLE
Fix typo in TempInputScalar that causes AddressSanitizer to report a "stack-buffer-overflow"

### DIFF
--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -2970,7 +2970,7 @@ bool ImGui::TempInputScalar(const ImRect& bb, ImGuiID id, const char* label, ImG
             DataTypeClamp(data_type, p_data, p_clamp_min, p_clamp_max);
 
         // Only mark as edited if new value is different
-        value_changed = memcmp(&data_type, p_data, data_type_size) != 0;
+        value_changed = memcmp(&data_backup, p_data, data_type_size) != 0;
         if (value_changed)
             MarkItemEdited(id);
     }


### PR DESCRIPTION
I pulled the latest code today, and my `DragScalar` and `SliderScalar` scalar calls with `double` values suddenly cause a crash when I type in a value. I used `git bisect` to find that the commit with the error is 0679e0567764d5b3362628bdf1e75c608b2a1b8b.