### PR TITLE
Update vulkan swapchain recreation examples

### DIFF
--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -225,6 +225,7 @@ Other Changes:
 - Backends: OpenGL3: Added support for glad2 loader. (#3330) [@moritz-h]
 - Backends: Allegro 5: Fixed horizontal scrolling direction with mouse wheel / touch pads (it seems
   like Allegro 5 reports it differently from GLFW and SDL). (#3394, #2424, #1463) [@nobody-special666]
+- Examples: Vulkan: Reworked buffer resize handling, fix for Linux/X11. (#3390, #2626) [@RoryO]
 - Examples: Vulkan: Fixed GLFW+Vulkan and SDL+Vulkan clear color not being set. (#3390) [@RoryO]
 - CI: Emscripten has stopped their support for their fastcomp backend, switching to latest sdk [@Xipiryon]
 

--- a/examples/example_glfw_vulkan/main.cpp
+++ b/examples/example_glfw_vulkan/main.cpp
@@ -348,7 +348,7 @@ int main(int, char**)
         return 1;
 
     glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
-    GLFWwindow *window = glfwCreateWindow(1280, 720, "Dear ImGui GLFW+Vulkan example", NULL, NULL);
+    GLFWwindow* window = glfwCreateWindow(1280, 720, "Dear ImGui GLFW+Vulkan example", NULL, NULL);
 
     // Setup Vulkan
     if (!glfwVulkanSupported())

--- a/examples/example_glfw_vulkan/main.cpp
+++ b/examples/example_glfw_vulkan/main.cpp
@@ -506,7 +506,7 @@ int main(int, char**)
             ImGui::Checkbox("Another Window", &show_another_window);
 
             ImGui::SliderFloat("float", &f, 0.0f, 1.0f);            // Edit 1 float using a slider from 0.0f to 1.0f
-            if(ImGui::ColorEdit3("clear color", (float*)&clear_color)) // Edit 3 floats representing a color
+            if (ImGui::ColorEdit3("clear color", (float*)&clear_color)) // Edit 3 floats representing a color
                 memcpy(&wd->ClearValue.color.float32[0], &clear_color, 4 * sizeof(float));
 
             if (ImGui::Button("Button"))                            // Buttons return true when clicked (most widgets return true when edited/activated)
@@ -542,9 +542,12 @@ int main(int, char**)
             ImGui::RenderPlatformWindowsDefault();
         }
 
+        if (g_SwapChainRebuild) // Main viewport resized in the middle of this frame, go on to next frame.
+            continue;
+
         // Present Main Platform Window
         if (!main_is_minimized)
-            FramePresent(wd, window);
+            FramePresent(wd);
 
     }
     // Cleanup

--- a/examples/example_glfw_vulkan/main.cpp
+++ b/examples/example_glfw_vulkan/main.cpp
@@ -42,6 +42,7 @@ static VkDescriptorPool         g_DescriptorPool = VK_NULL_HANDLE;
 
 static ImGui_ImplVulkanH_Window g_MainWindowData;
 static int                      g_MinImageCount = 2;
+static GLFWwindow*              g_Window;
 static bool                     g_SwapChainRebuild = false;
 
 static void check_vk_result(VkResult err)
@@ -348,7 +349,7 @@ int main(int, char**)
         return 1;
 
     glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
-    GLFWwindow* window = glfwCreateWindow(1280, 720, "Dear ImGui GLFW+Vulkan example", NULL, NULL);
+    g_Window = glfwCreateWindow(1280, 720, "Dear ImGui GLFW+Vulkan example", NULL, NULL);
 
     // Setup Vulkan
     if (!glfwVulkanSupported())
@@ -362,12 +363,12 @@ int main(int, char**)
 
     // Create Window Surface
     VkSurfaceKHR surface;
-    VkResult err = glfwCreateWindowSurface(g_Instance, window, g_Allocator, &surface);
+    VkResult err = glfwCreateWindowSurface(g_Instance, g_Window, g_Allocator, &surface);
     check_vk_result(err);
 
     // Create Framebuffers
     int w, h;
-    glfwGetFramebufferSize(window, &w, &h);
+    glfwGetFramebufferSize(g_Window, &w, &h);
     ImGui_ImplVulkanH_Window* wd = &g_MainWindowData;
     SetupVulkanWindow(wd, surface, w, h);
 
@@ -395,7 +396,7 @@ int main(int, char**)
     }
 
     // Setup Platform/Renderer bindings
-    ImGui_ImplGlfw_InitForVulkan(window, true);
+    ImGui_ImplGlfw_InitForVulkan(g_Window, true);
     ImGui_ImplVulkan_InitInfo init_info = {};
     init_info.Instance = g_Instance;
     init_info.PhysicalDevice = g_PhysicalDevice;
@@ -461,7 +462,7 @@ int main(int, char**)
     ImVec4 clear_color = ImVec4(0.45f, 0.55f, 0.60f, 1.00f);
 
     // Main loop
-    while (!glfwWindowShouldClose(window))
+    while (!glfwWindowShouldClose(g_Window))
     {
         // Poll and handle events (inputs, window resize, etc.)
         // You can read the io.WantCaptureMouse, io.WantCaptureKeyboard flags to tell if dear imgui wants to use your inputs.
@@ -556,7 +557,7 @@ int main(int, char**)
     CleanupVulkanWindow();
     CleanupVulkan();
 
-    glfwDestroyWindow(window);
+    glfwDestroyWindow(g_Window);
     glfwTerminate();
 
     return 0;

--- a/examples/example_glfw_vulkan/main.cpp
+++ b/examples/example_glfw_vulkan/main.cpp
@@ -460,6 +460,10 @@ int main(int, char**)
     bool show_demo_window = true;
     bool show_another_window = false;
     ImVec4 clear_color = ImVec4(0.45f, 0.55f, 0.60f, 1.00f);
+    wd->ClearValue.color.float32[0] = clear_color.x;
+    wd->ClearValue.color.float32[1] = clear_color.y;
+    wd->ClearValue.color.float32[2] = clear_color.z;
+    wd->ClearValue.color.float32[3] = clear_color.w;
 
     // Main loop
     while (!glfwWindowShouldClose(g_Window))
@@ -506,7 +510,13 @@ int main(int, char**)
             ImGui::Checkbox("Another Window", &show_another_window);
 
             ImGui::SliderFloat("float", &f, 0.0f, 1.0f);            // Edit 1 float using a slider from 0.0f to 1.0f
-            ImGui::ColorEdit3("clear color", (float*)&clear_color); // Edit 3 floats representing a color
+            if(ImGui::ColorEdit3("clear color", (float*)&clear_color)) // Edit 3 floats representing a color
+            {
+                wd->ClearValue.color.float32[0] = clear_color.x;
+                wd->ClearValue.color.float32[1] = clear_color.y;
+                wd->ClearValue.color.float32[2] = clear_color.z;
+                wd->ClearValue.color.float32[3] = clear_color.w;
+            };
 
             if (ImGui::Button("Button"))                            // Buttons return true when clicked (most widgets return true when edited/activated)
                 counter++;

--- a/examples/example_glfw_vulkan/main.cpp
+++ b/examples/example_glfw_vulkan/main.cpp
@@ -42,7 +42,6 @@ static VkDescriptorPool         g_DescriptorPool = VK_NULL_HANDLE;
 
 static ImGui_ImplVulkanH_Window g_MainWindowData;
 static int                      g_MinImageCount = 2;
-static GLFWwindow*              g_Window;
 static bool                     g_SwapChainRebuild = false;
 
 static void check_vk_result(VkResult err)
@@ -349,7 +348,7 @@ int main(int, char**)
         return 1;
 
     glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
-    g_Window = glfwCreateWindow(1280, 720, "Dear ImGui GLFW+Vulkan example", NULL, NULL);
+    GLFWwindow *window = glfwCreateWindow(1280, 720, "Dear ImGui GLFW+Vulkan example", NULL, NULL);
 
     // Setup Vulkan
     if (!glfwVulkanSupported())
@@ -363,12 +362,12 @@ int main(int, char**)
 
     // Create Window Surface
     VkSurfaceKHR surface;
-    VkResult err = glfwCreateWindowSurface(g_Instance, g_Window, g_Allocator, &surface);
+    VkResult err = glfwCreateWindowSurface(g_Instance, window, g_Allocator, &surface);
     check_vk_result(err);
 
     // Create Framebuffers
     int w, h;
-    glfwGetFramebufferSize(g_Window, &w, &h);
+    glfwGetFramebufferSize(window, &w, &h);
     ImGui_ImplVulkanH_Window* wd = &g_MainWindowData;
     SetupVulkanWindow(wd, surface, w, h);
 
@@ -396,7 +395,7 @@ int main(int, char**)
     }
 
     // Setup Platform/Renderer bindings
-    ImGui_ImplGlfw_InitForVulkan(g_Window, true);
+    ImGui_ImplGlfw_InitForVulkan(window, true);
     ImGui_ImplVulkan_InitInfo init_info = {};
     init_info.Instance = g_Instance;
     init_info.PhysicalDevice = g_PhysicalDevice;
@@ -466,7 +465,7 @@ int main(int, char**)
     wd->ClearValue.color.float32[3] = clear_color.w;
 
     // Main loop
-    while (!glfwWindowShouldClose(g_Window))
+    while (!glfwWindowShouldClose(window))
     {
         // Poll and handle events (inputs, window resize, etc.)
         // You can read the io.WantCaptureMouse, io.WantCaptureKeyboard flags to tell if dear imgui wants to use your inputs.
@@ -554,9 +553,9 @@ int main(int, char**)
 
         // Present Main Platform Window
         if (!main_is_minimized)
-            FramePresent(wd);
-    }
+            FramePresent(wd, window);
 
+    }
     // Cleanup
     err = vkDeviceWaitIdle(g_Device);
     check_vk_result(err);
@@ -567,7 +566,7 @@ int main(int, char**)
     CleanupVulkanWindow();
     CleanupVulkan();
 
-    glfwDestroyWindow(g_Window);
+    glfwDestroyWindow(window);
     glfwTerminate();
 
     return 0;

--- a/examples/example_glfw_vulkan/main.cpp
+++ b/examples/example_glfw_vulkan/main.cpp
@@ -459,10 +459,7 @@ int main(int, char**)
     bool show_demo_window = true;
     bool show_another_window = false;
     ImVec4 clear_color = ImVec4(0.45f, 0.55f, 0.60f, 1.00f);
-    wd->ClearValue.color.float32[0] = clear_color.x;
-    wd->ClearValue.color.float32[1] = clear_color.y;
-    wd->ClearValue.color.float32[2] = clear_color.z;
-    wd->ClearValue.color.float32[3] = clear_color.w;
+    memcpy(&wd->ClearValue.color.float32[0], &clear_color, 4 * sizeof(float));
 
     // Main loop
     while (!glfwWindowShouldClose(window))
@@ -510,12 +507,7 @@ int main(int, char**)
 
             ImGui::SliderFloat("float", &f, 0.0f, 1.0f);            // Edit 1 float using a slider from 0.0f to 1.0f
             if(ImGui::ColorEdit3("clear color", (float*)&clear_color)) // Edit 3 floats representing a color
-            {
-                wd->ClearValue.color.float32[0] = clear_color.x;
-                wd->ClearValue.color.float32[1] = clear_color.y;
-                wd->ClearValue.color.float32[2] = clear_color.z;
-                wd->ClearValue.color.float32[3] = clear_color.w;
-            };
+                memcpy(&wd->ClearValue.color.float32[0], &clear_color, 4 * sizeof(float));
 
             if (ImGui::Button("Button"))                            // Buttons return true when clicked (most widgets return true when edited/activated)
                 counter++;
@@ -540,7 +532,6 @@ int main(int, char**)
         ImGui::Render();
         ImDrawData* main_draw_data = ImGui::GetDrawData();
         const bool main_is_minimized = (main_draw_data->DisplaySize.x <= 0.0f || main_draw_data->DisplaySize.y <= 0.0f);
-        memcpy(&wd->ClearValue.color.float32[0], &clear_color, 4 * sizeof(float));
         if (!main_is_minimized)
             FrameRender(wd, main_draw_data);
 

--- a/examples/example_sdl_vulkan/main.cpp
+++ b/examples/example_sdl_vulkan/main.cpp
@@ -505,7 +505,7 @@ int main(int, char**)
             ImGui::Checkbox("Another Window", &show_another_window);
 
             ImGui::SliderFloat("float", &f, 0.0f, 1.0f);            // Edit 1 float using a slider from 0.0f to 1.0f
-            if(ImGui::ColorEdit3("clear color", (float*)&clear_color)) // Edit 3 floats representing a color
+            if (ImGui::ColorEdit3("clear color", (float*)&clear_color)) // Edit 3 floats representing a color
                 memcpy(&wd->ClearValue.color.float32[0], &clear_color, 4 * sizeof(float));
 
             if (ImGui::Button("Button"))                            // Buttons return true when clicked (most widgets return true when edited/activated)
@@ -540,6 +540,9 @@ int main(int, char**)
             ImGui::UpdatePlatformWindows();
             ImGui::RenderPlatformWindowsDefault();
         }
+
+        if (g_SwapChainRebuild) // Main viewport resized in the middle of this frame, go on to next frame.
+            continue;
 
         // Present Main Platform Window
         if (!main_is_minimized)

--- a/examples/example_sdl_vulkan/main.cpp
+++ b/examples/example_sdl_vulkan/main.cpp
@@ -338,20 +338,20 @@ int main(int, char**)
 
     // Setup window
     SDL_WindowFlags window_flags = (SDL_WindowFlags)(SDL_WINDOW_VULKAN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
-    SDL_Window* window = SDL_CreateWindow("Dear ImGui SDL2+Vulkan example", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 1280, 720, window_flags);
+    g_Window = SDL_CreateWindow("Dear ImGui SDL2+Vulkan example", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 1280, 720, window_flags);
 
     // Setup Vulkan
     uint32_t extensions_count = 0;
-    SDL_Vulkan_GetInstanceExtensions(window, &extensions_count, NULL);
+    SDL_Vulkan_GetInstanceExtensions(g_Window, &extensions_count, NULL);
     const char** extensions = new const char*[extensions_count];
-    SDL_Vulkan_GetInstanceExtensions(window, &extensions_count, extensions);
+    SDL_Vulkan_GetInstanceExtensions(g_Window, &extensions_count, extensions);
     SetupVulkan(extensions, extensions_count);
     delete[] extensions;
 
     // Create Window Surface
     VkSurfaceKHR surface;
     VkResult err;
-    if (SDL_Vulkan_CreateSurface(window, g_Instance, &surface) == 0)
+    if (SDL_Vulkan_CreateSurface(g_Window, g_Instance, &surface) == 0)
     {
         printf("Failed to create Vulkan surface.\n");
         return 1;
@@ -359,7 +359,7 @@ int main(int, char**)
 
     // Create Framebuffers
     int w, h;
-    SDL_GetWindowSize(window, &w, &h);
+    SDL_GetWindowSize(g_Window, &w, &h);
     ImGui_ImplVulkanH_Window* wd = &g_MainWindowData;
     SetupVulkanWindow(wd, surface, w, h);
 
@@ -387,7 +387,7 @@ int main(int, char**)
     }
 
     // Setup Platform/Renderer bindings
-    ImGui_ImplSDL2_InitForVulkan(window);
+    ImGui_ImplSDL2_InitForVulkan(g_Window);
     ImGui_ImplVulkan_InitInfo init_info = {};
     init_info.Instance = g_Instance;
     init_info.PhysicalDevice = g_PhysicalDevice;
@@ -485,7 +485,7 @@ int main(int, char**)
 
         // Start the Dear ImGui frame
         ImGui_ImplVulkan_NewFrame();
-        ImGui_ImplSDL2_NewFrame(window);
+        ImGui_ImplSDL2_NewFrame(g_Window);
         ImGui::NewFrame();
 
         // 1. Show the big demo window (Most of the sample code is in ImGui::ShowDemoWindow()! You can browse its code to learn more about Dear ImGui!).
@@ -555,7 +555,7 @@ int main(int, char**)
     CleanupVulkanWindow();
     CleanupVulkan();
 
-    SDL_DestroyWindow(window);
+    SDL_DestroyWindow(g_Window);
     SDL_Quit();
 
     return 0;

--- a/examples/example_sdl_vulkan/main.cpp
+++ b/examples/example_sdl_vulkan/main.cpp
@@ -451,10 +451,7 @@ int main(int, char**)
     bool show_demo_window = true;
     bool show_another_window = false;
     ImVec4 clear_color = ImVec4(0.45f, 0.55f, 0.60f, 1.00f);
-    wd->ClearValue.color.float32[0] = clear_color.x;
-    wd->ClearValue.color.float32[1] = clear_color.y;
-    wd->ClearValue.color.float32[2] = clear_color.z;
-    wd->ClearValue.color.float32[3] = clear_color.w;
+    memcpy(&wd->ClearValue.color.float32[0], &clear_color, 4 * sizeof(float));
 
     // Main loop
     bool done = false;
@@ -509,12 +506,7 @@ int main(int, char**)
 
             ImGui::SliderFloat("float", &f, 0.0f, 1.0f);            // Edit 1 float using a slider from 0.0f to 1.0f
             if(ImGui::ColorEdit3("clear color", (float*)&clear_color)) // Edit 3 floats representing a color
-            {
-                wd->ClearValue.color.float32[0] = clear_color.x;
-                wd->ClearValue.color.float32[1] = clear_color.y;
-                wd->ClearValue.color.float32[2] = clear_color.z;
-                wd->ClearValue.color.float32[3] = clear_color.w;
-            }
+                memcpy(&wd->ClearValue.color.float32[0], &clear_color, 4 * sizeof(float));
 
             if (ImGui::Button("Button"))                            // Buttons return true when clicked (most widgets return true when edited/activated)
                 counter++;
@@ -539,7 +531,6 @@ int main(int, char**)
         ImGui::Render();
         ImDrawData* main_draw_data = ImGui::GetDrawData();
         const bool main_is_minimized = (main_draw_data->DisplaySize.x <= 0.0f || main_draw_data->DisplaySize.y <= 0.0f);
-        memcpy(&wd->ClearValue.color.float32[0], &clear_color, 4 * sizeof(float));
         if (!main_is_minimized)
             FrameRender(wd, main_draw_data);
 

--- a/examples/example_sdl_vulkan/main.cpp
+++ b/examples/example_sdl_vulkan/main.cpp
@@ -338,20 +338,20 @@ int main(int, char**)
 
     // Setup window
     SDL_WindowFlags window_flags = (SDL_WindowFlags)(SDL_WINDOW_VULKAN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
-    g_Window = SDL_CreateWindow("Dear ImGui SDL2+Vulkan example", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 1280, 720, window_flags);
+    SDL_Window* window = SDL_CreateWindow("Dear ImGui SDL2+Vulkan example", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 1280, 720, window_flags);
 
     // Setup Vulkan
     uint32_t extensions_count = 0;
-    SDL_Vulkan_GetInstanceExtensions(g_Window, &extensions_count, NULL);
+    SDL_Vulkan_GetInstanceExtensions(window, &extensions_count, NULL);
     const char** extensions = new const char*[extensions_count];
-    SDL_Vulkan_GetInstanceExtensions(g_Window, &extensions_count, extensions);
+    SDL_Vulkan_GetInstanceExtensions(window, &extensions_count, extensions);
     SetupVulkan(extensions, extensions_count);
     delete[] extensions;
 
     // Create Window Surface
     VkSurfaceKHR surface;
     VkResult err;
-    if (SDL_Vulkan_CreateSurface(g_Window, g_Instance, &surface) == 0)
+    if (SDL_Vulkan_CreateSurface(window, g_Instance, &surface) == 0)
     {
         printf("Failed to create Vulkan surface.\n");
         return 1;
@@ -359,7 +359,7 @@ int main(int, char**)
 
     // Create Framebuffers
     int w, h;
-    SDL_GetWindowSize(g_Window, &w, &h);
+    SDL_GetWindowSize(window, &w, &h);
     ImGui_ImplVulkanH_Window* wd = &g_MainWindowData;
     SetupVulkanWindow(wd, surface, w, h);
 
@@ -387,7 +387,7 @@ int main(int, char**)
     }
 
     // Setup Platform/Renderer bindings
-    ImGui_ImplSDL2_InitForVulkan(g_Window);
+    ImGui_ImplSDL2_InitForVulkan(window);
     ImGui_ImplVulkan_InitInfo init_info = {};
     init_info.Instance = g_Instance;
     init_info.PhysicalDevice = g_PhysicalDevice;
@@ -489,7 +489,7 @@ int main(int, char**)
 
         // Start the Dear ImGui frame
         ImGui_ImplVulkan_NewFrame();
-        ImGui_ImplSDL2_NewFrame(g_Window);
+        ImGui_ImplSDL2_NewFrame(window);
         ImGui::NewFrame();
 
         // 1. Show the big demo window (Most of the sample code is in ImGui::ShowDemoWindow()! You can browse its code to learn more about Dear ImGui!).
@@ -565,7 +565,7 @@ int main(int, char**)
     CleanupVulkanWindow();
     CleanupVulkan();
 
-    SDL_DestroyWindow(g_Window);
+    SDL_DestroyWindow(window);
     SDL_Quit();
 
     return 0;

--- a/examples/example_sdl_vulkan/main.cpp
+++ b/examples/example_sdl_vulkan/main.cpp
@@ -451,6 +451,10 @@ int main(int, char**)
     bool show_demo_window = true;
     bool show_another_window = false;
     ImVec4 clear_color = ImVec4(0.45f, 0.55f, 0.60f, 1.00f);
+    wd->ClearValue.color.float32[0] = clear_color.x;
+    wd->ClearValue.color.float32[1] = clear_color.y;
+    wd->ClearValue.color.float32[2] = clear_color.z;
+    wd->ClearValue.color.float32[3] = clear_color.w;
 
     // Main loop
     bool done = false;
@@ -504,7 +508,13 @@ int main(int, char**)
             ImGui::Checkbox("Another Window", &show_another_window);
 
             ImGui::SliderFloat("float", &f, 0.0f, 1.0f);            // Edit 1 float using a slider from 0.0f to 1.0f
-            ImGui::ColorEdit3("clear color", (float*)&clear_color); // Edit 3 floats representing a color
+            if(ImGui::ColorEdit3("clear color", (float*)&clear_color)) // Edit 3 floats representing a color
+            {
+                wd->ClearValue.color.float32[0] = clear_color.x;
+                wd->ClearValue.color.float32[1] = clear_color.y;
+                wd->ClearValue.color.float32[2] = clear_color.z;
+                wd->ClearValue.color.float32[3] = clear_color.w;
+            }
 
             if (ImGui::Button("Button"))                            // Buttons return true when clicked (most widgets return true when edited/activated)
                 counter++;

--- a/examples/imgui_impl_vulkan.cpp
+++ b/examples/imgui_impl_vulkan.cpp
@@ -1346,7 +1346,7 @@ static void ImGui_ImplVulkan_RenderWindow(ImGuiViewport* viewport, void*)
     ImGui_ImplVulkan_InitInfo* v = &g_VulkanInitInfo;
     VkResult err;
 
-    if(data->SwapChainOutOfDate)
+    if (data->SwapChainOutOfDate)
     {
         ImVec2 dim = ImGui::GetPlatformIO().Platform_GetWindowSize(viewport);
         ImGui_ImplVulkanH_CreateOrResizeWindow(v->Instance, v->PhysicalDevice, v->Device, wd, v->QueueFamily, v->Allocator, dim.x, dim.y, v->MinImageCount);

--- a/examples/imgui_impl_vulkan.cpp
+++ b/examples/imgui_impl_vulkan.cpp
@@ -1429,7 +1429,14 @@ static void ImGui_ImplVulkan_SwapBuffers(ImGuiViewport* viewport, void*)
     info.pSwapchains = &wd->Swapchain;
     info.pImageIndices = &present_index;
     err = vkQueuePresentKHR(v->Queue, &info);
-    check_vk_result(err);
+    if (err == VK_ERROR_OUT_OF_DATE_KHR)
+    {
+        ImVec2 dim = ImGui::GetPlatformIO().Platform_GetWindowSize(viewport);
+        ImGui_ImplVulkanH_CreateOrResizeWindow(v->Instance, v->PhysicalDevice, v->Device, wd, v->QueueFamily, v->Allocator, dim.x, dim.y, v->MinImageCount);
+        return;
+    }
+    else
+        check_vk_result(err);
 
     wd->FrameIndex = (wd->FrameIndex + 1) % wd->ImageCount;         // This is for the next vkWaitForFences()
     wd->SemaphoreIndex = (wd->SemaphoreIndex + 1) % wd->ImageCount; // Now we can use the next set of semaphores

--- a/examples/imgui_impl_vulkan.cpp
+++ b/examples/imgui_impl_vulkan.cpp
@@ -1443,8 +1443,8 @@ static void ImGui_ImplVulkan_SwapBuffers(ImGuiViewport* viewport, void*)
         ImGui_ImplVulkanH_CreateOrResizeWindow(v->Instance, v->PhysicalDevice, v->Device, wd, v->QueueFamily, v->Allocator, dim.x, dim.y, v->MinImageCount);
         return;
     }
-    else
-        check_vk_result(err);
+
+    check_vk_result(err);
 
     wd->FrameIndex = (wd->FrameIndex + 1) % wd->ImageCount;         // This is for the next vkWaitForFences()
     wd->SemaphoreIndex = (wd->SemaphoreIndex + 1) % wd->ImageCount; // Now we can use the next set of semaphores

--- a/examples/imgui_impl_vulkan.cpp
+++ b/examples/imgui_impl_vulkan.cpp
@@ -1357,6 +1357,11 @@ static void ImGui_ImplVulkan_RenderWindow(ImGuiViewport* viewport, void*)
         }
         {
             err = vkAcquireNextImageKHR(v->Device, wd->Swapchain, UINT64_MAX, fsd->ImageAcquiredSemaphore, VK_NULL_HANDLE, &wd->FrameIndex);
+            if (err == VK_ERROR_OUT_OF_DATE_KHR)
+            {
+                viewport->DrawData = NULL;
+                return;
+            }
             check_vk_result(err);
             fd = &wd->Frames[wd->FrameIndex];
         }
@@ -1416,6 +1421,9 @@ static void ImGui_ImplVulkan_SwapBuffers(ImGuiViewport* viewport, void*)
     ImGuiViewportDataVulkan* data = (ImGuiViewportDataVulkan*)viewport->RendererUserData;
     ImGui_ImplVulkanH_Window* wd = &data->Window;
     ImGui_ImplVulkan_InitInfo* v = &g_VulkanInitInfo;
+
+    if (!viewport->DrawData) // Frame data became invalid in the middle of rendering
+        return;
 
     VkResult err;
     uint32_t present_index = wd->FrameIndex;

--- a/examples/imgui_impl_vulkan.cpp
+++ b/examples/imgui_impl_vulkan.cpp
@@ -79,8 +79,9 @@ struct ImGuiViewportDataVulkan
     bool                                    WindowOwned;
     ImGui_ImplVulkanH_Window                Window;             // Used by secondary viewports only
     ImGui_ImplVulkanH_WindowRenderBuffers   RenderBuffers;      // Used by all viewports
+    bool                                    SwapChainOutOfDate; // Flag when viewport swapchain resized in the middle of processing a frame
 
-    ImGuiViewportDataVulkan() { WindowOwned = false; memset(&RenderBuffers, 0, sizeof(RenderBuffers)); }
+    ImGuiViewportDataVulkan() { WindowOwned = false; SwapChainOutOfDate = false; memset(&RenderBuffers, 0, sizeof(RenderBuffers)); }
     ~ImGuiViewportDataVulkan() { }
 };
 
@@ -1345,6 +1346,13 @@ static void ImGui_ImplVulkan_RenderWindow(ImGuiViewport* viewport, void*)
     ImGui_ImplVulkan_InitInfo* v = &g_VulkanInitInfo;
     VkResult err;
 
+    if(data->SwapChainOutOfDate)
+    {
+        ImVec2 dim = ImGui::GetPlatformIO().Platform_GetWindowSize(viewport);
+        ImGui_ImplVulkanH_CreateOrResizeWindow(v->Instance, v->PhysicalDevice, v->Device, wd, v->QueueFamily, v->Allocator, dim.x, dim.y, v->MinImageCount);
+        data->SwapChainOutOfDate = false;
+    }
+
     ImGui_ImplVulkanH_Frame* fd = &wd->Frames[wd->FrameIndex];
     ImGui_ImplVulkanH_FrameSemaphores* fsd = &wd->FrameSemaphores[wd->SemaphoreIndex];
     {
@@ -1359,7 +1367,7 @@ static void ImGui_ImplVulkan_RenderWindow(ImGuiViewport* viewport, void*)
             err = vkAcquireNextImageKHR(v->Device, wd->Swapchain, UINT64_MAX, fsd->ImageAcquiredSemaphore, VK_NULL_HANDLE, &wd->FrameIndex);
             if (err == VK_ERROR_OUT_OF_DATE_KHR)
             {
-                viewport->DrawData = NULL;
+                data->SwapChainOutOfDate = true;
                 return;
             }
             check_vk_result(err);
@@ -1422,7 +1430,7 @@ static void ImGui_ImplVulkan_SwapBuffers(ImGuiViewport* viewport, void*)
     ImGui_ImplVulkanH_Window* wd = &data->Window;
     ImGui_ImplVulkan_InitInfo* v = &g_VulkanInitInfo;
 
-    if (!viewport->DrawData) // Frame data became invalid in the middle of rendering
+    if (data->SwapChainOutOfDate) // Frame data became invalid in the middle of rendering
         return;
 
     VkResult err;
@@ -1439,8 +1447,7 @@ static void ImGui_ImplVulkan_SwapBuffers(ImGuiViewport* viewport, void*)
     err = vkQueuePresentKHR(v->Queue, &info);
     if (err == VK_ERROR_OUT_OF_DATE_KHR)
     {
-        ImVec2 dim = ImGui::GetPlatformIO().Platform_GetWindowSize(viewport);
-        ImGui_ImplVulkanH_CreateOrResizeWindow(v->Instance, v->PhysicalDevice, v->Device, wd, v->QueueFamily, v->Allocator, dim.x, dim.y, v->MinImageCount);
+        data->SwapChainOutOfDate = true;
         return;
     }
 


### PR DESCRIPTION
Following up on #2626, this PR does a couple things. First, it changes all the Vulkan examples on the timing of resizing the swapchain. Currently the sdl and glfw examples respond to the library window resize events and then trigger the swapchain resize on those events. This accidentally works on Windows as Windows does not repaint a window using a GPU accelerated surface as it's resized. It treats accelerated windows differently as Windows repaints other windows as they're resized. Window managers on Linux and OSX will always resize the window contents as it's resized. This leads to a disconnect in timing where the display system redraws the window with different dimensions before processing the event and resizing the swapchain. This causes a crash with `VK_ERROR_OUT_OF_DATE_KHR`.

The best thing with Vulkan swapchain resizing is don't trigger recreating the swapchain outside the render loop. Instead, always present the swapchain images and check for `VK_ERROR_OUT_OF_DATE`. This is the last possible moment in the Vulkan pipeline. If it's out of date, resize the swapchain and go on to the next render loop.

Also made a minor updates. Fixed the clear color reference, the `clear_color` variable exists and was not copied to the vulkan `ClearValue` property.