### PR TITLE
Simplify CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,11 +9,11 @@ on:
 jobs:
   Windows:
     runs-on: windows-2019
+    env:
+      VS_PATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\
+      MSBUILD_PATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\
     steps:
       - uses: actions/checkout@v2
-
-      - name: Set up MSVC environment
-        uses: ilammy/msvc-dev-cmd@376515093de803c897e7e6d576553c3104267e17
 
       - name: Install Dependencies
         shell: powershell
@@ -44,8 +44,10 @@ jobs:
         run: mingw32-make -C examples/example_null WITH_EXTRA_WARNINGS=1
 
       - name: Build example_null (extra warnings, msvc 64-bit)
+        shell: cmd
         run: |
           cd examples\example_null
+          call "%VS_PATH%\VC\Auxiliary\Build\vcvars64.bat"
           .\build_win32.bat /W4
 
       - name: Build example_null (single file build)
@@ -90,80 +92,101 @@ jobs:
           cl.exe /I. ImGui.lib /Feexample_null.exe examples/example_null/main.cpp
 
       - name: Build Win32 example_glfw_opengl2
-        run: 'MSBuild.exe examples/example_glfw_opengl2/example_glfw_opengl2.vcxproj /p:Platform=Win32 /p:Configuration=Release'
+        shell: cmd
+        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_glfw_opengl2/example_glfw_opengl2.vcxproj /p:Platform=Win32 /p:Configuration=Release'
 
       - name: Build Win32 example_glfw_opengl3
-        run: 'MSBuild.exe examples/example_glfw_opengl3/example_glfw_opengl3.vcxproj /p:Platform=Win32 /p:Configuration=Release'
+        shell: cmd
+        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_glfw_opengl3/example_glfw_opengl3.vcxproj /p:Platform=Win32 /p:Configuration=Release'
         if: github.event_name == 'schedule'
 
       - name: Build Win32 example_glfw_vulkan
-        run: 'MSBuild.exe examples/example_glfw_vulkan/example_glfw_vulkan.vcxproj /p:Platform=Win32 /p:Configuration=Release'
+        shell: cmd
+        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_glfw_vulkan/example_glfw_vulkan.vcxproj /p:Platform=Win32 /p:Configuration=Release'
         if: github.event_name == 'schedule'
 
       - name: Build Win32 example_sdl_vulkan
-        run: 'MSBuild.exe examples/example_sdl_vulkan/example_sdl_vulkan.vcxproj /p:Platform=Win32 /p:Configuration=Release'
+        shell: cmd
+        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_sdl_vulkan/example_sdl_vulkan.vcxproj /p:Platform=Win32 /p:Configuration=Release'
         if: github.event_name == 'schedule'
 
       - name: Build Win32 example_sdl_opengl2
-        run: 'MSBuild.exe examples/example_sdl_opengl2/example_sdl_opengl2.vcxproj /p:Platform=Win32 /p:Configuration=Release'
+        shell: cmd
+        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_sdl_opengl2/example_sdl_opengl2.vcxproj /p:Platform=Win32 /p:Configuration=Release'
         if: github.event_name == 'schedule'
 
       - name: Build Win32 example_sdl_opengl3
-        run: 'MSBuild.exe examples/example_sdl_opengl3/example_sdl_opengl3.vcxproj /p:Platform=Win32 /p:Configuration=Release'
+        shell: cmd
+        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_sdl_opengl3/example_sdl_opengl3.vcxproj /p:Platform=Win32 /p:Configuration=Release'
 
       - name: Build Win32 example_sdl_directx11
-        run: 'MSBuild.exe examples/example_sdl_directx11/example_sdl_directx11.vcxproj /p:Platform=Win32 /p:Configuration=Release'
+        shell: cmd
+        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_sdl_directx11/example_sdl_directx11.vcxproj /p:Platform=Win32 /p:Configuration=Release'
         if: github.event_name == 'schedule'
 
       - name: Build Win32 example_win32_directx9
-        run: 'MSBuild.exe examples/example_win32_directx9/example_win32_directx9.vcxproj /p:Platform=Win32 /p:Configuration=Release'
+        shell: cmd
+        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_win32_directx9/example_win32_directx9.vcxproj /p:Platform=Win32 /p:Configuration=Release'
 
       - name: Build Win32 example_win32_directx10
-        run: 'MSBuild.exe examples/example_win32_directx10/example_win32_directx10.vcxproj /p:Platform=Win32 /p:Configuration=Release'
+        shell: cmd
+        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_win32_directx10/example_win32_directx10.vcxproj /p:Platform=Win32 /p:Configuration=Release'
 
       - name: Build Win32 example_win32_directx11
-        run: 'MSBuild.exe examples/example_win32_directx11/example_win32_directx11.vcxproj /p:Platform=Win32 /p:Configuration=Release'
+        shell: cmd
+        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_win32_directx11/example_win32_directx11.vcxproj /p:Platform=Win32 /p:Configuration=Release'
         if: github.event_name == 'schedule'
 
       - name: Build x64 example_glfw_opengl2
-        run: 'MSBuild.exe examples/example_glfw_opengl2/example_glfw_opengl2.vcxproj /p:Platform=x64 /p:Configuration=Release'
+        shell: cmd
+        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_glfw_opengl2/example_glfw_opengl2.vcxproj /p:Platform=x64 /p:Configuration=Release'
         if: github.event_name == 'schedule'
 
       - name: Build x64 example_glfw_opengl3
-        run: 'MSBuild.exe examples/example_glfw_opengl3/example_glfw_opengl3.vcxproj /p:Platform=x64 /p:Configuration=Release'
+        shell: cmd
+        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_glfw_opengl3/example_glfw_opengl3.vcxproj /p:Platform=x64 /p:Configuration=Release'
 
       - name: Build x64 example_glfw_vulkan
-        run: 'MSBuild.exe examples/example_glfw_vulkan/example_glfw_vulkan.vcxproj /p:Platform=x64 /p:Configuration=Release'
+        shell: cmd
+        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_glfw_vulkan/example_glfw_vulkan.vcxproj /p:Platform=x64 /p:Configuration=Release'
 
       - name: Build x64 example_sdl_vulkan
-        run: 'MSBuild.exe examples/example_sdl_vulkan/example_sdl_vulkan.vcxproj /p:Platform=x64 /p:Configuration=Release'
+        shell: cmd
+        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_sdl_vulkan/example_sdl_vulkan.vcxproj /p:Platform=x64 /p:Configuration=Release'
         if: github.event_name == 'schedule'
 
       - name: Build x64 example_sdl_opengl2
-        run: 'MSBuild.exe examples/example_sdl_opengl2/example_sdl_opengl2.vcxproj /p:Platform=x64 /p:Configuration=Release'
+        shell: cmd
+        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_sdl_opengl2/example_sdl_opengl2.vcxproj /p:Platform=x64 /p:Configuration=Release'
         if: github.event_name == 'schedule'
 
       - name: Build x64 example_sdl_opengl3
-        run: 'MSBuild.exe examples/example_sdl_opengl3/example_sdl_opengl3.vcxproj /p:Platform=x64 /p:Configuration=Release'
+        shell: cmd
+        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_sdl_opengl3/example_sdl_opengl3.vcxproj /p:Platform=x64 /p:Configuration=Release'
         if: github.event_name == 'schedule'
 
       - name: Build x64 example_sdl_directx11
-        run: 'MSBuild.exe examples/example_sdl_directx11/example_sdl_directx11.vcxproj /p:Platform=x64 /p:Configuration=Release'
+        shell: cmd
+        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_sdl_directx11/example_sdl_directx11.vcxproj /p:Platform=x64 /p:Configuration=Release'
 
       - name: Build x64 example_win32_directx9
-        run: 'MSBuild.exe examples/example_win32_directx9/example_win32_directx9.vcxproj /p:Platform=x64 /p:Configuration=Release'
+        shell: cmd
+        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_win32_directx9/example_win32_directx9.vcxproj /p:Platform=x64 /p:Configuration=Release'
         if: github.event_name == 'schedule'
 
       - name: Build x64 example_win32_directx10
-        run: 'MSBuild.exe examples/example_win32_directx10/example_win32_directx10.vcxproj /p:Platform=x64 /p:Configuration=Release'
+        shell: cmd
+        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_win32_directx10/example_win32_directx10.vcxproj /p:Platform=x64 /p:Configuration=Release'
         if: github.event_name == 'schedule'
 
       - name: Build x64 example_win32_directx11
-        run: 'MSBuild.exe examples/example_win32_directx11/example_win32_directx11.vcxproj /p:Platform=x64 /p:Configuration=Release'
+        shell: cmd
+        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_win32_directx11/example_win32_directx11.vcxproj /p:Platform=x64 /p:Configuration=Release'
         if: github.event_name == 'schedule'
 
       - name: Build x64 example_win32_directx12
-        run: 'MSBuild.exe examples/example_win32_directx12/example_win32_directx12.vcxproj /p:Platform=x64 /p:Configuration=Release'
+        shell: cmd
+        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_win32_directx12/example_win32_directx12.vcxproj /p:Platform=x64 /p:Configuration=Release'
 
   Linux:
     runs-on: ubuntu-20.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2
+
       - name: Set up MSVC environment
         uses: ilammy/msvc-dev-cmd@376515093de803c897e7e6d576553c3104267e17
 
@@ -51,9 +52,11 @@ jobs:
         shell: bash
         run: |
           cat > example_single_file.cpp <<'EOF'
+
           #define IMGUI_IMPLEMENTATION
           #include "misc/single_file/imgui_single_file.h"
           #include "examples/example_null/main.cpp"
+
           EOF
           g++ -I. -Wall -Wformat -o example_single_file.exe example_single_file.cpp
 
@@ -61,10 +64,12 @@ jobs:
         shell: bash
         run: |
           cat > example_single_file.cpp <<'EOF'
+
           #define IMGUI_DISABLE_WIN32_FUNCTIONS
           #define IMGUI_IMPLEMENTATION
           #include "misc/single_file/imgui_single_file.h"
           #include "examples/example_null/main.cpp"
+
           EOF
           g++ -I. -Wall -Wformat -o example_single_file.exe example_single_file.cpp
 
@@ -72,6 +77,7 @@ jobs:
         shell: cmd
         run: |
           call "%VS_PATH%\VC\Auxiliary\Build\vcvars64.bat"
+
           echo #ifdef _EXPORT                                  >  example_single_file.cpp
           echo #  define IMGUI_API __declspec(dllexport)       >> example_single_file.cpp
           echo #else                                           >> example_single_file.cpp
@@ -79,6 +85,7 @@ jobs:
           echo #endif                                          >> example_single_file.cpp
           echo #define IMGUI_IMPLEMENTATION                    >> example_single_file.cpp
           echo #include "misc/single_file/imgui_single_file.h" >> example_single_file.cpp
+
           cl.exe /D_USRDLL /D_WINDLL /D_EXPORT /I. example_single_file.cpp /LD /FeImGui.dll /link
           cl.exe /I. ImGui.lib /Feexample_null.exe examples/example_null/main.cpp
 
@@ -196,76 +203,91 @@ jobs:
     - name: Build example_null (single file build)
       run: |
         cat > example_single_file.cpp <<'EOF'
+
         #define IMGUI_IMPLEMENTATION
         #include "misc/single_file/imgui_single_file.h"
         #include "examples/example_null/main.cpp"
+
         EOF
         g++ -I. -Wall -Wformat -o example_single_file example_single_file.cpp
 
     - name: Build example_null (with ImWchar32)
       run: |
         cat > example_single_file.cpp <<'EOF'
+
         #define IMGUI_USE_WCHAR32
         #define IMGUI_IMPLEMENTATION
         #include "misc/single_file/imgui_single_file.h"
         #include "examples/example_null/main.cpp"
+
         EOF
         g++ -I. -Wall -Wformat -o example_single_file example_single_file.cpp
 
     - name: Build example_null (with large ImDrawIdx)
       run: |
         cat > example_single_file.cpp <<'EOF'
+
         #define ImDrawIdx unsigned int
         #define IMGUI_IMPLEMENTATION
         #include "misc/single_file/imgui_single_file.h"
         #include "examples/example_null/main.cpp"
+
         EOF
         g++ -I. -Wall -Wformat -o example_single_file example_single_file.cpp
 
     - name: Build example_null (with IMGUI_DISABLE_OBSOLETE_FUNCTIONS)
       run: |
         cat > example_single_file.cpp <<'EOF'
+
         #define IMGUI_DISABLE_OBSOLETE_FUNCTIONS
         #define IMGUI_IMPLEMENTATION
         #include "misc/single_file/imgui_single_file.h"
         #include "examples/example_null/main.cpp"
+
         EOF
         g++ -I. -Wall -Wformat -o example_single_file example_single_file.cpp
 
     - name: Build example_null (with IMGUI_DISABLE_DEMO_WINDOWS and IMGUI_DISABLE_METRICS_WINDOW)
       run: |
         cat > example_single_file.cpp <<'EOF'
+
         #define IMGUI_DISABLE_DEMO_WINDOWS
         #define IMGUI_DISABLE_METRICS_WINDOW
         #define IMGUI_IMPLEMENTATION
         #include "misc/single_file/imgui_single_file.h"
         #include "examples/example_null/main.cpp"
+
         EOF
         g++ -I. -Wall -Wformat -o example_single_file example_single_file.cpp
 
     - name: Build example_null (with IMGUI_DISABLE_FILE_FUNCTIONS)
       run: |
         cat > example_single_file.cpp <<'EOF'
+
         #define IMGUI_DISABLE_FILE_FUNCTIONS
         #define IMGUI_IMPLEMENTATION
         #include "misc/single_file/imgui_single_file.h"
         #include "examples/example_null/main.cpp"
+
         EOF
         g++ -I. -Wall -Wformat -o example_single_file example_single_file.cpp
 
     - name: Build example_null (with IMGUI_USE_BGRA_PACKED_COLOR)
       run: |
         cat > example_single_file.cpp <<'EOF'
+
         #define IMGUI_USE_BGRA_PACKED_COLOR
         #define IMGUI_IMPLEMENTATION
         #include "misc/single_file/imgui_single_file.h"
         #include "examples/example_null/main.cpp"
+
         EOF
         g++ -I. -Wall -Wformat -o example_single_file example_single_file.cpp
 
     - name: Build example_null (with IM_VEC2_CLASS_EXTRA and IM_VEC4_CLASS_EXTRA)
       run: |
         cat > example_single_file.cpp <<'EOF'
+
         struct MyVec2 { float x; float y; MyVec2(float x, float y) : x(x), y(y) { } };
         struct MyVec4 { float x; float y; float z; float w;
         MyVec4(float x, float y, float z, float w) : x(x), y(y), z(z), w(w) { } };
@@ -278,16 +300,19 @@ jobs:
         #define IMGUI_IMPLEMENTATION
         #include "misc/single_file/imgui_single_file.h"
         #include "examples/example_null/main.cpp"
+
         EOF
         g++ -I. -Wall -Wformat -o example_single_file example_single_file.cpp
 
     - name: Build example_null (without c++ runtime, Clang)
       run: |
         cat > example_single_file.cpp <<'EOF'
+
         #define IMGUI_IMPLEMENTATION
         #define IMGUI_DISABLE_DEMO_WINDOWS
         #include "misc/single_file/imgui_single_file.h"
         #include "examples/example_null/main.cpp"
+
         EOF
         clang++ -I. -Wall -Wformat -nodefaultlibs -fno-rtti -fno-exceptions -fno-threadsafe-statics -lc -lm -o example_single_file example_single_file.cpp
 
@@ -320,18 +345,22 @@ jobs:
     - name: Build example_null (single file build)
       run: |
         cat > example_single_file.cpp <<'EOF'
+
         #define IMGUI_IMPLEMENTATION
         #include "misc/single_file/imgui_single_file.h"
         #include "examples/example_null/main.cpp"
+
         EOF
         clang++ -I. -Wall -Wformat -o example_single_file example_single_file.cpp
 
     - name: Build example_null (without c++ runtime)
       run: |
         cat > example_single_file.cpp <<'EOF'
+
         #define IMGUI_IMPLEMENTATION
         #include "misc/single_file/imgui_single_file.h"
         #include "examples/example_null/main.cpp"
+
         EOF
         clang++ -I. -Wall -Wformat -nodefaultlibs -fno-rtti -fno-exceptions -fno-threadsafe-statics -lc -lm -o example_single_file example_single_file.cpp
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,32 +1,29 @@
 name: build
 
 on:
-  push: {}
-  pull_request: {}
+  push:
+  pull_request:
   schedule:
     - cron:  '0 9 * * *'
 
 jobs:
   Windows:
     runs-on: windows-2019
-    env:
-      VS_PATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\
-      MSBUILD_PATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\
-      # Until gh-actions allow us to use env variables inside other env variables (because we need %GITHUB_WORKSPACE%) we have to use relative path to imgui/examples/example_name directory.
-      SDL2_DIR: ..\..\SDL2-devel-2.0.10-VC\SDL2-2.0.10\
-      VULKAN_SDK: ..\..\vulkan-sdk-1.1.121.2\
     steps:
-      - uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
+      - uses: actions/checkout@v2
+      - name: Set up MSVC environment
+        uses: ilammy/msvc-dev-cmd@376515093de803c897e7e6d576553c3104267e17
 
       - name: Install Dependencies
         shell: powershell
         run: |
           Invoke-WebRequest -Uri "https://www.libsdl.org/release/SDL2-devel-2.0.10-VC.zip" -OutFile "SDL2-devel-2.0.10-VC.zip"
           Expand-Archive -Path SDL2-devel-2.0.10-VC.zip
+          echo "SDL2_DIR=$(pwd)\SDL2-devel-2.0.10-VC\SDL2-2.0.10\" >>${env:GITHUB_ENV}
+
           Invoke-WebRequest -Uri "https://github.com/ocornut/imgui/files/3789205/vulkan-sdk-1.1.121.2.zip" -OutFile vulkan-sdk-1.1.121.2.zip
           Expand-Archive -Path vulkan-sdk-1.1.121.2.zip
+          echo "VULKAN_SDK=$(pwd)\vulkan-sdk-1.1.121.2\" >>${env:GITHUB_ENV}
 
       - name: Fix Projects
         shell: powershell
@@ -46,27 +43,29 @@ jobs:
         run: mingw32-make -C examples/example_null WITH_EXTRA_WARNINGS=1
 
       - name: Build example_null (extra warnings, msvc 64-bit)
-        shell: cmd
         run: |
           cd examples\example_null
-          call "%VS_PATH%\VC\Auxiliary\Build\vcvars64.bat"
           .\build_win32.bat /W4
 
       - name: Build example_null (single file build)
         shell: bash
         run: |
-          echo '#define IMGUI_IMPLEMENTATION'                    >  example_single_file.cpp
-          echo '#include "misc/single_file/imgui_single_file.h"' >> example_single_file.cpp
-          echo '#include "examples/example_null/main.cpp"'       >> example_single_file.cpp
+          cat > example_single_file.cpp <<'EOF'
+          #define IMGUI_IMPLEMENTATION
+          #include "misc/single_file/imgui_single_file.h"
+          #include "examples/example_null/main.cpp"
+          EOF
           g++ -I. -Wall -Wformat -o example_single_file.exe example_single_file.cpp
 
       - name: Build example_null (with IMGUI_DISABLE_WIN32_FUNCTIONS)
         shell: bash
         run: |
-          echo '#define IMGUI_DISABLE_WIN32_FUNCTIONS'           >  example_single_file.cpp
-          echo '#define IMGUI_IMPLEMENTATION'                    >> example_single_file.cpp
-          echo '#include "misc/single_file/imgui_single_file.h"' >> example_single_file.cpp
-          echo '#include "examples/example_null/main.cpp"'       >> example_single_file.cpp
+          cat > example_single_file.cpp <<'EOF'
+          #define IMGUI_DISABLE_WIN32_FUNCTIONS
+          #define IMGUI_IMPLEMENTATION
+          #include "misc/single_file/imgui_single_file.h"
+          #include "examples/example_null/main.cpp"
+          EOF
           g++ -I. -Wall -Wformat -o example_single_file.exe example_single_file.cpp
 
       - name: Build example_null (as DLL)
@@ -84,108 +83,85 @@ jobs:
           cl.exe /I. ImGui.lib /Feexample_null.exe examples/example_null/main.cpp
 
       - name: Build Win32 example_glfw_opengl2
-        shell: cmd
-        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_glfw_opengl2/example_glfw_opengl2.vcxproj /p:Platform=Win32 /p:Configuration=Release'
+        run: 'MSBuild.exe examples/example_glfw_opengl2/example_glfw_opengl2.vcxproj /p:Platform=Win32 /p:Configuration=Release'
 
       - name: Build Win32 example_glfw_opengl3
-        shell: cmd
-        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_glfw_opengl3/example_glfw_opengl3.vcxproj /p:Platform=Win32 /p:Configuration=Release'
+        run: 'MSBuild.exe examples/example_glfw_opengl3/example_glfw_opengl3.vcxproj /p:Platform=Win32 /p:Configuration=Release'
         if: github.event_name == 'schedule'
 
       - name: Build Win32 example_glfw_vulkan
-        shell: cmd
-        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_glfw_vulkan/example_glfw_vulkan.vcxproj /p:Platform=Win32 /p:Configuration=Release'
+        run: 'MSBuild.exe examples/example_glfw_vulkan/example_glfw_vulkan.vcxproj /p:Platform=Win32 /p:Configuration=Release'
         if: github.event_name == 'schedule'
 
       - name: Build Win32 example_sdl_vulkan
-        shell: cmd
-        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_sdl_vulkan/example_sdl_vulkan.vcxproj /p:Platform=Win32 /p:Configuration=Release'
+        run: 'MSBuild.exe examples/example_sdl_vulkan/example_sdl_vulkan.vcxproj /p:Platform=Win32 /p:Configuration=Release'
         if: github.event_name == 'schedule'
 
       - name: Build Win32 example_sdl_opengl2
-        shell: cmd
-        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_sdl_opengl2/example_sdl_opengl2.vcxproj /p:Platform=Win32 /p:Configuration=Release'
+        run: 'MSBuild.exe examples/example_sdl_opengl2/example_sdl_opengl2.vcxproj /p:Platform=Win32 /p:Configuration=Release'
         if: github.event_name == 'schedule'
 
       - name: Build Win32 example_sdl_opengl3
-        shell: cmd
-        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_sdl_opengl3/example_sdl_opengl3.vcxproj /p:Platform=Win32 /p:Configuration=Release'
+        run: 'MSBuild.exe examples/example_sdl_opengl3/example_sdl_opengl3.vcxproj /p:Platform=Win32 /p:Configuration=Release'
 
       - name: Build Win32 example_sdl_directx11
-        shell: cmd
-        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_sdl_directx11/example_sdl_directx11.vcxproj /p:Platform=Win32 /p:Configuration=Release'
+        run: 'MSBuild.exe examples/example_sdl_directx11/example_sdl_directx11.vcxproj /p:Platform=Win32 /p:Configuration=Release'
         if: github.event_name == 'schedule'
 
       - name: Build Win32 example_win32_directx9
-        shell: cmd
-        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_win32_directx9/example_win32_directx9.vcxproj /p:Platform=Win32 /p:Configuration=Release'
+        run: 'MSBuild.exe examples/example_win32_directx9/example_win32_directx9.vcxproj /p:Platform=Win32 /p:Configuration=Release'
 
       - name: Build Win32 example_win32_directx10
-        shell: cmd
-        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_win32_directx10/example_win32_directx10.vcxproj /p:Platform=Win32 /p:Configuration=Release'
+        run: 'MSBuild.exe examples/example_win32_directx10/example_win32_directx10.vcxproj /p:Platform=Win32 /p:Configuration=Release'
 
       - name: Build Win32 example_win32_directx11
-        shell: cmd
-        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_win32_directx11/example_win32_directx11.vcxproj /p:Platform=Win32 /p:Configuration=Release'
+        run: 'MSBuild.exe examples/example_win32_directx11/example_win32_directx11.vcxproj /p:Platform=Win32 /p:Configuration=Release'
         if: github.event_name == 'schedule'
 
       - name: Build x64 example_glfw_opengl2
-        shell: cmd
-        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_glfw_opengl2/example_glfw_opengl2.vcxproj /p:Platform=x64 /p:Configuration=Release'
+        run: 'MSBuild.exe examples/example_glfw_opengl2/example_glfw_opengl2.vcxproj /p:Platform=x64 /p:Configuration=Release'
         if: github.event_name == 'schedule'
 
       - name: Build x64 example_glfw_opengl3
-        shell: cmd
-        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_glfw_opengl3/example_glfw_opengl3.vcxproj /p:Platform=x64 /p:Configuration=Release'
+        run: 'MSBuild.exe examples/example_glfw_opengl3/example_glfw_opengl3.vcxproj /p:Platform=x64 /p:Configuration=Release'
 
       - name: Build x64 example_glfw_vulkan
-        shell: cmd
-        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_glfw_vulkan/example_glfw_vulkan.vcxproj /p:Platform=x64 /p:Configuration=Release'
+        run: 'MSBuild.exe examples/example_glfw_vulkan/example_glfw_vulkan.vcxproj /p:Platform=x64 /p:Configuration=Release'
 
       - name: Build x64 example_sdl_vulkan
-        shell: cmd
-        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_sdl_vulkan/example_sdl_vulkan.vcxproj /p:Platform=x64 /p:Configuration=Release'
+        run: 'MSBuild.exe examples/example_sdl_vulkan/example_sdl_vulkan.vcxproj /p:Platform=x64 /p:Configuration=Release'
         if: github.event_name == 'schedule'
 
       - name: Build x64 example_sdl_opengl2
-        shell: cmd
-        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_sdl_opengl2/example_sdl_opengl2.vcxproj /p:Platform=x64 /p:Configuration=Release'
+        run: 'MSBuild.exe examples/example_sdl_opengl2/example_sdl_opengl2.vcxproj /p:Platform=x64 /p:Configuration=Release'
         if: github.event_name == 'schedule'
 
       - name: Build x64 example_sdl_opengl3
-        shell: cmd
-        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_sdl_opengl3/example_sdl_opengl3.vcxproj /p:Platform=x64 /p:Configuration=Release'
+        run: 'MSBuild.exe examples/example_sdl_opengl3/example_sdl_opengl3.vcxproj /p:Platform=x64 /p:Configuration=Release'
         if: github.event_name == 'schedule'
 
       - name: Build x64 example_sdl_directx11
-        shell: cmd
-        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_sdl_directx11/example_sdl_directx11.vcxproj /p:Platform=x64 /p:Configuration=Release'
+        run: 'MSBuild.exe examples/example_sdl_directx11/example_sdl_directx11.vcxproj /p:Platform=x64 /p:Configuration=Release'
 
       - name: Build x64 example_win32_directx9
-        shell: cmd
-        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_win32_directx9/example_win32_directx9.vcxproj /p:Platform=x64 /p:Configuration=Release'
+        run: 'MSBuild.exe examples/example_win32_directx9/example_win32_directx9.vcxproj /p:Platform=x64 /p:Configuration=Release'
         if: github.event_name == 'schedule'
 
       - name: Build x64 example_win32_directx10
-        shell: cmd
-        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_win32_directx10/example_win32_directx10.vcxproj /p:Platform=x64 /p:Configuration=Release'
+        run: 'MSBuild.exe examples/example_win32_directx10/example_win32_directx10.vcxproj /p:Platform=x64 /p:Configuration=Release'
         if: github.event_name == 'schedule'
 
       - name: Build x64 example_win32_directx11
-        shell: cmd
-        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_win32_directx11/example_win32_directx11.vcxproj /p:Platform=x64 /p:Configuration=Release'
+        run: 'MSBuild.exe examples/example_win32_directx11/example_win32_directx11.vcxproj /p:Platform=x64 /p:Configuration=Release'
         if: github.event_name == 'schedule'
 
       - name: Build x64 example_win32_directx12
-        shell: cmd
-        run: '"%MSBUILD_PATH%\MSBuild.exe" examples/example_win32_directx12/example_win32_directx12.vcxproj /p:Platform=x64 /p:Configuration=Release'
+        run: 'MSBuild.exe examples/example_win32_directx12/example_win32_directx12.vcxproj /p:Platform=x64 /p:Configuration=Release'
 
   Linux:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v1
-      with:
-        fetch-depth: 1
+    - uses: actions/checkout@v2
 
     - name: Install Dependencies
       run: |
@@ -219,82 +195,100 @@ jobs:
 
     - name: Build example_null (single file build)
       run: |
-        echo '#define IMGUI_IMPLEMENTATION'                    >  example_single_file.cpp
-        echo '#include "misc/single_file/imgui_single_file.h"' >> example_single_file.cpp
-        echo '#include "examples/example_null/main.cpp"'       >> example_single_file.cpp
+        cat > example_single_file.cpp <<'EOF'
+        #define IMGUI_IMPLEMENTATION
+        #include "misc/single_file/imgui_single_file.h"
+        #include "examples/example_null/main.cpp"
+        EOF
         g++ -I. -Wall -Wformat -o example_single_file example_single_file.cpp
 
     - name: Build example_null (with ImWchar32)
       run: |
-        echo '#define IMGUI_USE_WCHAR32'                       >  example_single_file.cpp
-        echo '#define IMGUI_IMPLEMENTATION'                    >> example_single_file.cpp
-        echo '#include "misc/single_file/imgui_single_file.h"' >> example_single_file.cpp
-        echo '#include "examples/example_null/main.cpp"'       >> example_single_file.cpp
+        cat > example_single_file.cpp <<'EOF'
+        #define IMGUI_USE_WCHAR32
+        #define IMGUI_IMPLEMENTATION
+        #include "misc/single_file/imgui_single_file.h"
+        #include "examples/example_null/main.cpp"
+        EOF
         g++ -I. -Wall -Wformat -o example_single_file example_single_file.cpp
 
     - name: Build example_null (with large ImDrawIdx)
       run: |
-        echo '#define ImDrawIdx unsigned int'                  >  example_single_file.cpp
-        echo '#define IMGUI_IMPLEMENTATION'                    >> example_single_file.cpp
-        echo '#include "misc/single_file/imgui_single_file.h"' >> example_single_file.cpp
-        echo '#include "examples/example_null/main.cpp"'       >> example_single_file.cpp
+        cat > example_single_file.cpp <<'EOF'
+        #define ImDrawIdx unsigned int
+        #define IMGUI_IMPLEMENTATION
+        #include "misc/single_file/imgui_single_file.h"
+        #include "examples/example_null/main.cpp"
+        EOF
         g++ -I. -Wall -Wformat -o example_single_file example_single_file.cpp
 
     - name: Build example_null (with IMGUI_DISABLE_OBSOLETE_FUNCTIONS)
       run: |
-        echo '#define IMGUI_DISABLE_OBSOLETE_FUNCTIONS'        >  example_single_file.cpp
-        echo '#define IMGUI_IMPLEMENTATION'                    >> example_single_file.cpp
-        echo '#include "misc/single_file/imgui_single_file.h"' >> example_single_file.cpp
-        echo '#include "examples/example_null/main.cpp"'       >> example_single_file.cpp
+        cat > example_single_file.cpp <<'EOF'
+        #define IMGUI_DISABLE_OBSOLETE_FUNCTIONS
+        #define IMGUI_IMPLEMENTATION
+        #include "misc/single_file/imgui_single_file.h"
+        #include "examples/example_null/main.cpp"
+        EOF
         g++ -I. -Wall -Wformat -o example_single_file example_single_file.cpp
 
     - name: Build example_null (with IMGUI_DISABLE_DEMO_WINDOWS and IMGUI_DISABLE_METRICS_WINDOW)
       run: |
-        echo '#define IMGUI_DISABLE_DEMO_WINDOWS'              >  example_single_file.cpp
-        echo '#define IMGUI_DISABLE_METRICS_WINDOW'            >> example_single_file.cpp
-        echo '#define IMGUI_IMPLEMENTATION'                    >> example_single_file.cpp
-        echo '#include "misc/single_file/imgui_single_file.h"' >> example_single_file.cpp
-        echo '#include "examples/example_null/main.cpp"'       >> example_single_file.cpp
+        cat > example_single_file.cpp <<'EOF'
+        #define IMGUI_DISABLE_DEMO_WINDOWS
+        #define IMGUI_DISABLE_METRICS_WINDOW
+        #define IMGUI_IMPLEMENTATION
+        #include "misc/single_file/imgui_single_file.h"
+        #include "examples/example_null/main.cpp"
+        EOF
         g++ -I. -Wall -Wformat -o example_single_file example_single_file.cpp
 
     - name: Build example_null (with IMGUI_DISABLE_FILE_FUNCTIONS)
       run: |
-        echo '#define IMGUI_DISABLE_FILE_FUNCTIONS'            >  example_single_file.cpp
-        echo '#define IMGUI_IMPLEMENTATION'                    >> example_single_file.cpp
-        echo '#include "misc/single_file/imgui_single_file.h"' >> example_single_file.cpp
-        echo '#include "examples/example_null/main.cpp"'       >> example_single_file.cpp
+        cat > example_single_file.cpp <<'EOF'
+        #define IMGUI_DISABLE_FILE_FUNCTIONS
+        #define IMGUI_IMPLEMENTATION
+        #include "misc/single_file/imgui_single_file.h"
+        #include "examples/example_null/main.cpp"
+        EOF
         g++ -I. -Wall -Wformat -o example_single_file example_single_file.cpp
 
     - name: Build example_null (with IMGUI_USE_BGRA_PACKED_COLOR)
       run: |
-        echo '#define IMGUI_USE_BGRA_PACKED_COLOR'             >  example_single_file.cpp
-        echo '#define IMGUI_IMPLEMENTATION'                    >> example_single_file.cpp
-        echo '#include "misc/single_file/imgui_single_file.h"' >> example_single_file.cpp
-        echo '#include "examples/example_null/main.cpp"'       >> example_single_file.cpp
+        cat > example_single_file.cpp <<'EOF'
+        #define IMGUI_USE_BGRA_PACKED_COLOR
+        #define IMGUI_IMPLEMENTATION
+        #include "misc/single_file/imgui_single_file.h"
+        #include "examples/example_null/main.cpp"
+        EOF
         g++ -I. -Wall -Wformat -o example_single_file example_single_file.cpp
 
     - name: Build example_null (with IM_VEC2_CLASS_EXTRA and IM_VEC4_CLASS_EXTRA)
       run: |
-        echo 'struct MyVec2 { float x; float y; MyVec2(float x, float y) : x(x), y(y) { } };' >  example_single_file.cpp
-        echo 'struct MyVec4 { float x; float y; float z; float w;'                            >> example_single_file.cpp
-        echo 'MyVec4(float x, float y, float z, float w) : x(x), y(y), z(z), w(w) { } };'     >> example_single_file.cpp
-        echo '#define IM_VEC2_CLASS_EXTRA                                             \'      >> example_single_file.cpp
-        echo '        ImVec2(const MyVec2& f) { x = f.x; y = f.y; }                   \'      >> example_single_file.cpp
-        echo '        operator MyVec2() const { return MyVec2(x, y); }'                       >> example_single_file.cpp
-        echo '#define IM_VEC4_CLASS_EXTRA                                             \'      >> example_single_file.cpp
-        echo '        ImVec4(const MyVec4& f) { x = f.x; y = f.y; z = f.z; w = f.w; } \'      >> example_single_file.cpp
-        echo '        operator MyVec4() const { return MyVec4(x, y, z, w); }'                 >> example_single_file.cpp
-        echo '#define IMGUI_IMPLEMENTATION'                                                   >> example_single_file.cpp
-        echo '#include "misc/single_file/imgui_single_file.h"'                                >> example_single_file.cpp
-        echo '#include "examples/example_null/main.cpp"'                                      >> example_single_file.cpp
+        cat > example_single_file.cpp <<'EOF'
+        struct MyVec2 { float x; float y; MyVec2(float x, float y) : x(x), y(y) { } };
+        struct MyVec4 { float x; float y; float z; float w;
+        MyVec4(float x, float y, float z, float w) : x(x), y(y), z(z), w(w) { } };
+        #define IM_VEC2_CLASS_EXTRA                                             \
+                ImVec2(const MyVec2& f) { x = f.x; y = f.y; }                   \
+                operator MyVec2() const { return MyVec2(x, y); }
+        #define IM_VEC4_CLASS_EXTRA                                             \
+                ImVec4(const MyVec4& f) { x = f.x; y = f.y; z = f.z; w = f.w; } \
+                operator MyVec4() const { return MyVec4(x, y, z, w); }
+        #define IMGUI_IMPLEMENTATION
+        #include "misc/single_file/imgui_single_file.h"
+        #include "examples/example_null/main.cpp"
+        EOF
         g++ -I. -Wall -Wformat -o example_single_file example_single_file.cpp
 
     - name: Build example_null (without c++ runtime, Clang)
       run: |
-        echo '#define IMGUI_IMPLEMENTATION'                    >  example_single_file.cpp
-        echo '#define IMGUI_DISABLE_DEMO_WINDOWS'              >> example_single_file.cpp
-        echo '#include "misc/single_file/imgui_single_file.h"' >> example_single_file.cpp
-        echo '#include "examples/example_null/main.cpp"'       >> example_single_file.cpp
+        cat > example_single_file.cpp <<'EOF'
+        #define IMGUI_IMPLEMENTATION
+        #define IMGUI_DISABLE_DEMO_WINDOWS
+        #include "misc/single_file/imgui_single_file.h"
+        #include "examples/example_null/main.cpp"
+        EOF
         clang++ -I. -Wall -Wformat -nodefaultlibs -fno-rtti -fno-exceptions -fno-threadsafe-statics -lc -lm -o example_single_file example_single_file.cpp
 
     - name: Build example_glfw_opengl2
@@ -314,30 +308,31 @@ jobs:
   MacOS:
     runs-on: macOS-latest
     steps:
-    - uses: actions/checkout@v1
-      with:
-        fetch-depth: 1
+    - uses: actions/checkout@v2
 
     - name: Install Dependencies
       run: |
-        brew install glfw3
-        brew install sdl2
+        brew install glfw3 sdl2
 
     - name: Build example_null (extra warnings, clang 64-bit)
       run: make -C examples/example_null WITH_EXTRA_WARNINGS=1
 
     - name: Build example_null (single file build)
       run: |
-        echo '#define IMGUI_IMPLEMENTATION'                    >  example_single_file.cpp
-        echo '#include "misc/single_file/imgui_single_file.h"' >> example_single_file.cpp
-        echo '#include "examples/example_null/main.cpp"'       >> example_single_file.cpp
+        cat > example_single_file.cpp <<'EOF'
+        #define IMGUI_IMPLEMENTATION
+        #include "misc/single_file/imgui_single_file.h"
+        #include "examples/example_null/main.cpp"
+        EOF
         clang++ -I. -Wall -Wformat -o example_single_file example_single_file.cpp
 
     - name: Build example_null (without c++ runtime)
       run: |
-        echo '#define IMGUI_IMPLEMENTATION'                    >  example_single_file.cpp
-        echo '#include "misc/single_file/imgui_single_file.h"' >> example_single_file.cpp
-        echo '#include "examples/example_null/main.cpp"'       >> example_single_file.cpp
+        cat > example_single_file.cpp <<'EOF'
+        #define IMGUI_IMPLEMENTATION
+        #include "misc/single_file/imgui_single_file.h"
+        #include "examples/example_null/main.cpp"
+        EOF
         clang++ -I. -Wall -Wformat -nodefaultlibs -fno-rtti -fno-exceptions -fno-threadsafe-statics -lc -lm -o example_single_file example_single_file.cpp
 
     - name: Build example_glfw_opengl2
@@ -369,9 +364,7 @@ jobs:
   iOS:
     runs-on: macOS-latest
     steps:
-    - uses: actions/checkout@v1
-      with:
-        fetch-depth: 1
+    - uses: actions/checkout@v2
 
     - name: Build example_apple_metal
       run: |
@@ -381,9 +374,7 @@ jobs:
   Emscripten:
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v1
-      with:
-        fetch-depth: 1
+    - uses: actions/checkout@v2
 
     - name: Install Dependencies
       run: |


### PR DESCRIPTION
* Eliminate path handling on Windows
    * ~~MSVC paths through https://github.com/ilammy/msvc-dev-cmd~~
    * Deps paths through https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
* Use heredocs for pasting source code
* Remove fetch-depth arg, it's the default
* Merge the `brew install`s, it's simpler and maybe even faster