### PR TITLE
fix calculate inputtext callback  utf-8(chinese input) length

### DIFF
--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -4273,7 +4273,7 @@ bool ImGui::InputTextEx(const char* label, const char* hint, char* buf, int buf_
                     IM_ASSERT(callback_data.Buf == state->TextA.Data);  // Invalid to modify those fields
                     IM_ASSERT(callback_data.BufSize == state->BufCapacityA);
                     IM_ASSERT(callback_data.Flags == flags);
-                    if (callback_data.CursorPos != utf8_cursor_pos)            { state->Stb.cursor = ImTextCountCharsFromUtf8(callback_data.Buf, callback_data.Buf + callback_data.CursorPos); state->CursorFollow = true; }
+                    if (callback_data.CursorPos != utf8_cursor_pos || callback_data.BufDirty) { state->Stb.cursor = ImTextCountCharsFromUtf8(callback_data.Buf, callback_data.Buf + callback_data.CursorPos); state->CursorFollow = true; }
                     if (callback_data.SelectionStart != utf8_selection_start)  { state->Stb.select_start = ImTextCountCharsFromUtf8(callback_data.Buf, callback_data.Buf + callback_data.SelectionStart); }
                     if (callback_data.SelectionEnd != utf8_selection_end)      { state->Stb.select_end = ImTextCountCharsFromUtf8(callback_data.Buf, callback_data.Buf + callback_data.SelectionEnd); }
                     if (callback_data.BufDirty)


### PR DESCRIPTION
This PR want fix a bug about InputText callback:

In  InputText callback I want translate chinese pinyin 'hao' to '好', before callback 'hao' length is 3,  
after callback '好''s utf-8 length is 3 too. So ImTextCountCharsFromUtf8 was ignored, that's not right.
Anyway, ImTextCountCharsFromUtf8 should be called to calculate real length.