### PR TITLE
FreeType: enable colored-glyphs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,7 +180,7 @@ jobs:
         run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_win32_directx12/example_win32_directx12.vcxproj /p:Platform=x64 /p:Configuration=Release'
 
   Linux:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v1
       with:

--- a/misc/freetype/imgui_freetype.cpp
+++ b/misc/freetype/imgui_freetype.cpp
@@ -289,9 +289,9 @@ namespace
                     {
                         for (uint32_t x = 0; x < w; x++)
                             dst[x] = IM_COL32(
-                                src[x * 4],
-                                src[x * 4 + 1],
                                 src[x * 4 + 2],
+                                src[x * 4 + 1],
+                                src[x * 4],
                                 src[x * 4 + 3]);
                     }
                 }
@@ -301,9 +301,9 @@ namespace
                     {
                         for (uint32_t x = 0; x < w; x++)
                             dst[x] = IM_COL32(
-                                multiply_table[src[x * 4]],
-                                multiply_table[src[x * 4 + 1]],
                                 multiply_table[src[x * 4 + 2]],
+                                multiply_table[src[x * 4 + 1]],
+                                multiply_table[src[x * 4]],
                                 multiply_table[src[x * 4 + 3]]);
                     }
                 }

--- a/misc/freetype/imgui_freetype.cpp
+++ b/misc/freetype/imgui_freetype.cpp
@@ -283,15 +283,17 @@ namespace
             }
         case FT_PIXEL_MODE_BGRA:
             {
+                #define DE_MULTIPLY(color, alpha) (ImU32)(255.0f * (float)color / (float)alpha + 0.5f)
+
                 if (multiply_table == NULL)
                 {
                     for (uint32_t y = 0; y < h; y++, src += src_pitch, dst += dst_pitch)
                     {
                         for (uint32_t x = 0; x < w; x++)
                             dst[x] = IM_COL32(
-                                src[x * 4 + 2],
-                                src[x * 4 + 1],
-                                src[x * 4],
+                                DE_MULTIPLY(src[x * 4 + 2], src[x * 4 + 3]),
+                                DE_MULTIPLY(src[x * 4 + 1], src[x * 4 + 3]),
+                                DE_MULTIPLY(src[x * 4],     src[x * 4 + 3]),
                                 src[x * 4 + 3]);
                     }
                 }
@@ -301,12 +303,14 @@ namespace
                     {
                         for (uint32_t x = 0; x < w; x++)
                             dst[x] = IM_COL32(
-                                multiply_table[src[x * 4 + 2]],
-                                multiply_table[src[x * 4 + 1]],
-                                multiply_table[src[x * 4]],
+                                multiply_table[DE_MULTIPLY(src[x * 4 + 2], src[x * 4 + 3])],
+                                multiply_table[DE_MULTIPLY(src[x * 4 + 1], src[x * 4 + 3])],
+                                multiply_table[DE_MULTIPLY(src[x * 4],     src[x * 4 + 3])],
                                 multiply_table[src[x * 4 + 3]]);
                     }
                 }
+
+                #undef DE_MULTIPLY
                 break;
             }
         default:

--- a/misc/freetype/imgui_freetype.h
+++ b/misc/freetype/imgui_freetype.h
@@ -25,7 +25,8 @@ namespace ImGuiFreeType
         MonoHinting     = 1 << 4,   // Strong hinting algorithm that should only be used for monochrome output.
         Bold            = 1 << 5,   // Styling: Should we artificially embolden the font?
         Oblique         = 1 << 6,   // Styling: Should we slant the font, emulating italic style?
-        Monochrome      = 1 << 7    // Disable anti-aliasing. Combine this with MonoHinting for best results!
+        Monochrome      = 1 << 7,   // Disable anti-aliasing. Combine this with MonoHinting for best results!
+        LoadColor       = 1 << 8    // Enable FreeType color-layered glyphs
     };
 
     IMGUI_API bool BuildFontAtlas(ImFontAtlas* atlas, unsigned int extra_flags = 0);


### PR DESCRIPTION
### Why?
FreeType supports color-layered glyphs since version 2.10.0. This feature allows render scalable icons. Different emoji, for, example.
Now any can use colored glyphs as icons in ImGui applications.

### Screenshot
![Annotation 2020-07-30 132631](https://user-images.githubusercontent.com/244044/88912692-51430580-d268-11ea-972f-9c9dad6f5099.png)
