### PR TITLE
Missing GetWindowContentRegionHeight()

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -7410,6 +7410,12 @@ float ImGui::GetWindowContentRegionWidth()
     return window->ContentRegionRect.GetWidth();
 }
 
+float ImGui::GetWindowContentRegionHeight()
+{
+    ImGuiWindow* window = GImGui->CurrentWindow;
+    return window->ContentRegionRect.GetHeight();
+}
+
 // Lock horizontal starting position + capture group bounding box into one "item" (so you can use IsItemHovered() or layout primitives such as SameLine() on whole group, etc.)
 // Groups are currently a mishmash of functionalities which should perhaps be clarified and separated.
 void ImGui::BeginGroup()

--- a/imgui.h
+++ b/imgui.h
@@ -336,6 +336,7 @@ namespace ImGui
     IMGUI_API ImVec2        GetWindowContentRegionMin();                                    // content boundaries min (roughly (0,0)-Scroll), in window coordinates
     IMGUI_API ImVec2        GetWindowContentRegionMax();                                    // content boundaries max (roughly (0,0)+Size-Scroll) where Size can be override with SetNextWindowContentSize(), in window coordinates
     IMGUI_API float         GetWindowContentRegionWidth();                                  //
+    IMGUI_API float         GetWindowContentRegionHeight();                                 //
 
     // Windows Scrolling
     IMGUI_API float         GetScrollX();                                                   // get scrolling amount [0..GetScrollMaxX()]


### PR DESCRIPTION
Adding `ImGui::GetWindowContentRegionHeight()` as a companion to `ImGui::GetWindowContentRegionWidth()`

I was building a vertical menu bar on the left size of a window and had need of this one to get the correct height. I've used `ImGui::GetContentContentRegionWidth()` several times and was surprised to learn there is no companion. So I duplicated that function and change Width to Height and wallah!