### PR TITLE
[Backends-GLFW/SDL2] Hover events when window is unfocused

### DIFF
--- a/backends/imgui_impl_glfw.cpp
+++ b/backends/imgui_impl_glfw.cpp
@@ -269,18 +269,16 @@ static void ImGui_ImplGlfw_UpdateMousePosAndButtons()
 #else
     const bool focused = glfwGetWindowAttrib(g_Window, GLFW_FOCUSED) != 0;
 #endif
-    if (focused)
+    if (io.WantSetMousePos)
     {
-        if (io.WantSetMousePos)
-        {
+        if (focused)
             glfwSetCursorPos(g_Window, (double)mouse_pos_backup.x, (double)mouse_pos_backup.y);
-        }
-        else
-        {
-            double mouse_x, mouse_y;
-            glfwGetCursorPos(g_Window, &mouse_x, &mouse_y);
-            io.MousePos = ImVec2((float)mouse_x, (float)mouse_y);
-        }
+    }
+    else
+    {
+        double mouse_x, mouse_y;
+        glfwGetCursorPos(g_Window, &mouse_x, &mouse_y);
+        io.MousePos = ImVec2((float)mouse_x, (float)mouse_y);
     }
 }
 

--- a/backends/imgui_impl_sdl.cpp
+++ b/backends/imgui_impl_sdl.cpp
@@ -252,7 +252,7 @@ static void ImGui_ImplSDL2_UpdateMousePosAndButtons()
     g_MousePressed[0] = g_MousePressed[1] = g_MousePressed[2] = false;
 
 #if SDL_HAS_CAPTURE_AND_GLOBAL_MOUSE && !defined(__EMSCRIPTEN__) && !defined(__ANDROID__) && !(defined(__APPLE__) && TARGET_OS_IOS)
-    SDL_Window* focused_window = SDL_GetKeyboardFocus();
+    SDL_Window* focused_window = SDL_GetMouseFocus();
     if (g_Window == focused_window)
     {
         if (g_MouseCanUseGlobalState)


### PR DESCRIPTION
In all other GUIs that I know of, including windows, it is possible to to trigger hover events as well as scroll in windows that are not currently selected/focused. Right now in ImGui, these events are completely ignored unless the window currently has focus. 

I saw there is already a pull request for this same functionality open for the Win32 backend (#2696).