### PR TITLE
Workaround for cases where glfwGetMonitorWorkarea fails

### DIFF
--- a/examples/imgui_impl_glfw.cpp
+++ b/examples/imgui_impl_glfw.cpp
@@ -447,8 +447,16 @@ static void ImGui_ImplGlfw_UpdateMonitors()
         monitor.MainSize = ImVec2((float)vid_mode->width, (float)vid_mode->height);
         int w, h;
         glfwGetMonitorWorkarea(glfw_monitors[n], &x, &y, &w, &h);
-        monitor.WorkPos = ImVec2((float)x, (float)y);;
-        monitor.WorkSize = ImVec2((float)w, (float)h);
+        if (w > 0 && h > 0)
+        {
+            monitor.WorkPos = ImVec2((float)x, (float)y);
+            monitor.WorkSize = ImVec2((float)w, (float)h);
+        }
+        else
+        {
+            monitor.WorkPos  = monitor.MainPos;
+            monitor.WorkSize = monitor.MainSize;
+        }
 #else
         monitor.MainPos = monitor.WorkPos = ImVec2((float)x, (float)y);
         monitor.MainSize = monitor.WorkSize = ImVec2((float)vid_mode->width, (float)vid_mode->height);


### PR DESCRIPTION
Due to an issue with GLFW (not yet reported, I am working on that now) on Windows, glfwGetMonitorWorkarea can report a zero size workarea after a monitor change.

The effect of this is to cause all windows with ImGuiWindowFlags_AlwaysAutoResize set to become almost 0 size, and for some Dear ImGui interactions to fail to work properly.

The simple future proof workaround is to detect 0 size workareas and set the size to the video mode size, and the position to the MainPos as per when the function is not available.