### PR TITLE
Docking: Added DockingSplitterSize to ImGuiStyle Struct

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -978,7 +978,8 @@ ImGuiStyle::ImGuiStyle()
     CurveTessellationTol    = 1.25f;            // Tessellation tolerance when using PathBezierCurveTo() without a specific number of segments. Decrease for highly tessellated curves (higher quality, more polygons), increase to reduce quality.
     CircleSegmentMaxError   = 1.60f;            // Maximum error (in pixels) allowed when using AddCircle()/AddCircleFilled() or drawing rounded corner rectangles with no explicit segment count specified. Decrease for higher quality but more geometry.
 
-    DockingSplitterSize     = 2.0f;             // Thickness of border/padding between docked windows
+    DockingOuterSplitterSize     = 2.0f;             // Thickness of border/padding between docked windows
+    DockingInnerSplitterSize     = 2.0f;             // Thickness of border/padding between docked windows
 
     // Default theme
     ImGui::StyleColorsDark(this);
@@ -13793,7 +13794,7 @@ void ImGui::DockNodeTreeSplit(ImGuiContext* ctx, ImGuiDockNode* parent_node, ImG
     parent_node->VisibleWindow = NULL;
     parent_node->AuthorityForPos = parent_node->AuthorityForSize = ImGuiDataAuthority_DockNode;
 
-    float size_avail = (parent_node->Size[split_axis] - g.Style.DockingSplitterSize);
+    float size_avail = parent_node->Size[split_axis] - g.Style.DockingInnerSplitterSize;
     size_avail = ImMax(size_avail, g.Style.WindowMinSize[split_axis] * 2.0f);
     IM_ASSERT(size_avail > 0.0f); // If you created a node manually with DockBuilderAddNode(), you need to also call DockBuilderSetNodeSize() before splitting.
     child_0->SizeRef = child_1->SizeRef = parent_node->Size;
@@ -13882,7 +13883,7 @@ void ImGui::DockNodeTreeUpdatePosSize(ImGuiDockNode* node, ImVec2 pos, ImVec2 si
     if (child_0->IsVisible && child_1->IsVisible)
     {
         ImGuiContext& g = *GImGui;
-        const float spacing = g.Style.DockingSplitterSize;
+        const float spacing = g.Style.DockingInnerSplitterSize;
         const ImGuiAxis axis = (ImGuiAxis)node->SplitAxis;
         const float size_avail = ImMax(size[axis] - spacing, 0.0f);
 
@@ -14198,6 +14199,8 @@ void ImGui::DockSpace(ImGuiID id, const ImVec2& size_arg, ImGuiDockNodeFlags fla
 
     const ImVec2 content_avail = GetContentRegionAvail();
     ImVec2 size = ImFloor(size_arg);
+    // reduce size due to extra outer padding (2 'sets' of padding on each side)
+    size -= ImVec2(g.Style.DockingOuterSplitterSize, g.Style.DockingOuterSplitterSize) * 2.0f;
     if (size.x <= 0.0f)
         size.x = ImMax(content_avail.x + size.x, 4.0f); // Arbitrary minimum child size (0.0f causing too much issues)
     if (size.y <= 0.0f)
@@ -14205,6 +14208,8 @@ void ImGui::DockSpace(ImGuiID id, const ImVec2& size_arg, ImGuiDockNodeFlags fla
     IM_ASSERT(size.x > 0.0f && size.y > 0.0f);
 
     node->Pos = window->DC.CursorPos;
+    // offset windows by padding amount
+    node->Pos += ImVec2(g.Style.DockingOuterSplitterSize, g.Style.DockingOuterSplitterSize);
     node->Size = node->SizeRef = size;
     SetNextWindowPos(node->Pos);
     SetNextWindowSize(node->Size);

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -821,7 +821,6 @@ static const float WINDOWS_MOUSE_WHEEL_SCROLL_LOCK_TIMER    = 2.00f;    // Lock 
 
 // Docking
 static const float DOCKING_TRANSPARENT_PAYLOAD_ALPHA        = 0.50f;    // For use with io.ConfigDockingTransparentPayload. Apply to Viewport _or_ WindowBg in host viewport.
-static const float DOCKING_SPLITTER_SIZE                    = 2.0f;
 
 //-------------------------------------------------------------------------
 // [SECTION] FORWARD DECLARATIONS
@@ -978,6 +977,8 @@ ImGuiStyle::ImGuiStyle()
     AntiAliasedFill         = true;             // Enable anti-aliased filled shapes (rounded rectangles, circles, etc.).
     CurveTessellationTol    = 1.25f;            // Tessellation tolerance when using PathBezierCurveTo() without a specific number of segments. Decrease for highly tessellated curves (higher quality, more polygons), increase to reduce quality.
     CircleSegmentMaxError   = 1.60f;            // Maximum error (in pixels) allowed when using AddCircle()/AddCircleFilled() or drawing rounded corner rectangles with no explicit segment count specified. Decrease for higher quality but more geometry.
+
+    DockingSplitterSize     = 2.0f;             // Thickness of border/padding between docked windows
 
     // Default theme
     ImGui::StyleColorsDark(this);
@@ -13792,7 +13793,7 @@ void ImGui::DockNodeTreeSplit(ImGuiContext* ctx, ImGuiDockNode* parent_node, ImG
     parent_node->VisibleWindow = NULL;
     parent_node->AuthorityForPos = parent_node->AuthorityForSize = ImGuiDataAuthority_DockNode;
 
-    float size_avail = (parent_node->Size[split_axis] - DOCKING_SPLITTER_SIZE);
+    float size_avail = (parent_node->Size[split_axis] - g.Style.DockingSplitterSize);
     size_avail = ImMax(size_avail, g.Style.WindowMinSize[split_axis] * 2.0f);
     IM_ASSERT(size_avail > 0.0f); // If you created a node manually with DockBuilderAddNode(), you need to also call DockBuilderSetNodeSize() before splitting.
     child_0->SizeRef = child_1->SizeRef = parent_node->Size;
@@ -13880,13 +13881,13 @@ void ImGui::DockNodeTreeUpdatePosSize(ImGuiDockNode* node, ImVec2 pos, ImVec2 si
     ImVec2 child_0_size = size, child_1_size = size;
     if (child_0->IsVisible && child_1->IsVisible)
     {
-        const float spacing = DOCKING_SPLITTER_SIZE;
+        ImGuiContext& g = *GImGui;
+        const float spacing = g.Style.DockingSplitterSize;
         const ImGuiAxis axis = (ImGuiAxis)node->SplitAxis;
         const float size_avail = ImMax(size[axis] - spacing, 0.0f);
 
         // Size allocation policy
         // 1) The first 0..WindowMinSize[axis]*2 are allocated evenly to both windows.
-        ImGuiContext& g = *GImGui;
         const float size_min_each = ImFloor(ImMin(size_avail, g.Style.WindowMinSize[axis] * 2.0f) * 0.5f);
 
         // 2) Process locked absolute size (during a splitter resize we preserve the child of nodes not touching the splitter edge)

--- a/imgui.h
+++ b/imgui.h
@@ -1557,6 +1557,8 @@ struct ImGuiStyle
     float       CircleSegmentMaxError;      // Maximum error (in pixels) allowed when using AddCircle()/AddCircleFilled() or drawing rounded corner rectangles with no explicit segment count specified. Decrease for higher quality but more geometry.
     ImVec4      Colors[ImGuiCol_COUNT];
 
+    float       DockingSplitterSize;        // Thickness of border/padding between docked windows
+
     IMGUI_API ImGuiStyle();
     IMGUI_API void ScaleAllSizes(float scale_factor);
 };

--- a/imgui.h
+++ b/imgui.h
@@ -1557,7 +1557,8 @@ struct ImGuiStyle
     float       CircleSegmentMaxError;      // Maximum error (in pixels) allowed when using AddCircle()/AddCircleFilled() or drawing rounded corner rectangles with no explicit segment count specified. Decrease for higher quality but more geometry.
     ImVec4      Colors[ImGuiCol_COUNT];
 
-    float       DockingSplitterSize;        // Thickness of border/padding between docked windows
+    float       DockingOuterSplitterSize;   // Thickness of border/padding between docked windows
+    float       DockingInnerSplitterSize;   // Thickness of border/padding around docked windows
 
     IMGUI_API ImGuiStyle();
     IMGUI_API void ScaleAllSizes(float scale_factor);

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -3921,7 +3921,8 @@ void ImGui::ShowStyleEditor(ImGuiStyle* ref)
             ImGui::SliderFloat("IndentSpacing", &style.IndentSpacing, 0.0f, 30.0f, "%.0f");
             ImGui::SliderFloat("ScrollbarSize", &style.ScrollbarSize, 1.0f, 20.0f, "%.0f");
             ImGui::SliderFloat("GrabMinSize", &style.GrabMinSize, 1.0f, 20.0f, "%.0f");
-            ImGui::SliderFloat("DockingSplitterSize", &style.DockingSplitterSize, 0.0f, 12.0f, "%.0f");
+            ImGui::SliderFloat("DockingInnerSplitterSize", &style.DockingInnerSplitterSize, 0.0f, 12.0f, "%.0f");
+            ImGui::SliderFloat("DockingOuterSplitterSize", &style.DockingOuterSplitterSize, 0.0f, 12.0f, "%.0f");
             ImGui::Text("Borders");
             ImGui::SliderFloat("WindowBorderSize", &style.WindowBorderSize, 0.0f, 1.0f, "%.0f");
             ImGui::SliderFloat("ChildBorderSize", &style.ChildBorderSize, 0.0f, 1.0f, "%.0f");

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -3921,6 +3921,7 @@ void ImGui::ShowStyleEditor(ImGuiStyle* ref)
             ImGui::SliderFloat("IndentSpacing", &style.IndentSpacing, 0.0f, 30.0f, "%.0f");
             ImGui::SliderFloat("ScrollbarSize", &style.ScrollbarSize, 1.0f, 20.0f, "%.0f");
             ImGui::SliderFloat("GrabMinSize", &style.GrabMinSize, 1.0f, 20.0f, "%.0f");
+            ImGui::SliderFloat("DockingSplitterSize", &style.DockingSplitterSize, 0.0f, 12.0f, "%.0f");
             ImGui::Text("Borders");
             ImGui::SliderFloat("WindowBorderSize", &style.WindowBorderSize, 0.0f, 1.0f, "%.0f");
             ImGui::SliderFloat("ChildBorderSize", &style.ChildBorderSize, 0.0f, 1.0f, "%.0f");


### PR DESCRIPTION
I have personally preferred more spacing between my docked windows (ie. a larger docking splitter size) I also have noticed that I am not the only one wishing for this feature (see https://github.com/ocornut/imgui/issues/2109#issuecomment-636401292)

Previously I would simply change the `DOCKING_SPLITTER_SIZE` definition (in `imgui.cpp`), while this did work, it required me to change Dear ImGui source code.

All I've done is add the `DockingSplitterSize` field to the `ImGuiStyle` struct. Then I updated some of the docking code to use this new field. Finally I added a corresponding slider in the style editor. Here's a gif of the result:

![5mCqKbswBo](https://user-images.githubusercontent.com/46799759/93694695-bb876200-fac3-11ea-980e-c27948943a8b.gif)