### PR TITLE
Collect input counts over one frame to avoid missing inputs within the same frame

### DIFF
--- a/examples/imgui_impl_win32.cpp
+++ b/examples/imgui_impl_win32.cpp
@@ -315,13 +315,15 @@ IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hwnd, UINT msg, WPARA
         return 0;
     case WM_KEYDOWN:
     case WM_SYSKEYDOWN:
-        if (wParam < 256)
-            io.KeysDown[wParam] = 1;
+        // Win32 sets bit 30 if the key is repeating. We handle that internally so we
+        // only want the first down.
+        if ((wParam < 256) && !(lParam & (1 << 30)))
+            io.KeysDown[wParam]++;
         return 0;
     case WM_KEYUP:
     case WM_SYSKEYUP:
         if (wParam < 256)
-            io.KeysDown[wParam] = 0;
+            io.KeysUp[wParam]++;
         return 0;
     case WM_CHAR:
         // You can also use ToAscii()+GetKeyboardState() to retrieve characters.

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -3609,7 +3609,7 @@ void ImGui::UpdateHoveredWindowAndCaptureFlags()
     {
         if (g.IO.MouseClicked[i])
             g.IO.MouseDownOwned[i] = (g.HoveredWindow != NULL) || (g.OpenPopupStack.Size > 0);
-        mouse_any_down |= g.IO.MouseDown[i];
+        mouse_any_down |= g.IO.MouseDown[i] ? true : false;
         if (g.IO.MouseDown[i])
             if (mouse_earliest_button_down == -1 || g.IO.MouseClickedTime[i] < g.IO.MouseClickedTime[mouse_earliest_button_down])
                 mouse_earliest_button_down = i;
@@ -3758,8 +3758,18 @@ void ImGui::NewFrame()
     // Synchronize io.KeyMods with individual modifiers io.KeyXXX bools
     g.IO.KeyMods = GetMergedKeyModFlags();
     memcpy(g.IO.KeysDownDurationPrev, g.IO.KeysDownDuration, sizeof(g.IO.KeysDownDuration));
-    for (int i = 0; i < IM_ARRAYSIZE(g.IO.KeysDown); i++)
-        g.IO.KeysDownDuration[i] = g.IO.KeysDown[i] ? (g.IO.KeysDownDuration[i] < 0.0f ? 0.0f : g.IO.KeysDownDuration[i] + g.IO.DeltaTime) : -1.0f;
+    for (int i = 0; i < IM_ARRAYSIZE(g.IO.KeysDown); i++) {
+        g.IO.KeysDown[i] -= g.IO.KeysUpPrev[i];
+        if(g.IO.KeysDown[i])
+            if(g.IO.KeysDownDuration[i] < 0.0f)
+                g.IO.KeysDownDuration[i] = 0.0f;
+            else
+                g.IO.KeysDownDuration[i] += g.IO.DeltaTime;
+        else
+            g.IO.KeysDownDuration[i] = -1.0f;
+    }
+    memcpy(g.IO.KeysUpPrev, g.IO.KeysUp, sizeof(g.IO.KeysUp));
+    memset(g.IO.KeysUp, 0, sizeof(g.IO.KeysUp));
 
     // Update gamepad/keyboard navigation
     NavUpdate();

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -3609,7 +3609,7 @@ void ImGui::UpdateHoveredWindowAndCaptureFlags()
     {
         if (g.IO.MouseClicked[i])
             g.IO.MouseDownOwned[i] = (g.HoveredWindow != NULL) || (g.OpenPopupStack.Size > 0);
-        mouse_any_down |= g.IO.MouseDown[i] ? true : false;
+        mouse_any_down |= g.IO.MouseDown[i];
         if (g.IO.MouseDown[i])
             if (mouse_earliest_button_down == -1 || g.IO.MouseClickedTime[i] < g.IO.MouseClickedTime[mouse_earliest_button_down])
                 mouse_earliest_button_down = i;

--- a/imgui.h
+++ b/imgui.h
@@ -1536,7 +1536,7 @@ struct ImGuiIO
     bool          KeySuper;                       // Keyboard modifier pressed: Cmd/Super/Windows
     unsigned char KeysDown[512];                  // Number of keyboard key inputs that are pressed since last frame (ideally left in the "native" order your engine has access to keyboard keys, so you can use your own defines/enums for keys).
     unsigned char KeysUp[512];                    // Number of keyboard up inputs since last frame
-    unsigned char KeysUpPrev[512];                // Number of keyboard up inputs since last frame
+    unsigned char KeysUpPrev[512];                // Number of keyboard up inputs since last frame - 1
     float         NavInputs[ImGuiNavInput_COUNT]; // Gamepad inputs. Cleared back to zero by EndFrame(). Keyboard keys will be auto-mapped and be written here by NewFrame().
 
     // Functions

--- a/imgui.h
+++ b/imgui.h
@@ -1536,7 +1536,7 @@ struct ImGuiIO
     bool          KeySuper;                       // Keyboard modifier pressed: Cmd/Super/Windows
     unsigned char KeysDown[512];                  // Number of keyboard key inputs that are pressed since last frame (ideally left in the "native" order your engine has access to keyboard keys, so you can use your own defines/enums for keys).
     unsigned char KeysUp[512];                    // Number of keyboard up inputs since last frame
-    int           KeysUpPrev[512];                // Number of keyboard up inputs since last frame
+    unsigned char KeysUpPrev[512];                // Number of keyboard up inputs since last frame
     float         NavInputs[ImGuiNavInput_COUNT]; // Gamepad inputs. Cleared back to zero by EndFrame(). Keyboard keys will be auto-mapped and be written here by NewFrame().
 
     // Functions

--- a/imgui.h
+++ b/imgui.h
@@ -1525,19 +1525,19 @@ struct ImGuiIO
     // Input - Fill before calling NewFrame()
     //------------------------------------------------------------------
 
-    ImVec2         MousePos;                       // Mouse position, in pixels. Set to ImVec2(-FLT_MAX, -FLT_MAX) if mouse is unavailable (on another screen, etc.)
-    unsigned short MouseDown[5];                   // Mouse buttons: 0 = left, 1=right, 2=middle + extras (ImGuiMouseButton_COUNT == 5). Dear ImGui mostly uses left and right buttons. Others buttons allows us to track if the mouse is being used by your application + available to user as a convenience via IsMouse** API.
-    unsigned short MouseUp[5];                     // Mouse buttons: 0 = left, 1=right, 2=middle + extras (ImGuiMouseButton_COUNT == 5). Dear ImGui mostly uses left and right buttons. Others buttons allows us to track if the mouse is being used by your application + available to user as a convenience via IsMouse** API.
-    float          MouseWheel;                     // Mouse wheel Vertical: 1 unit scrolls about 5 lines text.
-    float          MouseWheelH;                    // Mouse wheel Horizontal. Most users don't have a mouse with an horizontal wheel, may not be filled by all back-ends.
-    bool           KeyCtrl;                        // Keyboard modifier pressed: Control
-    bool           KeyShift;                       // Keyboard modifier pressed: Shift
-    bool           KeyAlt;                         // Keyboard modifier pressed: Alt
-    bool           KeySuper;                       // Keyboard modifier pressed: Cmd/Super/Windows
-    unsigned short KeysDown[512];                  // Number of keyboard key inputs that are pressed since last frame (ideally left in the "native" order your engine has access to keyboard keys, so you can use your own defines/enums for keys).
-    unsigned short KeysUp[512];                    // Number of keyboard up inputs since last frame
-    int            KeysUpPrev[512];                // Number of keyboard up inputs since last frame
-    float          NavInputs[ImGuiNavInput_COUNT]; // Gamepad inputs. Cleared back to zero by EndFrame(). Keyboard keys will be auto-mapped and be written here by NewFrame().
+    ImVec2        MousePos;                       // Mouse position, in pixels. Set to ImVec2(-FLT_MAX, -FLT_MAX) if mouse is unavailable (on another screen, etc.)
+    unsigned char MouseDown[5];                   // Mouse buttons: 0 = left, 1=right, 2=middle + extras (ImGuiMouseButton_COUNT == 5). Dear ImGui mostly uses left and right buttons. Others buttons allows us to track if the mouse is being used by your application + available to user as a convenience via IsMouse** API.
+    unsigned char MouseUp[5];                     // Mouse buttons: 0 = left, 1=right, 2=middle + extras (ImGuiMouseButton_COUNT == 5). Dear ImGui mostly uses left and right buttons. Others buttons allows us to track if the mouse is being used by your application + available to user as a convenience via IsMouse** API.
+    float         MouseWheel;                     // Mouse wheel Vertical: 1 unit scrolls about 5 lines text.
+    float         MouseWheelH;                    // Mouse wheel Horizontal. Most users don't have a mouse with an horizontal wheel, may not be filled by all back-ends.
+    bool          KeyCtrl;                        // Keyboard modifier pressed: Control
+    bool          KeyShift;                       // Keyboard modifier pressed: Shift
+    bool          KeyAlt;                         // Keyboard modifier pressed: Alt
+    bool          KeySuper;                       // Keyboard modifier pressed: Cmd/Super/Windows
+    unsigned char KeysDown[512];                  // Number of keyboard key inputs that are pressed since last frame (ideally left in the "native" order your engine has access to keyboard keys, so you can use your own defines/enums for keys).
+    unsigned char KeysUp[512];                    // Number of keyboard up inputs since last frame
+    int           KeysUpPrev[512];                // Number of keyboard up inputs since last frame
+    float         NavInputs[ImGuiNavInput_COUNT]; // Gamepad inputs. Cleared back to zero by EndFrame(). Keyboard keys will be auto-mapped and be written here by NewFrame().
 
     // Functions
     IMGUI_API void  AddInputCharacter(unsigned int c);          // Queue new character input

--- a/imgui.h
+++ b/imgui.h
@@ -1526,8 +1526,8 @@ struct ImGuiIO
     //------------------------------------------------------------------
 
     ImVec2        MousePos;                       // Mouse position, in pixels. Set to ImVec2(-FLT_MAX, -FLT_MAX) if mouse is unavailable (on another screen, etc.)
-    unsigned char MouseDown[5];                   // Mouse buttons: 0 = left, 1=right, 2=middle + extras (ImGuiMouseButton_COUNT == 5). Dear ImGui mostly uses left and right buttons. Others buttons allows us to track if the mouse is being used by your application + available to user as a convenience via IsMouse** API.
-    unsigned char MouseUp[5];                     // Mouse buttons: 0 = left, 1=right, 2=middle + extras (ImGuiMouseButton_COUNT == 5). Dear ImGui mostly uses left and right buttons. Others buttons allows us to track if the mouse is being used by your application + available to user as a convenience via IsMouse** API.
+    bool          MouseDown[5];                   // Mouse buttons: 0 = left, 1=right, 2=middle + extras (ImGuiMouseButton_COUNT == 5). Dear ImGui mostly uses left and right buttons. Others buttons allows us to track if the mouse is being used by your application + available to user as a convenience via IsMouse** API.
+    bool          MouseUp[5];                     // Mouse buttons: 0 = left, 1=right, 2=middle + extras (ImGuiMouseButton_COUNT == 5). Dear ImGui mostly uses left and right buttons. Others buttons allows us to track if the mouse is being used by your application + available to user as a convenience via IsMouse** API.
     float         MouseWheel;                     // Mouse wheel Vertical: 1 unit scrolls about 5 lines text.
     float         MouseWheelH;                    // Mouse wheel Horizontal. Most users don't have a mouse with an horizontal wheel, may not be filled by all back-ends.
     bool          KeyCtrl;                        // Keyboard modifier pressed: Control

--- a/imgui.h
+++ b/imgui.h
@@ -1525,16 +1525,19 @@ struct ImGuiIO
     // Input - Fill before calling NewFrame()
     //------------------------------------------------------------------
 
-    ImVec2      MousePos;                       // Mouse position, in pixels. Set to ImVec2(-FLT_MAX, -FLT_MAX) if mouse is unavailable (on another screen, etc.)
-    bool        MouseDown[5];                   // Mouse buttons: 0=left, 1=right, 2=middle + extras (ImGuiMouseButton_COUNT == 5). Dear ImGui mostly uses left and right buttons. Others buttons allows us to track if the mouse is being used by your application + available to user as a convenience via IsMouse** API.
-    float       MouseWheel;                     // Mouse wheel Vertical: 1 unit scrolls about 5 lines text.
-    float       MouseWheelH;                    // Mouse wheel Horizontal. Most users don't have a mouse with an horizontal wheel, may not be filled by all back-ends.
-    bool        KeyCtrl;                        // Keyboard modifier pressed: Control
-    bool        KeyShift;                       // Keyboard modifier pressed: Shift
-    bool        KeyAlt;                         // Keyboard modifier pressed: Alt
-    bool        KeySuper;                       // Keyboard modifier pressed: Cmd/Super/Windows
-    bool        KeysDown[512];                  // Keyboard keys that are pressed (ideally left in the "native" order your engine has access to keyboard keys, so you can use your own defines/enums for keys).
-    float       NavInputs[ImGuiNavInput_COUNT]; // Gamepad inputs. Cleared back to zero by EndFrame(). Keyboard keys will be auto-mapped and be written here by NewFrame().
+    ImVec2         MousePos;                       // Mouse position, in pixels. Set to ImVec2(-FLT_MAX, -FLT_MAX) if mouse is unavailable (on another screen, etc.)
+    unsigned short MouseDown[5];                   // Mouse buttons: 0 = left, 1=right, 2=middle + extras (ImGuiMouseButton_COUNT == 5). Dear ImGui mostly uses left and right buttons. Others buttons allows us to track if the mouse is being used by your application + available to user as a convenience via IsMouse** API.
+    unsigned short MouseUp[5];                     // Mouse buttons: 0 = left, 1=right, 2=middle + extras (ImGuiMouseButton_COUNT == 5). Dear ImGui mostly uses left and right buttons. Others buttons allows us to track if the mouse is being used by your application + available to user as a convenience via IsMouse** API.
+    float          MouseWheel;                     // Mouse wheel Vertical: 1 unit scrolls about 5 lines text.
+    float          MouseWheelH;                    // Mouse wheel Horizontal. Most users don't have a mouse with an horizontal wheel, may not be filled by all back-ends.
+    bool           KeyCtrl;                        // Keyboard modifier pressed: Control
+    bool           KeyShift;                       // Keyboard modifier pressed: Shift
+    bool           KeyAlt;                         // Keyboard modifier pressed: Alt
+    bool           KeySuper;                       // Keyboard modifier pressed: Cmd/Super/Windows
+    unsigned short KeysDown[512];                  // Number of keyboard key inputs that are pressed since last frame (ideally left in the "native" order your engine has access to keyboard keys, so you can use your own defines/enums for keys).
+    unsigned short KeysUp[512];                    // Number of keyboard up inputs since last frame
+    int            KeysUpPrev[512];                // Number of keyboard up inputs since last frame
+    float          NavInputs[ImGuiNavInput_COUNT]; // Gamepad inputs. Cleared back to zero by EndFrame(). Keyboard keys will be auto-mapped and be written here by NewFrame().
 
     // Functions
     IMGUI_API void  AddInputCharacter(unsigned int c);          // Queue new character input


### PR DESCRIPTION
In response to #2787 I'm attempting a low impact way of addressing dropped inputs over the course of a frame. This can happen at the standard 60hz refresh with high frequency devices like high quality keyboards. It's also possible this happens when frame rate drops.

This changes the KeysDown array from an array of bits to an array of unsigned integers. That change alone has no affect on any code since a standard C++ bool is 1/0 and not a special object. This means existing implementations can gradually adopt this change along with widgets. From there in the example win32 impl when we process pending window message we total up all the down events for that key. This also introduces KeysUp and KeysUpPrev arrays of unsigned integers. When processing the window messages, tally the up events into the KeysU array.

We have two Up arrays so we can process Up events in the next frame. Upon NewFrame, we subtract the Down events from Up events that occurred the _previous_ frame. This way we capture the down event and can process it when there is a down and up within the same frame.

I thought about also changing MouseUp/Down in this way. The more I thought about it the more I think that may actually make the problem worse with errant clicks in areas the user doesn't expect. Currently it appears the input interface checks if the mouse is down and then gets the current position of the mouse. This could lead to situations where the last recognized mouse position on a lagged frame was different than the position the user actually clicked causing inputs they didn't expect. I can't think of a quick slot in solution for that situation like this keyboard input one. I think we'd need either encoding a mouse click with the coordinates of the mouse at that moment in time or go full on event list and replay the events in order every frame. Both of those are a monumental undertaking and may not be worth the effort.
