### PR TITLE
example_apple: catch events from the right and other mouse buttons.

### DIFF
--- a/examples/example_apple_metal/Shared/ViewController.mm
+++ b/examples/example_apple_metal/Shared/ViewController.mm
@@ -72,11 +72,35 @@
     ImGui_ImplOSX_HandleEvent(event, self.view);
 }
 
+- (void)rightMouseDown:(NSEvent *)event {
+    ImGui_ImplOSX_HandleEvent(event, self.view);
+}
+
+- (void)otherMouseDown:(NSEvent *)event {
+    ImGui_ImplOSX_HandleEvent(event, self.view);
+}
+
 - (void)mouseUp:(NSEvent *)event {
     ImGui_ImplOSX_HandleEvent(event, self.view);
 }
 
+- (void)rightMouseUp:(NSEvent *)event {
+    ImGui_ImplOSX_HandleEvent(event, self.view);
+}
+
+- (void)otherMouseUp:(NSEvent *)event {
+    ImGui_ImplOSX_HandleEvent(event, self.view);
+}
+
 - (void)mouseDragged:(NSEvent *)event {
+    ImGui_ImplOSX_HandleEvent(event, self.view);
+}
+
+- (void)rightMouseDragged:(NSEvent *)event {
+    ImGui_ImplOSX_HandleEvent(event, self.view);
+}
+
+- (void)otherMouseDragged:(NSEvent *)event {
     ImGui_ImplOSX_HandleEvent(event, self.view);
 }
 

--- a/examples/example_apple_opengl2/main.mm
+++ b/examples/example_apple_opengl2/main.mm
@@ -139,14 +139,22 @@
 }
 
 // Forward Mouse/Keyboard events to dear imgui OSX back-end. It returns true when imgui is expecting to use the event.
--(void)keyUp:(NSEvent *)event           { ImGui_ImplOSX_HandleEvent(event, self); }
--(void)keyDown:(NSEvent *)event         { ImGui_ImplOSX_HandleEvent(event, self); }
--(void)flagsChanged:(NSEvent *)event    { ImGui_ImplOSX_HandleEvent(event, self); }
--(void)mouseDown:(NSEvent *)event       { ImGui_ImplOSX_HandleEvent(event, self); }
--(void)mouseUp:(NSEvent *)event         { ImGui_ImplOSX_HandleEvent(event, self); }
--(void)mouseMoved:(NSEvent *)event      { ImGui_ImplOSX_HandleEvent(event, self); }
--(void)mouseDragged:(NSEvent *)event    { ImGui_ImplOSX_HandleEvent(event, self); }
--(void)scrollWheel:(NSEvent *)event     { ImGui_ImplOSX_HandleEvent(event, self); }
+-(void)keyUp:(NSEvent *)event               { ImGui_ImplOSX_HandleEvent(event, self); }
+-(void)keyDown:(NSEvent *)event             { ImGui_ImplOSX_HandleEvent(event, self); }
+-(void)flagsChanged:(NSEvent *)event        { ImGui_ImplOSX_HandleEvent(event, self); }
+-(void)mouseDown:(NSEvent *)event           { ImGui_ImplOSX_HandleEvent(event, self); }
+-(void)rightMouseDown:(NSEvent *)event      { ImGui_ImplOSX_HandleEvent(event, self); }
+-(void)otherMouseDown:(NSEvent *)event      { ImGui_ImplOSX_HandleEvent(event, self); }
+-(void)mouseUp:(NSEvent *)event             { ImGui_ImplOSX_HandleEvent(event, self); }
+-(void)rightMouseUp:(NSEvent *)event        { ImGui_ImplOSX_HandleEvent(event, self); }
+-(void)otherMouseUp:(NSEvent *)event        { ImGui_ImplOSX_HandleEvent(event, self); }
+-(void)mouseMoved:(NSEvent *)event          { ImGui_ImplOSX_HandleEvent(event, self); }
+-(void)rightMouseMoved:(NSEvent *)event     { ImGui_ImplOSX_HandleEvent(event, self); }
+-(void)otherMouseMoved:(NSEvent *)event     { ImGui_ImplOSX_HandleEvent(event, self); }
+-(void)mouseDragged:(NSEvent *)event        { ImGui_ImplOSX_HandleEvent(event, self); }
+-(void)rightMouseDragged:(NSEvent *)event   { ImGui_ImplOSX_HandleEvent(event, self); }
+-(void)otherMouseDragged:(NSEvent *)event   { ImGui_ImplOSX_HandleEvent(event, self); }
+-(void)scrollWheel:(NSEvent *)event         { ImGui_ImplOSX_HandleEvent(event, self); }
 
 @end
 


### PR DESCRIPTION
The macOS examples example_apple_metal and example_apple_opengl2 do not catch the `right` and `other` mouse buttons.

As a consequence the Dear ImGui Demo does not work properly, for example the `Popups & Modal Windows / Context Menus` does not work as it requires a right click.

Note: the glfw examples are fine on macOS, so this PR only fixes the Cocoa-based examples.