### PR TITLE
imgui_impl_osx.mm: import the glfw workaround to avoid missing mouse clicks.

### DIFF
--- a/examples/imgui_impl_osx.mm
+++ b/examples/imgui_impl_osx.mm
@@ -14,6 +14,7 @@
 
 // CHANGELOG
 // (minor and older changes stripped away, please see git history for details)
+//  2020-05-25: Inputs: Added a fix for missing trackpad clicks when done with "soft tap".
 //  2019-12-05: Inputs: Added support for ImGuiMouseCursor_NotAllowed mouse cursor.
 //  2019-10-11: Inputs:  Fix using Backspace key.
 //  2019-07-21: Re-added clipboard handlers as they are not enabled by default in core imgui.cpp (reverted 2019-05-18 change).
@@ -27,6 +28,8 @@
 static CFAbsoluteTime g_Time = 0.0;
 static NSCursor*      g_MouseCursors[ImGuiMouseCursor_COUNT] = {};
 static bool           g_MouseCursorHidden = false;
+static bool           g_MouseJustPressed[5] = { false, false, false, false, false };
+static bool           g_MouseDown[5] = { false, false, false, false, false };
 
 // Undocumented methods for creating cursors.
 @interface NSCursor()
@@ -121,9 +124,17 @@ void ImGui_ImplOSX_Shutdown()
 {
 }
 
-static void ImGui_ImplOSX_UpdateMouseCursor()
+static void ImGui_ImplOSX_UpdateMouseCursorAndButtons()
 {
     ImGuiIO& io = ImGui::GetIO();
+
+    for (int i = 0; i < IM_ARRAYSIZE(io.MouseDown) && i < IM_ARRAYSIZE(g_MouseJustPressed); i++)
+    {
+        // If a mouse press event came, always pass it as "mouse held this frame", so we don't miss click-release events that are shorter than 1 frame.
+        io.MouseDown[i] = g_MouseJustPressed[i] || g_MouseDown[i];
+        g_MouseJustPressed[i] = false;
+    }
+
     if (io.ConfigFlags & ImGuiConfigFlags_NoMouseCursorChange)
         return;
 
@@ -167,7 +178,7 @@ void ImGui_ImplOSX_NewFrame(NSView* view)
     io.DeltaTime = current_time - g_Time;
     g_Time = current_time;
 
-    ImGui_ImplOSX_UpdateMouseCursor();
+    ImGui_ImplOSX_UpdateMouseCursorAndButtons();
 }
 
 static int mapCharacterToKey(int c)
@@ -197,16 +208,19 @@ bool ImGui_ImplOSX_HandleEvent(NSEvent* event, NSView* view)
     if (event.type == NSEventTypeLeftMouseDown || event.type == NSEventTypeRightMouseDown || event.type == NSEventTypeOtherMouseDown)
     {
         int button = (int)[event buttonNumber];
-        if (button >= 0 && button < IM_ARRAYSIZE(io.MouseDown))
-            io.MouseDown[button] = true;
+        if (button >= 0 && button < IM_ARRAYSIZE(g_MouseJustPressed))
+        {
+            g_MouseJustPressed[button] = true;
+            g_MouseDown[button] = true;
+        }
         return io.WantCaptureMouse;
     }
 
     if (event.type == NSEventTypeLeftMouseUp || event.type == NSEventTypeRightMouseUp || event.type == NSEventTypeOtherMouseUp)
     {
         int button = (int)[event buttonNumber];
-        if (button >= 0 && button < IM_ARRAYSIZE(io.MouseDown))
-            io.MouseDown[button] = false;
+        if (button >= 0 && button < IM_ARRAYSIZE(g_MouseDown))
+            g_MouseDown[button] = false;
         return io.WantCaptureMouse;
     }
 


### PR DESCRIPTION
This PR addresses the "missing clicks" issue on mac, which happens very easily with the trackpad when using the soft click feature (it generates very quick Press/Release events that often do not span over two frames).

It was also reported in https://github.com/ocornut/imgui/issues/1992 . The ideal solution requires a refactoring to add event queues, but a simple workaround was suggested by just following the GLFW example, this is the approach I took here. It is slightly different because it does not rely on an API call to get the instant mouse state, but instead maintains the freshest mouseDown state locally with `g_MouseDown`, and only forwards it to `ImGuiIO` when there was no press during that same frame.

I found that another more general fix was proposed in https://github.com/ocornut/imgui/pull/2525 , but since there is already an event queue design in the pipe, it might make sense to just merge the quick fix for macOS for now?
