### PR TITLE
Menus: Fix unclosable menus under popup window.

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -7768,6 +7768,8 @@ void ImGui::ClosePopupsOverWindow(ImGuiWindow* ref_window, bool restore_focus_to
             IM_ASSERT((popup.Window->Flags & ImGuiWindowFlags_Popup) != 0);
             if (popup.Window->Flags & ImGuiWindowFlags_ChildWindow)
                 continue;
+            if (popup.Window == ref_window->ParentWindow)
+                continue;
 
             // Trim the stack unless the popup is a direct parent of the reference window (the reference window is often the NavWindow)
             // - With this stack of window, clicking/focusing Popup1 will close Popup2 and Popup3:

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -6555,7 +6555,7 @@ bool ImGui::BeginMenu(const char* label, bool enabled)
 
     // Sub-menus are ChildWindow so that mouse can be hovering across them (otherwise top-most popup menu would steal focus and not allow hovering on parent menu)
     ImGuiWindowFlags flags = ImGuiWindowFlags_ChildMenu | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoNavFocus;
-    if (window->Flags & (ImGuiWindowFlags_Popup | ImGuiWindowFlags_ChildMenu))
+    if (window->Flags & (ImGuiWindowFlags_Popup | ImGuiWindowFlags_ChildMenu) && !(window->Flags & ImGuiWindowFlags_MenuBar))
         flags |= ImGuiWindowFlags_ChildWindow;
 
     // If a menu with same the ID was already submitted, we will append to it, matching the behavior of Begin().
@@ -6575,7 +6575,7 @@ bool ImGui::BeginMenu(const char* label, bool enabled)
 
     ImVec2 label_size = CalcTextSize(label, NULL, true);
     bool pressed;
-    bool menuset_is_open = !(window->Flags & ImGuiWindowFlags_Popup) && (g.OpenPopupStack.Size > g.BeginPopupStack.Size && g.OpenPopupStack[g.BeginPopupStack.Size].OpenParentId == window->IDStack.back());
+    bool menuset_is_open = (window->Flags & ImGuiWindowFlags_MenuBar) && (g.OpenPopupStack.Size > g.BeginPopupStack.Size && g.OpenPopupStack[g.BeginPopupStack.Size].OpenParentId == window->IDStack.back());
     ImGuiWindow* backed_nav_window = g.NavWindow;
     if (menuset_is_open)
         g.NavWindow = window;  // Odd hack to allow hovering across menus of a same menu-set (otherwise we wouldn't be able to hover parent)


### PR DESCRIPTION
The menus are not able to close under popup window. You can't close it by clicking the menubar again, nor by clicking outside of the menu. I am trying to fix it by following methods:
1. To check whether `menuset_is_open`, it seems we should use flag `ImGuiWindowFlags_MenuBar`, since now popup may also contains menus.
2. When clicking outside of the menus, it will try to close the menus by function `ClosePopupsOverWindow`, which will not check the popup with flag `ImGuiWindowFlags_ChildWindow`. So we should not add the flag for window with menubar.