### PR TITLE
Change drag&drop accept logic on same size items

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -10319,7 +10319,7 @@ const ImGuiPayload* ImGui::AcceptDragDropPayload(const char* type, ImGuiDragDrop
     const bool was_accepted_previously = (g.DragDropAcceptIdPrev == g.DragDropTargetId);
     ImRect r = g.DragDropTargetRect;
     float r_surface = r.GetWidth() * r.GetHeight();
-    if (r_surface < g.DragDropAcceptIdCurrRectSurface)
+    if (r_surface <= g.DragDropAcceptIdCurrRectSurface)
     {
         g.DragDropAcceptFlags = flags;
         g.DragDropAcceptIdCurr = g.DragDropTargetId;


### PR DESCRIPTION
Fix for https://github.com/ocornut/imgui/issues/2717

Problem was that `ImGui::AcceptDragDropPayload` takes the smallest drop target bounding box. In case of no padding it would select window instead of dockspace. This patch fixes problem by accepting last call with the same surface size.
Code for testing can be found in issue.
