### PR TITLE
Fix ListClipper for single-item-list

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -2266,6 +2266,26 @@ bool ImGuiListClipper::Step()
     if (table && table->IsInsideRow)
         ImGui::TableEndRow(table);
 
+    // Step 1: the clipper infer height from first element
+    // When StepNo == 1 we always need to calculate ItemHeight, before any early-outs
+    if (StepNo == 1)
+    {
+        IM_ASSERT(ItemsHeight <= 0.0f);
+        if (table)
+        {
+            const float pos_y1 = table->RowPosY1;   // Using this instead of StartPosY to handle clipper straddling the frozen row
+            const float pos_y2 = table->RowPosY2;   // Using this instead of CursorPos.y to take account of tallest cell.
+            ItemsHeight = pos_y2 - pos_y1;
+            window->DC.CursorPos.y = pos_y2;
+        }
+        else
+        {
+            ItemsHeight = window->DC.CursorPos.y - StartPosY;
+        }
+        IM_ASSERT(ItemsHeight > 0.0f && "Unable to calculate item height! First item hasn't moved the cursor vertically!");
+        StepNo = 2;
+    }
+
     // Reached end of list
     if (DisplayEnd >= ItemsCount || GetSkipItemForListClipping())
     {
@@ -2298,25 +2318,6 @@ bool ImGuiListClipper::Step()
 
         // Already has item height (given by user in Begin): skip to calculating step
         DisplayStart = DisplayEnd;
-        StepNo = 2;
-    }
-
-    // Step 1: the clipper infer height from first element
-    if (StepNo == 1)
-    {
-        IM_ASSERT(ItemsHeight <= 0.0f);
-        if (table)
-        {
-            const float pos_y1 = table->RowPosY1;   // Using this instead of StartPosY to handle clipper straddling the frozen row
-            const float pos_y2 = table->RowPosY2;   // Using this instead of CursorPos.y to take account of tallest cell.
-            ItemsHeight = pos_y2 - pos_y1;
-            window->DC.CursorPos.y = pos_y2;
-        }
-        else
-        {
-            ItemsHeight = window->DC.CursorPos.y - StartPosY;
-        }
-        IM_ASSERT(ItemsHeight > 0.0f && "Unable to calculate item height! First item hasn't moved the cursor vertically!");
         StepNo = 2;
     }
 


### PR DESCRIPTION
ImGuiListClipper did not correctly calculate item height for single-item lists and therefore got the total y-offset wrong in the end. Code like this

```cpp
for(auto& resList : resLists) {
  ImGui::Text("Begin");
  
  ImGuiListClipper clipper;
  clipper.Begin(int(resMap.size()));
  
  while(clipper.Step()) {
    for(auto i = clipper.DisplayStart; i < clipper.DisplayEnd; ++i) {
      auto& entry = resList[i];
      auto label = name(*entry.second);
      if(ImGui::Button(label.c_str())) {
        select(*entry.second.get());
      }
    }
  }
  
  ImGui::Text("End");
  ImGui::Separator();
}
```

Generates the following problem:

![19 12_21 38 52](https://user-images.githubusercontent.com/13062371/102699245-97165f80-4243-11eb-82ed-5b34cc6e087e.png)

(This problem is present without the "Begin"/"End" texts and separators as well, they are for issue clarification).
Fixed this issue by moving the item height calculation before the early-out and End() call.
This is just a quick fix, it makes the code uglier and even more spaghettish, you might want to find something cleaner. I tested that it still works for lists with any number of items (including 0).

![19 12_21 55 06](https://user-images.githubusercontent.com/13062371/102699426-e0b37a00-4244-11eb-9372-2165a353d68b.png)
