### PR TITLE
Silence memset warning.

### DIFF
--- a/misc/freetype/imgui_freetype.cpp
+++ b/misc/freetype/imgui_freetype.cpp
@@ -338,8 +338,8 @@ bool ImFontAtlasBuildWithFreeType(FT_Library ft_library, ImFontAtlas* atlas, uns
     ImVector<ImFontBuildDstDataFT> dst_tmp_array;
     src_tmp_array.resize(atlas->ConfigData.Size);
     dst_tmp_array.resize(atlas->Fonts.Size);
-    memset(src_tmp_array.Data, 0, (size_t)src_tmp_array.size_in_bytes());
-    memset(dst_tmp_array.Data, 0, (size_t)dst_tmp_array.size_in_bytes());
+    memset((void*)src_tmp_array.Data, 0, (size_t)src_tmp_array.size_in_bytes());
+    memset((void*)dst_tmp_array.Data, 0, (size_t)dst_tmp_array.size_in_bytes());
 
     // 1. Initialize font loading structure, check font data validity
     for (int src_i = 0; src_i < atlas->ConfigData.Size; src_i++)


### PR DESCRIPTION
Compiling the code as-is results in the following warning:

```
imgui_freetype.cpp:341:72: warning: ‘void* memset(void*, int, size_t)’
        clearing an object of type ‘struct ImFontBuildSrcDataFT’ with no
        trivial copy-assignment; use assignment or value-initialization
        instead [-Wclass-memaccess]
  341 |     memset(src_tmp_array.Data, 0, (size_t)src_tmp_array.size_in_bytes());
      |                                                                        ^
imgui_freetype.cpp:302:8: note: ‘struct ImFontBuildSrcDataFT’ declared here
  302 | struct ImFontBuildSrcDataFT
      |        ^~~~~~~~~~~~~~~~~~~~
```

This is caused by presence of `ImVector<>` directly in `ImFontBuildSrcDataFT` data structure, as well as in the child `ImBitVector`. Since `ImVector<>` has a constructor, the compiler infers that initialization by `memset` is not valid. Such initialization is not a bug, however, as the default `ImVector<>` ctor just sets the structure data members to 0, which is exactly what the `memset` does.

Casting the data structure address to `void*` pointer silences this warning.