### PR TITLE
Noticed typos in the Text in the ImGui::Text content for the "Nested tables" demo 

### DIFF
--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -4262,18 +4262,18 @@ static void ShowDemoWindowTables()
                     ImGui::TableNextColumn();
                     ImGui::Text("B0 Cell 0");
                     ImGui::TableNextColumn();
-                    ImGui::Text("B0 Cell 1");
+                    ImGui::Text("B1 Cell 0");
                     ImGui::TableNextRow(ImGuiTableRowFlags_None, rows_height);
                     ImGui::TableNextColumn();
-                    ImGui::Text("B1 Cell 0");
+                    ImGui::Text("B0 Cell 1");
                     ImGui::TableNextColumn();
                     ImGui::Text("B1 Cell 1");
 
                     ImGui::EndTable();
                 }
             }
-            ImGui::TableNextColumn(); ImGui::Text("A0 Cell 1");
             ImGui::TableNextColumn(); ImGui::Text("A1 Cell 0");
+            ImGui::TableNextColumn(); ImGui::Text("A0 Cell 1");
             ImGui::TableNextColumn(); ImGui::Text("A1 Cell 1");
             ImGui::EndTable();
         }


### PR DESCRIPTION
<img width="557" alt="Screenshot 2021-01-27 at 14 15 32" src="https://user-images.githubusercontent.com/47660154/106028728-35f46e00-60c4-11eb-8d8e-3960096e6823.png">
( e.g. 

in the blue rectangle :    "B0 Cell 1" should be "B1 Cell 0" 

in the yellow rectangle:  "B1 Cell 0  should be "B0 Cell 1" 

in the green rectangle:   "A1 Cell 0 should be "A0 Cell 1"

in the red rectangle:       "A0 Cell 1 should be "A1 Cell 0"
)
