### PR TITLE
fix bug: correct the blend function in DX12

### DIFF
--- a/examples/imgui_impl_dx12.cpp
+++ b/examples/imgui_impl_dx12.cpp
@@ -13,6 +13,7 @@
 
 // CHANGELOG
 // (minor and older changes stripped away, please see git history for details)
+//  2020-09-01: DirectX12: Corrected the blend function.
 //  2019-10-18: DirectX12: *BREAKING CHANGE* Added extra ID3D12DescriptorHeap parameter to ImGui_ImplDX12_Init() function.
 //  2019-05-29: DirectX12: Added support for large mesh (64K+ vertices), enable ImGuiBackendFlags_RendererHasVtxOffset flag.
 //  2019-04-30: DirectX12: Added support for special ImDrawCallback_ResetRenderState callback to reset render state.
@@ -552,8 +553,8 @@ bool    ImGui_ImplDX12_CreateDeviceObjects()
         desc.RenderTarget[0].SrcBlend = D3D12_BLEND_SRC_ALPHA;
         desc.RenderTarget[0].DestBlend = D3D12_BLEND_INV_SRC_ALPHA;
         desc.RenderTarget[0].BlendOp = D3D12_BLEND_OP_ADD;
-        desc.RenderTarget[0].SrcBlendAlpha = D3D12_BLEND_INV_SRC_ALPHA;
-        desc.RenderTarget[0].DestBlendAlpha = D3D12_BLEND_ZERO;
+        desc.RenderTarget[0].SrcBlendAlpha = D3D12_BLEND_ONE;
+        desc.RenderTarget[0].DestBlendAlpha = D3D12_BLEND_INV_SRC_ALPHA;
         desc.RenderTarget[0].BlendOpAlpha = D3D12_BLEND_OP_ADD;
         desc.RenderTarget[0].RenderTargetWriteMask = D3D12_COLOR_WRITE_ENABLE_ALL;
     }


### PR DESCRIPTION
formula
1. Result_alpha = Src_alpha + Dst_alpha * (1 - Src_alpha)
2. Result_rgb = Result_color * Result_alpha = Src_color * Src_alpha + Dst_color * Dst_alpha * (1 - Src_alpha)

assume
1. Dst_rgb = Dst_color * Dst_alpha
2. texture (like fonts) is (Src_color, Src_alpha), not premultiplied alpha, so Src_rgb = Src_color

then
1. Result_alpha = Src_alpha + Dst_alpha * (1 - Src_alpha)
2. Result_rgb = Result_color * Result_alpha = Src_rgb * Src_alpha + Dst_rgb * (1 - Src_alpha)

so
1. SrcBlendAlpha = **D3D12_BLEND_ONE**
2. DestBlendAlpha = **D3D12_BLEND_INV_SRC_ALPHA**

Why nobody found this bug? Because Dst_alpha is useless In the general case (only use Src_alpha, see `SrcBlend` and `DestBlend`)
I found this bug when I use two context, one for game, one for editor, and the error alpha in game context exposed in editor context.

Here I show a demo (there are two contexts, one in game window)

error result (text disappeared)
![CWM4(W2 SV9YR{`%0(CG L3](https://user-images.githubusercontent.com/15104079/91794887-bebec900-ec4e-11ea-924f-0623f0fec41b.png)

correct result
![{BRG~JRTKZFV_PMK5LYM}I9](https://user-images.githubusercontent.com/15104079/91794985-fc235680-ec4e-11ea-85db-dd005d462fef.png)

if fonts texture is premultiplied alpha, the blend mode should set to
SrcBlend = D3D12_BLEND_ONE