### PR TITLE
Removed export of methods from exported class (breaks windows DLL builds)

### DIFF
--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -1128,8 +1128,8 @@ struct IMGUI_API ImGuiStackSizes
     short   SizeOfBeginPopupStack;
 
     ImGuiStackSizes() { memset(this, 0, sizeof(*this)); }
-    IMGUI_API void SetToCurrentState();
-    IMGUI_API void CompareWithCurrentState();
+    void SetToCurrentState();
+    void CompareWithCurrentState();
 };
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
When building ImGui as a DLL on Windows there's a compilation error as Windows compilers don't allow giving a DLL interface to specific methods of a class which itself has a DLL interface. It should be one or the other.
