### PR TITLE
Fix AutoScroll in Console Example

### DIFF
--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -4279,7 +4279,7 @@ struct ExampleAppConsole
             ImGui::LogFinish();
 
         if (ScrollToBottom || (AutoScroll && ImGui::GetScrollY() >= ImGui::GetScrollMaxY()))
-            ImGui::SetScrollHereY(1.0f);
+            ImGui::SetScrollHereY(0.0f);
         ScrollToBottom = false;
 
         ImGui::PopStyleVar();


### PR DESCRIPTION
I know this is not the intended usage of **SetScrollHereY**, however this seems to fix the issue temporarily.
