### PR TITLE
Slider Size and Progress Contrast

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -1486,6 +1486,8 @@ ImGuiStyle::ImGuiStyle()
     ScrollbarPadding            = 2.0f;             // Padding of scrollbar grab within its frame (same for both axes)
     GrabMinSize                 = 12.0f;            // Minimum width/height of a grab box for slider/scrollbar
     GrabRounding                = 0.0f;             // Radius of grabs corners rounding. Set to 0.0f to have rectangular slider grabs.
+    SliderThickness             = 1.0f;             // Thickness of sliders. Can be set between 0.0f (rectangle width is null) and 1.0f (full rectangle is drawn).
+    SliderContrast              = 0.5f;             // Contrast between the left and right sides of the slider track.
     LogSliderDeadzone           = 4.0f;             // The size in pixels of the dead-zone around zero on logarithmic sliders that cross zero.
     ImageRounding               = 0.0f;             // Rounding of Image() calls.
     ImageBorderSize             = 0.0f;             // Thickness of border around tabs.
@@ -3634,6 +3636,8 @@ static const ImGuiStyleVarInfo GStyleVarsInfo[] =
     { 1, ImGuiDataType_Float, (ImU32)offsetof(ImGuiStyle, ScrollbarPadding) },          // ImGuiStyleVar_ScrollbarPadding
     { 1, ImGuiDataType_Float, (ImU32)offsetof(ImGuiStyle, GrabMinSize) },               // ImGuiStyleVar_GrabMinSize
     { 1, ImGuiDataType_Float, (ImU32)offsetof(ImGuiStyle, GrabRounding) },              // ImGuiStyleVar_GrabRounding
+    { 1, ImGuiDataType_Float, (ImU32)offsetof(ImGuiStyle, SliderThickness) },           // ImGuiStyleVar_SliderThickness
+    { 1, ImGuiDataType_Float, (ImU32)offsetof(ImGuiStyle, SliderContrast) },            // ImGuiStyleVar_SliderContrast
     { 1, ImGuiDataType_Float, (ImU32)offsetof(ImGuiStyle, ImageRounding) },             // ImGuiStyleVar_ImageRounding
     { 1, ImGuiDataType_Float, (ImU32)offsetof(ImGuiStyle, ImageBorderSize) },           // ImGuiStyleVar_ImageBorderSize
     { 1, ImGuiDataType_Float, (ImU32)offsetof(ImGuiStyle, TabRounding) },               // ImGuiStyleVar_TabRounding

--- a/imgui.h
+++ b/imgui.h
@@ -1836,6 +1836,8 @@ enum ImGuiStyleVar_
     ImGuiStyleVar_ScrollbarSize,            // float     ScrollbarSize
     ImGuiStyleVar_ScrollbarRounding,        // float     ScrollbarRounding
     ImGuiStyleVar_ScrollbarPadding,         // float     ScrollbarPadding
+    ImGuiStyleVar_SliderThickness,          // float     SliderThickness
+    ImGuiStyleVar_SliderContrast,           // float     SliderContrast
     ImGuiStyleVar_GrabMinSize,              // float     GrabMinSize
     ImGuiStyleVar_GrabRounding,             // float     GrabRounding
     ImGuiStyleVar_ImageRounding,            // float     ImageRounding
@@ -2309,6 +2311,8 @@ struct ImGuiStyle
     float       ScrollbarPadding;           // Padding of scrollbar grab within its frame (same for both axes).
     float       GrabMinSize;                // Minimum width/height of a grab box for slider/scrollbar.
     float       GrabRounding;               // Radius of grabs corners rounding. Set to 0.0f to have rectangular slider grabs.
+    float       SliderThickness;            // Thickness of sliders. Can be set between 0.0f (rectangle width is null) and 1.0f (full rectangle is drawn), 
+    float       SliderContrast;             // Contrast between the left and right sides of the slider track. 
     float       LogSliderDeadzone;          // The size in pixels of the dead-zone around zero on logarithmic sliders that cross zero.
     float       ImageRounding;              // Rounding of Image() calls.
     float       ImageBorderSize;            // Thickness of border around Image() calls.

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -4238,6 +4238,10 @@ static void DemoWindowWidgetsVerticalSliders()
         const float spacing = 4;
         ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(spacing, spacing));
 
+        static float sliderThickness = 0.25f;
+        ImGui::SliderFloat("Slider Thickness", &sliderThickness, 0.0f, 1.0f, "%.2f");
+        ImGui::PushStyleVar(ImGuiStyleVar_SliderThickness, sliderThickness);
+
         static int int_value = 0;
         ImGui::VSliderInt("##int", ImVec2(18, 160), &int_value, 0, 5);
         ImGui::SameLine();
@@ -4251,11 +4255,12 @@ static void DemoWindowWidgetsVerticalSliders()
             ImGui::PushStyleColor(ImGuiCol_FrameBg, (ImVec4)ImColor::HSV(i / 7.0f, 0.5f, 0.5f));
             ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, (ImVec4)ImColor::HSV(i / 7.0f, 0.6f, 0.5f));
             ImGui::PushStyleColor(ImGuiCol_FrameBgActive, (ImVec4)ImColor::HSV(i / 7.0f, 0.7f, 0.5f));
-            ImGui::PushStyleColor(ImGuiCol_SliderGrab, (ImVec4)ImColor::HSV(i / 7.0f, 0.9f, 0.9f));
+            ImGui::PushStyleColor(ImGuiCol_SliderGrab, (ImVec4)ImColor::HSV(i / 7.0f, 0.8f, 0.7f));
+            ImGui::PushStyleColor(ImGuiCol_SliderGrabActive, (ImVec4)ImColor::HSV(i / 7.0f,0.9f, 0.9f));
             ImGui::VSliderFloat("##v", ImVec2(18, 160), &values[i], 0.0f, 1.0f, "");
             if (ImGui::IsItemActive() || ImGui::IsItemHovered())
                 ImGui::SetTooltip("%.3f", values[i]);
-            ImGui::PopStyleColor(4);
+            ImGui::PopStyleColor(5);
             ImGui::PopID();
         }
         ImGui::PopID();
@@ -4293,7 +4298,7 @@ static void DemoWindowWidgetsVerticalSliders()
             ImGui::PopID();
         }
         ImGui::PopID();
-        ImGui::PopStyleVar();
+        ImGui::PopStyleVar(2);
         ImGui::TreePop();
     }
 }
@@ -8496,6 +8501,7 @@ void ImGui::ShowStyleEditor(ImGuiStyle* ref)
             SeparatorText("Windows");
             SliderFloat2("WindowTitleAlign", (float*)&style.WindowTitleAlign, 0.0f, 1.0f, "%.2f");
             SliderFloat("WindowBorderHoverPadding", &style.WindowBorderHoverPadding, 1.0f, 20.0f, "%.0f");
+
             int window_menu_button_position = style.WindowMenuButtonPosition + 1;
             if (Combo("WindowMenuButtonPosition", (int*)&window_menu_button_position, "None\0Left\0Right\0"))
                 style.WindowMenuButtonPosition = (ImGuiDir)(window_menu_button_position - 1);
@@ -8511,6 +8517,8 @@ void ImGui::ShowStyleEditor(ImGuiStyle* ref)
             SliderFloat("SeparatorTextBorderSize", &style.SeparatorTextBorderSize, 0.0f, 10.0f, "%.0f");
             SliderFloat2("SeparatorTextAlign", (float*)&style.SeparatorTextAlign, 0.0f, 1.0f, "%.2f");
             SliderFloat2("SeparatorTextPadding", (float*)&style.SeparatorTextPadding, 0.0f, 40.0f, "%.0f");
+            SliderFloat("SliderThickness", &style.SliderThickness, 0.0f, 1.0f, "%.2f");
+            SliderFloat("SliderContrast", &style.SliderContrast, -1.0f, 1.0f, "%.2f");
             SliderFloat("LogSliderDeadzone", &style.LogSliderDeadzone, 0.0f, 12.0f, "%.0f");
             SliderFloat("ImageRounding", &style.ImageRounding, 0.0f, 12.0f, "%.0f");
             SliderFloat("ImageBorderSize", &style.ImageBorderSize, 0.0f, max_border_size, "%.0f");

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -3349,18 +3349,30 @@ bool ImGui::SliderScalar(const char* label, ImGuiDataType data_type, void* p_dat
     }
 
     // Draw frame
-    const ImU32 frame_col = GetColorU32(g.ActiveId == id ? ImGuiCol_FrameBgActive : hovered ? ImGuiCol_FrameBgHovered : ImGuiCol_FrameBg);
+    const ImU32 frame_col = GetColorU32(g.ActiveId == id ? ImGuiCol_FrameBgActive : hovered ? ImGuiCol_FrameBgHovered : ImGuiCol_FrameBg, 1.0f + g.Style.SliderContrast);
+    const ImU32 frame_col_after = GetColorU32(g.ActiveId == id ? ImGuiCol_FrameBgActive : hovered ? ImGuiCol_FrameBgHovered : ImGuiCol_FrameBg, 1.0f - g.Style.SliderContrast);
     RenderNavCursor(frame_bb, id);
-    RenderFrame(frame_bb.Min, frame_bb.Max, frame_col, false, style.FrameRounding);
-    if (color_marker != 0 && style.ColorMarkerSize > 0.0f)
-        RenderColorComponentMarker(frame_bb, GetColorU32(color_marker), style.FrameRounding);
-    RenderFrameBorder(frame_bb.Min, frame_bb.Max, g.Style.FrameRounding);
 
     // Slider behavior
     ImRect grab_bb;
     const bool value_changed = SliderBehavior(frame_bb, id, data_type, p_data, p_min, p_max, format, flags, &grab_bb);
     if (value_changed)
         MarkItemEdited(id);
+
+    // Render track
+    ImRect draw_bb = frame_bb;
+    if (g.Style.SliderThickness != 1.0f)
+    {
+        float shrink_amount = (float)(int)((frame_bb.Max.y - frame_bb.Min.y) * 0.5f * (1.0f - g.Style.SliderThickness));
+        draw_bb.Min.y += shrink_amount;
+        draw_bb.Max.y -= shrink_amount;
+    }
+    window->DrawList->AddRectFilled(draw_bb.Min, ImVec2(grab_bb.Min.x + (grab_bb.Max.x - grab_bb.Min.x) * 0.65f, draw_bb.Max.y), frame_col, style.FrameRounding, ImDrawFlags_RoundCornersLeft);
+    window->DrawList->AddRectFilled(ImVec2(grab_bb.Max.x - (grab_bb.Max.x - grab_bb.Min.x) * 0.35f, draw_bb.Min.y), draw_bb.Max, frame_col_after, style.FrameRounding, ImDrawFlags_RoundCornersRight);
+    //RenderFrame(frame_bb.Min, frame_bb.Max, frame_col, false, style.FrameRounding);
+    if (color_marker != 0 && style.ColorMarkerSize > 0.0f)
+        RenderColorComponentMarker(draw_bb, GetColorU32(color_marker), style.FrameRounding);
+    //RenderFrameBorder(frame_bb.Min, frame_bb.Max, g.Style.FrameRounding);
 
     // Render grab
     if (grab_bb.Max.x > grab_bb.Min.x)
@@ -3504,15 +3516,27 @@ bool ImGui::VSliderScalar(const char* label, const ImVec2& size, ImGuiDataType d
     }
 
     // Draw frame
-    const ImU32 frame_col = GetColorU32(g.ActiveId == id ? ImGuiCol_FrameBgActive : hovered ? ImGuiCol_FrameBgHovered : ImGuiCol_FrameBg);
+    const ImU32 frame_col = GetColorU32(g.ActiveId == id ? ImGuiCol_FrameBgActive : hovered ? ImGuiCol_FrameBgHovered : ImGuiCol_FrameBg, 1.0f + g.Style.SliderContrast);
+    const ImU32 frame_col_after = GetColorU32(g.ActiveId == id ? ImGuiCol_FrameBgActive : hovered ? ImGuiCol_FrameBgHovered : ImGuiCol_FrameBg, 1.0f - g.Style.SliderContrast);
     RenderNavCursor(frame_bb, id);
-    RenderFrame(frame_bb.Min, frame_bb.Max, frame_col, true, g.Style.FrameRounding);
 
     // Slider behavior
     ImRect grab_bb;
     const bool value_changed = SliderBehavior(frame_bb, id, data_type, p_data, p_min, p_max, format, flags | ImGuiSliderFlags_Vertical, &grab_bb);
     if (value_changed)
         MarkItemEdited(id);
+
+    // Render track
+    ImRect draw_bb = frame_bb;
+    if (g.Style.SliderThickness != 1.0f)
+    {
+        float shrink_amount = (float)(int)((frame_bb.Max.x - frame_bb.Min.x) * 0.5f * (1.0f - g.Style.SliderThickness));
+        draw_bb.Min.x += shrink_amount;
+        draw_bb.Max.x -= shrink_amount;
+    }
+    //RenderFrame(frame_bb.Min, frame_bb.Max, frame_col, true, g.Style.FrameRounding);
+    window->DrawList->AddRectFilled(ImVec2(draw_bb.Min.x, grab_bb.Max.y - (grab_bb.Max.y - grab_bb.Min.y) * 0.65f), draw_bb.Max, frame_col, style.FrameRounding, ImDrawFlags_RoundCornersBottom);
+    window->DrawList->AddRectFilled(draw_bb.Min, ImVec2(draw_bb.Max.x, grab_bb.Min.y + (grab_bb.Max.y - grab_bb.Min.y) * 0.35f), frame_col_after, style.FrameRounding, ImDrawFlags_RoundCornersTop);
 
     // Render grab
     if (grab_bb.Max.y > grab_bb.Min.y)


### PR DESCRIPTION
This is basically a cleaned up and expanded version of #2305 since that PR seems to have been abandoned due to a weird branch deletion. I was able to use GitHub CLI to pull the code for that PR and continue working on it. I loved the way this looked in the screen captures of #2263 but sadly the PR never quite reached maturity.

I followed Omar's suggestions on those threads for the drawing calls and then kept on going a little further with the idea of contrast that was beginning to percolate in that discussion. In the process, I fixed most of the weird annoying ways to draw sliders. I also found a where the demo was missing the GrabActive color for the vertical slider example.

This now provides quite a range of possible slider looks without much additional code.

PR adds two new Style Vars:

- **ImGuiStyleVar_SliderThickness** allows you to change the slider track/background thickness.
- **ImGuiStyleVar_SliderConrast** allows you to change the contrast between the two sides as implied by the threads above.

I do no know of anything lingering on this. But I'm open to suggestions. I tried to make this as generic as possible.

Please consider for inclusion... Thanks! 😃 