### PR TITLE
Cleanup OpenGL 3 loader detection

### DIFF
--- a/examples/imgui_impl_opengl3.cpp
+++ b/examples/imgui_impl_opengl3.cpp
@@ -79,27 +79,7 @@
 #else
 #include <stdint.h>     // intptr_t
 #endif
-#if defined(__APPLE__)
-#include "TargetConditionals.h"
-#endif
 
-// Auto-enable GLES on matching platforms
-#if !defined(IMGUI_IMPL_OPENGL_ES2) && !defined(IMGUI_IMPL_OPENGL_ES3)
-#if (defined(__APPLE__) && (TARGET_OS_IOS || TARGET_OS_TV)) || (defined(__ANDROID__))
-#define IMGUI_IMPL_OPENGL_ES3           // iOS, Android  -> GL ES 3, "#version 300 es"
-#elif defined(__EMSCRIPTEN__)
-#define IMGUI_IMPL_OPENGL_ES2           // Emscripten    -> GL ES 2, "#version 100"
-#endif
-#endif
-
-#if defined(IMGUI_IMPL_OPENGL_ES2) || defined(IMGUI_IMPL_OPENGL_ES3)
-#undef IMGUI_IMPL_OPENGL_LOADER_GL3W
-#undef IMGUI_IMPL_OPENGL_LOADER_GLEW
-#undef IMGUI_IMPL_OPENGL_LOADER_GLAD
-#undef IMGUI_IMPL_OPENGL_LOADER_GLBINDING2
-#undef IMGUI_IMPL_OPENGL_LOADER_GLBINDING3
-#undef IMGUI_IMPL_OPENGL_LOADER_CUSTOM
-#endif
 
 // GL includes
 #if defined(IMGUI_IMPL_OPENGL_ES2)

--- a/examples/imgui_impl_opengl3.h
+++ b/examples/imgui_impl_opengl3.h
@@ -14,7 +14,19 @@
 // About Desktop OpenGL function loaders:
 //  Modern desktop OpenGL doesn't have a standard portable header file to load OpenGL function pointers.
 //  Helper libraries are often used for this purpose! Here we are supporting a few common ones (gl3w, glew, glad).
-//  You may use another loader/header of your choice (glext, glLoadGen, etc.), or chose to manually implement your own.
+//  We will attempt to detect default GL loader based on available header files. See the imgui_impl_opengl3.cpp for details.
+//  If auto-detection fails or doesn't select the same GL loader file as used by your application,
+//  you are likely to get a crash in ImGui_ImplOpenGL3_Init().
+//  You can explicitly select a loader by using '#define IMGUI_IMPL_OPENGL_LOADER_XXX' in imconfig.h or compiler command-line.
+//    #define IMGUI_IMPL_OPENGL_LOADER_GL3W
+//    #define IMGUI_IMPL_OPENGL_LOADER_GLEW
+//    #define IMGUI_IMPL_OPENGL_LOADER_GLAD
+//    #define IMGUI_IMPL_OPENGL_LOADER_GLBINDING2
+//    #define IMGUI_IMPL_OPENGL_LOADER_GLBINDING3
+//    #define IMGUI_IMPL_OPENGL_LOADER_CUSTOM
+//  Or you can select select specific Embedded OpenGL versions:
+//    #define IMGUI_IMPL_OPENGL_ES2     // Auto-detected on Emscripten
+//    #define IMGUI_IMPL_OPENGL_ES3     // Auto-detected on iOS/Android
 
 // About GLSL version:
 //  The 'glsl_version' initialization parameter should be NULL (default) or a "#version XXX" string.
@@ -36,21 +48,30 @@ IMGUI_IMPL_API void     ImGui_ImplOpenGL3_DestroyFontsTexture();
 IMGUI_IMPL_API bool     ImGui_ImplOpenGL3_CreateDeviceObjects();
 IMGUI_IMPL_API void     ImGui_ImplOpenGL3_DestroyDeviceObjects();
 
-// Specific OpenGL versions
-//#define IMGUI_IMPL_OPENGL_ES2     // Auto-detected on Emscripten
-//#define IMGUI_IMPL_OPENGL_ES3     // Auto-detected on iOS/Android
-
-// Desktop OpenGL: attempt to detect default GL loader based on available header files.
+// Attempt to auto-detect the default GL loader based on available header files.
 // If auto-detection fails or doesn't select the same GL loader file as used by your application,
 // you are likely to get a crash in ImGui_ImplOpenGL3_Init().
-// You can explicitly select a loader by using '#define IMGUI_IMPL_OPENGL_LOADER_XXX' in imconfig.h or compiler command-line.
+// You can explicitly select a loader by using '#define IMGUI_IMPL_OPENGL_LOADER_XXX'
+// or '#define IMGUI_IMPL_OPENGL_ESX' in imconfig.h or compiler command-line.
 #if !defined(IMGUI_IMPL_OPENGL_LOADER_GL3W) \
  && !defined(IMGUI_IMPL_OPENGL_LOADER_GLEW) \
  && !defined(IMGUI_IMPL_OPENGL_LOADER_GLAD) \
  && !defined(IMGUI_IMPL_OPENGL_LOADER_GLBINDING2) \
  && !defined(IMGUI_IMPL_OPENGL_LOADER_GLBINDING3) \
- && !defined(IMGUI_IMPL_OPENGL_LOADER_CUSTOM)
-    #if defined(__has_include)
+ && !defined(IMGUI_IMPL_OPENGL_LOADER_CUSTOM) \
+ && !defined(IMGUI_IMPL_OPENGL_ES2) \
+ && !defined(IMGUI_IMPL_OPENGL_ES3)
+    #if defined(__APPLE__)
+    #include "TargetConditionals.h"
+    #endif
+
+    // Auto-enable GLES on matching platforms
+    #if (defined(__APPLE__) && (TARGET_OS_IOS || TARGET_OS_TV)) || (defined(__ANDROID__))
+    #define IMGUI_IMPL_OPENGL_ES3           // iOS, Android  -> GL ES 3, "#version 300 es"
+    #elif defined(__EMSCRIPTEN__)
+    #define IMGUI_IMPL_OPENGL_ES2           // Emscripten    -> GL ES 2, "#version 100"
+    #elif defined(__has_include)
+        // Desktop OpenGL
         #if __has_include(<GL/glew.h>)
             #define IMGUI_IMPL_OPENGL_LOADER_GLEW
         #elif __has_include(<glad/glad.h>)
@@ -68,4 +89,3 @@ IMGUI_IMPL_API void     ImGui_ImplOpenGL3_DestroyDeviceObjects();
         #define IMGUI_IMPL_OPENGL_LOADER_GL3W       // Default to GL3W
     #endif
 #endif
-


### PR DESCRIPTION
OpenGL 3 backend header has some logic to auto-detect the GL loader, however that is only necessary for the implementation in the cpp, not in the header. This change moves the code from the header to the cpp. This avoids unnecessary global macro pollution as well as potential for mistakes since previously `IMGUI_IMPL_OPENGL_LOADER_*` and `IMGUI_IMPL_OPENGL_*` would have to have consistent values every time `imgui_impl_opengl3.h` was included.
