### PR TITLE
Fix for ImGui::SliderInt makes a value 0, when min_range==max_range

### DIFF
--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -2589,7 +2589,7 @@ template<typename TYPE, typename SIGNEDTYPE, typename FLOATTYPE>
 TYPE ImGui::ScaleValueFromRatioT(ImGuiDataType data_type, float t, TYPE v_min, TYPE v_max, bool is_logarithmic, float logarithmic_zero_epsilon, float zero_deadzone_halfsize)
 {
     if (v_min == v_max)
-        return (TYPE)0.0f;
+        return (TYPE)v_min;
     const bool is_decimal = (data_type == ImGuiDataType_Float) || (data_type == ImGuiDataType_Double);
 
     TYPE result;


### PR DESCRIPTION
Great project, thanks and kudos for all the tremendous effort!!!

Searched the FAQ and possibly similar issues, such as this old [issue](https://github.com/ocornut/imgui/issues/919) and more recent [issue](https://github.com/ocornut/imgui/issues/3388).

I maybe missing something, but an ImGui::SliderInt makes a value 0, while dragging, if min_range==max_range even if min_range=42 (for example).

Simple reproduction case:

~~~~~~~~~~~~~~~~~
static int test=42;
int min_range = 42;
int max_range = 42;
if(ImGui::SliderInt("Test",&test,min_range,max_range,0,ImGuiSliderFlags_ClampOnInput))
{
    printf("test=%d\n",test);
}
~~~~~~~~~~~~~~~~~

It prints test=0 while dragging the slider, would like it to stay in range 42,42

~~~~~~~~~~~
Patch makes it work, but perhaps breaks other widgets?

// Convert a parametric position on a slider into a value v in the output space (the logical opposite of ScaleRatioFromValueT)
template<typename TYPE, typename SIGNEDTYPE, typename FLOATTYPE>
TYPE ImGui::ScaleValueFromRatioT(ImGuiDataType data_type, float t, TYPE v_min, TYPE v_max, bool is_logarithmic, float logarithmic_zero_epsilon, float zero_deadzone_halfsize)
{
    if (v_min == v_max)
        return (TYPE)v_min;

instead of

// Convert a parametric position on a slider into a value v in the output space (the logical opposite of ScaleRatioFromValueT)
template<typename TYPE, typename SIGNEDTYPE, typename FLOATTYPE>
TYPE ImGui::ScaleValueFromRatioT(ImGuiDataType data_type, float t, TYPE v_min, TYPE v_max, bool is_logarithmic, float logarithmic_zero_epsilon, float zero_deadzone_halfsize)
{
    if (v_min == v_max)
        return (TYPE)0.0f;
~~~~~~~~~~~
