### PR TITLE
Correct the Makefiles so that `pkg-config` and `sdl-config` are invoked only once

### DIFF
--- a/examples/example_glfw_opengl2/Makefile
+++ b/examples/example_glfw_opengl2/Makefile
@@ -31,9 +31,9 @@ LIBS =
 
 ifeq ($(UNAME_S), Linux) #LINUX
 	ECHO_MESSAGE = "Linux"
-	LIBS += -lGL `pkg-config --static --libs glfw3`
+	LIBS += -lGL $(shell pkg-config --static --libs glfw3)
 
-	CXXFLAGS += `pkg-config --cflags glfw3`
+	CXXFLAGS += $(shell pkg-config --cflags glfw3)
 	CFLAGS = $(CXXFLAGS)
 endif
 
@@ -52,7 +52,7 @@ ifeq ($(findstring MINGW,$(UNAME_S)),MINGW)
 	ECHO_MESSAGE = "MinGW"
 	LIBS += -lglfw3 -lgdi32 -lopengl32 -limm32
 
-	CXXFLAGS += `pkg-config --cflags glfw3`
+	CXXFLAGS += $(shell pkg-config --cflags glfw3)
 	CFLAGS = $(CXXFLAGS)
 endif
 

--- a/examples/example_glfw_opengl3/Makefile
+++ b/examples/example_glfw_opengl3/Makefile
@@ -61,9 +61,9 @@ CXXFLAGS += -I../libs/gl3w -DIMGUI_IMPL_OPENGL_LOADER_GL3W
 
 ifeq ($(UNAME_S), Linux) #LINUX
 	ECHO_MESSAGE = "Linux"
-	LIBS += -lGL `pkg-config --static --libs glfw3`
+	LIBS += -lGL $(shell pkg-config --static --libs glfw3)
 
-	CXXFLAGS += `pkg-config --cflags glfw3`
+	CXXFLAGS += $(shell pkg-config --cflags glfw3)
 	CFLAGS = $(CXXFLAGS)
 endif
 
@@ -82,7 +82,7 @@ ifeq ($(findstring MINGW,$(UNAME_S)),MINGW)
 	ECHO_MESSAGE = "MinGW"
 	LIBS += -lglfw3 -lgdi32 -lopengl32 -limm32
 
-	CXXFLAGS += `pkg-config --cflags glfw3`
+	CXXFLAGS += $(shell pkg-config --cflags glfw3)
 	CFLAGS = $(CXXFLAGS)
 endif
 

--- a/examples/example_sdl_metal/Makefile
+++ b/examples/example_sdl_metal/Makefile
@@ -13,11 +13,11 @@ SOURCES += ../../imgui.cpp ../../imgui_widgets.cpp ../../imgui_demo.cpp ../../im
 OBJS = $(addsuffix .o, $(basename $(notdir $(SOURCES))))
 
 LIBS = -framework Metal -framework MetalKit -framework Cocoa -framework IOKit -framework CoreVideo -framework QuartzCore
-LIBS += `sdl2-config --libs`
+LIBS += $(shell sdl2-config --libs)
 LIBS += -L/usr/local/lib
 
 CXXFLAGS = -I../ -I../../ -I/usr/local/include
-CXXFLAGS += `sdl2-config --cflags`
+CXXFLAGS += $(shell sdl2-config --cflags)
 CXXFLAGS += -Wall -Wformat
 CFLAGS = $(CXXFLAGS)
 

--- a/examples/example_sdl_opengl2/Makefile
+++ b/examples/example_sdl_opengl2/Makefile
@@ -31,27 +31,27 @@ LIBS =
 
 ifeq ($(UNAME_S), Linux) #LINUX
 	ECHO_MESSAGE = "Linux"
-	LIBS += -lGL -ldl `sdl2-config --libs`
+	LIBS += -lGL -ldl $(shell sdl2-config --libs)
 
-	CXXFLAGS += `sdl2-config --cflags`
+	CXXFLAGS += $(shell sdl2-config --cflags)
 	CFLAGS = $(CXXFLAGS)
 endif
 
 ifeq ($(UNAME_S), Darwin) #APPLE
 	ECHO_MESSAGE = "Mac OS X"
-	LIBS += -framework OpenGL -framework Cocoa -framework IOKit -framework CoreVideo `sdl2-config --libs`
+	LIBS += -framework OpenGL -framework Cocoa -framework IOKit -framework CoreVideo $(shell sdl2-config --libs)
 	LIBS += -L/usr/local/lib -L/opt/local/lib
 
-	CXXFLAGS += `sdl2-config --cflags`
+	CXXFLAGS += $(shell sdl2-config --cflags)
 	CXXFLAGS += -I/usr/local/include -I/opt/local/include
 	CFLAGS = $(CXXFLAGS)
 endif
 
 ifeq ($(findstring MINGW,$(UNAME_S)),MINGW)
 	ECHO_MESSAGE = "MinGW"
-	LIBS += -lgdi32 -lopengl32 -limm32 `pkg-config --static --libs sdl2`
+	LIBS += -lgdi32 -lopengl32 -limm32 $(shell pkg-config --static --libs sdl2)
 
-	CXXFLAGS += `pkg-config --cflags sdl2`
+	CXXFLAGS += $(shell pkg-config --cflags sdl2)
 	CFLAGS = $(CXXFLAGS)
 endif
 

--- a/examples/example_sdl_opengl3/Makefile
+++ b/examples/example_sdl_opengl3/Makefile
@@ -61,27 +61,27 @@ CXXFLAGS += -I../libs/gl3w -DIMGUI_IMPL_OPENGL_LOADER_GL3W
 
 ifeq ($(UNAME_S), Linux) #LINUX
 	ECHO_MESSAGE = "Linux"
-	LIBS += -lGL -ldl `sdl2-config --libs`
+	LIBS += -lGL -ldl $(shell sdl2-config --libs)
 
-	CXXFLAGS += `sdl2-config --cflags`
+	CXXFLAGS += $(shell sdl2-config --cflags)
 	CFLAGS = $(CXXFLAGS)
 endif
 
 ifeq ($(UNAME_S), Darwin) #APPLE
 	ECHO_MESSAGE = "Mac OS X"
-	LIBS += -framework OpenGL -framework Cocoa -framework IOKit -framework CoreVideo `sdl2-config --libs`
+	LIBS += -framework OpenGL -framework Cocoa -framework IOKit -framework CoreVideo $(shell sdl2-config --libs)
 	LIBS += -L/usr/local/lib -L/opt/local/lib
 
-	CXXFLAGS += `sdl2-config --cflags`
+	CXXFLAGS += $(shell sdl2-config --cflags)
 	CXXFLAGS += -I/usr/local/include -I/opt/local/include
 	CFLAGS = $(CXXFLAGS)
 endif
 
 ifeq ($(findstring MINGW,$(UNAME_S)),MINGW)
    ECHO_MESSAGE = "MinGW"
-   LIBS += -lgdi32 -lopengl32 -limm32 `pkg-config --static --libs sdl2`
+   LIBS += -lgdi32 -lopengl32 -limm32 $(shell pkg-config --static --libs sdl2)
 
-   CXXFLAGS += `pkg-config --cflags sdl2`
+   CXXFLAGS += $(shell pkg-config --cflags sdl2)
    CFLAGS = $(CXXFLAGS)
 endif
 


### PR DESCRIPTION
As of this change, backticks (\`\`) are replaced with _GNU Make_ `$(shell)`
function, and the `CXXFLAGS`/`LIBS` variables are expanded by _Make_ (once)
rather than by the underlying shell (each time the variable is referenced).

Apart from being more optimal, this is also more portable.