### PR TITLE
Fix -Wshadow, -Wimplicit-float-conversion, and -Wsign-conversion warnings in macOS and Metal backends

### DIFF
--- a/backends/imgui_impl_metal.mm
+++ b/backends/imgui_impl_metal.mm
@@ -234,8 +234,8 @@ void ImGui_ImplMetal_DestroyDeviceObjects()
     int width, height;
     io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);
     MTLTextureDescriptor *textureDescriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatRGBA8Unorm
-                                                                                                 width:width
-                                                                                                height:height
+                                                                                                 width:(NSUInteger)width
+                                                                                                height:(NSUInteger)height
                                                                                              mipmapped:NO];
     textureDescriptor.usage = MTLTextureUsageShaderRead;
 #if TARGET_OS_OSX
@@ -244,7 +244,7 @@ void ImGui_ImplMetal_DestroyDeviceObjects()
     textureDescriptor.storageMode = MTLStorageModeShared;
 #endif
     id <MTLTexture> texture = [device newTextureWithDescriptor:textureDescriptor];
-    [texture replaceRegion:MTLRegionMake2D(0, 0, width, height) mipmapLevel:0 withBytes:pixels bytesPerRow:width * 4];
+    [texture replaceRegion:MTLRegionMake2D(0, 0, (NSUInteger)width, (NSUInteger)height) mipmapLevel:0 withBytes:pixels bytesPerRow:(NSUInteger)width * 4];
     self.fontTexture = texture;
 }
 
@@ -435,8 +435,8 @@ void ImGui_ImplMetal_DestroyDeviceObjects()
     float R = drawData->DisplayPos.x + drawData->DisplaySize.x;
     float T = drawData->DisplayPos.y;
     float B = drawData->DisplayPos.y + drawData->DisplaySize.y;
-    float N = viewport.znear;
-    float F = viewport.zfar;
+    float N = (float)viewport.znear;
+    float F = (float)viewport.zfar;
     const float ortho_projection[4][4] =
     {
         { 2.0f/(R-L),   0.0f,           0.0f,   0.0f },
@@ -464,8 +464,8 @@ void ImGui_ImplMetal_DestroyDeviceObjects()
 
     id<MTLRenderPipelineState> renderPipelineState = [self renderPipelineStateForFrameAndDevice:commandBuffer.device];
 
-    size_t vertexBufferLength = drawData->TotalVtxCount * sizeof(ImDrawVert);
-    size_t indexBufferLength = drawData->TotalIdxCount * sizeof(ImDrawIdx);
+    size_t vertexBufferLength = (size_t)drawData->TotalVtxCount * sizeof(ImDrawVert);
+    size_t indexBufferLength = (size_t)drawData->TotalIdxCount * sizeof(ImDrawIdx);
     MetalBuffer* vertexBuffer = [self dequeueReusableBufferOfLength:vertexBufferLength device:commandBuffer.device];
     MetalBuffer* indexBuffer = [self dequeueReusableBufferOfLength:indexBufferLength device:commandBuffer.device];
 
@@ -482,8 +482,8 @@ void ImGui_ImplMetal_DestroyDeviceObjects()
     {
         const ImDrawList* cmd_list = drawData->CmdLists[n];
 
-        memcpy((char *)vertexBuffer.buffer.contents + vertexBufferOffset, cmd_list->VtxBuffer.Data, cmd_list->VtxBuffer.Size * sizeof(ImDrawVert));
-        memcpy((char *)indexBuffer.buffer.contents + indexBufferOffset, cmd_list->IdxBuffer.Data, cmd_list->IdxBuffer.Size * sizeof(ImDrawIdx));
+        memcpy((char *)vertexBuffer.buffer.contents + vertexBufferOffset, cmd_list->VtxBuffer.Data, (size_t)cmd_list->VtxBuffer.Size * sizeof(ImDrawVert));
+        memcpy((char *)indexBuffer.buffer.contents + indexBufferOffset, cmd_list->IdxBuffer.Data, (size_t)cmd_list->IdxBuffer.Size * sizeof(ImDrawIdx));
 
         for (int cmd_i = 0; cmd_i < cmd_list->CmdBuffer.Size; cmd_i++)
         {
@@ -533,8 +533,8 @@ void ImGui_ImplMetal_DestroyDeviceObjects()
             }
         }
 
-        vertexBufferOffset += cmd_list->VtxBuffer.Size * sizeof(ImDrawVert);
-        indexBufferOffset += cmd_list->IdxBuffer.Size * sizeof(ImDrawIdx);
+        vertexBufferOffset += (size_t)cmd_list->VtxBuffer.Size * sizeof(ImDrawVert);
+        indexBufferOffset += (size_t)cmd_list->IdxBuffer.Size * sizeof(ImDrawIdx);
     }
 
     __weak id weakSelf = self;

--- a/backends/imgui_impl_osx.mm
+++ b/backends/imgui_impl_osx.mm
@@ -170,7 +170,7 @@ void ImGui_ImplOSX_NewFrame(NSView* view)
     ImGuiIO& io = ImGui::GetIO();
     if (view)
     {
-        const float dpi = [view.window backingScaleFactor];
+        const float dpi = (float)[view.window backingScaleFactor];
         io.DisplaySize = ImVec2((float)view.bounds.size.width, (float)view.bounds.size.height);
         io.DisplayFramebufferScale = ImVec2(dpi, dpi);
     }
@@ -179,7 +179,7 @@ void ImGui_ImplOSX_NewFrame(NSView* view)
     if (g_Time == 0.0)
         g_Time = CFAbsoluteTimeGetCurrent();
     CFAbsoluteTime current_time = CFAbsoluteTimeGetCurrent();
-    io.DeltaTime = current_time - g_Time;
+    io.DeltaTime = (float)(current_time - g_Time);
     g_Time = current_time;
 
     ImGui_ImplOSX_UpdateMouseCursorAndButtons();
@@ -230,7 +230,7 @@ bool ImGui_ImplOSX_HandleEvent(NSEvent* event, NSView* view)
         NSPoint mousePoint = event.locationInWindow;
         mousePoint = [view convertPoint:mousePoint fromView:nil];
         mousePoint = NSMakePoint(mousePoint.x, view.bounds.size.height - mousePoint.y);
-        io.MousePos = ImVec2(mousePoint.x, mousePoint.y);
+        io.MousePos = ImVec2((float)mousePoint.x, (float)mousePoint.y);
     }
 
     if (event.type == NSEventTypeScrollWheel)
@@ -257,9 +257,9 @@ bool ImGui_ImplOSX_HandleEvent(NSEvent* event, NSView* view)
         }
 
         if (fabs(wheel_dx) > 0.0)
-            io.MouseWheelH += wheel_dx * 0.1f;
+            io.MouseWheelH += (float)wheel_dx * 0.1f;
         if (fabs(wheel_dy) > 0.0)
-            io.MouseWheel += wheel_dy * 0.1f;
+            io.MouseWheel += (float)wheel_dy * 0.1f;
         return io.WantCaptureMouse;
     }
 
@@ -267,8 +267,8 @@ bool ImGui_ImplOSX_HandleEvent(NSEvent* event, NSView* view)
     if (event.type == NSEventTypeKeyDown)
     {
         NSString* str = [event characters];
-        int len = (int)[str length];
-        for (int i = 0; i < len; i++)
+        NSUInteger len = [str length];
+        for (NSUInteger i = 0; i < len; i++)
         {
             int c = [str characterAtIndex:i];
             if (!io.KeyCtrl && !(c >= 0xF700 && c <= 0xFFFF) && c != 127)
@@ -287,8 +287,8 @@ bool ImGui_ImplOSX_HandleEvent(NSEvent* event, NSView* view)
     if (event.type == NSEventTypeKeyUp)
     {
         NSString* str = [event characters];
-        int len = (int)[str length];
-        for (int i = 0; i < len; i++)
+        NSUInteger len = [str length];
+        for (NSUInteger i = 0; i < len; i++)
         {
             int c = [str characterAtIndex:i];
             int key = mapCharacterToKey(c);
@@ -300,7 +300,6 @@ bool ImGui_ImplOSX_HandleEvent(NSEvent* event, NSView* view)
 
     if (event.type == NSEventTypeFlagsChanged)
     {
-        ImGuiIO& io = ImGui::GetIO();
         unsigned int flags = [event modifierFlags] & NSEventModifierFlagDeviceIndependentFlagsMask;
 
         bool oldKeyCtrl = io.KeyCtrl;


### PR DESCRIPTION
This PR fixes a few warnings in the macOS (`imgui_impl_osx.mm`) and Metal (`imgui_impl_metal.mm`) backends encountered when compiling with `-Wimplicit-float-conversion`, `-Wsign-conversion`, and `-Wshadow`.

The compiler used is:
```
% /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang --version
Apple clang version 12.0.0 (clang-1200.0.32.2)
Target: x86_64-apple-darwin19.6.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

I've attached the compiler logs.
[imgui_impl_metal.mm.log](https://github.com/ocornut/imgui/files/5430852/imgui_impl_metal.mm.log)
[imgui_impl_osx.mm.log](https://github.com/ocornut/imgui/files/5430853/imgui_impl_osx.mm.log)

