### PR TITLE
Backends: DX12: improve Windows 7 compatibility

### DIFF
--- a/backends/imgui_impl_dx12.cpp
+++ b/backends/imgui_impl_dx12.cpp
@@ -15,6 +15,7 @@
 
 // CHANGELOG
 // (minor and older changes stripped away, please see git history for details)
+//  2021-01-04: DirectX12: Windows 7 compatibility improvements.
 //  2020-09-16: DirectX12: Avoid rendering calls with zero-sized scissor rectangle since it generates a validation layer warning.
 //  2020-09-08: DirectX12: Clarified support for building on 32-bit systems by redefining ImTextureID.
 //  2019-10-18: DirectX12: *BREAKING CHANGE* Added extra ID3D12DescriptorHeap parameter to ImGui_ImplDX12_Init() function.
@@ -452,8 +453,41 @@ bool    ImGui_ImplDX12_CreateDeviceObjects()
             D3D12_ROOT_SIGNATURE_FLAG_DENY_DOMAIN_SHADER_ROOT_ACCESS |
             D3D12_ROOT_SIGNATURE_FLAG_DENY_GEOMETRY_SHADER_ROOT_ACCESS;
 
+        // See if any version of d3d12.dll is already loaded in the process. If so, give preference to that.
+        static HINSTANCE d3d12_dll = ::GetModuleHandleA("d3d12.dll");
+        if (d3d12_dll == NULL)
+        {
+            // Attempt to load d3d12.dll from local directories. This will only succeed if
+            // (1) the current OS is Windows 7, and
+            // (2) there exists a version of d3d12.dll for Windows 7 (D3D12On7) in one of the following directories.
+            static const char* localD3d12Paths[] =
+            {
+                ".\\d3d12.dll",             // current directory
+                ".\\d3d12on7\\d3d12.dll",   // used by some games
+                ".\\12on7\\d3d12.dll"       // used in the Microsoft D3D12On7 sample
+            };
+
+            for (unsigned int i = 0; i < _countof(localD3d12Paths); i++)
+            {
+                d3d12_dll = LoadLibraryA(localD3d12Paths[i]);
+                if (d3d12_dll != NULL)
+                    break;
+            }
+
+            // If failed, we are on Windows >= 10.
+            if (d3d12_dll == NULL)
+                d3d12_dll = ::LoadLibraryA("d3d12.dll");
+
+            if (d3d12_dll == NULL)
+                return false;
+        }
+
+        PFN_D3D12_SERIALIZE_ROOT_SIGNATURE D3D12SerializeRootSignatureFn = (PFN_D3D12_SERIALIZE_ROOT_SIGNATURE)::GetProcAddress(d3d12_dll, "D3D12SerializeRootSignature");
+        if (D3D12SerializeRootSignatureFn == NULL)
+            return false;
+
         ID3DBlob* blob = NULL;
-        if (D3D12SerializeRootSignature(&desc, D3D_ROOT_SIGNATURE_VERSION_1, &blob, NULL) != S_OK)
+        if (D3D12SerializeRootSignatureFn(&desc, D3D_ROOT_SIGNATURE_VERSION_1, &blob, NULL) != S_OK)
             return false;
 
         g_pd3dDevice->CreateRootSignature(0, blob->GetBufferPointer(), blob->GetBufferSize(), IID_PPV_ARGS(&g_pRootSignature));


### PR DESCRIPTION
Recently I've worked on two separate projects that both use ImGui and needed Windows 7 support for a D3D12 game overlay. This PR is an attempt to get the most important changes required for this to work merged upstream.

Background: D3D12 support for Windows 7 is called [D3D12On7](https://devblogs.microsoft.com/directx/porting-directx-12-games-to-windows-7/) and requires loading a separate DLL located in the application directory or a subdirectory of it. Both changes in this PR are related to accommodating local (non-System32) versions of `d3d12.dll`:

- Attempt to load `d3d12.dll` from local D3D12On7 paths before falling back to System32: this change is the most important one. I based the code for this on the [Microsoft recommended way to load d3d12.dll](https://microsoft.github.io/DirectX-Specs/d3d/D3D12onWin7.html#load-dlls-properly), with the added change that there are three local paths tried instead of one. The local paths tried are those I've seen used in the wild by various games. Finally, if there is a `d3d12.dll` already loaded, it is given priority. This covers the case where a different path was used to load the DLL.
- Do not statically import `D3D12SerializeRootSignature`: this change is required in order for ImGui not to fail to be loaded on Windows 7 when `d3d12.dll` is in a local subdirectory. I based the code for this change on the existing `GetProcAddress`-using code in `imgui_impl_win32.cpp`.

The current PR should suffice for anyone integrating ImGui in an application that already has working D3D12On7 support. That means that **not** included in this PR are changes required to make the DX12 sample work on Windows 7. The reason for this is that I felt the amount of added code required for this would make the sample harder to follow due to having two separate `Present()` paths, while not adding much value except for a small subset of users. Another reason is the dependency on the redistributable binary `d3d12.dll`. However if desired I can add this to the PR as well.

More information on D3D12On7:
- [Development Guidance Document](https://microsoft.github.io/DirectX-Specs/d3d/D3D12onWin7.html)
- [D3D12On7 NuGet package](https://www.nuget.org/packages/Microsoft.Direct3D.D3D12On7) (to obtain `d3d12.dll` for Windows 7)
- [D3D12On7 sample](https://github.com/microsoft/DirectX-Graphics-Samples/tree/develop/Samples/Desktop/D3D12On7)