### PR TITLE
Unrounded font size / Avoid floating point rounding error

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -5596,7 +5596,7 @@ static inline void ClampWindowRect(ImGuiWindow* window, const ImRect& rect, cons
 {
     ImGuiContext& g = *GImGui;
     ImVec2 size_for_clamping = (g.IO.ConfigWindowsMoveFromTitleBarOnly && !(window->Flags & ImGuiWindowFlags_NoTitleBar)) ? ImVec2(window->Size.x, window->TitleBarHeight()) : window->Size;
-    window->Pos = ImMin(rect.Max - padding, ImMax(window->Pos + size_for_clamping, rect.Min + padding) - size_for_clamping);
+    window->Pos = ImMin(rect.Max - padding, ImMax(window->Pos, rect.Min + padding - size_for_clamping));
 }
 
 static void ImGui::RenderWindowOuterBorders(ImGuiWindow* window)


### PR DESCRIPTION
Platform: Win32, DX11
Branch: docking

I had a problem that popup modals were sometimes drifting upwards on their own, exactly 1 pixel per frame. This also happened in the "Delete?" sample modal in the demo window.

I added a breakpoint to window->Pos and saw that inside ClampWindowRect, `Pos.y` went from 472.0 -> 471.999969, and later in the code this got floored to 471.0.

Avoiding unnecessary (a+b)-b calculation fixes the problem for me.