### PR TITLE
binary_to_compressed_c.cpp: allow injection of custom code before and after generated code

### DIFF
--- a/misc/fonts/binary_to_compressed_c.cpp
+++ b/misc/fonts/binary_to_compressed_c.cpp
@@ -31,7 +31,13 @@ typedef unsigned int stb_uint;
 typedef unsigned char stb_uchar;
 stb_uint stb_compress(stb_uchar* out, stb_uchar* in, stb_uint len);
 
-static bool binary_to_compressed_c(const char* filename, const char* symbol, bool use_base85_encoding, bool use_compression);
+#ifdef CUSTOM_BINARY_TO_COMPRESSED_C
+    #define call_binary_to_compressed_c CUSTOM_BINARY_TO_COMPRESSED_C
+#else
+    #define call_binary_to_compressed_c binary_to_compressed_c
+#endif
+
+static bool call_binary_to_compressed_c(const char* filename, const char* symbol, bool use_base85_encoding, bool use_compression);
 
 int main(int argc, char** argv)
 {
@@ -55,7 +61,7 @@ int main(int argc, char** argv)
         }
     }
 
-    bool ret = binary_to_compressed_c(argv[argn], argv[argn + 1], use_base85_encoding, use_compression);
+    bool ret = call_binary_to_compressed_c(argv[argn], argv[argn + 1], use_base85_encoding, use_compression);
     if (!ret)
         fprintf(stderr, "Error opening or reading file: '%s'\n", argv[argn]);
     return ret ? 0 : 1;


### PR DESCRIPTION
No features are added/changed to the existing `binary_to_compressed_c` utility but this change allows a user to insert, during code generation, custom code before and after the "generated code".

One way this is done is by defining the name of the "callback" and including the code in a new translation unit:
```cpp
#define CUSTOM_BINARY_TO_COMPRESSED_C custom_binary_to_compressed_c
#include "binary_to_compressed_c.cpp"

bool custom_binary_to_compressed_c(const char* filename, const char* symbol, bool use_base85_encoding, bool use_compression)
{
    FILE* out = stdout;

    fprintf(out, "// before\n");

    bool result = binary_to_compressed_c(filename, symbol, use_base85_encoding, use_compression);
    if(!result) {return result;}

    fprintf(out, "// after\n");

    return result;
}
```

The real-world usage is not to add some comments but (in my case) to add custom include and a constexpr code to generate a constant with a  constant name but a type depending on the arguments to more easily switch between compression/base85 options without modifying the code ([example](https://github.com/madeso/tred/commit/5a9e8b41c31c08e5e4eda9ae0e3dab12b8ea32fe)). This could of course be implemented differently depending on how much C++ one wants.

Example usage (with custom modifications not shown):
```cpp
#include "DroidSans.ttf.h"

void LoadFont(EmbeddedBinary binary);
void LoadFont(CompressedBinary binary);

// ...

LoadFont(DROIDSANS_TTF);
```