### PR TITLE
emscripten fastcomp backend is now deprecated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -389,8 +389,8 @@ jobs:
         wget -q https://github.com/emscripten-core/emsdk/archive/master.tar.gz
         tar -xvf master.tar.gz
         emsdk-master/emsdk update
-        emsdk-master/emsdk install latest-fastcomp
-        emsdk-master/emsdk activate latest-fastcomp
+        emsdk-master/emsdk install latest
+        emsdk-master/emsdk activate latest
 
     - name: Build example_emscripten
       run: |

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -83,6 +83,7 @@ Other Changes:
 - Backends: Allegro 5: Fixed horizontal scrolling direction with mouse wheel / touch pads (it seems
   like Allegro 5 reports it differently from GLFW and SDL). (#3394, #2424, #1463) [@nobody-special666]
 - Examples: Vulkan: Fixed GLFW+Vulkan and SDL+Vulkan clear color not being set. (#3390) [@RoryO]
+- CI: Emscripten has stopped their support for their fastcomp backend, switching to latest sdk [@Xipiryon]
 
 
 -----------------------------------------------------------------------


### PR DESCRIPTION
Fastcomp backend was introduced here: https://github.com/ocornut/imgui/commit/14b18697e653de80f75af18113033b2086846194
Emscripten changelog: https://emscripten.org/docs/introducing_emscripten/release_notes.html?highlight=2.0.0:%2008/10/2020
Emscripten issue: https://github.com/emscripten-core/emsdk/pull/590