### PR TITLE
Override 3 more functions for stb_truetype

### DIFF
--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -140,8 +140,11 @@ namespace IMGUI_STB_NAMESPACE
 #define STBTT_sqrt(x)       ImSqrt(x)
 #define STBTT_pow(x,y)      ImPow(x,y)
 #define STBTT_fabs(x)       ImFabs(x)
+#define STBTT_cos(x)        ImCos(x)
+#define STBTT_acos(x)       ImAcos(x)
 #define STBTT_ifloor(x)     ((int)ImFloorStd(x))
 #define STBTT_iceil(x)      ((int)ImCeil(x))
+// #define STBTT_strlen(x)     // TODO
 #define STBTT_STATIC
 #define STB_TRUETYPE_IMPLEMENTATION
 #else


### PR DESCRIPTION
Just redefining 3 more macros for stb_truetype, because I am not using the default implementations and stbtt throws.
This way, stbtt will compile without any more modifications (if the user properly redefined the math functions, obviously [#ifdef/#endif]).

I'm not sure for STBTT_strlen, I havn't seen a strlen function in ImGui, only one for wide chars I believe. Feel free to modify if there is actually one.

Those 2 functions can also be overriden:
```
STBTT_memcpy
STBTT_memset
```

It throws because I am not implementing the default ones, and instead use/define my own functions (using SS3/AVX-512) :

![image](https://user-images.githubusercontent.com/15068742/100550275-24841680-3279-11eb-9e02-c01e6a7f009d.png)
