### PR TITLE
Backends: Allegro: Don't call AddInputCharacter if the pressed key has no character.

### DIFF
--- a/examples/imgui_impl_allegro5.cpp
+++ b/examples/imgui_impl_allegro5.cpp
@@ -357,7 +357,8 @@ bool ImGui_ImplAllegro5_ProcessEvent(ALLEGRO_EVENT *ev)
         return true;
     case ALLEGRO_EVENT_KEY_CHAR:
         if (ev->keyboard.display == g_Display)
-            io.AddInputCharacter((unsigned int)ev->keyboard.unichar);
+            if (ev->keyboard.unichar != 0)
+                io.AddInputCharacter((unsigned int)ev->keyboard.unichar);
         return true;
     case ALLEGRO_EVENT_KEY_DOWN:
     case ALLEGRO_EVENT_KEY_UP:


### PR DESCRIPTION
- Commit ef13d95466f27b4a955d6f95da90822001ace25f moved the logic of checking for invalid Unicode codes from each backend to Dear ImGui's AddInputCharacter function proper.
- Commit c8ea0a017d0ea851225f159f26816d86799163a8 then removed that logic, replacing it with something that inserts a question mark-like character in the case of an invalid Unicode code.
- As a result, after these two commits, if an Allegro keypress has no associated character (arrow keys, End, Page Up, etc.), it will send zero with nobody to filter it out.
- With this fix, no-character inputs won't even call AddInputCharacter to begin with.
- Tested with arrow keys, Page Up, etc., tested with regular character keys, and tested with some Unicode symbols directly from the keyboard, like €.