### PR TITLE
Fixes WebGPU blending issue on Chrome 90+

### DIFF
--- a/backends/imgui_impl_wgpu.cpp
+++ b/backends/imgui_impl_wgpu.cpp
@@ -19,6 +19,8 @@
 #include <limits.h>
 #include <webgpu/webgpu.h>
 
+#define HAS_EMSCRIPTEN_VERSION(major, minor, tiny) (__EMSCRIPTEN_major__ > (major) || (__EMSCRIPTEN_major__ == (major) && __EMSCRIPTEN_minor__ > (minor)) || (__EMSCRIPTEN_major__ == (major) && __EMSCRIPTEN_minor__ == (minor) && __EMSCRIPTEN_tiny__ >= (tiny)))
+
 // Dear ImGui prototypes from imgui_internal.h
 extern ImGuiID ImHashData(const void* data_p, size_t data_size, ImU32 seed = 0);
 
@@ -495,7 +497,7 @@ static void ImGui_ImplWGPU_CreateFontsTexture()
         textureCopyView.texture = g_resources.FontTexture;
         textureCopyView.mipLevel = 0;
         textureCopyView.origin = { 0, 0, 0 };
-#ifndef __EMSCRIPTEN__
+#if !defined(__EMSCRIPTEN__) || HAS_EMSCRIPTEN_VERSION(2, 0, 14)
         textureCopyView.aspect = WGPUTextureAspect_All;
 #endif
 
@@ -522,6 +524,9 @@ static void ImGui_ImplWGPU_CreateFontsTexture()
         sampler_desc.addressModeU = WGPUAddressMode_Repeat;
         sampler_desc.addressModeV = WGPUAddressMode_Repeat;
         sampler_desc.addressModeW = WGPUAddressMode_Repeat;
+#if !defined(__EMSCRIPTEN__) || HAS_EMSCRIPTEN_VERSION(2, 0, 14)
+        sampler_desc.maxAnisotropy = 1;
+#endif
         g_resources.Sampler = wgpuDeviceCreateSampler(g_wgpuDevice, &sampler_desc);
     }
 
@@ -559,15 +564,28 @@ bool ImGui_ImplWGPU_CreateDeviceObjects()
     WGPUBindGroupLayoutEntry common_bg_layout_entries[2] = {};
     common_bg_layout_entries[0].binding = 0;
     common_bg_layout_entries[0].visibility = WGPUShaderStage_Vertex;
+#if !defined(__EMSCRIPTEN__) || HAS_EMSCRIPTEN_VERSION(2, 0, 14)
+    common_bg_layout_entries[0].buffer.type = WGPUBufferBindingType_Uniform;
+#else
     common_bg_layout_entries[0].type = WGPUBindingType_UniformBuffer;
+#endif
     common_bg_layout_entries[1].binding = 1;
     common_bg_layout_entries[1].visibility = WGPUShaderStage_Fragment;
+#if !defined(__EMSCRIPTEN__) || HAS_EMSCRIPTEN_VERSION(2, 0, 14)
+    common_bg_layout_entries[1].sampler.type = WGPUSamplerBindingType_Filtering;
+#else
     common_bg_layout_entries[1].type = WGPUBindingType_Sampler;
+#endif
 
     WGPUBindGroupLayoutEntry image_bg_layout_entries[1] = {};
     image_bg_layout_entries[0].binding = 0;
     image_bg_layout_entries[0].visibility = WGPUShaderStage_Fragment;
+#if !defined(__EMSCRIPTEN__) || HAS_EMSCRIPTEN_VERSION(2, 0, 14)
+    image_bg_layout_entries[0].texture.sampleType = WGPUTextureSampleType_Float;
+    image_bg_layout_entries[0].texture.viewDimension = WGPUTextureViewDimension_2D;
+#else
     image_bg_layout_entries[0].type = WGPUBindingType_SampledTexture;
+#endif
 
     WGPUBindGroupLayoutDescriptor common_bg_layout_desc = {};
     common_bg_layout_desc.entryCount = 2;
@@ -620,8 +638,8 @@ bool ImGui_ImplWGPU_CreateDeviceObjects()
     {
         color_state.format = g_renderTargetFormat;
         color_state.alphaBlend.operation = WGPUBlendOperation_Add;
-        color_state.alphaBlend.srcFactor = WGPUBlendFactor_OneMinusSrcAlpha;
-        color_state.alphaBlend.dstFactor = WGPUBlendFactor_Zero;
+        color_state.alphaBlend.srcFactor = WGPUBlendFactor_SrcAlpha;
+        color_state.alphaBlend.dstFactor = WGPUBlendFactor_OneMinusSrcAlpha;
         color_state.colorBlend.operation = WGPUBlendOperation_Add;
         color_state.colorBlend.srcFactor = WGPUBlendFactor_SrcAlpha;
         color_state.colorBlend.dstFactor = WGPUBlendFactor_OneMinusSrcAlpha;


### PR DESCRIPTION
@ocornut, @Henauxg, I don't quite understand what has changed in the Chrome WebGPU backend, as the previous implementation worked both in Chrome and when using the native Dawn library.
However, the blending function for the alpha value was wrongly configured. The fixed version works both for Dawn and Version 90.0.4403.7.

In addition, this PR makes the WebGPU backend compatible with the latest WebGPU updates in Emscripten (merged right after 2.0.13)
https://github.com/emscripten-core/emscripten/commit/f825fa99d9605437c0fae0abada4e9113b36c833