### PR TITLE
Add an ability to update font atlas texture

### DIFF
--- a/backends/imgui_impl_dx10.cpp
+++ b/backends/imgui_impl_dx10.cpp
@@ -15,6 +15,7 @@
 
 // CHANGELOG
 // (minor and older changes stripped away, please see git history for details)
+//  2023-XX-XX: DirectX10: Add support for ImGuiBackendFlags_RendererHasTexReload.
 //  2022-10-11: Using 'nullptr' instead of 'NULL' as per our switch to C++11.
 //  2021-06-29: Reorganized backend to pull data from a single structure to facilitate usage with multiple-contexts (all g_XXXX access changed to bd->XXXX).
 //  2021-05-19: DirectX10: Replaced direct access to ImDrawCmd::TextureId with a call to ImDrawCmd::GetTexID(). (will become a requirement)
@@ -57,6 +58,9 @@ struct ImGui_ImplDX10_Data
     ID3D10Buffer*               pVertexConstantBuffer;
     ID3D10PixelShader*          pPixelShader;
     ID3D10SamplerState*         pFontSampler;
+    ID3D10Texture2D*            pFontTexture;
+    int                         FontTextureWidth;
+    int                         FontTextureHeight;
     ID3D10ShaderResourceView*   pFontTextureView;
     ID3D10RasterizerState*      pRasterizerState;
     ID3D10BlendState*           pBlendState;
@@ -296,46 +300,73 @@ void ImGui_ImplDX10_RenderDrawData(ImDrawData* draw_data)
     ctx->IASetInputLayout(old.InputLayout); if (old.InputLayout) old.InputLayout->Release();
 }
 
-static void ImGui_ImplDX10_CreateFontsTexture()
+static void ImGui_ImplDX10_UpdateFontsTexture()
 {
     // Build texture atlas
     ImGui_ImplDX10_Data* bd = ImGui_ImplDX10_GetBackendData();
     ImGuiIO& io = ImGui::GetIO();
+
     unsigned char* pixels;
     int width, height;
     io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);
+    io.Fonts->MarkClean();
 
-    // Upload texture to graphics system
+    if ((!bd->pFontTextureView) || (bd->FontTextureWidth != width) || (bd->FontTextureHeight != height))
     {
-        D3D10_TEXTURE2D_DESC desc;
-        ZeroMemory(&desc, sizeof(desc));
-        desc.Width = width;
-        desc.Height = height;
-        desc.MipLevels = 1;
-        desc.ArraySize = 1;
-        desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-        desc.SampleDesc.Count = 1;
-        desc.Usage = D3D10_USAGE_DEFAULT;
-        desc.BindFlags = D3D10_BIND_SHADER_RESOURCE;
-        desc.CPUAccessFlags = 0;
+        // Either we have no texture or the size has changed, so (re-)create the texture
 
-        ID3D10Texture2D* pTexture = nullptr;
-        D3D10_SUBRESOURCE_DATA subResource;
-        subResource.pSysMem = pixels;
-        subResource.SysMemPitch = desc.Width * 4;
-        subResource.SysMemSlicePitch = 0;
-        bd->pd3dDevice->CreateTexture2D(&desc, &subResource, &pTexture);
-        IM_ASSERT(pTexture != nullptr);
+        // Release old texture
+        if (bd->pFontTextureView) { bd->pFontTextureView->Release(); bd->pFontTextureView = nullptr; ImGui::GetIO().Fonts->SetTexID(0); } // We copied g_pFontTextureView to io.Fonts->TexID so let's clear that as well.
+        if (bd->pFontTexture) { bd->pFontTexture->Release(); bd->pFontTexture = nullptr; }
 
-        // Create texture view
-        D3D10_SHADER_RESOURCE_VIEW_DESC srv_desc;
-        ZeroMemory(&srv_desc, sizeof(srv_desc));
-        srv_desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-        srv_desc.ViewDimension = D3D10_SRV_DIMENSION_TEXTURE2D;
-        srv_desc.Texture2D.MipLevels = desc.MipLevels;
-        srv_desc.Texture2D.MostDetailedMip = 0;
-        bd->pd3dDevice->CreateShaderResourceView(pTexture, &srv_desc, &bd->pFontTextureView);
-        pTexture->Release();
+        // Create new texture
+        {
+            D3D10_TEXTURE2D_DESC desc;
+            ZeroMemory(&desc, sizeof(desc));
+            desc.Width = width;
+            desc.Height = height;
+            desc.MipLevels = 1;
+            desc.ArraySize = 1;
+            desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+            desc.SampleDesc.Count = 1;
+            desc.Usage = D3D10_USAGE_DEFAULT;
+            desc.BindFlags = D3D10_BIND_SHADER_RESOURCE;
+            desc.CPUAccessFlags = 0;
+
+            D3D10_SUBRESOURCE_DATA subResource;
+            subResource.pSysMem = pixels;
+            subResource.SysMemPitch = desc.Width * 4;
+            subResource.SysMemSlicePitch = 0;
+            bd->pd3dDevice->CreateTexture2D(&desc, &subResource, &bd->pFontTexture);
+            IM_ASSERT(bd->pFontTexture != nullptr);
+
+            // Create texture view
+            D3D10_SHADER_RESOURCE_VIEW_DESC srv_desc;
+            ZeroMemory(&srv_desc, sizeof(srv_desc));
+            srv_desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+            srv_desc.ViewDimension = D3D10_SRV_DIMENSION_TEXTURE2D;
+            srv_desc.Texture2D.MipLevels = desc.MipLevels;
+            srv_desc.Texture2D.MostDetailedMip = 0;
+            bd->pd3dDevice->CreateShaderResourceView(bd->pFontTexture, &srv_desc, &bd->pFontTextureView);
+        }
+
+        // Store size
+        bd->FontTextureWidth = width;
+        bd->FontTextureHeight = height;
+    }
+    else
+    {
+        // Upload new atlas data
+
+        D3D10_BOX box;
+        box.left = 0;
+        box.right = width;
+        box.top = 0;
+        box.bottom = height;
+        box.front = 0;
+        box.back = 1;
+
+        bd->pd3dDevice->UpdateSubresource(bd->pFontTexture, 0, &box, pixels, bd->FontTextureWidth * 4, 0);
     }
 
     // Store our identifier
@@ -343,6 +374,7 @@ static void ImGui_ImplDX10_CreateFontsTexture()
 
     // Create texture sampler
     // (Bilinear sampling is required by default. Set 'io.Fonts->Flags |= ImFontAtlasFlags_NoBakedLines' or 'style.AntiAliasedLinesUseTex = false' to allow point/nearest sampling)
+    if (!bd->pFontSampler)
     {
         D3D10_SAMPLER_DESC desc;
         ZeroMemory(&desc, sizeof(desc));
@@ -507,7 +539,7 @@ bool    ImGui_ImplDX10_CreateDeviceObjects()
         bd->pd3dDevice->CreateDepthStencilState(&desc, &bd->pDepthStencilState);
     }
 
-    ImGui_ImplDX10_CreateFontsTexture();
+    ImGui_ImplDX10_UpdateFontsTexture();
 
     return true;
 }
@@ -520,6 +552,7 @@ void    ImGui_ImplDX10_InvalidateDeviceObjects()
 
     if (bd->pFontSampler)           { bd->pFontSampler->Release(); bd->pFontSampler = nullptr; }
     if (bd->pFontTextureView)       { bd->pFontTextureView->Release(); bd->pFontTextureView = nullptr; ImGui::GetIO().Fonts->SetTexID(0); } // We copied bd->pFontTextureView to io.Fonts->TexID so let's clear that as well.
+    if (bd->pFontTexture)           { bd->pFontTexture->Release(); bd->pFontTexture = nullptr; }
     if (bd->pIB)                    { bd->pIB->Release(); bd->pIB = nullptr; }
     if (bd->pVB)                    { bd->pVB->Release(); bd->pVB = nullptr; }
     if (bd->pBlendState)            { bd->pBlendState->Release(); bd->pBlendState = nullptr; }
@@ -542,6 +575,7 @@ bool    ImGui_ImplDX10_Init(ID3D10Device* device)
     io.BackendRendererUserData = (void*)bd;
     io.BackendRendererName = "imgui_impl_dx10";
     io.BackendFlags |= ImGuiBackendFlags_RendererHasVtxOffset;  // We can honor the ImDrawCmd::VtxOffset field, allowing for large meshes.
+    io.BackendFlags |= ImGuiBackendFlags_RendererHasTexReload;  // We support font atlas texture reloading (IsDirty() check in ImGui_ImplDX10_NewFrame)
 
     // Get factory from device
     IDXGIDevice* pDXGIDevice = nullptr;
@@ -583,6 +617,10 @@ void ImGui_ImplDX10_NewFrame()
 
     if (!bd->pFontSampler)
         ImGui_ImplDX10_CreateDeviceObjects();
+
+    ImGuiIO& io = ImGui::GetIO();
+    if (io.Fonts->IsDirty())
+        ImGui_ImplDX10_UpdateFontsTexture();
 }
 
 //-----------------------------------------------------------------------------

--- a/backends/imgui_impl_dx11.cpp
+++ b/backends/imgui_impl_dx11.cpp
@@ -15,6 +15,7 @@
 
 // CHANGELOG
 // (minor and older changes stripped away, please see git history for details)
+//  2023-XX-XX: DirectX11: Add support for ImGuiBackendFlags_RendererHasTexReload.
 //  2022-10-11: Using 'nullptr' instead of 'NULL' as per our switch to C++11.
 //  2021-06-29: Reorganized backend to pull data from a single structure to facilitate usage with multiple-contexts (all g_XXXX access changed to bd->XXXX).
 //  2021-05-19: DirectX11: Replaced direct access to ImDrawCmd::TextureId with a call to ImDrawCmd::GetTexID(). (will become a requirement)
@@ -58,6 +59,9 @@ struct ImGui_ImplDX11_Data
     ID3D11Buffer*               pVertexConstantBuffer;
     ID3D11PixelShader*          pPixelShader;
     ID3D11SamplerState*         pFontSampler;
+    ID3D11Texture2D*            pFontTexture;
+    int                         FontTextureWidth;
+    int                         FontTextureHeight;
     ID3D11ShaderResourceView*   pFontTextureView;
     ID3D11RasterizerState*      pRasterizerState;
     ID3D11BlendState*           pBlendState;
@@ -308,46 +312,73 @@ void ImGui_ImplDX11_RenderDrawData(ImDrawData* draw_data)
     ctx->IASetInputLayout(old.InputLayout); if (old.InputLayout) old.InputLayout->Release();
 }
 
-static void ImGui_ImplDX11_CreateFontsTexture()
+static void ImGui_ImplDX11_UpdateFontsTexture()
 {
-    // Build texture atlas
     ImGuiIO& io = ImGui::GetIO();
     ImGui_ImplDX11_Data* bd = ImGui_ImplDX11_GetBackendData();
+
+    // Build texture atlas
     unsigned char* pixels;
     int width, height;
     io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);
+    io.Fonts->MarkClean();
 
-    // Upload texture to graphics system
+    if ((!bd->pFontTextureView) || (bd->FontTextureWidth != width) || (bd->FontTextureHeight != height))
     {
-        D3D11_TEXTURE2D_DESC desc;
-        ZeroMemory(&desc, sizeof(desc));
-        desc.Width = width;
-        desc.Height = height;
-        desc.MipLevels = 1;
-        desc.ArraySize = 1;
-        desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-        desc.SampleDesc.Count = 1;
-        desc.Usage = D3D11_USAGE_DEFAULT;
-        desc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
-        desc.CPUAccessFlags = 0;
+        // Either we have no texture or the size has changed, so (re-)create the texture
 
-        ID3D11Texture2D* pTexture = nullptr;
-        D3D11_SUBRESOURCE_DATA subResource;
-        subResource.pSysMem = pixels;
-        subResource.SysMemPitch = desc.Width * 4;
-        subResource.SysMemSlicePitch = 0;
-        bd->pd3dDevice->CreateTexture2D(&desc, &subResource, &pTexture);
-        IM_ASSERT(pTexture != nullptr);
+        // Release old texture
+        if (bd->pFontTextureView) { bd->pFontTextureView->Release(); bd->pFontTextureView = nullptr; ImGui::GetIO().Fonts->SetTexID(0); } // We copied g_pFontTextureView to io.Fonts->TexID so let's clear that as well.
+        if (bd->pFontTexture) { bd->pFontTexture->Release(); bd->pFontTexture = nullptr; }
 
-        // Create texture view
-        D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc;
-        ZeroMemory(&srvDesc, sizeof(srvDesc));
-        srvDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-        srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
-        srvDesc.Texture2D.MipLevels = desc.MipLevels;
-        srvDesc.Texture2D.MostDetailedMip = 0;
-        bd->pd3dDevice->CreateShaderResourceView(pTexture, &srvDesc, &bd->pFontTextureView);
-        pTexture->Release();
+        // Create new texture
+        {
+            D3D11_TEXTURE2D_DESC desc;
+            ZeroMemory(&desc, sizeof(desc));
+            desc.Width = width;
+            desc.Height = height;
+            desc.MipLevels = 1;
+            desc.ArraySize = 1;
+            desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+            desc.SampleDesc.Count = 1;
+            desc.Usage = D3D11_USAGE_DEFAULT;
+            desc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+            desc.CPUAccessFlags = 0;
+
+            D3D11_SUBRESOURCE_DATA subResource;
+            subResource.pSysMem = pixels;
+            subResource.SysMemPitch = desc.Width * 4;
+            subResource.SysMemSlicePitch = 0;
+            bd->pd3dDevice->CreateTexture2D(&desc, &subResource, &bd->pFontTexture);
+            IM_ASSERT(bd->pFontTexture != nullptr);
+
+            // Create texture view
+            D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc;
+            ZeroMemory(&srvDesc, sizeof(srvDesc));
+            srvDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+            srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+            srvDesc.Texture2D.MipLevels = desc.MipLevels;
+            srvDesc.Texture2D.MostDetailedMip = 0;
+            bd->pd3dDevice->CreateShaderResourceView(bd->pFontTexture, &srvDesc, &bd->pFontTextureView);
+        }
+
+        // Store size
+        bd->FontTextureWidth = width;
+        bd->FontTextureHeight = height;
+    }
+    else
+    {
+        // Upload new atlas data
+
+        D3D11_BOX box;
+        box.left = 0;
+        box.right = width;
+        box.top = 0;
+        box.bottom = height;
+        box.front = 0;
+        box.back = 1;
+
+        bd->pd3dDeviceContext->UpdateSubresource(bd->pFontTexture, 0, &box, pixels, bd->FontTextureWidth * 4, 0);
     }
 
     // Store our identifier
@@ -355,6 +386,7 @@ static void ImGui_ImplDX11_CreateFontsTexture()
 
     // Create texture sampler
     // (Bilinear sampling is required by default. Set 'io.Fonts->Flags |= ImFontAtlasFlags_NoBakedLines' or 'style.AntiAliasedLinesUseTex = false' to allow point/nearest sampling)
+    if (!bd->pFontSampler)
     {
         D3D11_SAMPLER_DESC desc;
         ZeroMemory(&desc, sizeof(desc));
@@ -519,7 +551,7 @@ bool    ImGui_ImplDX11_CreateDeviceObjects()
         bd->pd3dDevice->CreateDepthStencilState(&desc, &bd->pDepthStencilState);
     }
 
-    ImGui_ImplDX11_CreateFontsTexture();
+    ImGui_ImplDX11_UpdateFontsTexture();
 
     return true;
 }
@@ -532,6 +564,7 @@ void    ImGui_ImplDX11_InvalidateDeviceObjects()
 
     if (bd->pFontSampler)           { bd->pFontSampler->Release(); bd->pFontSampler = nullptr; }
     if (bd->pFontTextureView)       { bd->pFontTextureView->Release(); bd->pFontTextureView = nullptr; ImGui::GetIO().Fonts->SetTexID(0); } // We copied data->pFontTextureView to io.Fonts->TexID so let's clear that as well.
+    if (bd->pFontTexture)           { bd->pFontTexture->Release(); bd->pFontTexture = nullptr; }
     if (bd->pIB)                    { bd->pIB->Release(); bd->pIB = nullptr; }
     if (bd->pVB)                    { bd->pVB->Release(); bd->pVB = nullptr; }
     if (bd->pBlendState)            { bd->pBlendState->Release(); bd->pBlendState = nullptr; }
@@ -554,6 +587,7 @@ bool    ImGui_ImplDX11_Init(ID3D11Device* device, ID3D11DeviceContext* device_co
     io.BackendRendererUserData = (void*)bd;
     io.BackendRendererName = "imgui_impl_dx11";
     io.BackendFlags |= ImGuiBackendFlags_RendererHasVtxOffset;  // We can honor the ImDrawCmd::VtxOffset field, allowing for large meshes.
+    io.BackendFlags |= ImGuiBackendFlags_RendererHasTexReload;  // We support font atlas texture reloading (IsDirty() check in ImGui_ImplDX11_NewFrame)
 
     // Get factory from device
     IDXGIDevice* pDXGIDevice = nullptr;
@@ -599,6 +633,10 @@ void ImGui_ImplDX11_NewFrame()
 
     if (!bd->pFontSampler)
         ImGui_ImplDX11_CreateDeviceObjects();
+
+    ImGuiIO& io = ImGui::GetIO();
+    if (io.Fonts->IsDirty())
+        ImGui_ImplDX11_UpdateFontsTexture();
 }
 
 //-----------------------------------------------------------------------------

--- a/backends/imgui_impl_dx12.cpp
+++ b/backends/imgui_impl_dx12.cpp
@@ -23,6 +23,7 @@
 
 // CHANGELOG
 // (minor and older changes stripped away, please see git history for details)
+//  2023-XX-XX: *BREAKING CHANGE*: DirectX12: Changed ImGui_ImplDX12_CreateFontsTexture() to ImGui_ImplDX12_UpdateFontsTexture(), which should be called at the start of the frame when ImGui::GetIO().Fonts->IsDirty() is true to reupload the font texture. ImGuiBackendFlags_RendererHasTexReload should be set once this is implemented.
 //  2022-10-11: Using 'nullptr' instead of 'NULL' as per our switch to C++11.
 //  2021-06-29: Reorganized backend to pull data from a single structure to facilitate usage with multiple-contexts (all g_XXXX access changed to bd->XXXX).
 //  2021-05-19: DirectX12: Replaced direct access to ImDrawCmd::TextureId with a call to ImDrawCmd::GetTexID(). (will become a requirement)
@@ -62,6 +63,8 @@ struct ImGui_ImplDX12_Data
     ID3D12PipelineState*        pPipelineState;
     DXGI_FORMAT                 RTVFormat;
     ID3D12Resource*             pFontTextureResource;
+    int                         FontTextureWidth;
+    int                         FontTextureHeight;
     D3D12_CPU_DESCRIPTOR_HANDLE hFontSrvCpuDescHandle;
     D3D12_GPU_DESCRIPTOR_HANDLE hFontSrvGpuDescHandle;
     ID3D12DescriptorHeap*       pd3dSrvDescHeap;
@@ -287,7 +290,7 @@ void ImGui_ImplDX12_RenderDrawData(ImDrawData* draw_data, ID3D12GraphicsCommandL
     }
 }
 
-static void ImGui_ImplDX12_CreateFontsTexture()
+void ImGui_ImplDX12_UpdateFontsTexture()
 {
     // Build texture atlas
     ImGuiIO& io = ImGui::GetIO();
@@ -295,9 +298,13 @@ static void ImGui_ImplDX12_CreateFontsTexture()
     unsigned char* pixels;
     int width, height;
     io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);
+    io.Fonts->MarkClean();
 
-    // Upload texture to graphics system
+    bool need_barrier_before_copy = true; // Do we need a resource barrier before we copy new data in?
+
+    if ((!bd->pFontTextureResource) || (bd->FontTextureWidth != width) || (bd->FontTextureHeight != height))
     {
+        // Either we have no texture or the size has changed, so (re-)create the texture
         D3D12_HEAP_PROPERTIES props;
         memset(&props, 0, sizeof(D3D12_HEAP_PROPERTIES));
         props.Type = D3D12_HEAP_TYPE_DEFAULT;
@@ -322,8 +329,42 @@ static void ImGui_ImplDX12_CreateFontsTexture()
         bd->pd3dDevice->CreateCommittedResource(&props, D3D12_HEAP_FLAG_NONE, &desc,
             D3D12_RESOURCE_STATE_COPY_DEST, nullptr, IID_PPV_ARGS(&pTexture));
 
+        // Create SRV
+        D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc;
+        ZeroMemory(&srvDesc, sizeof(srvDesc));
+        srvDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+        srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+        srvDesc.Texture2D.MipLevels = desc.MipLevels;
+        srvDesc.Texture2D.MostDetailedMip = 0;
+        srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+        bd->pd3dDevice->CreateShaderResourceView(pTexture, &srvDesc, bd->hFontSrvCpuDescHandle);
+        SafeRelease(bd->pFontTextureResource);
+        bd->pFontTextureResource = pTexture;
+
+        bd->FontTextureWidth = width;
+        bd->FontTextureHeight = height;
+
+        need_barrier_before_copy = false; // Because this is a newly-created texture it will be in D3D12_RESOURCE_STATE_COMMON and thus we don't need a barrier
+    }
+
+    // Store our identifier
+    // READ THIS IF THE STATIC_ASSERT() TRIGGERS:
+    // - Important: to compile on 32-bit systems, this backend requires code to be compiled with '#define ImTextureID ImU64'.
+    // - This is because we need ImTextureID to carry a 64-bit value and by default ImTextureID is defined as void*.
+    // [Solution 1] IDE/msbuild: in "Properties/C++/Preprocessor Definitions" add 'ImTextureID=ImU64' (this is what we do in the 'example_win32_direct12/example_win32_direct12.vcxproj' project file)
+    // [Solution 2] IDE/msbuild: in "Properties/C++/Preprocessor Definitions" add 'IMGUI_USER_CONFIG="my_imgui_config.h"' and inside 'my_imgui_config.h' add '#define ImTextureID ImU64' and as many other options as you like.
+    // [Solution 3] IDE/msbuild: edit imconfig.h and add '#define ImTextureID ImU64' (prefer solution 2 to create your own config file!)
+    // [Solution 4] command-line: add '/D ImTextureID=ImU64' to your cl.exe command-line (this is what we do in the example_win32_direct12/build_win32.bat file)
+    static_assert(sizeof(ImTextureID) >= sizeof(bd->hFontSrvGpuDescHandle.ptr), "Can't pack descriptor handle into TexID, 32-bit not supported yet.");
+    io.Fonts->SetTexID((ImTextureID)bd->hFontSrvGpuDescHandle.ptr);
+
+    // Upload texture
+    {
         UINT uploadPitch = (width * 4 + D3D12_TEXTURE_DATA_PITCH_ALIGNMENT - 1u) & ~(D3D12_TEXTURE_DATA_PITCH_ALIGNMENT - 1u);
         UINT uploadSize = height * uploadPitch;
+
+        D3D12_RESOURCE_DESC desc;
+        ZeroMemory(&desc, sizeof(desc));
         desc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
         desc.Alignment = 0;
         desc.Width = uploadSize;
@@ -336,6 +377,8 @@ static void ImGui_ImplDX12_CreateFontsTexture()
         desc.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
         desc.Flags = D3D12_RESOURCE_FLAG_NONE;
 
+        D3D12_HEAP_PROPERTIES props;
+        memset(&props, 0, sizeof(D3D12_HEAP_PROPERTIES));
         props.Type = D3D12_HEAP_TYPE_UPLOAD;
         props.CPUPageProperty = D3D12_CPU_PAGE_PROPERTY_UNKNOWN;
         props.MemoryPoolPreference = D3D12_MEMORY_POOL_UNKNOWN;
@@ -363,17 +406,11 @@ static void ImGui_ImplDX12_CreateFontsTexture()
         srcLocation.PlacedFootprint.Footprint.RowPitch = uploadPitch;
 
         D3D12_TEXTURE_COPY_LOCATION dstLocation = {};
-        dstLocation.pResource = pTexture;
+        dstLocation.pResource = bd->pFontTextureResource;
         dstLocation.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
         dstLocation.SubresourceIndex = 0;
 
-        D3D12_RESOURCE_BARRIER barrier = {};
-        barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
-        barrier.Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
-        barrier.Transition.pResource   = pTexture;
-        barrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
-        barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_DEST;
-        barrier.Transition.StateAfter  = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+        // Create temporary command list and execute immediately
 
         ID3D12Fence* fence = nullptr;
         hr = bd->pd3dDevice->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&fence));
@@ -399,8 +436,30 @@ static void ImGui_ImplDX12_CreateFontsTexture()
         hr = bd->pd3dDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, cmdAlloc, nullptr, IID_PPV_ARGS(&cmdList));
         IM_ASSERT(SUCCEEDED(hr));
 
+        if (need_barrier_before_copy)
+        {
+            D3D12_RESOURCE_BARRIER barrier = {};
+            barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+            barrier.Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
+            barrier.Transition.pResource = bd->pFontTextureResource;
+            barrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+            barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+            barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_DEST;
+            cmdList->ResourceBarrier(1, &barrier);
+        }
+
         cmdList->CopyTextureRegion(&dstLocation, 0, 0, 0, &srcLocation, nullptr);
-        cmdList->ResourceBarrier(1, &barrier);
+
+        {
+            D3D12_RESOURCE_BARRIER barrier = {};
+            barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+            barrier.Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
+            barrier.Transition.pResource = bd->pFontTextureResource;
+            barrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+            barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_DEST;
+            barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+            cmdList->ResourceBarrier(1, &barrier);
+        }
 
         hr = cmdList->Close();
         IM_ASSERT(SUCCEEDED(hr));
@@ -418,30 +477,7 @@ static void ImGui_ImplDX12_CreateFontsTexture()
         CloseHandle(event);
         fence->Release();
         uploadBuffer->Release();
-
-        // Create texture view
-        D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc;
-        ZeroMemory(&srvDesc, sizeof(srvDesc));
-        srvDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-        srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-        srvDesc.Texture2D.MipLevels = desc.MipLevels;
-        srvDesc.Texture2D.MostDetailedMip = 0;
-        srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-        bd->pd3dDevice->CreateShaderResourceView(pTexture, &srvDesc, bd->hFontSrvCpuDescHandle);
-        SafeRelease(bd->pFontTextureResource);
-        bd->pFontTextureResource = pTexture;
     }
-
-    // Store our identifier
-    // READ THIS IF THE STATIC_ASSERT() TRIGGERS:
-    // - Important: to compile on 32-bit systems, this backend requires code to be compiled with '#define ImTextureID ImU64'.
-    // - This is because we need ImTextureID to carry a 64-bit value and by default ImTextureID is defined as void*.
-    // [Solution 1] IDE/msbuild: in "Properties/C++/Preprocessor Definitions" add 'ImTextureID=ImU64' (this is what we do in the 'example_win32_direct12/example_win32_direct12.vcxproj' project file)
-    // [Solution 2] IDE/msbuild: in "Properties/C++/Preprocessor Definitions" add 'IMGUI_USER_CONFIG="my_imgui_config.h"' and inside 'my_imgui_config.h' add '#define ImTextureID ImU64' and as many other options as you like.
-    // [Solution 3] IDE/msbuild: edit imconfig.h and add '#define ImTextureID ImU64' (prefer solution 2 to create your own config file!)
-    // [Solution 4] command-line: add '/D ImTextureID=ImU64' to your cl.exe command-line (this is what we do in the example_win32_direct12/build_win32.bat file)
-    static_assert(sizeof(ImTextureID) >= sizeof(bd->hFontSrvGpuDescHandle.ptr), "Can't pack descriptor handle into TexID, 32-bit not supported yet.");
-    io.Fonts->SetTexID((ImTextureID)bd->hFontSrvGpuDescHandle.ptr);
 }
 
 bool    ImGui_ImplDX12_CreateDeviceObjects()
@@ -673,7 +709,7 @@ bool    ImGui_ImplDX12_CreateDeviceObjects()
     if (result_pipeline_state != S_OK)
         return false;
 
-    ImGui_ImplDX12_CreateFontsTexture();
+    ImGui_ImplDX12_UpdateFontsTexture();
 
     return true;
 }
@@ -710,6 +746,7 @@ bool ImGui_ImplDX12_Init(ID3D12Device* device, int num_frames_in_flight, DXGI_FO
     io.BackendRendererUserData = (void*)bd;
     io.BackendRendererName = "imgui_impl_dx12";
     io.BackendFlags |= ImGuiBackendFlags_RendererHasVtxOffset;  // We can honor the ImDrawCmd::VtxOffset field, allowing for large meshes.
+    // Note that we explicitly do *not* set ImGuiBackendFlags_RendererHasTexReload here, because in DX12 that requires support in the caller as well, so we leave setting it (or not) up to that code.
 
     bd->pd3dDevice = device;
     bd->RTVFormat = rtv_format;

--- a/backends/imgui_impl_dx12.h
+++ b/backends/imgui_impl_dx12.h
@@ -38,6 +38,7 @@ IMGUI_IMPL_API bool     ImGui_ImplDX12_Init(ID3D12Device* device, int num_frames
 IMGUI_IMPL_API void     ImGui_ImplDX12_Shutdown();
 IMGUI_IMPL_API void     ImGui_ImplDX12_NewFrame();
 IMGUI_IMPL_API void     ImGui_ImplDX12_RenderDrawData(ImDrawData* draw_data, ID3D12GraphicsCommandList* graphics_command_list);
+IMGUI_IMPL_API void     ImGui_ImplDX12_UpdateFontsTexture(); // This should be called when the font texture needs updating (if ImGuiBackendFlags_RendererHasTexReload was set), with the GPU idle. It will perform the update using a temporary command list, and block internally until it completes.
 
 // Use if you want to reset your rendering device without losing Dear ImGui state.
 IMGUI_IMPL_API void     ImGui_ImplDX12_InvalidateDeviceObjects();

--- a/backends/imgui_impl_dx9.cpp
+++ b/backends/imgui_impl_dx9.cpp
@@ -464,15 +464,19 @@ static void ImGui_ImplDX9_DeleteTextures(ImVector<LPDIRECT3DTEXTURE9>& textures)
         textures[i]->Release();
 }
 
-static void ImGui_ImplDX9_UpdateTextures(ImVector<LPDIRECT3DTEXTURE9>& textures, const ImVector<ImTextureData*>& textures_data)
+void ImGui_ImplDX9_UpdateTextures()
 {
+    ImGui_ImplDX9_Data* bd = ImGui_ImplDX9_GetBackendData();
+    ImVector<LPDIRECT3DTEXTURE9>& textures = bd->FontTextures;
+    ImTextureUpdateData* update_data = ImGui::GetTextureUpdateData();
+
     ImVector<LPDIRECT3DTEXTURE9> discarded = textures;
 
-    bool recreate_all = textures.empty();
+    bool recreate_all = (textures.Size == 0);
 
-    for (int i = 0; i < textures_data.Size; ++i)
+    for (int i = 0; i < update_data->Textures.Size; ++i)
     {
-        ImTextureData* texture_data = textures_data[i];
+        ImTextureData* texture_data = update_data->Textures[i];
 
         LPDIRECT3DTEXTURE9 current_texture = (LPDIRECT3DTEXTURE9)texture_data->GetTexID();
         if (current_texture == nullptr || recreate_all || texture_data->IsDirty())
@@ -492,21 +496,15 @@ static void ImGui_ImplDX9_UpdateTextures(ImVector<LPDIRECT3DTEXTURE9>& textures,
             texture_data->MarkClean();
         }
         else if (current_texture)
+        {
             discarded.find_erase_unsorted(current_texture);
+        }
     }
 
     ImGui_ImplDX9_DeleteTextures(discarded);
 
     for (int i = 0; i < discarded.Size; ++i)
         textures.find_erase_unsorted(discarded[i]);
-}
-
-void ImGui_ImplDX9_UpdateTextures()
-{
-    ImGui_ImplDX9_Data* bd = ImGui_ImplDX9_GetBackendData();
-    ImTextureUpdateData texture_update_data = ImGui::GetTextureUpdateData();
-
-    ImGui_ImplDX9_UpdateTextures(bd->FontTextures, texture_update_data.Textures);
 }
 
 //-----------------------------------------------------------------------------

--- a/backends/imgui_impl_dx9.cpp
+++ b/backends/imgui_impl_dx9.cpp
@@ -49,12 +49,12 @@ struct ImGui_ImplDX9_Data
     LPDIRECT3DDEVICE9           pd3dDevice;
     LPDIRECT3DVERTEXBUFFER9     pVB;
     LPDIRECT3DINDEXBUFFER9      pIB;
-    ImVector<LPDIRECT3DTEXTURE9>FontTextures;
-    int                         FontTexturesUpdateFrame;
+    ImVector<LPDIRECT3DTEXTURE9>Textures;
+    int                         TexturesUpdateFrame;
     int                         VertexBufferSize;
     int                         IndexBufferSize;
 
-    ImGui_ImplDX9_Data()        { memset((void*)this, 0, sizeof(*this)); FontTexturesUpdateFrame = -1; VertexBufferSize = 5000; IndexBufferSize = 10000; }
+    ImGui_ImplDX9_Data()        { memset((void*)this, 0, sizeof(*this)); TexturesUpdateFrame = -1; VertexBufferSize = 5000; IndexBufferSize = 10000; }
 };
 
 struct CUSTOMVERTEX
@@ -77,9 +77,6 @@ static ImGui_ImplDX9_Data* ImGui_ImplDX9_GetBackendData()
 {
     return ImGui::GetCurrentContext() ? (ImGui_ImplDX9_Data*)ImGui::GetIO().BackendRendererUserData : nullptr;
 }
-
-// Functions
-static LPDIRECT3DTEXTURE9 ImGui_ImplDX9_UpdateTexture(const ImTextureData& texture_data);
 
 static void ImGui_ImplDX9_SetupRenderState(ImDrawData* draw_data)
 {
@@ -159,7 +156,7 @@ void ImGui_ImplDX9_RenderDrawData(ImDrawData* draw_data)
 
     // Update textures if not done already
     ImGui_ImplDX9_Data* bd = ImGui_ImplDX9_GetBackendData();
-    if (bd->FontTexturesUpdateFrame != ImGui::GetFrameCount())
+    if (bd->TexturesUpdateFrame != ImGui::GetFrameCount())
         ImGui_ImplDX9_UpdateTextures();
 
     // Create and grow buffers if needed
@@ -341,17 +338,17 @@ static bool ImGui_ImplDX9_CheckFormatSupport(IDirect3DDevice9* pDevice, D3DFORMA
     return support;
 }
 
-static LPDIRECT3DTEXTURE9 ImGui_ImplDX9_UpdateTexture(LPDIRECT3DTEXTURE9 texture, const ImTextureData& texture_data)
+static LPDIRECT3DTEXTURE9 ImGui_ImplDX9_UpdateTexture(LPDIRECT3DTEXTURE9 gpu_tex, const ImTextureData* in_tex_data)
 {
     ImGui_ImplDX9_Data* bd = ImGui_ImplDX9_GetBackendData();
-    unsigned char*     pixels          = (unsigned char*)texture_data.TexPixels;
-    int                width           = texture_data.TexWidth;
-    int                height          = texture_data.TexHeight;
+    unsigned char*  pixels  = (unsigned char*)in_tex_data->TexPixels;
+    int             width   = in_tex_data->TexWidth;
+    int             height  = in_tex_data->TexHeight;
 
     // Convert RGBA32 to BGRA32 (because RGBA32 is not well supported by DX9 devices)
 #ifndef IMGUI_USE_BGRA_PACKED_COLOR
     const bool rgba_support = ImGui_ImplDX9_CheckFormatSupport(bd->pd3dDevice, D3DFMT_A8B8G8R8);
-    if (!rgba_support && texture_data.TexFormat == ImTextureFormat_RGBA32)
+    if (!rgba_support && in_tex_data->TexFormat == ImTextureFormat_RGBA32)
     {
         int bytes_per_pixel = 4;
         ImU32* dst_start = (ImU32*)ImGui::MemAlloc((size_t)width * height * bytes_per_pixel);
@@ -363,16 +360,15 @@ static LPDIRECT3DTEXTURE9 ImGui_ImplDX9_UpdateTexture(LPDIRECT3DTEXTURE9 texture
     const bool rgba_support = false;
 #endif
 
+    // Create or recreate texture if needed
     D3DSURFACE_DESC surface_desc = {};
-    if (texture)
-        texture->GetLevelDesc(0, &surface_desc);
-
-    // Upload texture to graphics system
-    if (texture == nullptr || surface_desc.Width != (UINT)width || surface_desc.Height != (UINT)height)
+    if (gpu_tex != nullptr)
+        gpu_tex->GetLevelDesc(0, &surface_desc);
+    if (gpu_tex == nullptr || surface_desc.Width != (UINT)width || surface_desc.Height != (UINT)height)
     {
         // Create texture
-        texture = nullptr;
-        if (bd->pd3dDevice->CreateTexture(width, height, 1, D3DUSAGE_DYNAMIC, rgba_support ? D3DFMT_A8B8G8R8 : D3DFMT_A8R8G8B8, D3DPOOL_DEFAULT, &texture, nullptr) < 0)
+        gpu_tex = nullptr;
+        if (bd->pd3dDevice->CreateTexture(width, height, 1, D3DUSAGE_DYNAMIC, rgba_support ? D3DFMT_A8B8G8R8 : D3DFMT_A8R8G8B8, D3DPOOL_DEFAULT, &gpu_tex, nullptr) < 0)
             return false;
 
         // Store size
@@ -380,6 +376,7 @@ static LPDIRECT3DTEXTURE9 ImGui_ImplDX9_UpdateTexture(LPDIRECT3DTEXTURE9 texture
         surface_desc.Height = height;
     }
 
+    // Update pixels
     {
         D3DLOCKED_RECT tex_locked_rect;
         RECT dirty_rect;
@@ -387,7 +384,7 @@ static LPDIRECT3DTEXTURE9 ImGui_ImplDX9_UpdateTexture(LPDIRECT3DTEXTURE9 texture
         dirty_rect.right = width;
         dirty_rect.top = 0;
         dirty_rect.bottom = height;
-        if (texture->LockRect(0, &tex_locked_rect, &dirty_rect, 0) != D3D_OK)
+        if (gpu_tex->LockRect(0, &tex_locked_rect, &dirty_rect, 0) != D3D_OK)
             return false;
 
         if (tex_locked_rect.Pitch == (width * 4))
@@ -410,16 +407,15 @@ static LPDIRECT3DTEXTURE9 ImGui_ImplDX9_UpdateTexture(LPDIRECT3DTEXTURE9 texture
                 read_ptr += src_stride;
             }
         }
-        texture->UnlockRect(0);
+        gpu_tex->UnlockRect(0);
     }
 
-    // Upload the dirty region
 #ifndef IMGUI_USE_BGRA_PACKED_COLOR
-    if (!rgba_support && texture_data.TexFormat == ImTextureFormat_RGBA32)
+    if (!rgba_support && in_tex_data->TexFormat == ImTextureFormat_RGBA32)
         ImGui::MemFree(pixels);
 #endif
 
-    return texture;
+    return gpu_tex;
 }
 
 bool ImGui_ImplDX9_CreateDeviceObjects()
@@ -438,9 +434,9 @@ void ImGui_ImplDX9_InvalidateDeviceObjects()
         return;
     if (bd->pVB) { bd->pVB->Release(); bd->pVB = nullptr; }
     if (bd->pIB) { bd->pIB->Release(); bd->pIB = nullptr; }
-    for (int i = 0; i < bd->FontTextures.Size; ++i)
-        bd->FontTextures[i]->Release();
-    bd->FontTextures.resize(0);
+    for (int i = 0; i < bd->Textures.Size; ++i)
+        bd->Textures[i]->Release();
+    bd->Textures.resize(0);
 }
 
 void ImGui_ImplDX9_NewFrame()
@@ -450,42 +446,33 @@ void ImGui_ImplDX9_NewFrame()
     IM_UNUSED(bd);
 }
 
-static void ImGui_ImplDX9_DeleteTextures(ImVector<LPDIRECT3DTEXTURE9>& textures)
-{
-    if (textures.empty())
-        return;
-
-    for (int i = 0; i < textures.Size; ++i)
-        textures[i]->Release();
-}
-
+// FIXME-TEXUPDATE: Can we somehow allow multiple "observer" for the dirty data? (local + remote client).... means that we don't store IsDirty() in texture but instead maybe counter?
 void ImGui_ImplDX9_UpdateTextures()
 {
     ImGui_ImplDX9_Data* bd = ImGui_ImplDX9_GetBackendData();
 
     // We automatically call this from _RenderDrawData() but allow user to call it explicitely earlier is desired
     const int frame_count = ImGui::GetFrameCount();
-    if (bd->FontTexturesUpdateFrame == frame_count)
+    if (bd->TexturesUpdateFrame == frame_count)
         return;
-    bd->FontTexturesUpdateFrame = frame_count;
+    bd->TexturesUpdateFrame = frame_count;
 
-    ImVector<LPDIRECT3DTEXTURE9>& textures = bd->FontTextures;
+    // Get texture list
+    ImVector<LPDIRECT3DTEXTURE9>& textures = bd->Textures;
     ImTextureUpdateData* update_data = ImGui::GetTextureUpdateData();
-
-    ImVector<LPDIRECT3DTEXTURE9> discarded = textures;
+    ImVector<LPDIRECT3DTEXTURE9> discarded = textures; // FIXME-TEXUPDATE: This would allocate every frame, try to avoid it (holding on a static ImVector<> buffer?)
 
     bool recreate_all = (textures.Size == 0);
-
     for (int i = 0; i < update_data->Textures.Size; ++i)
     {
-        ImTextureData* texture_data = update_data->Textures[i];
+        ImTextureData* in_tex_data = update_data->Textures[i];
 
-        LPDIRECT3DTEXTURE9 current_texture = (LPDIRECT3DTEXTURE9)texture_data->GetTexID();
-        if (current_texture == nullptr || recreate_all || texture_data->IsDirty())
+        LPDIRECT3DTEXTURE9 current_texture = (LPDIRECT3DTEXTURE9)in_tex_data->GetTexID();
+        if (current_texture == nullptr || recreate_all || in_tex_data->IsDirty())
         {
-            texture_data->EnsureFormat(ImTextureFormat_RGBA32);
+            in_tex_data->EnsureFormat(ImTextureFormat_RGBA32);
 
-            LPDIRECT3DTEXTURE9 new_texture = ImGui_ImplDX9_UpdateTexture(current_texture, *texture_data);
+            LPDIRECT3DTEXTURE9 new_texture = ImGui_ImplDX9_UpdateTexture(current_texture, in_tex_data);
             if (current_texture != nullptr && new_texture != current_texture)
                 textures.find_erase_unsorted(current_texture);
 
@@ -494,8 +481,8 @@ void ImGui_ImplDX9_UpdateTextures()
 
             discarded.find_erase_unsorted(new_texture);
 
-            texture_data->SetTexID(new_texture);
-            texture_data->MarkClean();
+            in_tex_data->SetTexID(new_texture);
+            in_tex_data->MarkClean();
         }
         else if (current_texture)
         {
@@ -503,10 +490,12 @@ void ImGui_ImplDX9_UpdateTextures()
         }
     }
 
-    ImGui_ImplDX9_DeleteTextures(discarded);
-
+    // Remove unused textures
     for (int i = 0; i < discarded.Size; ++i)
+    {
+        discarded[i]->Release();
         textures.find_erase_unsorted(discarded[i]);
+    }
 }
 
 //-----------------------------------------------------------------------------

--- a/backends/imgui_impl_dx9.cpp
+++ b/backends/imgui_impl_dx9.cpp
@@ -15,6 +15,7 @@
 
 // CHANGELOG
 // (minor and older changes stripped away, please see git history for details)
+//  XXXX-XX-XX: DirectX9: Add support for ImGuiBackendFlags_RendererHasTexReload.
 //  2024-02-12: DirectX9: Using RGBA format when supported by the driver to avoid CPU side conversion. (#6575)
 //  2022-10-11: Using 'nullptr' instead of 'NULL' as per our switch to C++11.
 //  2021-06-29: Reorganized backend to pull data from a single structure to facilitate usage with multiple-contexts (all g_XXXX access changed to bd->XXXX).
@@ -49,6 +50,8 @@ struct ImGui_ImplDX9_Data
     LPDIRECT3DVERTEXBUFFER9     pVB;
     LPDIRECT3DINDEXBUFFER9      pIB;
     LPDIRECT3DTEXTURE9          FontTexture;
+    int                         FontTextureWidth;
+    int                         FontTextureHeight;
     int                         VertexBufferSize;
     int                         IndexBufferSize;
 
@@ -293,6 +296,7 @@ bool ImGui_ImplDX9_Init(IDirect3DDevice9* device)
     io.BackendRendererUserData = (void*)bd;
     io.BackendRendererName = "imgui_impl_dx9";
     io.BackendFlags |= ImGuiBackendFlags_RendererHasVtxOffset;  // We can honor the ImDrawCmd::VtxOffset field, allowing for large meshes.
+    io.BackendFlags |= ImGuiBackendFlags_RendererHasTexReload;  // We support font atlas texture reloading (IsDirty() check in ImGui_ImplDX11_NewFrame)
 
     bd->pd3dDevice = device;
     bd->pd3dDevice->AddRef();
@@ -332,14 +336,16 @@ static bool ImGui_ImplDX9_CheckFormatSupport(IDirect3DDevice9* pDevice, D3DFORMA
     return support;
 }
 
-static bool ImGui_ImplDX9_CreateFontsTexture()
+static bool ImGui_ImplDX9_UpdateFontsTexture()
 {
     // Build texture atlas
     ImGuiIO& io = ImGui::GetIO();
     ImGui_ImplDX9_Data* bd = ImGui_ImplDX9_GetBackendData();
+
     unsigned char* pixels;
     int width, height, bytes_per_pixel;
     io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height, &bytes_per_pixel);
+    io.Fonts->MarkClean();
 
     // Convert RGBA32 to BGRA32 (because RGBA32 is not well supported by DX9 devices)
 #ifndef IMGUI_USE_BGRA_PACKED_COLOR
@@ -356,19 +362,58 @@ static bool ImGui_ImplDX9_CreateFontsTexture()
 #endif
 
     // Upload texture to graphics system
-    bd->FontTexture = nullptr;
-    if (bd->pd3dDevice->CreateTexture(width, height, 1, D3DUSAGE_DYNAMIC, rgba_support ? D3DFMT_A8B8G8R8 : D3DFMT_A8R8G8B8, D3DPOOL_DEFAULT, &bd->FontTexture, nullptr) < 0)
-        return false;
-    D3DLOCKED_RECT tex_locked_rect;
-    if (bd->FontTexture->LockRect(0, &tex_locked_rect, nullptr, 0) != D3D_OK)
-        return false;
-    for (int y = 0; y < height; y++)
-        memcpy((unsigned char*)tex_locked_rect.pBits + (size_t)tex_locked_rect.Pitch * y, pixels + (size_t)width * bytes_per_pixel * y, (size_t)width * bytes_per_pixel);
-    bd->FontTexture->UnlockRect(0);
+    if (bd->FontTexture == nullptr || bd->FontTextureWidth != width || bd->FontTextureHeight != height)
+    {
+        // (Re-)create texture
+        if (bd->FontTexture)
+            bd->FontTexture->Release();
+        io.Fonts->SetTexID(0);
+        bd->FontTexture = nullptr;
+        if (bd->pd3dDevice->CreateTexture(width, height, 1, D3DUSAGE_DYNAMIC, rgba_support ? D3DFMT_A8B8G8R8 : D3DFMT_A8R8G8B8, D3DPOOL_DEFAULT, &bd->FontTexture, nullptr) < 0)
+            return false;
+
+        // Store size
+        bd->FontTextureWidth = width;
+        bd->FontTextureHeight = height;
+    }
 
     // Store our identifier
     io.Fonts->SetTexID((ImTextureID)bd->FontTexture);
 
+    {
+        D3DLOCKED_RECT tex_locked_rect;
+        RECT dirty_rect;
+        dirty_rect.left = 0;
+        dirty_rect.right = width;
+        dirty_rect.top = 0;
+        dirty_rect.bottom = height;
+        if (bd->FontTexture->LockRect(0, &tex_locked_rect, &dirty_rect, 0) != D3D_OK)
+            return false;
+
+        if (tex_locked_rect.Pitch == (width * 4))
+        {
+            memcpy(tex_locked_rect.pBits, pixels, (size_t)width * height * 4); // Fast path for full image upload
+        }
+        else
+        {
+            // Sub-region upload
+            const int src_stride = width * 4;
+            const int dest_stride = tex_locked_rect.Pitch;
+            const int copy_bytes = width * 4; // Bytes to copy for each line
+            unsigned char* read_ptr = pixels;
+            char* write_ptr = (char*)tex_locked_rect.pBits;
+
+            for (int y = 0; y < height; y++)
+            {
+                memcpy(write_ptr, read_ptr, copy_bytes);
+                write_ptr += dest_stride;
+                read_ptr += src_stride;
+            }
+        }
+        bd->FontTexture->UnlockRect(0);
+    }
+
+    // Upload the dirty region
 #ifndef IMGUI_USE_BGRA_PACKED_COLOR
     if (!rgba_support && io.Fonts->TexPixelsUseColors)
         ImGui::MemFree(pixels);
@@ -382,7 +427,7 @@ bool ImGui_ImplDX9_CreateDeviceObjects()
     ImGui_ImplDX9_Data* bd = ImGui_ImplDX9_GetBackendData();
     if (!bd || !bd->pd3dDevice)
         return false;
-    if (!ImGui_ImplDX9_CreateFontsTexture())
+    if (!ImGui_ImplDX9_UpdateFontsTexture())
         return false;
     return true;
 }
@@ -404,6 +449,10 @@ void ImGui_ImplDX9_NewFrame()
 
     if (!bd->FontTexture)
         ImGui_ImplDX9_CreateDeviceObjects();
+
+    ImGuiIO& io = ImGui::GetIO();
+    if (io.Fonts->IsDirty())
+        ImGui_ImplDX9_UpdateFontsTexture(); // We ignore the return value because if it fails that almost certainly means the device is invalid, and the font will get reinitialised by ImGui_ImplDX9_CreateDeviceObjects() later
 }
 
 //-----------------------------------------------------------------------------

--- a/backends/imgui_impl_dx9.cpp
+++ b/backends/imgui_impl_dx9.cpp
@@ -49,9 +49,7 @@ struct ImGui_ImplDX9_Data
     LPDIRECT3DDEVICE9           pd3dDevice;
     LPDIRECT3DVERTEXBUFFER9     pVB;
     LPDIRECT3DINDEXBUFFER9      pIB;
-    LPDIRECT3DTEXTURE9          FontTexture;
-    int                         FontTextureWidth;
-    int                         FontTextureHeight;
+    ImVector<LPDIRECT3DTEXTURE9>FontTextures;
     int                         VertexBufferSize;
     int                         IndexBufferSize;
 
@@ -80,6 +78,8 @@ static ImGui_ImplDX9_Data* ImGui_ImplDX9_GetBackendData()
 }
 
 // Functions
+static LPDIRECT3DTEXTURE9 ImGui_ImplDX9_UpdateTexture(const ImTextureData& texture_data);
+
 static void ImGui_ImplDX9_SetupRenderState(ImDrawData* draw_data)
 {
     ImGui_ImplDX9_Data* bd = ImGui_ImplDX9_GetBackendData();
@@ -336,22 +336,19 @@ static bool ImGui_ImplDX9_CheckFormatSupport(IDirect3DDevice9* pDevice, D3DFORMA
     return support;
 }
 
-static bool ImGui_ImplDX9_UpdateFontsTexture()
+static LPDIRECT3DTEXTURE9 ImGui_ImplDX9_UpdateTexture(LPDIRECT3DTEXTURE9 texture, const ImTextureData& texture_data)
 {
-    // Build texture atlas
-    ImGuiIO& io = ImGui::GetIO();
     ImGui_ImplDX9_Data* bd = ImGui_ImplDX9_GetBackendData();
-
-    unsigned char* pixels;
-    int width, height, bytes_per_pixel;
-    io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height, &bytes_per_pixel);
-    io.Fonts->MarkClean();
+    unsigned char*     pixels          = (unsigned char*)texture_data.TexPixels;
+    int                width           = texture_data.TexWidth;
+    int                height          = texture_data.TexHeight;
 
     // Convert RGBA32 to BGRA32 (because RGBA32 is not well supported by DX9 devices)
 #ifndef IMGUI_USE_BGRA_PACKED_COLOR
     const bool rgba_support = ImGui_ImplDX9_CheckFormatSupport(bd->pd3dDevice, D3DFMT_A8B8G8R8);
-    if (!rgba_support && io.Fonts->TexData.TexFormat == ImTextureFormat_RGBA32)
+    if (!rgba_support && texture_data.TexFormat == ImTextureFormat_RGBA32)
     {
+        int bytes_per_pixel = 4;
         ImU32* dst_start = (ImU32*)ImGui::MemAlloc((size_t)width * height * bytes_per_pixel);
         for (ImU32* src = (ImU32*)pixels, *dst = dst_start, *dst_end = dst_start + (size_t)width * height; dst < dst_end; src++, dst++)
             *dst = IMGUI_COL_TO_DX9_ARGB(*src);
@@ -361,24 +358,22 @@ static bool ImGui_ImplDX9_UpdateFontsTexture()
     const bool rgba_support = false;
 #endif
 
+    D3DSURFACE_DESC surface_desc = {};
+    if (texture)
+        texture->GetLevelDesc(0, &surface_desc);
+
     // Upload texture to graphics system
-    if (bd->FontTexture == nullptr || bd->FontTextureWidth != width || bd->FontTextureHeight != height)
+    if (texture == nullptr || surface_desc.Width != (UINT)width || surface_desc.Height != (UINT)height)
     {
-        // (Re-)create texture
-        if (bd->FontTexture)
-            bd->FontTexture->Release();
-        io.Fonts->SetTexID(0);
-        bd->FontTexture = nullptr;
-        if (bd->pd3dDevice->CreateTexture(width, height, 1, D3DUSAGE_DYNAMIC, rgba_support ? D3DFMT_A8B8G8R8 : D3DFMT_A8R8G8B8, D3DPOOL_DEFAULT, &bd->FontTexture, nullptr) < 0)
+        // Create texture
+        texture = nullptr;
+        if (bd->pd3dDevice->CreateTexture(width, height, 1, D3DUSAGE_DYNAMIC, rgba_support ? D3DFMT_A8B8G8R8 : D3DFMT_A8R8G8B8, D3DPOOL_DEFAULT, &texture, nullptr) < 0)
             return false;
 
         // Store size
-        bd->FontTextureWidth = width;
-        bd->FontTextureHeight = height;
+        surface_desc.Width  = width;
+        surface_desc.Height = height;
     }
-
-    // Store our identifier
-    io.Fonts->SetTexID((ImTextureID)bd->FontTexture);
 
     {
         D3DLOCKED_RECT tex_locked_rect;
@@ -387,7 +382,7 @@ static bool ImGui_ImplDX9_UpdateFontsTexture()
         dirty_rect.right = width;
         dirty_rect.top = 0;
         dirty_rect.bottom = height;
-        if (bd->FontTexture->LockRect(0, &tex_locked_rect, &dirty_rect, 0) != D3D_OK)
+        if (texture->LockRect(0, &tex_locked_rect, &dirty_rect, 0) != D3D_OK)
             return false;
 
         if (tex_locked_rect.Pitch == (width * 4))
@@ -410,16 +405,16 @@ static bool ImGui_ImplDX9_UpdateFontsTexture()
                 read_ptr += src_stride;
             }
         }
-        bd->FontTexture->UnlockRect(0);
+        texture->UnlockRect(0);
     }
 
     // Upload the dirty region
 #ifndef IMGUI_USE_BGRA_PACKED_COLOR
-    if (!rgba_support && io.Fonts->TexData.TexFormat == ImTextureFormat_RGBA32)
+    if (!rgba_support && texture_data.TexFormat == ImTextureFormat_RGBA32)
         ImGui::MemFree(pixels);
 #endif
 
-    return true;
+    return texture;
 }
 
 bool ImGui_ImplDX9_CreateDeviceObjects()
@@ -427,8 +422,7 @@ bool ImGui_ImplDX9_CreateDeviceObjects()
     ImGui_ImplDX9_Data* bd = ImGui_ImplDX9_GetBackendData();
     if (!bd || !bd->pd3dDevice)
         return false;
-    if (!ImGui_ImplDX9_UpdateFontsTexture())
-        return false;
+
     return true;
 }
 
@@ -439,7 +433,9 @@ void ImGui_ImplDX9_InvalidateDeviceObjects()
         return;
     if (bd->pVB) { bd->pVB->Release(); bd->pVB = nullptr; }
     if (bd->pIB) { bd->pIB->Release(); bd->pIB = nullptr; }
-    if (bd->FontTexture) { bd->FontTexture->Release(); bd->FontTexture = nullptr; ImGui::GetIO().Fonts->SetTexID(0); } // We copied bd->pFontTextureView to io.Fonts->TexID so let's clear that as well.
+    for (int i = 0; i < bd->FontTextures.Size; ++i)
+        bd->FontTextures[i]->Release();
+    bd->FontTextures.resize(0);
 }
 
 void ImGui_ImplDX9_NewFrame()
@@ -447,12 +443,70 @@ void ImGui_ImplDX9_NewFrame()
     ImGui_ImplDX9_Data* bd = ImGui_ImplDX9_GetBackendData();
     IM_ASSERT(bd != nullptr && "Context or backend not initialized! Did you call ImGui_ImplDX9_Init()?");
 
-    if (!bd->FontTexture)
-        ImGui_ImplDX9_CreateDeviceObjects();
-
     ImGuiIO& io = ImGui::GetIO();
-    if (io.Fonts->IsDirty())
-        ImGui_ImplDX9_UpdateFontsTexture(); // We ignore the return value because if it fails that almost certainly means the device is invalid, and the font will get reinitialised by ImGui_ImplDX9_CreateDeviceObjects() later
+    if (bd->FontTextures.empty())
+    {
+        if (io.Fonts->TexData.TexPixels == nullptr || io.Fonts->IsDirty())
+        {
+            if (io.Fonts->ConfigData.empty())
+                io.Fonts->AddFontDefault();
+            io.Fonts->Build();
+        }
+    }
+}
+
+static void ImGui_ImplDX9_DeleteTextures(ImVector<LPDIRECT3DTEXTURE9>& textures)
+{
+    if (textures.empty())
+        return;
+
+    for (int i = 0; i < textures.Size; ++i)
+        textures[i]->Release();
+}
+
+static void ImGui_ImplDX9_UpdateTextures(ImVector<LPDIRECT3DTEXTURE9>& textures, const ImVector<ImTextureData*>& textures_data)
+{
+    ImVector<LPDIRECT3DTEXTURE9> discarded = textures;
+
+    bool recreate_all = textures.empty();
+
+    for (int i = 0; i < textures_data.Size; ++i)
+    {
+        ImTextureData* texture_data = textures_data[i];
+
+        LPDIRECT3DTEXTURE9 current_texture = (LPDIRECT3DTEXTURE9)texture_data->GetTexID();
+        if (current_texture == nullptr || recreate_all || texture_data->IsDirty())
+        {
+            texture_data->EnsureFormat(ImTextureFormat_RGBA32);
+
+            LPDIRECT3DTEXTURE9 new_texture = ImGui_ImplDX9_UpdateTexture(current_texture, *texture_data);
+            if (current_texture != nullptr && new_texture != current_texture)
+                textures.find_erase_unsorted(current_texture);
+
+            if (new_texture != nullptr && new_texture != current_texture)
+                textures.push_back(new_texture);
+
+            discarded.find_erase_unsorted(new_texture);
+
+            texture_data->SetTexID(new_texture);
+            texture_data->MarkClean();
+        }
+        else if (current_texture)
+            discarded.find_erase_unsorted(current_texture);
+    }
+
+    ImGui_ImplDX9_DeleteTextures(discarded);
+
+    for (int i = 0; i < discarded.Size; ++i)
+        textures.find_erase_unsorted(discarded[i]);
+}
+
+void ImGui_ImplDX9_UpdateTextures()
+{
+    ImGui_ImplDX9_Data* bd = ImGui_ImplDX9_GetBackendData();
+    ImTextureUpdateData texture_update_data = ImGui::GetTextureUpdateData();
+
+    ImGui_ImplDX9_UpdateTextures(bd->FontTextures, texture_update_data.Textures);
 }
 
 //-----------------------------------------------------------------------------

--- a/backends/imgui_impl_dx9.cpp
+++ b/backends/imgui_impl_dx9.cpp
@@ -447,6 +447,12 @@ void ImGui_ImplDX9_NewFrame()
 }
 
 // FIXME-TEXUPDATE: Can we somehow allow multiple "observer" for the dirty data? (local + remote client).... means that we don't store IsDirty() in texture but instead maybe counter?
+// FIXME-TEXUPDATE: Can we somehow design the update data so that "no update" result in a trivial and obvious early out?
+// FIXME-TEXUPDATE: Aim to make this function less complex, so it's more evident for custom backend implementers what to do
+// - why do we need the "recreate_all" flag?
+// - could imgui track past requested textures and automatically submit the "destroy list" ? that would remove complexity on backend side
+// - similarly texture that don't need an update may not need to be in the list (would fulfill the earlier point to allow for trivial early out)
+// FIXME-TEXUPDATE: [advanced] Make sure the design of backend functions can allow advanced user to update for multiple atlas?
 void ImGui_ImplDX9_UpdateTextures()
 {
     ImGui_ImplDX9_Data* bd = ImGui_ImplDX9_GetBackendData();
@@ -472,8 +478,18 @@ void ImGui_ImplDX9_UpdateTextures()
         {
             in_tex_data->EnsureFormat(ImTextureFormat_RGBA32);
 
-            if (current_texture != NULL && textures.find(current_texture) == textures.end())
-                current_texture = NULL; // Make sure we do not access textures released by ImGui_ImplDX9_InvalidateDeviceObjects()
+            // Make sure we do not access textures released by ImGui_ImplDX9_InvalidateDeviceObjects()
+            // FIXME-TEXUPDATE: this can be break!
+            //  g_TexturesID = { 0x0001, 0x0002 }
+            //  ImGui_ImplDX9_InvalidateDeviceObjects() -> destroy 0x0001, 0x0002, but values are kept in TexID fields
+            //  ImGui_ImplDX9_UpdateTextures()
+            //   - update_data contains two textures
+            //   - first one create a new texture, DX9 return 0x0002 (UNLIKELY BUT TECHNICALLY POSSIBLE)
+            //   - second one has TexID = 0x0002 but it is contained in textures array so we don't NULL it <-- ERROR
+            // Conclusion: we should invalidate tex id! maybe add bool TexIDValid, SetTexID() can set it to true....
+            // ImGui_ImplDX9_InvalidateDeviceObjects() could clear it... maybe helper call in ImFontAtlas...
+            if (current_texture != NULL && !textures.contains(current_texture))
+                current_texture = NULL;
 
             LPDIRECT3DTEXTURE9 new_texture = ImGui_ImplDX9_UpdateTexture(current_texture, in_tex_data);
             if (current_texture != nullptr && new_texture != current_texture)

--- a/backends/imgui_impl_dx9.cpp
+++ b/backends/imgui_impl_dx9.cpp
@@ -50,10 +50,11 @@ struct ImGui_ImplDX9_Data
     LPDIRECT3DVERTEXBUFFER9     pVB;
     LPDIRECT3DINDEXBUFFER9      pIB;
     ImVector<LPDIRECT3DTEXTURE9>FontTextures;
+    int                         FontTexturesUpdateFrame;
     int                         VertexBufferSize;
     int                         IndexBufferSize;
 
-    ImGui_ImplDX9_Data()        { memset((void*)this, 0, sizeof(*this)); VertexBufferSize = 5000; IndexBufferSize = 10000; }
+    ImGui_ImplDX9_Data()        { memset((void*)this, 0, sizeof(*this)); FontTexturesUpdateFrame = -1; VertexBufferSize = 5000; IndexBufferSize = 10000; }
 };
 
 struct CUSTOMVERTEX
@@ -156,8 +157,12 @@ void ImGui_ImplDX9_RenderDrawData(ImDrawData* draw_data)
     if (draw_data->DisplaySize.x <= 0.0f || draw_data->DisplaySize.y <= 0.0f)
         return;
 
-    // Create and grow buffers if needed
+    // Update textures if not done already
     ImGui_ImplDX9_Data* bd = ImGui_ImplDX9_GetBackendData();
+    if (bd->FontTexturesUpdateFrame != ImGui::GetFrameCount())
+        ImGui_ImplDX9_UpdateTextures();
+
+    // Create and grow buffers if needed
     if (!bd->pVB || bd->VertexBufferSize < draw_data->TotalVtxCount)
     {
         if (bd->pVB) { bd->pVB->Release(); bd->pVB = nullptr; }
@@ -442,17 +447,7 @@ void ImGui_ImplDX9_NewFrame()
 {
     ImGui_ImplDX9_Data* bd = ImGui_ImplDX9_GetBackendData();
     IM_ASSERT(bd != nullptr && "Context or backend not initialized! Did you call ImGui_ImplDX9_Init()?");
-
-    ImGuiIO& io = ImGui::GetIO();
-    if (bd->FontTextures.empty())
-    {
-        if (io.Fonts->TexData.TexPixels == nullptr || io.Fonts->IsDirty())
-        {
-            if (io.Fonts->ConfigData.empty())
-                io.Fonts->AddFontDefault();
-            io.Fonts->Build();
-        }
-    }
+    IM_UNUSED(bd);
 }
 
 static void ImGui_ImplDX9_DeleteTextures(ImVector<LPDIRECT3DTEXTURE9>& textures)
@@ -467,6 +462,13 @@ static void ImGui_ImplDX9_DeleteTextures(ImVector<LPDIRECT3DTEXTURE9>& textures)
 void ImGui_ImplDX9_UpdateTextures()
 {
     ImGui_ImplDX9_Data* bd = ImGui_ImplDX9_GetBackendData();
+
+    // We automatically call this from _RenderDrawData() but allow user to call it explicitely earlier is desired
+    const int frame_count = ImGui::GetFrameCount();
+    if (bd->FontTexturesUpdateFrame == frame_count)
+        return;
+    bd->FontTexturesUpdateFrame = frame_count;
+
     ImVector<LPDIRECT3DTEXTURE9>& textures = bd->FontTextures;
     ImTextureUpdateData* update_data = ImGui::GetTextureUpdateData();
 

--- a/backends/imgui_impl_dx9.cpp
+++ b/backends/imgui_impl_dx9.cpp
@@ -350,7 +350,7 @@ static bool ImGui_ImplDX9_UpdateFontsTexture()
     // Convert RGBA32 to BGRA32 (because RGBA32 is not well supported by DX9 devices)
 #ifndef IMGUI_USE_BGRA_PACKED_COLOR
     const bool rgba_support = ImGui_ImplDX9_CheckFormatSupport(bd->pd3dDevice, D3DFMT_A8B8G8R8);
-    if (!rgba_support && io.Fonts->TexPixelsUseColors)
+    if (!rgba_support && io.Fonts->TexData.TexFormat == ImTextureFormat_RGBA32)
     {
         ImU32* dst_start = (ImU32*)ImGui::MemAlloc((size_t)width * height * bytes_per_pixel);
         for (ImU32* src = (ImU32*)pixels, *dst = dst_start, *dst_end = dst_start + (size_t)width * height; dst < dst_end; src++, dst++)
@@ -415,7 +415,7 @@ static bool ImGui_ImplDX9_UpdateFontsTexture()
 
     // Upload the dirty region
 #ifndef IMGUI_USE_BGRA_PACKED_COLOR
-    if (!rgba_support && io.Fonts->TexPixelsUseColors)
+    if (!rgba_support && io.Fonts->TexData.TexFormat == ImTextureFormat_RGBA32)
         ImGui::MemFree(pixels);
 #endif
 

--- a/backends/imgui_impl_dx9.cpp
+++ b/backends/imgui_impl_dx9.cpp
@@ -472,6 +472,9 @@ void ImGui_ImplDX9_UpdateTextures()
         {
             in_tex_data->EnsureFormat(ImTextureFormat_RGBA32);
 
+            if (current_texture != NULL && textures.find(current_texture) == textures.end())
+                current_texture = NULL; // Make sure we do not access textures released by ImGui_ImplDX9_InvalidateDeviceObjects()
+
             LPDIRECT3DTEXTURE9 new_texture = ImGui_ImplDX9_UpdateTexture(current_texture, in_tex_data);
             if (current_texture != nullptr && new_texture != current_texture)
                 textures.find_erase_unsorted(current_texture);

--- a/backends/imgui_impl_dx9.h
+++ b/backends/imgui_impl_dx9.h
@@ -23,6 +23,7 @@ struct IDirect3DDevice9;
 IMGUI_IMPL_API bool     ImGui_ImplDX9_Init(IDirect3DDevice9* device);
 IMGUI_IMPL_API void     ImGui_ImplDX9_Shutdown();
 IMGUI_IMPL_API void     ImGui_ImplDX9_NewFrame();
+IMGUI_IMPL_API void     ImGui_ImplDX9_UpdateTextures();
 IMGUI_IMPL_API void     ImGui_ImplDX9_RenderDrawData(ImDrawData* draw_data);
 
 // Use if you want to reset your rendering device without losing Dear ImGui state.

--- a/backends/imgui_impl_metal.mm
+++ b/backends/imgui_impl_metal.mm
@@ -15,6 +15,7 @@
 
 // CHANGELOG
 // (minor and older changes stripped away, please see git history for details)
+//  2023-XX-XX: Metal: Add support for ImGuiBackendFlags_RendererHasTexReload.
 //  2022-08-23: Metal: Update deprecated property 'sampleCount'->'rasterSampleCount'.
 //  2022-07-05: Metal: Add dispatch synchronization.
 //  2022-06-30: Metal: Use __bridge for ARC based systems.
@@ -68,6 +69,8 @@
 @property (nonatomic, strong, nullable) id<MTLTexture>      fontTexture;
 @property (nonatomic, strong) NSMutableArray<MetalBuffer*>* bufferCache;
 @property (nonatomic, assign) double                        lastBufferCachePurge;
+- (void)makeFontTextureWithDevice:(id<MTLDevice>)device;
+- (void)updateFontTexture;
 - (MetalBuffer*)dequeueReusableBufferOfLength:(NSUInteger)length device:(id<MTLDevice>)device;
 - (id<MTLRenderPipelineState>)renderPipelineStateForFramebufferDescriptor:(FramebufferDescriptor*)descriptor device:(id<MTLDevice>)device;
 @end
@@ -132,6 +135,7 @@ bool ImGui_ImplMetal_Init(id<MTLDevice> device)
     io.BackendRendererUserData = (void*)bd;
     io.BackendRendererName = "imgui_impl_metal";
     io.BackendFlags |= ImGuiBackendFlags_RendererHasVtxOffset;  // We can honor the ImDrawCmd::VtxOffset field, allowing for large meshes.
+    io.BackendFlags |= ImGuiBackendFlags_RendererHasTexReload;
 
     bd->SharedMetalContext = [[MetalContext alloc] init];
     bd->SharedMetalContext.device = device;
@@ -160,6 +164,13 @@ void ImGui_ImplMetal_NewFrame(MTLRenderPassDescriptor* renderPassDescriptor)
 
     if (bd->SharedMetalContext.depthStencilState == nil)
         ImGui_ImplMetal_CreateDeviceObjects(bd->SharedMetalContext.device);
+
+    ImGuiIO& io = ImGui::GetIO();
+    if (io.Fonts->IsDirty())
+    {
+        [bd->SharedMetalContext updateFontTexture];
+        io.Fonts->SetTexID((__bridge void *)bd->SharedMetalContext.fontTexture); // ImTextureID == void*
+    }
 }
 
 static void ImGui_ImplMetal_SetupRenderState(ImDrawData* drawData, id<MTLCommandBuffer> commandBuffer,
@@ -325,29 +336,10 @@ void ImGui_ImplMetal_RenderDrawData(ImDrawData* drawData, id<MTLCommandBuffer> c
 bool ImGui_ImplMetal_CreateFontsTexture(id<MTLDevice> device)
 {
     ImGui_ImplMetal_Data* bd = ImGui_ImplMetal_GetBackendData();
-    ImGuiIO& io = ImGui::GetIO();
+    [bd->SharedMetalContext makeFontTextureWithDevice:device];
 
-    // We are retrieving and uploading the font atlas as a 4-channels RGBA texture here.
-    // In theory we could call GetTexDataAsAlpha8() and upload a 1-channel texture to save on memory access bandwidth.
-    // However, using a shader designed for 1-channel texture would make it less obvious to use the ImTextureID facility to render users own textures.
-    // You can make that change in your implementation.
-    unsigned char* pixels;
-    int width, height;
-    io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);
-    MTLTextureDescriptor* textureDescriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatRGBA8Unorm
-                                                                                                 width:(NSUInteger)width
-                                                                                                height:(NSUInteger)height
-                                                                                             mipmapped:NO];
-    textureDescriptor.usage = MTLTextureUsageShaderRead;
-#if TARGET_OS_OSX || TARGET_OS_MACCATALYST
-    textureDescriptor.storageMode = MTLStorageModeManaged;
-#else
-    textureDescriptor.storageMode = MTLStorageModeShared;
-#endif
-    id <MTLTexture> texture = [device newTextureWithDescriptor:textureDescriptor];
-    [texture replaceRegion:MTLRegionMake2D(0, 0, (NSUInteger)width, (NSUInteger)height) mipmapLevel:0 withBytes:pixels bytesPerRow:(NSUInteger)width * 4];
-    bd->SharedMetalContext.fontTexture = texture;
-    io.Fonts->SetTexID((__bridge void*)bd->SharedMetalContext.fontTexture); // ImTextureID == void*
+    ImGuiIO& io = ImGui::GetIO();
+    io.Fonts->SetTexID((__bridge void *)bd->SharedMetalContext.fontTexture); // ImTextureID == void*
 
     return (bd->SharedMetalContext.fontTexture != nil);
 }
@@ -453,6 +445,47 @@ void ImGui_ImplMetal_DestroyDeviceObjects()
         _lastBufferCachePurge = GetMachAbsoluteTimeInSeconds();
     }
     return self;
+}
+
+- (void)makeFontTextureWithDevice:(id<MTLDevice>)device
+{
+    ImGuiIO &io = ImGui::GetIO();
+
+    // We are retrieving and uploading the font atlas as a 4-channels RGBA texture here.
+    // In theory we could call GetTexDataAsAlpha8() and upload a 1-channel texture to save on memory access bandwidth.
+    // However, using a shader designed for 1-channel texture would make it less obvious to use the ImTextureID facility to render users own textures.
+    // You can make that change in your implementation.
+    unsigned char* pixels;
+    int width, height;
+    io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);
+    MTLTextureDescriptor* textureDescriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatRGBA8Unorm
+                                                                                                 width:(NSUInteger)width
+                                                                                                height:(NSUInteger)height
+                                                                                             mipmapped:NO];
+    textureDescriptor.usage = MTLTextureUsageShaderRead;
+#if TARGET_OS_OSX || TARGET_OS_MACCATALYST
+    textureDescriptor.storageMode = MTLStorageModeManaged;
+#else
+    textureDescriptor.storageMode = MTLStorageModeShared;
+#endif
+    id <MTLTexture> texture = [device newTextureWithDescriptor:textureDescriptor];
+    self.fontTexture = texture;
+
+    [self updateFontTexture];
+}
+
+- (void)updateFontTexture
+{
+    ImGuiIO &io = ImGui::GetIO();
+    unsigned char* pixels;
+    int width, height;
+    io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);
+    io.Fonts->MarkClean();
+
+    if (!self.fontTexture || width != self.fontTexture.width || height != self.fontTexture.height)
+        [self makeFontTextureWithDevice:self.fontTexture.device];
+
+    [self.fontTexture replaceRegion:MTLRegionMake2D(0, 0, (NSUInteger)width, (NSUInteger)height) mipmapLevel:0 withBytes:pixels bytesPerRow:(NSUInteger)width * 4];
 }
 
 - (MetalBuffer*)dequeueReusableBufferOfLength:(NSUInteger)length device:(id<MTLDevice>)device

--- a/backends/imgui_impl_opengl2.cpp
+++ b/backends/imgui_impl_opengl2.cpp
@@ -22,6 +22,7 @@
 
 // CHANGELOG
 // (minor and older changes stripped away, please see git history for details)
+//  2024-XX-XX: OpenGL: Add support for ImGuiBackendFlags_RendererHasTexReload.
 //  2024-06-28: OpenGL: ImGui_ImplOpenGL2_NewFrame() recreates font texture if it has been destroyed by ImGui_ImplOpenGL2_DestroyFontsTexture(). (#7748)
 //  2022-10-11: Using 'nullptr' instead of 'NULL' as per our switch to C++11.
 //  2021-12-08: OpenGL: Fixed mishandling of the ImDrawCmd::IdxOffset field! This is an old bug but it never had an effect until some internal rendering changes in 1.86.
@@ -80,6 +81,8 @@ static ImGui_ImplOpenGL2_Data* ImGui_ImplOpenGL2_GetBackendData()
     return ImGui::GetCurrentContext() ? (ImGui_ImplOpenGL2_Data*)ImGui::GetIO().BackendRendererUserData : nullptr;
 }
 
+static void ImGui_ImplOpenGL2_UpdateFontsTexture();
+
 // Functions
 bool    ImGui_ImplOpenGL2_Init()
 {
@@ -91,6 +94,7 @@ bool    ImGui_ImplOpenGL2_Init()
     ImGui_ImplOpenGL2_Data* bd = IM_NEW(ImGui_ImplOpenGL2_Data)();
     io.BackendRendererUserData = (void*)bd;
     io.BackendRendererName = "imgui_impl_opengl2";
+    io.BackendFlags |= ImGuiBackendFlags_RendererHasTexReload;  // We can update font atlas texture when requested.
 
     return true;
 }
@@ -114,8 +118,8 @@ void    ImGui_ImplOpenGL2_NewFrame()
 
     if (!bd->FontTexture)
         ImGui_ImplOpenGL2_CreateDeviceObjects();
-    if (!bd->FontTexture)
-        ImGui_ImplOpenGL2_CreateFontsTexture();
+    if (ImGui::GetIO().Fonts->IsDirty())
+        ImGui_ImplOpenGL2_UpdateFontsTexture();
 }
 
 static void ImGui_ImplOpenGL2_SetupRenderState(ImDrawData* draw_data, int fb_width, int fb_height)
@@ -246,11 +250,13 @@ void ImGui_ImplOpenGL2_RenderDrawData(ImDrawData* draw_data)
     glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, last_tex_env_mode);
 }
 
-bool ImGui_ImplOpenGL2_CreateFontsTexture()
+static void ImGui_ImplOpenGL2_UpdateFontsTexture()
 {
     // Build texture atlas
     ImGuiIO& io = ImGui::GetIO();
     ImGui_ImplOpenGL2_Data* bd = ImGui_ImplOpenGL2_GetBackendData();
+
+    IM_ASSERT(bd->FontTexture != 0); // Update expect texture to already been created
     unsigned char* pixels;
     int width, height;
     io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);   // Load as RGBA 32-bit (75% of the memory is wasted, but default font is so small) because it is more likely to be compatible with user's existing shaders. If your ImTextureId represent a higher-level concept than just a GL texture id, consider calling GetTexDataAsAlpha8() instead to save on GPU memory.
@@ -259,7 +265,6 @@ bool ImGui_ImplOpenGL2_CreateFontsTexture()
     // (Bilinear sampling is required by default. Set 'io.Fonts->Flags |= ImFontAtlasFlags_NoBakedLines' or 'style.AntiAliasedLinesUseTex = false' to allow point/nearest sampling)
     GLint last_texture;
     glGetIntegerv(GL_TEXTURE_BINDING_2D, &last_texture);
-    glGenTextures(1, &bd->FontTexture);
     glBindTexture(GL_TEXTURE_2D, bd->FontTexture);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
@@ -271,6 +276,14 @@ bool ImGui_ImplOpenGL2_CreateFontsTexture()
 
     // Restore state
     glBindTexture(GL_TEXTURE_2D, last_texture);
+}
+
+bool ImGui_ImplOpenGL2_CreateFontsTexture()
+{
+    ImGui_ImplOpenGL2_Data* bd = ImGui_ImplOpenGL2_GetBackendData();
+    IM_ASSERT(bd->FontTexture == 0);
+    glGenTextures(1, &bd->FontTexture);
+    ImGui_ImplOpenGL2_UpdateFontsTexture();
 
     return true;
 }

--- a/backends/imgui_impl_opengl3.cpp
+++ b/backends/imgui_impl_opengl3.cpp
@@ -25,6 +25,7 @@
 //  2024-06-28: OpenGL: ImGui_ImplOpenGL3_NewFrame() recreates font texture if it has been destroyed by ImGui_ImplOpenGL3_DestroyFontsTexture(). (#7748)
 //  2024-05-07: OpenGL: Update loader for Linux to support EGL/GLVND. (#7562)
 //  2024-04-16: OpenGL: Detect ES3 contexts on desktop based on version string, to e.g. avoid calling glPolygonMode() on them. (#7447)
+//  XXXX-XX-XX: OpenGL: Add support for ImGuiBackendFlags_RendererHasTexReload.
 //  2024-01-09: OpenGL: Update GL3W based imgui_impl_opengl3_loader.h to load "libGL.so" and variants, fixing regression on distros missing a symlink.
 //  2023-11-08: OpenGL: Update GL3W based imgui_impl_opengl3_loader.h to load "libGL.so" instead of "libGL.so.1", accommodating for NetBSD systems having only "libGL.so.3" available. (#6983)
 //  2023-10-05: OpenGL: Rename symbols in our internal loader so that LTO compilation with another copy of gl3w is possible. (#6875, #6668, #4445)
@@ -249,6 +250,8 @@ static ImGui_ImplOpenGL3_Data* ImGui_ImplOpenGL3_GetBackendData()
     return ImGui::GetCurrentContext() ? (ImGui_ImplOpenGL3_Data*)ImGui::GetIO().BackendRendererUserData : nullptr;
 }
 
+static void ImGui_ImplOpenGL3_UpdateFontsTexture();
+
 // OpenGL vertex attribute state (for ES 1.0 and ES 2.0 only)
 #ifndef IMGUI_IMPL_OPENGL_USE_VERTEX_ARRAY
 struct ImGui_ImplOpenGL3_VtxAttribState
@@ -341,6 +344,7 @@ bool    ImGui_ImplOpenGL3_Init(const char* glsl_version)
     if (bd->GlVersion >= 320)
         io.BackendFlags |= ImGuiBackendFlags_RendererHasVtxOffset;  // We can honor the ImDrawCmd::VtxOffset field, allowing for large meshes.
 #endif
+    io.BackendFlags |= ImGuiBackendFlags_RendererHasTexReload;  // We can update font atlas texture when requested.
 
     // Store GLSL version string so we can refer to it later in case we recreate shaders.
     // Note: GLSL version is NOT the same as GL version. Leave this to nullptr if unsure.
@@ -404,8 +408,8 @@ void    ImGui_ImplOpenGL3_NewFrame()
 
     if (!bd->ShaderHandle)
         ImGui_ImplOpenGL3_CreateDeviceObjects();
-    if (!bd->FontTexture)
-        ImGui_ImplOpenGL3_CreateFontsTexture();
+    if (ImGui::GetIO().Fonts->IsDirty())
+        ImGui_ImplOpenGL3_UpdateFontsTexture();
 }
 
 static void ImGui_ImplOpenGL3_SetupRenderState(ImDrawData* draw_data, int fb_width, int fb_height, GLuint vertex_array_object)
@@ -663,21 +667,23 @@ void    ImGui_ImplOpenGL3_RenderDrawData(ImDrawData* draw_data)
     (void)bd; // Not all compilation paths use this
 }
 
-bool ImGui_ImplOpenGL3_CreateFontsTexture()
+static void ImGui_ImplOpenGL3_UpdateFontsTexture()
 {
+    // Build texture atlas
     ImGuiIO& io = ImGui::GetIO();
     ImGui_ImplOpenGL3_Data* bd = ImGui_ImplOpenGL3_GetBackendData();
+    IM_ASSERT(bd->FontTexture != 0); // Update expect texture to already been created
 
     // Build texture atlas
     unsigned char* pixels;
     int width, height;
     io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);   // Load as RGBA 32-bit (75% of the memory is wasted, but default font is so small) because it is more likely to be compatible with user's existing shaders. If your ImTextureId represent a higher-level concept than just a GL texture id, consider calling GetTexDataAsAlpha8() instead to save on GPU memory.
+    io.Fonts->MarkClean();
 
     // Upload texture to graphics system
     // (Bilinear sampling is required by default. Set 'io.Fonts->Flags |= ImFontAtlasFlags_NoBakedLines' or 'style.AntiAliasedLinesUseTex = false' to allow point/nearest sampling)
     GLint last_texture;
     GL_CALL(glGetIntegerv(GL_TEXTURE_BINDING_2D, &last_texture));
-    GL_CALL(glGenTextures(1, &bd->FontTexture));
     GL_CALL(glBindTexture(GL_TEXTURE_2D, bd->FontTexture));
     GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR));
     GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR));
@@ -691,6 +697,15 @@ bool ImGui_ImplOpenGL3_CreateFontsTexture()
 
     // Restore state
     GL_CALL(glBindTexture(GL_TEXTURE_2D, last_texture));
+}
+
+bool ImGui_ImplOpenGL3_CreateFontsTexture()
+{
+    ImGui_ImplOpenGL3_Data* bd = ImGui_ImplOpenGL3_GetBackendData();
+
+    IM_ASSERT(bd->FontTexture == 0);
+    GL_CALL(glGenTextures(1, &bd->FontTexture));
+    ImGui_ImplOpenGL3_UpdateFontsTexture();
 
     return true;
 }

--- a/backends/imgui_impl_vulkan.cpp
+++ b/backends/imgui_impl_vulkan.cpp
@@ -590,11 +590,11 @@ void ImGui_ImplVulkan_RenderDrawData(ImDrawData* draw_data, VkCommandBuffer comm
                 vkCmdSetScissor(command_buffer, 0, 1, &scissor);
 
                 // Bind DescriptorSet with font or user texture
-                VkDescriptorSet desc_set[1] = { (VkDescriptorSet)pcmd->TextureId };
+                VkDescriptorSet desc_set[1] = { (VkDescriptorSet)pcmd->Texture.GetID() };
                 if (sizeof(ImTextureID) < sizeof(ImU64))
                 {
                     // We don't support texture switches if ImTextureID hasn't been redefined to be 64-bit. Do a flaky check that other textures haven't been used.
-                    IM_ASSERT(pcmd->TextureId == (ImTextureID)bd->FontDescriptorSet);
+                    IM_ASSERT(pcmd->Texture.GetID() == (ImTextureID)bd->FontDescriptorSet);
                     desc_set[0] = bd->FontDescriptorSet;
                 }
                 vkCmdBindDescriptorSets(command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, bd->PipelineLayout, 0, 1, desc_set, 0, nullptr);

--- a/backends/imgui_impl_vulkan.cpp
+++ b/backends/imgui_impl_vulkan.cpp
@@ -46,6 +46,7 @@
 //              ImGui_ImplVulkan_CreateFontsTexture() is automatically called by NewFrame() the first time.
 //              You can call ImGui_ImplVulkan_CreateFontsTexture() again to recreate the font atlas texture.
 //              Added ImGui_ImplVulkan_DestroyFontsTexture() but you probably never need to call this.
+//  2023-XX-XX: *BREAKING CHANGE*: Vulkan: Changed ImGui_ImplVulkan_CreateFontsTexture() to ImGui_ImplVulkan_UpdateFontsTexture(), which should be called at the start of the frame when ImGui::GetIO().Fonts->IsDirty() is true to reupload the font texture. ImGuiBackendFlags_RendererHasTexReload should be set once this is implemented.
 //  2023-07-04: Vulkan: Added optional support for VK_KHR_dynamic_rendering. User needs to set init_info->UseDynamicRendering = true and init_info->ColorAttachmentFormat.
 //  2023-01-02: Vulkan: Fixed sampler passed to ImGui_ImplVulkan_AddTexture() not being honored + removed a bunch of duplicate code.
 //  2022-10-11: Using 'nullptr' instead of 'NULL' as per our switch to C++11.
@@ -232,8 +233,11 @@ struct ImGui_ImplVulkan_Data
     VkImage                     FontImage;
     VkImageView                 FontView;
     VkDescriptorSet             FontDescriptorSet;
+
     VkCommandPool               FontCommandPool;
     VkCommandBuffer             FontCommandBuffer;
+    int                         FontTextureWidth;
+    int                         FontTextureHeight;
 
     // Render buffers for main window
     ImGui_ImplVulkan_WindowRenderBuffers MainWindowRenderBuffers;
@@ -614,7 +618,7 @@ void ImGui_ImplVulkan_RenderDrawData(ImDrawData* draw_data, VkCommandBuffer comm
     vkCmdSetScissor(command_buffer, 0, 1, &scissor);
 }
 
-bool ImGui_ImplVulkan_CreateFontsTexture()
+bool ImGui_ImplVulkan_UpdateFontsTexture()
 {
     ImGuiIO& io = ImGui::GetIO();
     ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
@@ -661,54 +665,79 @@ bool ImGui_ImplVulkan_CreateFontsTexture()
     unsigned char* pixels;
     int width, height;
     io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);
+    io.Fonts->MarkClean();
+
+    if ((!bd->FontView) || (bd->FontTextureWidth != width) || (bd->FontTextureHeight != height))
+    {
+        // Either we have no texture or the size has changed, so (re-)create the texture
+        //if (bd->FontView) { vkDestroyImageView(v->Device, bd->FontView, v->Allocator); bd->FontView = VK_NULL_HANDLE; }
+        //if (bd->FontImage) { vkDestroyImage(v->Device, bd->FontImage, v->Allocator); bd->FontImage = VK_NULL_HANDLE; }
+        //if (bd->FontMemory) { vkFreeMemory(v->Device, bd->FontMemory, v->Allocator); bd->FontMemory = VK_NULL_HANDLE; }
+
+        // Create the Image:
+        {
+            VkImageCreateInfo info = {};
+            info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+            info.imageType = VK_IMAGE_TYPE_2D;
+            info.format = VK_FORMAT_R8G8B8A8_UNORM;
+            info.extent.width = width;
+            info.extent.height = height;
+            info.extent.depth = 1;
+            info.mipLevels = 1;
+            info.arrayLayers = 1;
+            info.samples = VK_SAMPLE_COUNT_1_BIT;
+            info.tiling = VK_IMAGE_TILING_OPTIMAL;
+            info.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+            info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+            info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+            err = vkCreateImage(v->Device, &info, v->Allocator, &bd->FontImage);
+            check_vk_result(err);
+            VkMemoryRequirements req;
+            vkGetImageMemoryRequirements(v->Device, bd->FontImage, &req);
+            VkMemoryAllocateInfo alloc_info = {};
+            alloc_info.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+            alloc_info.allocationSize = IM_MAX(v->MinAllocationSize, req.size);
+            alloc_info.memoryTypeIndex = ImGui_ImplVulkan_MemoryType(VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, req.memoryTypeBits);
+            err = vkAllocateMemory(v->Device, &alloc_info, v->Allocator, &bd->FontMemory);
+            check_vk_result(err);
+            err = vkBindImageMemory(v->Device, bd->FontImage, bd->FontMemory, 0);
+            check_vk_result(err);
+        }
+
+        // Create the Image View:
+        {
+            VkImageViewCreateInfo info = {};
+            info.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+            info.image = bd->FontImage;
+            info.viewType = VK_IMAGE_VIEW_TYPE_2D;
+            info.format = VK_FORMAT_R8G8B8A8_UNORM;
+            info.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+            info.subresourceRange.levelCount = 1;
+            info.subresourceRange.layerCount = 1;
+            err = vkCreateImageView(v->Device, &info, v->Allocator, &bd->FontView);
+            check_vk_result(err);
+        }
+
+        // Create the Descriptor Set:
+        bd->FontDescriptorSet = (VkDescriptorSet)ImGui_ImplVulkan_AddTexture(bd->FontSampler, bd->FontView, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+
+        // Update the Descriptor Set:
+        {
+            VkDescriptorImageInfo desc_image[1] = {};
+            desc_image[0].sampler = bd->FontSampler;
+            desc_image[0].imageView = bd->FontView;
+            desc_image[0].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+            VkWriteDescriptorSet write_desc[1] = {};
+            write_desc[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+            write_desc[0].dstSet = bd->FontDescriptorSet;
+            write_desc[0].descriptorCount = 1;
+            write_desc[0].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+            write_desc[0].pImageInfo = desc_image;
+            vkUpdateDescriptorSets(v->Device, 1, write_desc, 0, nullptr);
+        }
+    }
+
     size_t upload_size = width * height * 4 * sizeof(char);
-
-    // Create the Image:
-    {
-        VkImageCreateInfo info = {};
-        info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
-        info.imageType = VK_IMAGE_TYPE_2D;
-        info.format = VK_FORMAT_R8G8B8A8_UNORM;
-        info.extent.width = width;
-        info.extent.height = height;
-        info.extent.depth = 1;
-        info.mipLevels = 1;
-        info.arrayLayers = 1;
-        info.samples = VK_SAMPLE_COUNT_1_BIT;
-        info.tiling = VK_IMAGE_TILING_OPTIMAL;
-        info.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-        info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-        info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-        err = vkCreateImage(v->Device, &info, v->Allocator, &bd->FontImage);
-        check_vk_result(err);
-        VkMemoryRequirements req;
-        vkGetImageMemoryRequirements(v->Device, bd->FontImage, &req);
-        VkMemoryAllocateInfo alloc_info = {};
-        alloc_info.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-        alloc_info.allocationSize = IM_MAX(v->MinAllocationSize, req.size);
-        alloc_info.memoryTypeIndex = ImGui_ImplVulkan_MemoryType(VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, req.memoryTypeBits);
-        err = vkAllocateMemory(v->Device, &alloc_info, v->Allocator, &bd->FontMemory);
-        check_vk_result(err);
-        err = vkBindImageMemory(v->Device, bd->FontImage, bd->FontMemory, 0);
-        check_vk_result(err);
-    }
-
-    // Create the Image View:
-    {
-        VkImageViewCreateInfo info = {};
-        info.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
-        info.image = bd->FontImage;
-        info.viewType = VK_IMAGE_VIEW_TYPE_2D;
-        info.format = VK_FORMAT_R8G8B8A8_UNORM;
-        info.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-        info.subresourceRange.levelCount = 1;
-        info.subresourceRange.layerCount = 1;
-        err = vkCreateImageView(v->Device, &info, v->Allocator, &bd->FontView);
-        check_vk_result(err);
-    }
-
-    // Create the Descriptor Set:
-    bd->FontDescriptorSet = (VkDescriptorSet)ImGui_ImplVulkan_AddTexture(bd->FontSampler, bd->FontView, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
     // Create the Upload Buffer:
     VkDeviceMemory upload_buffer_memory;
@@ -739,7 +768,7 @@ bool ImGui_ImplVulkan_CreateFontsTexture()
         char* map = nullptr;
         err = vkMapMemory(v->Device, upload_buffer_memory, 0, upload_size, 0, (void**)(&map));
         check_vk_result(err);
-        memcpy(map, pixels, upload_size);
+        memcpy(map, pixels, upload_size); // Fast path for full image upload
         VkMappedMemoryRange range[1] = {};
         range[0].sType = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;
         range[0].memory = upload_buffer_memory;
@@ -767,9 +796,14 @@ bool ImGui_ImplVulkan_CreateFontsTexture()
         VkBufferImageCopy region = {};
         region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
         region.imageSubresource.layerCount = 1;
+        region.imageOffset.x = 0;
+        region.imageOffset.y = 0;
         region.imageExtent.width = width;
         region.imageExtent.height = height;
         region.imageExtent.depth = 1;
+        region.bufferOffset = 0;
+        region.bufferRowLength = width;
+        region.bufferImageHeight = height;
         vkCmdCopyBufferToImage(bd->FontCommandBuffer, upload_buffer, bd->FontImage, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
 
         VkImageMemoryBarrier use_barrier[1] = {};
@@ -789,6 +823,8 @@ bool ImGui_ImplVulkan_CreateFontsTexture()
 
     // Store our identifier
     io.Fonts->SetTexID((ImTextureID)bd->FontDescriptorSet);
+    bd->FontTextureWidth = width;
+    bd->FontTextureHeight = height;
 
     // End command buffer
     VkSubmitInfo end_info = {};
@@ -1100,6 +1136,7 @@ bool    ImGui_ImplVulkan_Init(ImGui_ImplVulkan_InitInfo* info)
     io.BackendRendererUserData = (void*)bd;
     io.BackendRendererName = "imgui_impl_vulkan";
     io.BackendFlags |= ImGuiBackendFlags_RendererHasVtxOffset;  // We can honor the ImDrawCmd::VtxOffset field, allowing for large meshes.
+    // Note that we explicitly do *not* set ImGuiBackendFlags_RendererHasTexReload here, because in Vulkan that requires support in the caller as well, so we leave setting it (or not) up to that code.
 
     IM_ASSERT(info->Instance != VK_NULL_HANDLE);
     IM_ASSERT(info->PhysicalDevice != VK_NULL_HANDLE);
@@ -1136,8 +1173,10 @@ void ImGui_ImplVulkan_NewFrame()
     ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
     IM_ASSERT(bd != nullptr && "Context or backend not initialized! Did you call ImGui_ImplVulkan_Init()?");
 
-    if (!bd->FontDescriptorSet)
-        ImGui_ImplVulkan_CreateFontsTexture();
+    // Upload Fonts
+    ImGuiIO& io = ImGui::GetIO();
+    if (!bd->FontDescriptorSet || io.Fonts->IsDirty())
+        ImGui_ImplVulkan_UpdateFontsTexture();
 }
 
 void ImGui_ImplVulkan_SetMinImageCount(uint32_t min_image_count)

--- a/backends/imgui_impl_vulkan.h
+++ b/backends/imgui_impl_vulkan.h
@@ -103,7 +103,7 @@ IMGUI_IMPL_API bool         ImGui_ImplVulkan_Init(ImGui_ImplVulkan_InitInfo* inf
 IMGUI_IMPL_API void         ImGui_ImplVulkan_Shutdown();
 IMGUI_IMPL_API void         ImGui_ImplVulkan_NewFrame();
 IMGUI_IMPL_API void         ImGui_ImplVulkan_RenderDrawData(ImDrawData* draw_data, VkCommandBuffer command_buffer, VkPipeline pipeline = VK_NULL_HANDLE);
-IMGUI_IMPL_API bool         ImGui_ImplVulkan_CreateFontsTexture();
+IMGUI_IMPL_API bool         ImGui_ImplVulkan_UpdateFontsTexture();
 IMGUI_IMPL_API void         ImGui_ImplVulkan_DestroyFontsTexture();
 IMGUI_IMPL_API void         ImGui_ImplVulkan_SetMinImageCount(uint32_t min_image_count); // To override MinImageCount after initialization (e.g. if swap chain is recreated)
 

--- a/examples/example_glfw_vulkan/main.cpp
+++ b/examples/example_glfw_vulkan/main.cpp
@@ -453,6 +453,8 @@ int main(int, char**)
     init_info.CheckVkResultFn = check_vk_result;
     ImGui_ImplVulkan_Init(&init_info);
 
+    io.BackendFlags |= ImGuiBackendFlags_RendererHasTexReload;  // Set flag to indicate that we can reload textures when requested.
+
     // Load Fonts
     // - If no fonts are loaded, dear imgui will use the default font. You can also load multiple fonts and use ImGui::PushFont()/PopFont() to select them.
     // - AddFontFromFileTTF() will return the ImFont* so you can store it if you need to select the font among multiple.
@@ -499,6 +501,19 @@ int main(int, char**)
             ImGui_ImplGlfw_Sleep(10);
             continue;
         }
+
+#if 1
+        if (ImGui::IsKeyPressed(ImGuiKey_KeypadAdd))
+        {
+            static float size = 13.0f;
+            size += 1.0f;
+            ImFontConfig cfg;
+            cfg.SizePixels = size;
+            io.Fonts->Clear();
+            io.Fonts->AddFontDefault(&cfg);
+            io.Fonts->MarkDirty();
+        }
+#endif
 
         // Start the Dear ImGui frame
         ImGui_ImplVulkan_NewFrame();

--- a/examples/example_sdl2_vulkan/main.cpp
+++ b/examples/example_sdl2_vulkan/main.cpp
@@ -429,6 +429,7 @@ int main(int, char**)
     ImGuiIO& io = ImGui::GetIO(); (void)io;
     io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;     // Enable Keyboard Controls
     io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;      // Enable Gamepad Controls
+    io.BackendFlags |= ImGuiBackendFlags_RendererHasTexReload;// ???
 
     // Setup Dear ImGui style
     ImGui::StyleColorsDark();
@@ -508,6 +509,19 @@ int main(int, char**)
             g_MainWindowData.FrameIndex = 0;
             g_SwapChainRebuild = false;
         }
+
+#if 1
+        if (ImGui::IsKeyPressed(ImGuiKey_KeypadAdd))
+        {
+            static float size = 13.0f;
+            size += 1.0f;
+            ImFontConfig cfg;
+            cfg.SizePixels = size;
+            io.Fonts->Clear();
+            io.Fonts->AddFontDefault(&cfg);
+            io.Fonts->MarkDirty();
+        }
+#endif
 
         // Start the Dear ImGui frame
         ImGui_ImplVulkan_NewFrame();

--- a/examples/example_win32_directx12/main.cpp
+++ b/examples/example_win32_directx12/main.cpp
@@ -102,6 +102,8 @@ int main(int, char**)
         g_pd3dSrvDescHeap->GetCPUDescriptorHandleForHeapStart(),
         g_pd3dSrvDescHeap->GetGPUDescriptorHandleForHeapStart());
 
+    io.BackendFlags |= ImGuiBackendFlags_RendererHasTexReload;  // Set flag to indicate that we can reload textures when requested.
+
     // Load Fonts
     // - If no fonts are loaded, dear imgui will use the default font. You can also load multiple fonts and use ImGui::PushFont()/PopFont() to select them.
     // - AddFontFromFileTTF() will return the ImFont* so you can store it if you need to select the font among multiple.
@@ -151,6 +153,14 @@ int main(int, char**)
         // Start the Dear ImGui frame
         ImGui_ImplDX12_NewFrame();
         ImGui_ImplWin32_NewFrame();
+
+        // Upload Fonts
+        if (io.Fonts->IsDirty())
+        {
+            WaitForLastSubmittedFrame();
+            ImGui_ImplDX12_UpdateFontsTexture();
+        }
+
         ImGui::NewFrame();
 
         // 1. Show the big demo window (Most of the sample code is in ImGui::ShowDemoWindow()! You can browse its code to learn more about Dear ImGui!).

--- a/examples/example_win32_directx9/main.cpp
+++ b/examples/example_win32_directx9/main.cpp
@@ -174,6 +174,7 @@ int main(int, char**)
         if (g_pd3dDevice->BeginScene() >= 0)
         {
             ImGui::Render();
+            ImGui_ImplDX9_UpdateTextures();
             ImGui_ImplDX9_RenderDrawData(ImGui::GetDrawData());
             g_pd3dDevice->EndScene();
         }

--- a/examples/example_win32_directx9/main.cpp
+++ b/examples/example_win32_directx9/main.cpp
@@ -174,7 +174,7 @@ int main(int, char**)
         if (g_pd3dDevice->BeginScene() >= 0)
         {
             ImGui::Render();
-            ImGui_ImplDX9_UpdateTextures();
+            //ImGui_ImplDX9_UpdateTextures();
             ImGui_ImplDX9_RenderDrawData(ImGui::GetDrawData());
             g_pd3dDevice->EndScene();
         }

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -4740,6 +4740,12 @@ ImDrawData* ImGui::GetDrawData()
     return viewport->DrawDataP.Valid ? &viewport->DrawDataP : NULL;
 }
 
+ImTextureUpdateData ImGui::GetTextureUpdateData()
+{
+    ImGuiContext& g = *GImGui;
+    return g.IO.Fonts->GetTextureUpdateData();
+}
+
 double ImGui::GetTime()
 {
     return GImGui->Time;
@@ -5066,6 +5072,7 @@ void ImGui::NewFrame()
     SetupDrawListSharedData();
     SetCurrentFont(GetDefaultFont());
     IM_ASSERT(g.Font->IsLoaded());
+    g.IO.Fonts->ClearTransientTextures();
 
     // Mark rendering data as invalid to prevent user who may have a handle on it to use it.
     for (ImGuiViewportP* viewport : g.Viewports)
@@ -7951,7 +7958,7 @@ void  ImGui::PopFont()
     g.FontStack.pop_back();
     ImFont* font = g.FontStack.Size == 0 ? GetDefaultFont() : g.FontStack.back();
     SetCurrentFont(font);
-    g.CurrentWindow->DrawList->_SetTexture(ImTexture(font->ContainerAtlas->TexID));
+    g.CurrentWindow->DrawList->_SetTexture(ImTexture(font->ContainerAtlas));
 }
 
 void ImGui::PushItemFlag(ImGuiItemFlags option, bool enabled)

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -4767,7 +4767,7 @@ static ImDrawList* GetViewportBgFgDrawList(ImGuiViewportP* viewport, size_t draw
     if (viewport->BgFgDrawListsLastFrame[drawlist_no] != g.FrameCount)
     {
         draw_list->_ResetForNewFrame();
-        draw_list->PushTextureID(g.IO.Fonts->TexID);
+        draw_list->PushTexture(ImTexture(g.IO.Fonts));
         draw_list->PushClipRect(viewport->Pos, viewport->Pos + viewport->Size, false);
         viewport->BgFgDrawListsLastFrame[drawlist_no] = g.FrameCount;
     }
@@ -7435,7 +7435,7 @@ bool ImGui::Begin(const char* name, bool* p_open, ImGuiWindowFlags flags)
 
         // Setup draw list and outer clipping rectangle
         IM_ASSERT(window->DrawList->CmdBuffer.Size == 1 && window->DrawList->CmdBuffer[0].ElemCount == 0);
-        window->DrawList->PushTextureID(g.Font->ContainerAtlas->TexID);
+        window->DrawList->PushTexture(ImTexture(g.Font->ContainerAtlas));
         PushClipRect(host_rect.Min, host_rect.Max, false);
 
         // Child windows can render their decoration (bg color, border, scrollbars, etc.) within their parent to save a draw call (since 1.71)
@@ -7937,7 +7937,7 @@ void ImGui::PushFont(ImFont* font)
         font = GetDefaultFont();
     g.FontStack.push_back(font);
     SetCurrentFont(font);
-    g.CurrentWindow->DrawList->_SetTextureID(font->ContainerAtlas->TexID);
+    g.CurrentWindow->DrawList->_SetTexture(ImTexture(font->ContainerAtlas));
 }
 
 void  ImGui::PopFont()
@@ -7951,7 +7951,7 @@ void  ImGui::PopFont()
     g.FontStack.pop_back();
     ImFont* font = g.FontStack.Size == 0 ? GetDefaultFont() : g.FontStack.back();
     SetCurrentFont(font);
-    g.CurrentWindow->DrawList->_SetTextureID(font->ContainerAtlas->TexID);
+    g.CurrentWindow->DrawList->_SetTexture(ImTexture(font->ContainerAtlas->TexID));
 }
 
 void ImGui::PushItemFlag(ImGuiItemFlags option, bool enabled)
@@ -15959,7 +15959,7 @@ void ImGui::DebugNodeDrawList(ImGuiWindow* window, ImGuiViewportP* viewport, con
         }
 
         char texid_desc[20];
-        FormatTextureIDForDebugDisplay(texid_desc, IM_ARRAYSIZE(texid_desc), pcmd->TextureId);
+        FormatTextureIDForDebugDisplay(texid_desc, IM_ARRAYSIZE(texid_desc), pcmd->GetTexID());
         char buf[300];
         ImFormatString(buf, IM_ARRAYSIZE(buf), "DrawCmd:%5d tris, Tex %s, ClipRect (%4.0f,%4.0f)-(%4.0f,%4.0f)",
             pcmd->ElemCount / 3, texid_desc, pcmd->ClipRect.x, pcmd->ClipRect.y, pcmd->ClipRect.z, pcmd->ClipRect.w);

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -3729,13 +3729,13 @@ void ImGui::RenderMouseCursor(ImVec2 base_pos, float base_scale, ImGuiMouseCurso
         if (!viewport->GetMainRect().Overlaps(ImRect(pos, pos + ImVec2(size.x + 2, size.y + 2) * scale)))
             continue;
         ImDrawList* draw_list = GetForegroundDrawList(viewport);
-        ImTextureID tex_id = font_atlas->TexID;
-        draw_list->PushTextureID(tex_id);
-        draw_list->AddImage(tex_id, pos + ImVec2(1, 0) * scale, pos + (ImVec2(1, 0) + size) * scale, uv[2], uv[3], col_shadow);
-        draw_list->AddImage(tex_id, pos + ImVec2(2, 0) * scale, pos + (ImVec2(2, 0) + size) * scale, uv[2], uv[3], col_shadow);
-        draw_list->AddImage(tex_id, pos,                        pos + size * scale,                  uv[2], uv[3], col_border);
-        draw_list->AddImage(tex_id, pos,                        pos + size * scale,                  uv[0], uv[1], col_fill);
-        draw_list->PopTextureID();
+        draw_list->PushTexture(ImTexture(font_atlas));
+        ImTexture tex = draw_list->_CmdHeader.Texture;
+        draw_list->AddImage(tex, pos + ImVec2(1, 0) * scale, pos + (ImVec2(1, 0) + size) * scale, uv[2], uv[3], col_shadow);
+        draw_list->AddImage(tex, pos + ImVec2(2, 0) * scale, pos + (ImVec2(2, 0) + size) * scale, uv[2], uv[3], col_shadow);
+        draw_list->AddImage(tex, pos, pos + size * scale, uv[2], uv[3], col_border);
+        draw_list->AddImage(tex, pos, pos + size * scale, uv[0], uv[1], col_fill);
+        draw_list->PopTexture();
     }
 }
 
@@ -15239,14 +15239,14 @@ void ImGui::ShowFontAtlas(ImFontAtlas* atlas)
         DebugNodeFont(font);
         PopID();
     }
-    if (TreeNode("Font Atlas", "Font Atlas (%dx%d pixels)", atlas->TexWidth, atlas->TexHeight))
+    if (TreeNode("Font Atlas", "Font Atlas (%dx%d pixels)", atlas->TexData.TexWidth, atlas->TexData.TexHeight))
     {
         ImGuiContext& g = *GImGui;
         ImGuiMetricsConfig* cfg = &g.DebugMetricsConfig;
         Checkbox("Tint with Text Color", &cfg->ShowAtlasTintedWithTextColor); // Using text color ensure visibility of core atlas data, but will alter custom colored icons
         ImVec4 tint_col = cfg->ShowAtlasTintedWithTextColor ? GetStyleColorVec4(ImGuiCol_Text) : ImVec4(1.0f, 1.0f, 1.0f, 1.0f);
         ImVec4 border_col = GetStyleColorVec4(ImGuiCol_Border);
-        Image(atlas->TexID, ImVec2((float)atlas->TexWidth, (float)atlas->TexHeight), ImVec2(0.0f, 0.0f), ImVec2(1.0f, 1.0f), tint_col, border_col);
+        Image(atlas->TexData.TexID, ImVec2((float)atlas->TexData.TexWidth, (float)atlas->TexData.TexHeight), ImVec2(0.0f, 0.0f), ImVec2(1.0f, 1.0f), tint_col, border_col);
         TreePop();
     }
 }

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -4740,7 +4740,7 @@ ImDrawData* ImGui::GetDrawData()
     return viewport->DrawDataP.Valid ? &viewport->DrawDataP : NULL;
 }
 
-ImTextureUpdateData ImGui::GetTextureUpdateData()
+ImTextureUpdateData* ImGui::GetTextureUpdateData()
 {
     ImGuiContext& g = *GImGui;
     return g.IO.Fonts->GetTextureUpdateData();

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -5040,6 +5040,11 @@ void ImGui::NewFrame()
 
     CallContextHooks(&g, ImGuiContextHookType_NewFramePre);
 
+    // Check that font atlas was built or backend support texture reload in which case we can build now
+    ImFontAtlas* atlas = g.IO.Fonts;
+    if (!atlas->IsBuilt() && (g.IO.BackendFlags & ImGuiBackendFlags_RendererHasTexReload))
+        atlas->Build();
+
     // Check and assert for various common IO and Configuration mistakes
     ErrorCheckNewFrameSanityChecks();
 

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -596,6 +596,7 @@ void ImGui::ShowDemoWindow(bool* p_open)
             ImGui::CheckboxFlags("io.BackendFlags: HasMouseCursors",      &io.BackendFlags, ImGuiBackendFlags_HasMouseCursors);
             ImGui::CheckboxFlags("io.BackendFlags: HasSetMousePos",       &io.BackendFlags, ImGuiBackendFlags_HasSetMousePos);
             ImGui::CheckboxFlags("io.BackendFlags: RendererHasVtxOffset", &io.BackendFlags, ImGuiBackendFlags_RendererHasVtxOffset);
+            ImGui::CheckboxFlags("io.BackendFlags: RendererHasTexReload", &io.BackendFlags, ImGuiBackendFlags_RendererHasTexReload);
             ImGui::EndDisabled();
 
             ImGui::TreePop();

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -1308,7 +1308,7 @@ static void ShowDemoWindowWidgets(ImGuiDemoWindowData* demo_data)
         // - Consider using the lower-level ImDrawList::AddImage() API, via ImGui::GetWindowDrawList()->AddImage().
         // - Read https://github.com/ocornut/imgui/blob/master/docs/FAQ.md
         // - Read https://github.com/ocornut/imgui/wiki/Image-Loading-and-Displaying-Examples
-        ImTextureID my_tex_id = io.Fonts->TexID;
+        ImTextureID my_tex_id = io.Fonts->GetTexID();
         float my_tex_w = (float)io.Fonts->TexWidth;
         float my_tex_h = (float)io.Fonts->TexHeight;
         {

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -1309,8 +1309,8 @@ static void ShowDemoWindowWidgets(ImGuiDemoWindowData* demo_data)
         // - Read https://github.com/ocornut/imgui/blob/master/docs/FAQ.md
         // - Read https://github.com/ocornut/imgui/wiki/Image-Loading-and-Displaying-Examples
         ImTextureID my_tex_id = io.Fonts->GetTexID();
-        float my_tex_w = (float)io.Fonts->TexWidth;
-        float my_tex_h = (float)io.Fonts->TexHeight;
+        float my_tex_w = (float)io.Fonts->TexData.TexWidth;
+        float my_tex_h = (float)io.Fonts->TexData.TexHeight;
         {
             static bool use_text_color_for_tint = false;
             ImGui::Checkbox("Use Text Color for Tint", &use_text_color_for_tint);
@@ -7770,7 +7770,7 @@ void ImGui::ShowAboutWindow(bool* p_open)
         if (io.BackendFlags & ImGuiBackendFlags_HasSetMousePos)         ImGui::Text(" HasSetMousePos");
         if (io.BackendFlags & ImGuiBackendFlags_RendererHasVtxOffset)   ImGui::Text(" RendererHasVtxOffset");
         ImGui::Separator();
-        ImGui::Text("io.Fonts: %d fonts, Flags: 0x%08X, TexSize: %d,%d", io.Fonts->Fonts.Size, io.Fonts->Flags, io.Fonts->TexWidth, io.Fonts->TexHeight);
+        ImGui::Text("io.Fonts: %d fonts, Flags: 0x%08X, TexSize: %d,%d", io.Fonts->Fonts.Size, io.Fonts->Flags, io.Fonts->TexData.TexWidth, io.Fonts->TexData.TexHeight);
         ImGui::Text("io.DisplaySize: %.2f,%.2f", io.DisplaySize.x, io.DisplaySize.y);
         ImGui::Text("io.DisplayFramebufferScale: %.2f,%.2f", io.DisplayFramebufferScale.x, io.DisplayFramebufferScale.y);
         ImGui::Separator();

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -2648,19 +2648,15 @@ void    ImFontAtlas::GetTexDataAsRGBA32(unsigned char** out_pixels, int* out_wid
     if (out_bytes_per_pixel) *out_bytes_per_pixel = 4;
 }
 
-void ImFontAtlas::BuildTextureUpdateData(ImTextureUpdateData* texture_update_data)
+ImTextureUpdateData* ImFontAtlas::GetTextureUpdateData()
 {
-    texture_update_data->Textures.reserve(texture_update_data->Textures.Size + TexPages.Size + 1);
-    texture_update_data->Textures.push_back(&TexData);
+    ImTextureUpdateData* tex_update_data = &TexUpdateData;
+    tex_update_data->Textures.resize(0);
+    tex_update_data->Textures.reserve(TexPages.Size + 1);
+    tex_update_data->Textures.push_back(&TexData);
     for (int i = 0; i < TexPages.Size; ++i)
-        texture_update_data->Textures.push_back(&TexPages[i]);
-}
-
-ImTextureUpdateData ImFontAtlas::GetTextureUpdateData()
-{
-    ImTextureUpdateData result;
-    BuildTextureUpdateData(&result);
-    return result;
+        tex_update_data->Textures.push_back(&TexPages[i]);
+    return tex_update_data;
 }
 
 ImFont* ImFontAtlas::AddFont(const ImFontConfig* font_cfg)

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -399,8 +399,8 @@ void ImDrawList::_ResetForNewFrame()
 {
     // Verify that the ImDrawCmd fields we want to memcmp() are contiguous in memory.
     IM_STATIC_ASSERT(offsetof(ImDrawCmd, ClipRect) == 0);
-    IM_STATIC_ASSERT(offsetof(ImDrawCmd, TextureId) == sizeof(ImVec4));
-    IM_STATIC_ASSERT(offsetof(ImDrawCmd, VtxOffset) == sizeof(ImVec4) + sizeof(ImTextureID));
+    IM_STATIC_ASSERT(offsetof(ImDrawCmd, Texture) == sizeof(ImVec4));
+    IM_STATIC_ASSERT(offsetof(ImDrawCmd, VtxOffset) == sizeof(ImVec4) + sizeof(ImTexture));
     if (_Splitter._Count > 1)
         _Splitter.Merge(this);
 
@@ -413,7 +413,7 @@ void ImDrawList::_ResetForNewFrame()
     _VtxWritePtr = NULL;
     _IdxWritePtr = NULL;
     _ClipRectStack.resize(0);
-    _TextureIdStack.resize(0);
+    _TextureStack.resize(0);
     _Path.resize(0);
     _Splitter.Clear();
     CmdBuffer.push_back(ImDrawCmd());
@@ -430,7 +430,7 @@ void ImDrawList::_ClearFreeMemory()
     _VtxWritePtr = NULL;
     _IdxWritePtr = NULL;
     _ClipRectStack.clear();
-    _TextureIdStack.clear();
+    _TextureStack.clear();
     _Path.clear();
     _Splitter.ClearFreeMemory();
 }
@@ -449,7 +449,7 @@ void ImDrawList::AddDrawCmd()
 {
     ImDrawCmd draw_cmd;
     draw_cmd.ClipRect = _CmdHeader.ClipRect;    // Same as calling ImDrawCmd_HeaderCopy()
-    draw_cmd.TextureId = _CmdHeader.TextureId;
+    draw_cmd.Texture = _CmdHeader.Texture;
     draw_cmd.VtxOffset = _CmdHeader.VtxOffset;
     draw_cmd.IdxOffset = IdxBuffer.Size;
 
@@ -529,12 +529,12 @@ void ImDrawList::_OnChangedClipRect()
     curr_cmd->ClipRect = _CmdHeader.ClipRect;
 }
 
-void ImDrawList::_OnChangedTextureID()
+void ImDrawList::_OnChangedTexture()
 {
     // If current command is used with different settings we need to add a new command
     IM_ASSERT_PARANOID(CmdBuffer.Size > 0);
     ImDrawCmd* curr_cmd = &CmdBuffer.Data[CmdBuffer.Size - 1];
-    if (curr_cmd->ElemCount != 0 && curr_cmd->TextureId != _CmdHeader.TextureId)
+    if (curr_cmd->ElemCount != 0 && curr_cmd->Texture != _CmdHeader.Texture)
     {
         AddDrawCmd();
         return;
@@ -548,7 +548,7 @@ void ImDrawList::_OnChangedTextureID()
         CmdBuffer.pop_back();
         return;
     }
-    curr_cmd->TextureId = _CmdHeader.TextureId;
+    curr_cmd->Texture = _CmdHeader.Texture;
 }
 
 void ImDrawList::_OnChangedVtxOffset()
@@ -609,27 +609,40 @@ void ImDrawList::PopClipRect()
     _OnChangedClipRect();
 }
 
+void ImDrawList::PushTexture(ImTexture texture)
+{
+    _CmdHeader.Texture = texture;
+    _TextureStack.push_back(_CmdHeader.Texture);
+    _OnChangedTexture();
+}
+
+void ImDrawList::PopTexture()
+{
+    _TextureStack.pop_back();
+    if (_TextureStack.Size == 0)
+        memset(&_CmdHeader.Texture, 0, sizeof(ImTexture));
+    else
+        _CmdHeader.Texture = _TextureStack.Data[_TextureStack.Size - 1];
+    _OnChangedTexture();
+}
+
 void ImDrawList::PushTextureID(ImTextureID texture_id)
 {
-    _TextureIdStack.push_back(texture_id);
-    _CmdHeader.TextureId = texture_id;
-    _OnChangedTextureID();
+    PushTexture(ImTexture(texture_id));
 }
 
 void ImDrawList::PopTextureID()
 {
-    _TextureIdStack.pop_back();
-    _CmdHeader.TextureId = (_TextureIdStack.Size == 0) ? (ImTextureID)NULL : _TextureIdStack.Data[_TextureIdStack.Size - 1];
-    _OnChangedTextureID();
+    PopTexture();
 }
 
 // This is used by ImGui::PushFont()/PopFont(). It works because we never use _TextureIdStack[] elsewhere than in PushTextureID()/PopTextureID().
-void ImDrawList::_SetTextureID(ImTextureID texture_id)
+void ImDrawList::_SetTexture(ImTexture texture)
 {
-    if (_CmdHeader.TextureId == texture_id)
+    if (_CmdHeader.Texture == texture)
         return;
-    _CmdHeader.TextureId = texture_id;
-    _OnChangedTextureID();
+    _CmdHeader.Texture = texture;
+    _OnChangedTexture();
 }
 
 // Reserve space for a number of vertices and indices.
@@ -1643,7 +1656,7 @@ void ImDrawList::AddText(const ImFont* font, float font_size, const ImVec2& pos,
     if (font_size == 0.0f)
         font_size = _Data->FontSize;
 
-    IM_ASSERT(font->ContainerAtlas->TexID == _CmdHeader.TextureId);  // Use high-level ImGui::PushFont() or low-level ImDrawList::PushTextureId() to change font.
+    IM_ASSERT(ImTexture(font->ContainerAtlas) == _CmdHeader.Texture);  // Use high-level ImGui::PushFont() or low-level ImDrawList::PushTextureId() to change font.
 
     ImVec4 clip_rect = _CmdHeader.ClipRect;
     if (cpu_fine_clip_rect)
@@ -1661,39 +1674,49 @@ void ImDrawList::AddText(const ImVec2& pos, ImU32 col, const char* text_begin, c
     AddText(NULL, 0.0f, pos, col, text_begin, text_end);
 }
 
-void ImDrawList::AddImage(ImTextureID user_texture_id, const ImVec2& p_min, const ImVec2& p_max, const ImVec2& uv_min, const ImVec2& uv_max, ImU32 col)
+void ImDrawList::AddImage(ImTexture texture, const ImVec2& p_min, const ImVec2& p_max, const ImVec2& uv_min, const ImVec2& uv_max, ImU32 col)
 {
     if ((col & IM_COL32_A_MASK) == 0)
         return;
 
-    const bool push_texture_id = user_texture_id != _CmdHeader.TextureId;
-    if (push_texture_id)
-        PushTextureID(user_texture_id);
+    const bool push_texture = texture != _CmdHeader.Texture;
+    if (push_texture)
+        PushTexture(texture);
 
     PrimReserve(6, 4);
     PrimRectUV(p_min, p_max, uv_min, uv_max, col);
 
-    if (push_texture_id)
+    if (push_texture)
         PopTextureID();
 }
 
-void ImDrawList::AddImageQuad(ImTextureID user_texture_id, const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, const ImVec2& uv1, const ImVec2& uv2, const ImVec2& uv3, const ImVec2& uv4, ImU32 col)
+void ImDrawList::AddImage(ImTextureID user_texture_id, const ImVec2& p_min, const ImVec2& p_max, const ImVec2& uv_min, const ImVec2& uv_max, ImU32 col)
+{
+    AddImage(ImTexture(user_texture_id), p_min, p_max, uv_min, uv_max, col);
+}
+
+void ImDrawList::AddImageQuad(ImTexture texture, const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, const ImVec2& uv1, const ImVec2& uv2, const ImVec2& uv3, const ImVec2& uv4, ImU32 col)
 {
     if ((col & IM_COL32_A_MASK) == 0)
         return;
 
-    const bool push_texture_id = user_texture_id != _CmdHeader.TextureId;
-    if (push_texture_id)
-        PushTextureID(user_texture_id);
+    const bool push_texture = texture != _CmdHeader.Texture;
+    if (push_texture)
+        PushTexture(texture);
 
     PrimReserve(6, 4);
     PrimQuadUV(p1, p2, p3, p4, uv1, uv2, uv3, uv4, col);
 
-    if (push_texture_id)
-        PopTextureID();
+    if (push_texture)
+        PopTexture();
 }
 
-void ImDrawList::AddImageRounded(ImTextureID user_texture_id, const ImVec2& p_min, const ImVec2& p_max, const ImVec2& uv_min, const ImVec2& uv_max, ImU32 col, float rounding, ImDrawFlags flags)
+void ImDrawList::AddImageQuad(ImTextureID user_texture_id, const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, const ImVec2& uv1, const ImVec2& uv2, const ImVec2& uv3, const ImVec2& uv4, ImU32 col)
+{
+    AddImageQuad(ImTexture(user_texture_id), p1, p2, p3, p4, uv1, uv2, uv3, uv4, col);
+}
+
+void ImDrawList::AddImageRounded(ImTexture texture, const ImVec2& p_min, const ImVec2& p_max, const ImVec2& uv_min, const ImVec2& uv_max, ImU32 col, float rounding, ImDrawFlags flags)
 {
     if ((col & IM_COL32_A_MASK) == 0)
         return;
@@ -1701,13 +1724,13 @@ void ImDrawList::AddImageRounded(ImTextureID user_texture_id, const ImVec2& p_mi
     flags = FixRectCornerFlags(flags);
     if (rounding < 0.5f || (flags & ImDrawFlags_RoundCornersMask_) == ImDrawFlags_RoundCornersNone)
     {
-        AddImage(user_texture_id, p_min, p_max, uv_min, uv_max, col);
+        AddImage(texture, p_min, p_max, uv_min, uv_max, col);
         return;
     }
 
-    const bool push_texture_id = user_texture_id != _CmdHeader.TextureId;
-    if (push_texture_id)
-        PushTextureID(user_texture_id);
+    const bool push_texture = texture != _CmdHeader.Texture;
+    if (push_texture)
+        PushTexture(texture);
 
     int vert_start_idx = VtxBuffer.Size;
     PathRect(p_min, p_max, rounding, flags);
@@ -1715,8 +1738,13 @@ void ImDrawList::AddImageRounded(ImTextureID user_texture_id, const ImVec2& p_mi
     int vert_end_idx = VtxBuffer.Size;
     ImGui::ShadeVertsLinearUV(this, vert_start_idx, vert_end_idx, p_min, p_max, uv_min, uv_max, true);
 
-    if (push_texture_id)
-        PopTextureID();
+    if (push_texture)
+        PopTexture();
+}
+
+void ImDrawList::AddImageRounded(ImTextureID user_texture_id, const ImVec2& p_min, const ImVec2& p_max, const ImVec2& uv_min, const ImVec2& uv_max, ImU32 col, float rounding, ImDrawFlags flags)
+{
+    AddImageRounded(ImTexture(user_texture_id), p_min, p_max, uv_min, uv_max, col, rounding, flags);
 }
 
 //-----------------------------------------------------------------------------

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -3356,7 +3356,7 @@ namespace ImGui
     IMGUI_API void          TextEx(const char* text, const char* text_end = NULL, ImGuiTextFlags flags = 0);
     IMGUI_API bool          ButtonEx(const char* label, const ImVec2& size_arg = ImVec2(0, 0), ImGuiButtonFlags flags = 0);
     IMGUI_API bool          ArrowButtonEx(const char* str_id, ImGuiDir dir, ImVec2 size_arg, ImGuiButtonFlags flags = 0);
-    IMGUI_API bool          ImageButtonEx(ImGuiID id, ImTextureID texture_id, const ImVec2& image_size, const ImVec2& uv0, const ImVec2& uv1, const ImVec4& bg_col, const ImVec4& tint_col, ImGuiButtonFlags flags = 0);
+    IMGUI_API bool          ImageButtonEx(ImGuiID id, ImTexture texture, const ImVec2& image_size, const ImVec2& uv0, const ImVec2& uv1, const ImVec4& bg_col, const ImVec4& tint_col, ImGuiButtonFlags flags = 0);
     IMGUI_API void          SeparatorEx(ImGuiSeparatorFlags flags, float thickness = 1.0f);
     IMGUI_API void          SeparatorTextEx(ImGuiID id, const char* label, const char* label_end, float extra_width);
     IMGUI_API bool          CheckboxFlags(const char* label, ImS64* flags, ImS64 flags_value);

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -1053,7 +1053,7 @@ bool ImGui::ScrollbarEx(const ImRect& bb_frame, ImGuiID id, ImGuiAxis axis, ImS6
 
 // - Read about ImTextureID here: https://github.com/ocornut/imgui/wiki/Image-Loading-and-Displaying-Examples
 // - 'uv0' and 'uv1' are texture coordinates. Read about them from the same link above.
-void ImGui::Image(ImTextureID user_texture_id, const ImVec2& image_size, const ImVec2& uv0, const ImVec2& uv1, const ImVec4& tint_col, const ImVec4& border_col)
+void ImGui::Image(ImTexture texture, const ImVec2& image_size, const ImVec2& uv0, const ImVec2& uv1, const ImVec4& tint_col, const ImVec4& border_col)
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -1069,12 +1069,17 @@ void ImGui::Image(ImTextureID user_texture_id, const ImVec2& image_size, const I
     // Render
     if (border_size > 0.0f)
         window->DrawList->AddRect(bb.Min, bb.Max, GetColorU32(border_col), 0.0f, ImDrawFlags_None, border_size);
-    window->DrawList->AddImage(user_texture_id, bb.Min + padding, bb.Max - padding, uv0, uv1, GetColorU32(tint_col));
+    window->DrawList->AddImage(texture, bb.Min + padding, bb.Max - padding, uv0, uv1, GetColorU32(tint_col));
+}
+
+void ImGui::Image(ImTextureID user_texture_id, const ImVec2& image_size, const ImVec2& uv0, const ImVec2& uv1, const ImVec4& tint_col, const ImVec4& border_col)
+{
+    Image(ImTexture(user_texture_id), image_size, uv0, uv1, tint_col, border_col);
 }
 
 // ImageButton() is flawed as 'id' is always derived from 'texture_id' (see #2464 #1390)
 // We provide this internal helper to write your own variant while we figure out how to redesign the public ImageButton() API.
-bool ImGui::ImageButtonEx(ImGuiID id, ImTextureID texture_id, const ImVec2& image_size, const ImVec2& uv0, const ImVec2& uv1, const ImVec4& bg_col, const ImVec4& tint_col, ImGuiButtonFlags flags)
+bool ImGui::ImageButtonEx(ImGuiID id, ImTexture texture, const ImVec2& image_size, const ImVec2& uv0, const ImVec2& uv1, const ImVec4& bg_col, const ImVec4& tint_col, ImGuiButtonFlags flags)
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = GetCurrentWindow();
@@ -1096,7 +1101,7 @@ bool ImGui::ImageButtonEx(ImGuiID id, ImTextureID texture_id, const ImVec2& imag
     RenderFrame(bb.Min, bb.Max, col, true, ImClamp((float)ImMin(padding.x, padding.y), 0.0f, g.Style.FrameRounding));
     if (bg_col.w > 0.0f)
         window->DrawList->AddRectFilled(bb.Min + padding, bb.Max - padding, GetColorU32(bg_col));
-    window->DrawList->AddImage(texture_id, bb.Min + padding, bb.Max - padding, uv0, uv1, GetColorU32(tint_col));
+    window->DrawList->AddImage(texture, bb.Min + padding, bb.Max - padding, uv0, uv1, GetColorU32(tint_col));
 
     return pressed;
 }
@@ -1109,7 +1114,7 @@ bool ImGui::ImageButton(const char* str_id, ImTextureID user_texture_id, const I
     if (window->SkipItems)
         return false;
 
-    return ImageButtonEx(window->GetID(str_id), user_texture_id, image_size, uv0, uv1, bg_col, tint_col);
+    return ImageButtonEx(window->GetID(str_id), ImTexture(user_texture_id), image_size, uv0, uv1, bg_col, tint_col);
 }
 
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
@@ -1130,6 +1135,10 @@ bool ImGui::ImageButton(ImTextureID user_texture_id, const ImVec2& size, const I
         PopStyleVar();
     PopID();
     return ret;
+}
+bool ImGui::ImageButton(ImTextureID user_texture_id, const ImVec2& size, const ImVec2& uv0, const ImVec2& uv1, int frame_padding, const ImVec4& bg_col, const ImVec4& tint_col)
+{
+    return ImageButton(ImTexture(user_texture_id), size, uv0, uv1, frame_padding, bg_col, tint_col);
 }
 */
 #endif // #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS

--- a/misc/freetype/imgui_freetype.cpp
+++ b/misc/freetype/imgui_freetype.cpp
@@ -437,8 +437,7 @@ bool ImFontAtlasBuildWithFreeTypeEx(FT_Library ft_library, ImFontAtlas* atlas, u
     ImFontAtlasBuildInit(atlas);
 
     // Clear atlas
-    atlas->TexID = 0;
-    atlas->TexWidth = atlas->TexHeight = 0;
+    atlas->TexData = ImTextureData();
     atlas->TexUvScale = ImVec2(0.0f, 0.0f);
     atlas->TexUvWhitePixel = ImVec2(0.0f, 0.0f);
     atlas->ClearTexData();
@@ -617,20 +616,20 @@ bool ImFontAtlasBuildWithFreeTypeEx(FT_Library ft_library, ImFontAtlas* atlas, u
     // The exact width doesn't really matter much, but some API/GPU have texture size limitations and increasing width can decrease height.
     // User can override TexDesiredWidth and TexGlyphPadding if they wish, otherwise we use a simple heuristic to select the width based on expected surface.
     const int surface_sqrt = (int)ImSqrt((float)total_surface) + 1;
-    atlas->TexHeight = 0;
+    atlas->TexData.TexHeight = 0;
     if (atlas->TexDesiredWidth > 0)
-        atlas->TexWidth = atlas->TexDesiredWidth;
+        atlas->TexData.TexWidth = atlas->TexDesiredWidth;
     else
-        atlas->TexWidth = (surface_sqrt >= 4096 * 0.7f) ? 4096 : (surface_sqrt >= 2048 * 0.7f) ? 2048 : (surface_sqrt >= 1024 * 0.7f) ? 1024 : 512;
+        atlas->TexData.TexWidth = (surface_sqrt >= 4096 * 0.7f) ? 4096 : (surface_sqrt >= 2048 * 0.7f) ? 2048 : (surface_sqrt >= 1024 * 0.7f) ? 1024 : 512;
 
     // 5. Start packing
     // Pack our extra data rectangles first, so it will be on the upper-left corner of our texture (UV will have small values).
     const int TEX_HEIGHT_MAX = 1024 * 32;
-    const int num_nodes_for_packing_algorithm = atlas->TexWidth - atlas->TexGlyphPadding;
+    const int num_nodes_for_packing_algorithm = atlas->TexData.TexWidth - atlas->TexGlyphPadding;
     ImVector<stbrp_node> pack_nodes;
     pack_nodes.resize(num_nodes_for_packing_algorithm);
     stbrp_context pack_context;
-    stbrp_init_target(&pack_context, atlas->TexWidth - atlas->TexGlyphPadding, TEX_HEIGHT_MAX - atlas->TexGlyphPadding, pack_nodes.Data, pack_nodes.Size);
+    stbrp_init_target(&pack_context, atlas->TexData.TexWidth - atlas->TexGlyphPadding, TEX_HEIGHT_MAX - atlas->TexGlyphPadding, pack_nodes.Data, pack_nodes.Size);
     ImFontAtlasBuildPackCustomRects(atlas, &pack_context);
 
     // 6. Pack each source font. No rendering yet, we are working with rectangles in an infinitely tall texture at this point.
@@ -646,28 +645,17 @@ bool ImFontAtlasBuildWithFreeTypeEx(FT_Library ft_library, ImFontAtlas* atlas, u
         // FIXME: We are not handling packing failure here (would happen if we got off TEX_HEIGHT_MAX or if a single if larger than TexWidth?)
         for (int glyph_i = 0; glyph_i < src_tmp.GlyphsCount; glyph_i++)
             if (src_tmp.Rects[glyph_i].was_packed)
-                atlas->TexHeight = ImMax(atlas->TexHeight, src_tmp.Rects[glyph_i].y + src_tmp.Rects[glyph_i].h);
+                atlas->TexData.TexHeight = ImMax(atlas->TexData.TexHeight, src_tmp.Rects[glyph_i].y + src_tmp.Rects[glyph_i].h);
     }
 
     // 7. Allocate texture
-    atlas->TexHeight = (atlas->Flags & ImFontAtlasFlags_NoPowerOfTwoHeight) ? (atlas->TexHeight + 1) : ImUpperPowerOfTwo(atlas->TexHeight);
-    atlas->TexUvScale = ImVec2(1.0f / atlas->TexWidth, 1.0f / atlas->TexHeight);
-    if (src_load_color)
-    {
-        size_t tex_size = (size_t)atlas->TexWidth * atlas->TexHeight * 4;
-        atlas->TexPixelsRGBA32 = (unsigned int*)IM_ALLOC(tex_size);
-        memset(atlas->TexPixelsRGBA32, 0, tex_size);
-    }
-    else
-    {
-        size_t tex_size = (size_t)atlas->TexWidth * atlas->TexHeight * 1;
-        atlas->TexPixelsAlpha8 = (unsigned char*)IM_ALLOC(tex_size);
-        memset(atlas->TexPixelsAlpha8, 0, tex_size);
-    }
+    atlas->TexData.TexHeight = (atlas->Flags & ImFontAtlasFlags_NoPowerOfTwoHeight) ? (atlas->TexData.TexHeight + 1) : ImUpperPowerOfTwo(atlas->TexData.TexHeight);
+    atlas->TexUvScale = ImVec2(1.0f / atlas->TexData.TexWidth, 1.0f / atlas->TexData.TexHeight);
+    atlas->TexData.AllocatePixels(atlas->TexData.TexWidth, atlas->TexData.TexHeight,
+        src_load_color ? ImTextureFormat_RGBA32 : ImTextureFormat_Alpha8);
 
     // 8. Copy rasterized font characters back into the main texture
     // 9. Setup ImFont and glyphs for runtime
-    bool tex_use_colors = false;
     for (int src_i = 0; src_i < src_tmp_array.Size; src_i++)
     {
         ImFontBuildSrcDataFT& src_tmp = src_tmp_array[src_i];
@@ -706,31 +694,31 @@ bool ImFontAtlasBuildWithFreeTypeEx(FT_Library ft_library, ImFontAtlas* atlas, u
             float y0 = info.OffsetY * src_tmp.Font.InvRasterizationDensity + font_off_y;
             float x1 = x0 + info.Width * src_tmp.Font.InvRasterizationDensity;
             float y1 = y0 + info.Height * src_tmp.Font.InvRasterizationDensity;
-            float u0 = (tx) / (float)atlas->TexWidth;
-            float v0 = (ty) / (float)atlas->TexHeight;
-            float u1 = (tx + info.Width) / (float)atlas->TexWidth;
-            float v1 = (ty + info.Height) / (float)atlas->TexHeight;
+            float u0 = (tx) / (float)atlas->TexData.TexWidth;
+            float v0 = (ty) / (float)atlas->TexData.TexHeight;
+            float u1 = (tx + info.Width) / (float)atlas->TexData.TexWidth;
+            float v1 = (ty + info.Height) / (float)atlas->TexData.TexHeight;
             dst_font->AddGlyph(&cfg, (ImWchar)src_glyph.Codepoint, x0, y0, x1, y1, u0, v0, u1, v1, info.AdvanceX * src_tmp.Font.InvRasterizationDensity);
 
             ImFontGlyph* dst_glyph = &dst_font->Glyphs.back();
             IM_ASSERT(dst_glyph->Codepoint == src_glyph.Codepoint);
             if (src_glyph.Info.IsColored)
-                dst_glyph->Colored = tex_use_colors = true;
+                atlas->TexData.EnsureFormat(ImTextureFormat_RGBA32);
 
             // Blit from temporary buffer to final texture
             size_t blit_src_stride = (size_t)src_glyph.Info.Width;
-            size_t blit_dst_stride = (size_t)atlas->TexWidth;
+            size_t blit_dst_stride = (size_t)atlas->TexData.TexWidth;
             unsigned int* blit_src = src_glyph.BitmapData;
-            if (atlas->TexPixelsAlpha8 != nullptr)
+            if (atlas->TexData.TexFormat == ImTextureFormat_Alpha8)
             {
-                unsigned char* blit_dst = atlas->TexPixelsAlpha8 + (ty * blit_dst_stride) + tx;
+                unsigned char* blit_dst = (unsigned char*)atlas->TexData.TexPixels + (ty * blit_dst_stride) + tx;
                 for (int y = 0; y < info.Height; y++, blit_dst += blit_dst_stride, blit_src += blit_src_stride)
                     for (int x = 0; x < info.Width; x++)
                         blit_dst[x] = (unsigned char)((blit_src[x] >> IM_COL32_A_SHIFT) & 0xFF);
             }
             else
             {
-                unsigned int* blit_dst = atlas->TexPixelsRGBA32 + (ty * blit_dst_stride) + tx;
+                unsigned int* blit_dst = (unsigned int*)atlas->TexData.TexPixels + (ty * blit_dst_stride) + tx;
                 for (int y = 0; y < info.Height; y++, blit_dst += blit_dst_stride, blit_src += blit_src_stride)
                     for (int x = 0; x < info.Width; x++)
                         blit_dst[x] = blit_src[x];
@@ -739,7 +727,6 @@ bool ImFontAtlasBuildWithFreeTypeEx(FT_Library ft_library, ImFontAtlas* atlas, u
 
         src_tmp.Rects = nullptr;
     }
-    atlas->TexPixelsUseColors = tex_use_colors;
 
     // Cleanup
     for (int buf_i = 0; buf_i < buf_bitmap_buffers.Size; buf_i++)


### PR DESCRIPTION
PR add an ability to update font atlas texture. Based on `feature/shadows`.

There is an information about overall progress:
 - SDL, GLUT, GLFW3 and Allegro 5 backends were tested on Windows.
 - Metal backends was tested on macOS Big Sur.
 - Emscripten was tested on emcc 2.0.12.
 - Marmalade backend and example is not supported.

# Backend
### `Progress: 15/15`
| Backend | Status | Comment |
| - | :-: | - |
| imgui_impl_win32.h | ✔ | No change required.
| imgui_impl_vulkan.h | ✔ | There is `ImGui_ImplVulkan_UpdateFontsTexture` user can need to use in own code.
| imgui_impl_sdl.h | ✔ | No change required.
| imgui_impl_osx.h | ✔ | No change required.
| imgui_impl_opengl3.h | ✔ | Done.
| imgui_impl_opengl2.h | ✔ | Done.
| imgui_impl_metal.h | ✔ | Done.
| imgui_impl_marmalade.h | ❌ | Not supported.
| imgui_impl_glut.h | ✔ | No change required.
| imgui_impl_glfw.h | ✔ | No change required.
| imgui_impl_dx12.h | ✔ | There is `ImGui_ImplDX12_UpdateFontsTexture` user need to call in own code.
| imgui_impl_dx11.h | ✔ | Done.
| imgui_impl_dx10.h | ✔ | Done.
| imgui_impl_dx9.h | ✔ | Done.
| imgui_impl_allegro5.h | ✔ | Done.


# Examples
### `Progress: 20/20`

| Example | Status | Comment
| - | :-: | - |
| example_allegro5 | ✔ | Works.
| example_apple_metal | ✔ | Works.
| example_apple_opengl2 | ✔ | Works.
| example_emscripten_opengl3 | ✔ | Works.
| example_glfw_metal | ✔ | Works.
| example_glfw_opengl2 | ✔ | Works.
| example_glfw_opengl3 | ✔ | Works.
| example_glfw_vulkan | ✔ | Works. Use `ImGui_ImplVulkan_UpdateFontsTexture` and explicitly set `ImGuiBackendFlags_RendererHasTexReload` flag.
| example_glut_opengl2 | ✔ | Works.
| example_marmalade | ❌ | Not supported.
| example_null | ✔ | No change required.
| example_sdl_directx11 | ✔ | Works.
| example_sdl_metal | ✔ | Works.
| example_sdl_opengl2 | ✔ | Works.
| example_sdl_opengl3 | ✔ | Works.
| example_sdl_vulkan | ✔ | Works. Use `ImGui_ImplVulkan_UpdateFontsTexture` and explicitly set `ImGuiBackendFlags_RendererHasTexReload` flag.
| example_win32_directx9 | ✔ | Works.
| example_win32_directx10 | ✔ | Works.
| example_win32_directx11 | ✔ | Works.
| example_win32_directx12 | ✔ | Works. Use `ImGui_ImplDX12_UpdateFontsTexture` and explicitly set `ImGuiBackendFlags_RendererHasTexReload` flag.