### PR TITLE
fix scroll-x on touchpad

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -3655,28 +3655,22 @@ void ImGui::UpdateMouseWheel()
     // If a child window has the ImGuiWindowFlags_NoScrollWithMouse flag, we give a chance to scroll its parent
 
     // Vertical Mouse Wheel scrolling
-    const float wheel_y = (g.IO.MouseWheel != 0.0f && !g.IO.KeyShift) ? g.IO.MouseWheel : 0.0f;
-    if (wheel_y != 0.0f && !g.IO.KeyCtrl)
+    const float wheel_y = (!g.IO.KeyShift) ? g.IO.MouseWheel : 0.0f;
+    // Horizontal Mouse Wheel scrolling, or Vertical Mouse Wheel w/ Shift held
+    const float wheel_x = (!g.IO.KeyShift) ? g.IO.MouseWheelH : g.IO.MouseWheel;
+    if ((wheel_y != 0.0f || wheel_x != 0.0f) && !g.IO.KeyCtrl)
     {
-        StartLockWheelingWindow(window);
-        while ((window->Flags & ImGuiWindowFlags_ChildWindow) && ((window->ScrollMax.y == 0.0f) || ((window->Flags & ImGuiWindowFlags_NoScrollWithMouse) && !(window->Flags & ImGuiWindowFlags_NoMouseInputs))))
+        bool noScroll = (window->Flags & ImGuiWindowFlags_NoScrollWithMouse) && !(window->Flags & ImGuiWindowFlags_NoMouseInputs);
+        while ((window->Flags & ImGuiWindowFlags_ChildWindow) && ((window->ScrollMax.y == 0.0f && window->ScrollMax.x == 0.0f) || noScroll))
             window = window->ParentWindow;
-        if (!(window->Flags & ImGuiWindowFlags_NoScrollWithMouse) && !(window->Flags & ImGuiWindowFlags_NoMouseInputs))
+        StartLockWheelingWindow(window);
+        if (!noScroll && wheel_y != 0.0f)
         {
             float max_step = window->InnerRect.GetHeight() * 0.67f;
             float scroll_step = ImFloor(ImMin(5 * window->CalcFontSize(), max_step));
             SetScrollY(window, window->Scroll.y - wheel_y * scroll_step);
         }
-    }
-
-    // Horizontal Mouse Wheel scrolling, or Vertical Mouse Wheel w/ Shift held
-    const float wheel_x = (g.IO.MouseWheelH != 0.0f && !g.IO.KeyShift) ? g.IO.MouseWheelH : (g.IO.MouseWheel != 0.0f && g.IO.KeyShift) ? g.IO.MouseWheel : 0.0f;
-    if (wheel_x != 0.0f && !g.IO.KeyCtrl)
-    {
-        StartLockWheelingWindow(window);
-        while ((window->Flags & ImGuiWindowFlags_ChildWindow) && ((window->ScrollMax.x == 0.0f) || ((window->Flags & ImGuiWindowFlags_NoScrollWithMouse) && !(window->Flags & ImGuiWindowFlags_NoMouseInputs))))
-            window = window->ParentWindow;
-        if (!(window->Flags & ImGuiWindowFlags_NoScrollWithMouse) && !(window->Flags & ImGuiWindowFlags_NoMouseInputs))
+        if (!noScroll && wheel_x != 0.0f)
         {
             float max_step = window->InnerRect.GetWidth() * 0.67f;
             float scroll_step = ImFloor(ImMin(2 * window->CalcFontSize(), max_step));


### PR DESCRIPTION
# Description

Fix scroll-x on touchpad

The standalone imgui "demo" exhibit the faulty behavior.
`Table & columns` -> `Advanced` ; Open `Options`

- reduce item count to a few (~5), so the `Table` is not "full" y-wise and thus **y-scrollbar disappear**
- raise the `inner width` to go beyond the width so that **x-scrollbar appear**

You are now in a situation with a `Table` having `x-scrollbar` but not `y-scrollbar`.

You can of course easily recreate the same situation in homemade code. Just fill a `Table` with large lignes (number of columns), small number of items.

With a touchpad (at least on Mac), the `x-scrollbar` is 99% unusable.

The x-scrollbar can be moved left/right ONLY IF we very very carefully (and with difficulty) touch the touchpad so that the operating system only issue a +/- on the x-axis and 0 on the y-axis.

Because the `Table` is not interested for scroll-y, the event is being "bubbled up" to the parent window.
It mess with the code which would have taken interest in the `x-scroll` on behalf of the `Table`.

# Expected behavior

I guess that when the user has a mouse with two scroll wheels, the users can easily choose to "scroll only on X and be neutral (0) on Y".

But I have a hard time figuring out any situation where an user would really wish to **AT THE SAME TIME** scrolling on **two different widgets** (parent and children).
I guess that the expected behavior are rather:

- scroll only on X and ignore the other axis
- scroll only on Y and ignore the other axis
- scroll both on X and Y (diagonally) but **only if inside the same widget**


# FIX of the pull request

If **children** window has interest for scroll-x, the fix prevent bubbling scroll-y events and lock further wheeling events to **parent** window.

The code changes of the pull request are including 3 components ;
The first 2 changes below should not change the "logic" of the code, they are for readability only.
The 3 change below should fix the bug.

## 1) Simplify the 2 lines calculating `const float`: `wheel_y` and `wheel_x`.
The two artimethic operations are being factorized to their simpler form.
The results should be 100% the same than before, if I'm right, it's only some boolean arithmetics.

Those two calculations are also moved at the top of the `diff`, the patch needing those resuls early.

## 2) Replace a frequent calculus by its own boolean
I replaced:

- BEFORE : `(window->Flags & ImGuiWindowFlags_NoScrollWithMouse) && !(window->Flags & ImGuiWindowFlags_NoMouseInputs)` everywhere
- AFTER : the `bool noScroll` in replacements

## 3) The bug fix

The patch aim to stop bubbling the event as soon as a widget has interest for either scroll-x or scroll-y.
If the widget has interest for only one of the two scrolling axes, the second one will be ignored, which is probably the better situation.

I do not pretend to have inside knowledge of the internal of imgui.
I think I still have respected the intention of the original code.

In the case where the widget has no interest for one of the two scrolling axes, I guess a flag could also be introduced which would enable/disable bubbling up the ignored event to the parent window.
But it would probably require to split the `StartLockWheelingWindow` subsystem for the two axes.