### PR TITLE
Fix warning about M_PI already being defined

### DIFF
--- a/examples/imgui_impl_sdl.cpp
+++ b/examples/imgui_impl_sdl.cpp
@@ -47,6 +47,11 @@
 #include "imgui.h"
 #include "imgui_impl_sdl.h"
 
+#ifndef _USE_MATH_DEFINES
+#define _USE_MATH_DEFINES // So M_PI and company get defined on MSVC when we include math.h
+#endif
+#include <math.h> // if this gets included after SDL.h, then M_PI is already defined and we get a warning
+
 // SDL
 #include <SDL.h>
 #include <SDL_syswm.h>


### PR DESCRIPTION
`SDL.h` defines `M_PI` if it's not defined yet. This causes a warning (on MSVC) if later on we include `math.h`, because of `M_PI` being redefined. By always including `math.h` before `SDL.h` we workaround this problem.

Note that on top of including `math.h`, MSVC needs `_USE_MATH_DEFINES` to actually define `M_PI`.
