### PR TITLE
ImDrawList::PathArcToAdaptive - path arc that automatically adjust precision according to arc radius

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -2419,7 +2419,9 @@ struct ImDrawList
     inline    void  PathFillConvex(ImU32 col)                                   { AddConvexPolyFilled(_Path.Data, _Path.Size, col); _Path.Size = 0; }  // Note: Anti-aliased filling requires points to be in clockwise order.
     inline    void  PathStroke(ImU32 col, bool closed, float thickness = 1.0f)  { AddPolyline(_Path.Data, _Path.Size, col, closed, thickness); _Path.Size = 0; }
     IMGUI_API void  PathArcTo(const ImVec2& center, float radius, float a_min, float a_max, int num_segments = 10);
+    IMGUI_API void  PathArcTo2(const ImVec2& center, float radius, float a_min, float a_max, int num_segments);
     IMGUI_API void  PathArcToFast(const ImVec2& center, float radius, int a_min_of_12, int a_max_of_12);                // Use precomputed angles for a 12 steps circle
+    IMGUI_API void  PathArcToFast2(const ImVec2& center, float radius, int a_min_of_12, int a_max_of_12);               // Use precomputed angles for a 12 steps circle
     IMGUI_API void  PathBezierCubicCurveTo(const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, int num_segments = 0); // Cubic Bezier (4 control points)
     IMGUI_API void  PathBezierQuadraticCurveTo(const ImVec2& p2, const ImVec2& p3, int num_segments = 0);               // Quadratic Bezier (3 control points)
     IMGUI_API void  PathRect(const ImVec2& rect_min, const ImVec2& rect_max, float rounding = 0.0f, ImDrawCornerFlags rounding_corners = ImDrawCornerFlags_All);
@@ -2464,6 +2466,8 @@ struct ImDrawList
     IMGUI_API void  _OnChangedTextureID();
     IMGUI_API void  _OnChangedVtxOffset();
     IMGUI_API int   _CalcCircleAutoSegmentCount(float radius) const;
+    IMGUI_API int   _CalcArcAutoSegmentStepSize(float radius) const;
+    IMGUI_API void  _PathArcToFastEx(const ImVec2& center, float radius, int a_min_sample, int a_max_sample, int a_step);
 };
 
 // All draw data to render a Dear ImGui frame

--- a/imgui.h
+++ b/imgui.h
@@ -2418,10 +2418,8 @@ struct ImDrawList
     inline    void  PathLineToMergeDuplicate(const ImVec2& pos)                 { if (_Path.Size == 0 || memcmp(&_Path.Data[_Path.Size - 1], &pos, 8) != 0) _Path.push_back(pos); }
     inline    void  PathFillConvex(ImU32 col)                                   { AddConvexPolyFilled(_Path.Data, _Path.Size, col); _Path.Size = 0; }  // Note: Anti-aliased filling requires points to be in clockwise order.
     inline    void  PathStroke(ImU32 col, bool closed, float thickness = 1.0f)  { AddPolyline(_Path.Data, _Path.Size, col, closed, thickness); _Path.Size = 0; }
-    IMGUI_API void  PathArcTo(const ImVec2& center, float radius, float a_min, float a_max, int num_segments = 10);
-    IMGUI_API void  PathArcTo2(const ImVec2& center, float radius, float a_min, float a_max, int num_segments);
-    IMGUI_API void  PathArcToFast(const ImVec2& center, float radius, int a_min_of_12, int a_max_of_12);                // Use precomputed angles for a 12 steps circle
-    IMGUI_API void  PathArcToFast2(const ImVec2& center, float radius, int a_min_of_12, int a_max_of_12);               // Use precomputed angles for a 12 steps circle
+    IMGUI_API void  PathArcTo(const ImVec2& center, float radius, float a_min, float a_max, int num_segments = 0);
+    IMGUI_API void  PathArcToFast(const ImVec2& center, float radius, int a_min_of_12, int a_max_of_12);               // Use precomputed angles for a 12 steps circle
     IMGUI_API void  PathBezierCubicCurveTo(const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, int num_segments = 0); // Cubic Bezier (4 control points)
     IMGUI_API void  PathBezierQuadraticCurveTo(const ImVec2& p2, const ImVec2& p3, int num_segments = 0);               // Quadratic Bezier (3 control points)
     IMGUI_API void  PathRect(const ImVec2& rect_min, const ImVec2& rect_max, float rounding = 0.0f, ImDrawCornerFlags rounding_corners = ImDrawCornerFlags_All);
@@ -2468,6 +2466,7 @@ struct ImDrawList
     IMGUI_API int   _CalcCircleAutoSegmentCount(float radius) const;
     IMGUI_API int   _CalcArcAutoSegmentStepSize(float radius) const;
     IMGUI_API void  _PathArcToFastEx(const ImVec2& center, float radius, int a_min_sample, int a_max_sample, int a_step);
+    IMGUI_API void  _PathArcToN(const ImVec2& center, float radius, float a_min, float a_max, int num_segments);
 };
 
 // All draw data to render a Dear ImGui frame

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -7388,10 +7388,10 @@ static void ShowExampleAppCustomRendering(bool* p_open)
                         const float rounding_tr = (rounding_corners & ImDrawCornerFlags_TopRight) ? rounding : 0.0f;
                         const float rounding_br = (rounding_corners & ImDrawCornerFlags_BotRight) ? rounding : 0.0f;
                         const float rounding_bl = (rounding_corners & ImDrawCornerFlags_BotLeft) ? rounding : 0.0f;
-                        draw_list->PathArcToFast2(ImVec2(a.x + rounding_tl, a.y + rounding_tl), rounding_tl, 6, 9);
-                        draw_list->PathArcToFast2(ImVec2(b.x - rounding_tr, a.y + rounding_tr), rounding_tr, 9, 12);
-                        draw_list->PathArcToFast2(ImVec2(b.x - rounding_br, b.y - rounding_br), rounding_br, 0, 3);
-                        draw_list->PathArcToFast2(ImVec2(a.x + rounding_bl, b.y - rounding_bl), rounding_bl, 3, 6);
+                        draw_list->PathArcToFast(ImVec2(a.x + rounding_tl, a.y + rounding_tl), rounding_tl, 6, 9);
+                        draw_list->PathArcToFast(ImVec2(b.x - rounding_tr, a.y + rounding_tr), rounding_tr, 9, 12);
+                        draw_list->PathArcToFast(ImVec2(b.x - rounding_br, b.y - rounding_br), rounding_br, 0, 3);
+                        draw_list->PathArcToFast(ImVec2(a.x + rounding_bl, b.y - rounding_bl), rounding_bl, 3, 6);
                     }
                 };
             };
@@ -7429,12 +7429,12 @@ static void ShowExampleAppCustomRendering(bool* p_open)
             ImGui::Columns(2);
 # if defined(IM_DRAWLIST_ARCFAST_SAMPLE_MAX)
             ImGui::Text("ArcFast Lookup Table Size: %d", IM_ARRAYSIZE(draw_list->_Data->ArcFastVtx));
-            ImGui::Text("ArcFast Radius Cutoff: %.2f", draw_list->_Data->ArcFastExRadiusCutoff);
+            ImGui::Text("ArcFast Radius Cutoff: %.2f", draw_list->_Data->ArcFastRadiusCutoff);
 # endif
             ImGui::Text("Radius: %.2f", set_radius);
 # if defined(IM_DRAWLIST_ARCFAST_SAMPLE_MAX)
             ImGui::SameLine();
-            if (set_radius < draw_list->_Data->ArcFastExRadiusCutoff)
+            if (set_radius < draw_list->_Data->ArcFastRadiusCutoff)
             {
                 ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.5f, 1.0f, 0.5f, 1.0f));
                 ImGui::TextUnformatted("(adaptive)");
@@ -7560,7 +7560,7 @@ static void ShowExampleAppCustomRendering(bool* p_open)
                 for (int n = 0; n < _N; ++n)
                 {
                     draw_list->_Path.resize(0);
-                    draw_list->PathArcToFast2(data.CanvasCenter, data.Radius,
+                    draw_list->PathArcToFast(data.CanvasCenter, data.Radius,
                         (int)(data.AngleStart * 12 / (IM_PI * 2.0f)),
                         (int)(data.AngleEnd * 12 / (IM_PI * 2.0f))
                     );
@@ -7584,7 +7584,7 @@ static void ShowExampleAppCustomRendering(bool* p_open)
                 for (int n = 0; n < _N; ++n)
                 {
                     draw_list->_Path.resize(0);
-                    draw_list->PathArcTo2(data.CanvasCenter, data.Radius, data.AngleStart, data.AngleEnd, 0);
+                    draw_list->PathArcTo(data.CanvasCenter, data.Radius, data.AngleStart, data.AngleEnd, 0);
                 }
             });
 
@@ -7692,7 +7692,7 @@ static void ShowExampleAppCustomRendering(bool* p_open)
                     stats.appendf(
                         "Thickness;Start Angle;Arc Step;Repeats;ArcFastExRadiusCutoff\n"
                         "%f;%f;%f;%d;%f\n\n",
-                        thickness, arc_start, arc_length, N, draw_list->_Data->ArcFastExRadiusCutoff);
+                        thickness, arc_start, arc_length, N, draw_list->_Data->ArcFastRadiusCutoff);
 
                     stats.append("Radius;");
                     for (int test_index = 0; test_index < tests.Size; ++test_index)

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -369,20 +369,15 @@ void ImGui::StyleColorsLight(ImGuiStyle* dst)
 ImDrawListSharedData::ImDrawListSharedData()
 {
     memset(this, 0, sizeof(*this));
+
+    // Sample quarter of the circle.
     for (int i = 0; i < IM_ARRAYSIZE(ArcFastVtx); i++)
     {
-        const float a = ((float)i * 2 * IM_PI) / (float)IM_ARRAYSIZE(ArcFastVtx);
+        const float a = ((float)i * 0.5f * IM_PI) / (float)IM_ARRAYSIZE(ArcFastVtx);
         ArcFastVtx[i] = ImVec2(ImCos(a), ImSin(a));
     }
 
-    // Sample quarter of the circle.
-    for (int i = 0; i < IM_ARRAYSIZE(ArcFastExVtx); i++)
-    {
-        const float a = ((float)i * 0.5f * IM_PI) / (float)IM_ARRAYSIZE(ArcFastExVtx);
-        ArcFastExVtx[i] = ImVec2(ImCos(a), ImSin(a));
-    }
-
-    ArcFastExRadiusCutoff = IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_CALC_R(IM_DRAWLIST_ARCFAST_SAMPLE_MAX, CircleSegmentMaxError);
+    ArcFastRadiusCutoff = IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_CALC_R(IM_DRAWLIST_ARCFAST_SAMPLE_MAX, CircleSegmentMaxError);
 }
 
 void ImDrawListSharedData::SetCircleTessellationMaxError(float max_error)
@@ -399,7 +394,7 @@ void ImDrawListSharedData::SetCircleTessellationMaxError(float max_error)
         CircleSegmentCounts[i] = (ImU8)((i > 0) ? IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_CALC(radius, CircleSegmentMaxError) : 0);
     }
 
-    ArcFastExRadiusCutoff = IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_CALC_R(IM_DRAWLIST_ARCFAST_SAMPLE_MAX, CircleSegmentMaxError);
+    ArcFastRadiusCutoff = IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_CALC_R(IM_DRAWLIST_ARCFAST_SAMPLE_MAX, CircleSegmentMaxError);
 }
 
 // Initialize before use in a new frame. We always have a command ready in the buffer.
@@ -1042,7 +1037,7 @@ void ImDrawList::AddConvexPolyFilled(const ImVec2* points, const int points_coun
 
 int ImDrawList::_CalcArcAutoSegmentStepSize(float radius) const
 {
-    if (radius <= 0.0f || radius > _Data->ArcFastExRadiusCutoff)
+    if (radius <= 0.0f || radius > _Data->ArcFastRadiusCutoff)
         return 0;
 
     const int n = _CalcCircleAutoSegmentCount(radius);
@@ -1117,23 +1112,23 @@ void ImDrawList::_PathArcToFastEx(const ImVec2& center, float radius, int a_min_
 
         if (sample_index < IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE)
         {
-            s = _Data->ArcFastExVtx[sample_index];
+            s = _Data->ArcFastVtx[sample_index];
         }
         else if (sample_index < IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE * 2)
         {
-            const ImVec2& c = _Data->ArcFastExVtx[sample_index - IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE];
+            const ImVec2& c = _Data->ArcFastVtx[sample_index - IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE];
             s.x = -c.y;
             s.y =  c.x;
         }
         else if (sample_index < IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE * 3)
         {
-            const ImVec2& c = _Data->ArcFastExVtx[sample_index - IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE * 2];
+            const ImVec2& c = _Data->ArcFastVtx[sample_index - IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE * 2];
             s.x = -c.x;
             s.y = -c.y;
         }
         else
         {
-            const ImVec2& c = _Data->ArcFastExVtx[sample_index - IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE * 3];
+            const ImVec2& c = _Data->ArcFastVtx[sample_index - IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE * 3];
             s.x =  c.y;
             s.y = -c.x;
         }
@@ -1154,23 +1149,23 @@ void ImDrawList::_PathArcToFastEx(const ImVec2& center, float radius, int a_min_
 
         if (sample_index < IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE)
         {
-            s = _Data->ArcFastExVtx[sample_index];
+            s = _Data->ArcFastVtx[sample_index];
         }
         else if (sample_index < IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE * 2)
         {
-            const ImVec2& c = _Data->ArcFastExVtx[sample_index - IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE];
+            const ImVec2& c = _Data->ArcFastVtx[sample_index - IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE];
             s.x = -c.y;
             s.y =  c.x;
         }
         else if (sample_index < IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE * 3)
         {
-            const ImVec2& c = _Data->ArcFastExVtx[sample_index - IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE * 2];
+            const ImVec2& c = _Data->ArcFastVtx[sample_index - IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE * 2];
             s.x = -c.x;
             s.y = -c.y;
         }
         else
         {
-            const ImVec2& c = _Data->ArcFastExVtx[sample_index - IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE * 3];
+            const ImVec2& c = _Data->ArcFastVtx[sample_index - IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE * 3];
             s.x =  c.y;
             s.y = -c.x;
         }
@@ -1184,7 +1179,7 @@ void ImDrawList::_PathArcToFastEx(const ImVec2& center, float radius, int a_min_
     IM_ASSERT(_Path.Data + _Path.Size == out_ptr);
 }
 
-void ImDrawList::PathArcToFast(const ImVec2& center, float radius, int a_min_of_12, int a_max_of_12)
+void ImDrawList::_PathArcToN(const ImVec2& center, float radius, float a_min, float a_max, int num_segments)
 {
     if (radius < 0.0f)
         return;
@@ -1194,24 +1189,19 @@ void ImDrawList::PathArcToFast(const ImVec2& center, float radius, int a_min_of_
         _Path.push_back(center);
         return;
     }
-    IM_ASSERT(a_min_of_12 <= a_max_of_12);
+    IM_ASSERT(a_min <= a_max);
 
-    // For legacy reason the PathArcToFast() always takes angles where 2*PI is represented by 12,
-    // but it is possible to set IM_DRAWLIST_ARCFAST_TESSELATION_MULTIPLIER to a higher value. This should compile to a no-op otherwise.
-#if IM_DRAWLIST_ARCFAST_TESSELLATION_MULTIPLIER != 1
-    a_min_of_12 *= IM_DRAWLIST_ARCFAST_TESSELLATION_MULTIPLIER;
-    a_max_of_12 *= IM_DRAWLIST_ARCFAST_TESSELLATION_MULTIPLIER;
-#endif
-
-    _Path.reserve(_Path.Size + (a_max_of_12 - a_min_of_12 + 1));
-    for (int a = a_min_of_12; a <= a_max_of_12; a++)
+    // Note that we are adding a point at both a_min and a_max.
+    // If you are trying to draw a full closed circle you don't want the overlapping points!
+    _Path.reserve(_Path.Size + (num_segments + 1));
+    for (int i = 0; i <= num_segments; i++)
     {
-        const ImVec2& c = _Data->ArcFastVtx[a % IM_ARRAYSIZE(_Data->ArcFastVtx)];
-        _Path.push_back(ImVec2(center.x + c.x * radius, center.y + c.y * radius));
+        const float a = a_min + ((float)i / (float)num_segments) * (a_max - a_min);
+        _Path.push_back(ImVec2(center.x + ImCos(a) * radius, center.y + ImSin(a) * radius));
     }
 }
 
-void ImDrawList::PathArcToFast2(const ImVec2& center, float radius, int a_min_of_12, int a_max_of_12)
+void ImDrawList::PathArcToFast(const ImVec2& center, float radius, int a_min_of_12, int a_max_of_12)
 {
     if (radius < 0.0f)
         return;
@@ -1241,29 +1231,7 @@ void ImDrawList::PathArcTo(const ImVec2& center, float radius, float a_min, floa
     }
     IM_ASSERT(a_min <= a_max);
 
-    // Note that we are adding a point at both a_min and a_max.
-    // If you are trying to draw a full closed circle you don't want the overlapping points!
-    _Path.reserve(_Path.Size + (num_segments + 1));
-    for (int i = 0; i <= num_segments; i++)
-    {
-        const float a = a_min + ((float)i / (float)num_segments) * (a_max - a_min);
-        _Path.push_back(ImVec2(center.x + ImCos(a) * radius, center.y + ImSin(a) * radius));
-    }
-}
-
-void ImDrawList::PathArcTo2(const ImVec2& center, float radius, float a_min, float a_max, int num_segments)
-{
-    if (radius < 0.0f)
-        return;
-
-    if (radius == 0.0f)
-    {
-        _Path.push_back(center);
-        return;
-    }
-    IM_ASSERT(a_min <= a_max);
-
-    if (num_segments <= 0 && (radius <= _Data->ArcFastExRadiusCutoff))
+    if (num_segments <= 0 && (radius <= _Data->ArcFastRadiusCutoff))
     {
         // Determine first and last sample in lookup table that belong to the arc.
         const int a_min_sample = (int)ImCeil(IM_DRAWLIST_ARCFAST_SAMPLE_MAX * a_min / (IM_PI * 2.0f));
@@ -1298,7 +1266,7 @@ void ImDrawList::PathArcTo2(const ImVec2& center, float radius, float a_min, flo
             num_segments = arc_segment_count;
         }
 
-        PathArcTo(center, radius, a_min, a_max, num_segments);
+        _PathArcToN(center, radius, a_min, a_max, num_segments);
     }
 }
 

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -373,7 +373,7 @@ ImDrawListSharedData::ImDrawListSharedData()
     // Sample quarter of the circle.
     for (int i = 0; i < IM_ARRAYSIZE(ArcFastVtx); i++)
     {
-        const float a = ((float)i * 2.0f * IM_PI) / (float)IM_ARRAYSIZE(ArcFastVtx);
+        const float a = ((float)i * 0.5f * IM_PI) / (float)IM_ARRAYSIZE(ArcFastVtx);
         ArcFastVtx[i] = ImVec2(ImCos(a), ImSin(a));
     }
 
@@ -1063,7 +1063,7 @@ void ImDrawList::_PathArcToFastEx(const ImVec2& center, float radius, int a_min_
         a_step = _CalcArcAutoSegmentStepSize(radius);
 
     // Make sure we never do steps larger than one quarter of the circle
-    a_step = ImClamp(a_step, 1, IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE / 4);
+    a_step = ImClamp(a_step, 1, IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE);
 
     // Normalize a_min_sample to always start lie in [0..IM_DRAWLIST_ARCFAST_SAMPLE_MAX] range.
     if (a_min_sample < 0)
@@ -1101,6 +1101,7 @@ void ImDrawList::_PathArcToFastEx(const ImVec2& center, float radius, int a_min_
     _Path.resize(_Path.Size + samples);
     ImVec2* out_ptr = _Path.Data + (_Path.Size - samples);
 
+    ImVec2 s;
     int sample_index = a_min_sample;
     for (int a = a_min_sample; a <= a_max_sample; a += a_step, sample_index += a_step, a_step = a_next_step)
     {
@@ -1109,7 +1110,28 @@ void ImDrawList::_PathArcToFastEx(const ImVec2& center, float radius, int a_min_
         if (sample_index >= IM_DRAWLIST_ARCFAST_SAMPLE_MAX)
             sample_index -= IM_DRAWLIST_ARCFAST_SAMPLE_MAX;
 
-        const ImVec2 s = _Data->ArcFastVtx[sample_index];
+        if (sample_index < IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE)
+        {
+            s = _Data->ArcFastVtx[sample_index];
+        }
+        else if (sample_index < IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE * 2)
+        {
+            const ImVec2& c = _Data->ArcFastVtx[sample_index - IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE];
+            s.x = -c.y;
+            s.y =  c.x;
+        }
+        else if (sample_index < IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE * 3)
+        {
+            const ImVec2& c = _Data->ArcFastVtx[sample_index - IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE * 2];
+            s.x = -c.x;
+            s.y = -c.y;
+        }
+        else
+        {
+            const ImVec2& c = _Data->ArcFastVtx[sample_index - IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE * 3];
+            s.x =  c.y;
+            s.y = -c.x;
+        }
 
         out_ptr->x = center.x + s.x * radius;
         out_ptr->y = center.y + s.y * radius;
@@ -1125,7 +1147,28 @@ void ImDrawList::_PathArcToFastEx(const ImVec2& center, float radius, int a_min_
 
         sample_index = normalized_max_sample;
 
-        const ImVec2 s = _Data->ArcFastVtx[sample_index];
+        if (sample_index < IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE)
+        {
+            s = _Data->ArcFastVtx[sample_index];
+        }
+        else if (sample_index < IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE * 2)
+        {
+            const ImVec2& c = _Data->ArcFastVtx[sample_index - IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE];
+            s.x = -c.y;
+            s.y =  c.x;
+        }
+        else if (sample_index < IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE * 3)
+        {
+            const ImVec2& c = _Data->ArcFastVtx[sample_index - IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE * 2];
+            s.x = -c.x;
+            s.y = -c.y;
+        }
+        else
+        {
+            const ImVec2& c = _Data->ArcFastVtx[sample_index - IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE * 3];
+            s.x =  c.y;
+            s.y = -c.x;
+        }
 
         out_ptr->x = center.x + s.x * radius;
         out_ptr->y = center.y + s.y * radius;

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -373,7 +373,7 @@ ImDrawListSharedData::ImDrawListSharedData()
     // Sample quarter of the circle.
     for (int i = 0; i < IM_ARRAYSIZE(ArcFastVtx); i++)
     {
-        const float a = ((float)i * 0.5f * IM_PI) / (float)IM_ARRAYSIZE(ArcFastVtx);
+        const float a = ((float)i * 2.0f * IM_PI) / (float)IM_ARRAYSIZE(ArcFastVtx);
         ArcFastVtx[i] = ImVec2(ImCos(a), ImSin(a));
     }
 
@@ -1063,7 +1063,7 @@ void ImDrawList::_PathArcToFastEx(const ImVec2& center, float radius, int a_min_
         a_step = _CalcArcAutoSegmentStepSize(radius);
 
     // Make sure we never do steps larger than one quarter of the circle
-    a_step = ImClamp(a_step, 1, IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE);
+    a_step = ImClamp(a_step, 1, IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE / 4);
 
     // Normalize a_min_sample to always start lie in [0..IM_DRAWLIST_ARCFAST_SAMPLE_MAX] range.
     if (a_min_sample < 0)
@@ -1101,7 +1101,6 @@ void ImDrawList::_PathArcToFastEx(const ImVec2& center, float radius, int a_min_
     _Path.resize(_Path.Size + samples);
     ImVec2* out_ptr = _Path.Data + (_Path.Size - samples);
 
-    ImVec2 s;
     int sample_index = a_min_sample;
     for (int a = a_min_sample; a <= a_max_sample; a += a_step, sample_index += a_step, a_step = a_next_step)
     {
@@ -1110,28 +1109,7 @@ void ImDrawList::_PathArcToFastEx(const ImVec2& center, float radius, int a_min_
         if (sample_index >= IM_DRAWLIST_ARCFAST_SAMPLE_MAX)
             sample_index -= IM_DRAWLIST_ARCFAST_SAMPLE_MAX;
 
-        if (sample_index < IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE)
-        {
-            s = _Data->ArcFastVtx[sample_index];
-        }
-        else if (sample_index < IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE * 2)
-        {
-            const ImVec2& c = _Data->ArcFastVtx[sample_index - IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE];
-            s.x = -c.y;
-            s.y =  c.x;
-        }
-        else if (sample_index < IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE * 3)
-        {
-            const ImVec2& c = _Data->ArcFastVtx[sample_index - IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE * 2];
-            s.x = -c.x;
-            s.y = -c.y;
-        }
-        else
-        {
-            const ImVec2& c = _Data->ArcFastVtx[sample_index - IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE * 3];
-            s.x =  c.y;
-            s.y = -c.x;
-        }
+        const ImVec2 s = _Data->ArcFastVtx[sample_index];
 
         out_ptr->x = center.x + s.x * radius;
         out_ptr->y = center.y + s.y * radius;
@@ -1147,28 +1125,7 @@ void ImDrawList::_PathArcToFastEx(const ImVec2& center, float radius, int a_min_
 
         sample_index = normalized_max_sample;
 
-        if (sample_index < IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE)
-        {
-            s = _Data->ArcFastVtx[sample_index];
-        }
-        else if (sample_index < IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE * 2)
-        {
-            const ImVec2& c = _Data->ArcFastVtx[sample_index - IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE];
-            s.x = -c.y;
-            s.y =  c.x;
-        }
-        else if (sample_index < IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE * 3)
-        {
-            const ImVec2& c = _Data->ArcFastVtx[sample_index - IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE * 2];
-            s.x = -c.x;
-            s.y = -c.y;
-        }
-        else
-        {
-            const ImVec2& c = _Data->ArcFastVtx[sample_index - IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE * 3];
-            s.x =  c.y;
-            s.y = -c.x;
-        }
+        const ImVec2 s = _Data->ArcFastVtx[sample_index];
 
         out_ptr->x = center.x + s.x * radius;
         out_ptr->y = center.y + s.y * radius;

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -636,14 +636,9 @@ struct IMGUI_API ImChunkStream
 #define IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_CALC_R(_N,_MAXERROR)    ((_MAXERROR) / (1 - ImCos(IM_PI / ImMax((float)(_N), IM_PI))))
 #define IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_CALC_ERROR(_N,_RAD)     ((1 - ImCos(IM_PI / ImMax((float)(_N), IM_PI))) / (_RAD))
 
-// ImDrawList: You may set this to higher values (e.g. 2 or 3) to increase tessellation of fast rounded corners path.
-#ifndef IM_DRAWLIST_ARCFAST_TESSELLATION_MULTIPLIER
-#define IM_DRAWLIST_ARCFAST_TESSELLATION_MULTIPLIER             1
-#endif
-
 // ImDrawList: Lookup table size for adaptive arc drawing, cover quarter of the circle.
 #ifndef IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE
-#define IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE                   12          // Number of samples in lookup table.
+#define IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE                   12 // Number of samples in lookup table.
 #endif
 #define IM_DRAWLIST_ARCFAST_SAMPLE_MAX                          (4 * IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE) // Sample index _PathArcToFastEx() for 360 angle.
 
@@ -660,9 +655,8 @@ struct IMGUI_API ImDrawListSharedData
     ImDrawListFlags InitialFlags;               // Initial flags at the beginning of the frame (it is possible to alter flags on a per-drawlist basis afterwards)
 
     // [Internal] Lookup tables
-    ImVec2          ArcFastVtx[12 * IM_DRAWLIST_ARCFAST_TESSELLATION_MULTIPLIER];  // FIXME: Bake rounded corners fill/borders in atlas
-    ImVec2          ArcFastExVtx[IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE];  // Sample points on the quarter of the circle.
-    float           ArcFastExRadiusCutoff;                                // Cutoff radius after which arc drawing will fallback to slower PathArcTo()
+    ImVec2          ArcFastVtx[IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE];  // Sample points on the quarter of the circle.
+    float           ArcFastRadiusCutoff;                                // Cutoff radius after which arc drawing will fallback to slower PathArcTo()
     ImU8            CircleSegmentCounts[64];    // Precomputed segment count for given radius before we calculate it dynamically (to avoid calculation overhead)
     const ImVec4*   TexUvLines;                 // UV of anti-aliased lines in the atlas
 

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -636,11 +636,11 @@ struct IMGUI_API ImChunkStream
 #define IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_CALC_R(_N,_MAXERROR)    ((_MAXERROR) / (1 - ImCos(IM_PI / ImMax((float)(_N), IM_PI))))
 #define IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_CALC_ERROR(_N,_RAD)     ((1 - ImCos(IM_PI / ImMax((float)(_N), IM_PI))) / (_RAD))
 
-// ImDrawList: Lookup table size for adaptive arc drawing, cover quarter of the circle.
+// ImDrawList: Lookup table size for adaptive arc drawing, cover full circle.
 #ifndef IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE
-#define IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE                   12 // Number of samples in lookup table.
+#define IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE                   48 // Number of samples in lookup table.
 #endif
-#define IM_DRAWLIST_ARCFAST_SAMPLE_MAX                          (4 * IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE) // Sample index _PathArcToFastEx() for 360 angle.
+#define IM_DRAWLIST_ARCFAST_SAMPLE_MAX                          IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE // Sample index _PathArcToFastEx() for 360 angle.
 
 // Data shared between all ImDrawList instances
 // You may want to create your own instance of this if you want to use ImDrawList completely without ImGui. In that case, watch out for future changes to this structure.

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -636,11 +636,11 @@ struct IMGUI_API ImChunkStream
 #define IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_CALC_R(_N,_MAXERROR)    ((_MAXERROR) / (1 - ImCos(IM_PI / ImMax((float)(_N), IM_PI))))
 #define IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_CALC_ERROR(_N,_RAD)     ((1 - ImCos(IM_PI / ImMax((float)(_N), IM_PI))) / (_RAD))
 
-// ImDrawList: Lookup table size for adaptive arc drawing, cover full circle.
+// ImDrawList: Lookup table size for adaptive arc drawing, cover quarter of the circle.
 #ifndef IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE
-#define IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE                   48 // Number of samples in lookup table.
+#define IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE                   12 // Number of samples in lookup table.
 #endif
-#define IM_DRAWLIST_ARCFAST_SAMPLE_MAX                          IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE // Sample index _PathArcToFastEx() for 360 angle.
+#define IM_DRAWLIST_ARCFAST_SAMPLE_MAX                          (4 * IM_DRAWLIST_ARCFAST_LOOKUP_TABLE_SIZE) // Sample index _PathArcToFastEx() for 360 angle.
 
 // Data shared between all ImDrawList instances
 // You may want to create your own instance of this if you want to use ImDrawList completely without ImGui. In that case, watch out for future changes to this structure.


### PR DESCRIPTION
This PR adds `ImDrawList::PathArcToAdaptive()`. An implementation of `PathArcTo` that automatically adjust number of used samples according to used arc radius.

Implementation use 32 element lookup table to fill arc content. On worst case scenario calculate two sampling points when start or end angles are not in lookup table. 32 samples cover radii up to 80 pixels.

To complete this PR decision to call `PathArcToAdptive` instead of `PathArcTo` by default in `AddXXX` functions should be made.

I'm looking for your feedback.

Node: Demo in **DO NOT MERGE** commit may not work out of the box.

### Drawing results
![image](https://user-images.githubusercontent.com/1197433/94201851-db03fd80-febc-11ea-9586-c863ca2ee4d6.png)

### Benchmark results
Notice a jump around 80 pixel radius. This is where fallback to `PathArcTo` kick in.

#### With PathArcToFast
| ![bench_2_25](https://user-images.githubusercontent.com/1197433/94203898-8b273580-fec0-11ea-875c-310f1ac1bc47.png) | ![bench_2_50](https://user-images.githubusercontent.com/1197433/94203901-8bbfcc00-fec0-11ea-975f-defddb452ecf.png)  |
|--------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
| ![bench_2_75](https://user-images.githubusercontent.com/1197433/94203902-8bbfcc00-fec0-11ea-9009-f471cfc5095a.png) | ![bench_2_100](https://user-images.githubusercontent.com/1197433/94203903-8c586280-fec0-11ea-92e8-5017b309b0dc.png) |
#### With PathArcTo
| ![bench_25](https://user-images.githubusercontent.com/1197433/94202425-ea377b00-febd-11ea-86b5-10a57757e04b.png) | ![bench_50](https://user-images.githubusercontent.com/1197433/94202426-ead01180-febd-11ea-8def-491e4aac6ce9.png)  |
|------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
| ![bench_75](https://user-images.githubusercontent.com/1197433/94202428-eb68a800-febd-11ea-90ef-8b8f1fbb7711.png) | ![bench_100](https://user-images.githubusercontent.com/1197433/94202429-eb68a800-febd-11ea-8993-d03724fe4628.png) |