### PR TITLE
Columns: Make sure the ClipRect is valid.

### DIFF
--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -7938,7 +7938,7 @@ void ImGui::BeginColumns(const char* str_id, int columns_count, ImGuiColumnsFlag
         float clip_x1 = IM_ROUND(window->Pos.x + GetColumnOffset(n));
         float clip_x2 = IM_ROUND(window->Pos.x + GetColumnOffset(n + 1) - 1.0f);
         column->ClipRect = ImRect(clip_x1, -FLT_MAX, clip_x2, +FLT_MAX);
-        column->ClipRect.ClipWith(window->ClipRect);
+        column->ClipRect.ClipWithFull(window->ClipRect);
     }
 
     if (columns->Count > 1)


### PR DESCRIPTION
When a window with columns is dragged horizontally outside of the viewport, the `ClipRect` of a column may fall entirely outside `ClipRect` of the containing window. Intersecting those `ClipRects` using `ClipWith()` member function may cause the resulting rectangle to be invalid (meaning: `ClipRect.Min.x > ClipRect.Max.x`).

Fix this issue by using `ClipWithFull()` instead.
