### PR TITLE
Move visual studio 'Fix Projects' step to standalone script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,16 +30,7 @@ jobs:
 
       - name: Fix Projects
         shell: powershell
-        run: |
-          # WARNING: This will need updating if toolset/sdk change in project files!
-          gci -recurse -filter "*.vcxproj" | ForEach-Object {
-            # Fix SDK and toolset for most samples.
-            (Get-Content $_.FullName) -Replace "<PlatformToolset>v110</PlatformToolset>","<PlatformToolset>v142</PlatformToolset>" | Set-Content -Path $_.FullName
-            (Get-Content $_.FullName) -Replace "<WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>","<WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>" | Set-Content -Path $_.FullName
-            # Fix SDK and toolset for samples that require newer SDK/toolset. At the moment it is only dx12.
-            (Get-Content $_.FullName) -Replace "<PlatformToolset>v140</PlatformToolset>","<PlatformToolset>v142</PlatformToolset>" | Set-Content -Path $_.FullName
-            (Get-Content $_.FullName) -Replace "<WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>","<WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>" | Set-Content -Path $_.FullName
-          }
+        run: misc/scripts/update-toolset.ps1
 
       # Not using matrix here because it would inflate job count too much. Check out and setup is done for every job and that makes build times way too long.
       - name: Build example_null (extra warnings, mingw 64-bit)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Fix Projects
         shell: powershell
-        run: misc/scripts/update-toolset.ps1
+        run: misc/scripts/update-toolset.ps1 v142 10.0.18362.0
 
       # Not using matrix here because it would inflate job count too much. Check out and setup is done for every job and that makes build times way too long.
       - name: Build example_null (extra warnings, mingw 64-bit)

--- a/misc/scripts/update-toolset.ps1
+++ b/misc/scripts/update-toolset.ps1
@@ -1,0 +1,9 @@
+# WARNING: This will need updating if toolset/sdk change in project files!
+gci -recurse -filter "*.vcxproj" | ForEach-Object {
+    # Fix SDK and toolset for most samples.
+    (Get-Content $_.FullName) -Replace "<PlatformToolset>v110</PlatformToolset>","<PlatformToolset>v142</PlatformToolset>" | Set-Content -Path $_.FullName
+    (Get-Content $_.FullName) -Replace "<WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>","<WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>" | Set-Content -Path $_.FullName
+    # Fix SDK and toolset for samples that require newer SDK/toolset. At the moment it is only dx12.
+    (Get-Content $_.FullName) -Replace "<PlatformToolset>v140</PlatformToolset>","<PlatformToolset>v142</PlatformToolset>" | Set-Content -Path $_.FullName
+    (Get-Content $_.FullName) -Replace "<WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>","<WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>" | Set-Content -Path $_.FullName
+}

--- a/misc/scripts/update-toolset.ps1
+++ b/misc/scripts/update-toolset.ps1
@@ -1,9 +1,9 @@
-# WARNING: This will need updating if toolset/sdk change in project files!
+
+$platformtoolset=$args[0]   #"v142"
+$targetplatform=$args[1]    #"10.0.18362.0"
+
 gci -recurse -filter "*.vcxproj" | ForEach-Object {
-    # Fix SDK and toolset for most samples.
-    (Get-Content $_.FullName) -Replace "<PlatformToolset>v110</PlatformToolset>","<PlatformToolset>v142</PlatformToolset>" | Set-Content -Path $_.FullName
-    (Get-Content $_.FullName) -Replace "<WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>","<WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>" | Set-Content -Path $_.FullName
-    # Fix SDK and toolset for samples that require newer SDK/toolset. At the moment it is only dx12.
-    (Get-Content $_.FullName) -Replace "<PlatformToolset>v140</PlatformToolset>","<PlatformToolset>v142</PlatformToolset>" | Set-Content -Path $_.FullName
-    (Get-Content $_.FullName) -Replace "<WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>","<WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>" | Set-Content -Path $_.FullName
+    # Fix SDK and toolset
+    (Get-Content $_.FullName) -Replace "<PlatformToolset>v\d{3}</PlatformToolset>","<PlatformToolset>$platformtoolset</PlatformToolset>" | Set-Content -Path $_.FullName
+    (Get-Content $_.FullName) -Replace "<WindowsTargetPlatformVersion>[\d\.]+</WindowsTargetPlatformVersion>","<WindowsTargetPlatformVersion>$targetplatform</WindowsTargetPlatformVersion>" | Set-Content -Path $_.FullName
 }


### PR DESCRIPTION
- Move visual studio 'Fix Projects' step to standalone script
- Simplify the script, so that it searches for a regex match instead of a hardcoded version.

The rationale behind moving it to a standalone script is that it makes it easier for people to upgrade to a specific version that is most convenient for them.