### PR TITLE
Small one-liner bugfix for lost docking information

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -14087,6 +14087,7 @@ void ImGui::DockNodeTreeSplit(ImGuiContext* ctx, ImGuiDockNode* parent_node, ImG
     child_1->SizeRef[split_axis] = ImFloor(size_avail - child_0->SizeRef[split_axis]);
 
     DockNodeMoveWindows(parent_node->ChildNodes[split_inheritor_child_idx], parent_node);
+    DockSettingsRenameNodeReferences(parent_node->ID, parent_node->ChildNodes[split_inheritor_child_idx]->ID);
     DockNodeTreeUpdatePosSize(parent_node, parent_node->Pos, parent_node->Size);
 
     // Flags transfer (e.g. this is where we transfer the ImGuiDockNodeFlags_CentralNode property)


### PR DESCRIPTION
Most of the calls to DockNodeMoveWindows() had a call to DockSettingsRenameNodeReferences() following, but in DockNodeTreeSplit() this call was missing.

----------
**Update:** The steps described reproduce the bug only when I use the DockBuilder for an initial dock node setup. The bug can still be reproduced with pure manual splitting, see [here](https://github.com/ocornut/imgui/pull/3716#issuecomment-760761240) for the exact steps. The fix still remains the same.
----------

A few steps to reproduce the docking bug...

1. create a dock space (every frame)
2. open "Window 1", dock it on the left side (or any other)
3. close "Window 1"
4. open "Window 2", dock it on the left again
5. open "Window 3", dock it under "Window 2" (split its dock node)
6. optionally close "Window 2" and/or "Window 3"
7. open "Window 1" again

If you do these steps, "Window 1" will reappear undocked. It memorized the dock node ID from step 2, but that one was made into a split node later, so now "Window 1" cannot dock into that node again. With the added call to DockSettingsRenameNodeReferences(), the memorized DockId will be updated for currently closed windows on subsequent splits.