### PR TITLE
VtxOffset offset related fix (fixes blown up triangles on the screen)

### DIFF
--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -462,7 +462,13 @@ void ImDrawList::UpdateClipRect()
     // Try to merge with previous command if it matches, else use current command
     ImDrawCmd* prev_cmd = CmdBuffer.Size > 1 ? curr_cmd - 1 : NULL;
     if (curr_cmd->ElemCount == 0 && prev_cmd && memcmp(&prev_cmd->ClipRect, &curr_clip_rect, sizeof(ImVec4)) == 0 && prev_cmd->TextureId == GetCurrentTextureId() && prev_cmd->UserCallback == NULL)
-        CmdBuffer.pop_back();
+    {       
+       CmdBuffer.pop_back();
+
+       //The command being popped may have triggered VtxOffset update (and _VtxCurrentIdx reset - see above AddDrawCmd), restore it here to avoid triangle mess on the screen
+       _VtxCurrentOffset = prev_cmd->VtxOffset;
+       _VtxCurrentIdx = VtxBuffer.size() - prev_cmd->VtxOffset;
+    }
     else
         curr_cmd->ClipRect = curr_clip_rect;
 }

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -463,11 +463,11 @@ void ImDrawList::UpdateClipRect()
     ImDrawCmd* prev_cmd = CmdBuffer.Size > 1 ? curr_cmd - 1 : NULL;
     if (curr_cmd->ElemCount == 0 && prev_cmd && memcmp(&prev_cmd->ClipRect, &curr_clip_rect, sizeof(ImVec4)) == 0 && prev_cmd->TextureId == GetCurrentTextureId() && prev_cmd->UserCallback == NULL)
     {       
-       CmdBuffer.pop_back();
+        CmdBuffer.pop_back();
 
-       //The command being popped may have triggered VtxOffset update (and _VtxCurrentIdx reset - see above AddDrawCmd), restore it here to avoid triangle mess on the screen
-       _VtxCurrentOffset = prev_cmd->VtxOffset;
-       _VtxCurrentIdx = VtxBuffer.size() - prev_cmd->VtxOffset;
+        //The command being popped may have triggered VtxOffset update (and _VtxCurrentIdx reset - see above AddDrawCmd), restore it here to avoid triangle mess on the screen
+        _VtxCurrentOffset = prev_cmd->VtxOffset;
+        _VtxCurrentIdx = VtxBuffer.size() - prev_cmd->VtxOffset;
     }
     else
         curr_cmd->ClipRect = curr_clip_rect;

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -470,7 +470,9 @@ void ImDrawList::UpdateClipRect()
         _VtxCurrentIdx = VtxBuffer.size() - prev_cmd->VtxOffset;
     }
     else
+    {
         curr_cmd->ClipRect = curr_clip_rect;
+    }
 }
 
 void ImDrawList::UpdateTextureID()


### PR DESCRIPTION
It is possible to get VtxCurrentOffset and VtxCurrentIdx out of sync with buffers state. This scenario triggers it: Do PrimReserve , which thinks you are reserving too many vertices and triggers new draw command and vtxoffset update. Then you do unreserve same amount (leaving emptry draw command). Next clip rect update this draw command gets poped but does not restore vtx/idx buffer offset, resulting all following draw commands reference incorrect vertex data