### PR TITLE
Fix vcvars calls. Fix MSVC DLL build step echos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,8 @@ jobs:
         shell: cmd
         run: |
           cd examples\example_null
-          "%VS_PATH%\VC\Auxiliary\Build\vcvarsall.bat" x64 && .\build_win32.bat /W4
+          call "%VS_PATH%\VC\Auxiliary\Build\vcvars64.bat" 
+          .\build_win32.bat /W4
 
       - name: Build example_null (single file build)
         shell: bash
@@ -71,14 +72,14 @@ jobs:
       - name: Build example_null (as DLL)
         shell: cmd
         run: |
-          "%VS_PATH%\VC\Auxiliary\Build\vcvarsall.bat" x64
-          echo '#ifdef _EXPORT'                                  >  example_single_file.cpp
-          echo '#  define IMGUI_API __declspec(dllexport)'       >> example_single_file.cpp
-          echo '#else'                                           >> example_single_file.cpp
-          echo '#  define IMGUI_API __declspec(dllimport)'       >> example_single_file.cpp
-          echo '#endif'                                          >> example_single_file.cpp
-          echo '#define IMGUI_IMPLEMENTATION'                    >> example_single_file.cpp
-          echo '#include "misc/single_file/imgui_single_file.h"' >> example_single_file.cpp
+          call "%VS_PATH%\VC\Auxiliary\Build\vcvars64.bat" 
+          echo #ifdef _EXPORT                                  >  example_single_file.cpp
+          echo #  define IMGUI_API __declspec(dllexport)       >> example_single_file.cpp
+          echo #else                                           >> example_single_file.cpp
+          echo #  define IMGUI_API __declspec(dllimport)       >> example_single_file.cpp
+          echo #endif                                          >> example_single_file.cpp
+          echo #define IMGUI_IMPLEMENTATION                    >> example_single_file.cpp
+          echo #include "misc/single_file/imgui_single_file.h" >> example_single_file.cpp
           cl.exe /D_USRDLL /D_WINDLL /D_EXPORT /I. example_single_file.cpp /LD /FeImGui.dll /link
           cl.exe /I. ImGui.lib /Feexample_null.exe examples/example_null/main.cpp
 


### PR DESCRIPTION
This is related to https://github.com/ocornut/imgui/pull/3601

_Note that the CI is expected to fail after this commit. The fix is in the aforementioned PR_

Two CI steps weren't being run. Calling `vcvarsall` causes the CI step to immediately complete with a success ignoring subsequent commands.

The fix is to use `call` of a complete batch file (the steps are being exectuted as a batch file and the correct way to "source" batch from batch is to use `call`)

Another fix here is the cmd `echo`-s in the MSVC DLL build step. `echo` on cmd doesn't work the same way it does on bash. The single quotes are literally echoed back. So removing the quotes fixes echo to output valid C++
