### PR TITLE
Emscripten 2.0 broke CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -386,15 +386,15 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        wget -q https://github.com/emscripten-core/emsdk/archive/master.tar.gz
-        tar -xvf master.tar.gz
-        emsdk-master/emsdk update
-        emsdk-master/emsdk install latest
-        emsdk-master/emsdk activate latest
+        wget -q https://github.com/emscripten-core/emsdk/archive/1.40.1.tar.gz
+        tar -xvf 1.40.1.tar.gz
+        emsdk-1.40.1/emsdk update
+        emsdk-1.40.1/emsdk install latest
+        emsdk-1.40.1/emsdk activate latest
 
     - name: Build example_emscripten
       run: |
-        pushd emsdk-master
+        pushd emsdk-1.40.1
         source ./emsdk_env.sh
         popd
         make -C examples/example_emscripten


### PR DESCRIPTION
They changed the compiler backend to llvm and broke default builds, [example](https://github.com/ocornut/imgui/pull/3372/checks?check_run_id=995595916). https://github.com/emscripten-core/emscripten/issues/11319. Yay webdev! Hard coding to 1.40.1 works for now and fixes CI. I don't know really anything about emscripten, perhaps someone who does can bring it up to 2.0.