### PR TITLE
Remove redundant GetMainViewport decl in imgui.h

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -905,7 +905,6 @@ namespace ImGui
     // Read comments around the ImGuiPlatformIO structure for more details.
     // Note: You may use GetWindowViewport() to get the current viewport of the current window.
     IMGUI_API ImGuiPlatformIO&  GetPlatformIO();                                                // platform/renderer functions, for backend to setup + viewports list.
-    IMGUI_API ImGuiViewport*    GetMainViewport();                                              // return primary/default viewport. In the future in "no main platform window" mode we will direct this to primary monitor.
     IMGUI_API void              UpdatePlatformWindows();                                        // call in main loop. will call CreateWindow/ResizeWindow/etc. platform functions for each secondary viewport, and DestroyWindow for each inactive viewport.
     IMGUI_API void              RenderPlatformWindowsDefault(void* platform_render_arg = NULL, void* renderer_render_arg = NULL); // call in main loop. will call RenderWindow/SwapBuffers platform functions for each secondary viewport which doesn't have the ImGuiViewportFlags_Minimized flag set. May be reimplemented by user for custom rendering needs.
     IMGUI_API void              DestroyPlatformWindows();                                       // call DestroyWindow platform functions for all viewports. call from backend Shutdown() if you need to close platform windows before imgui shutdown. otherwise will be called by DestroyContext().


### PR DESCRIPTION
Issue here: https://github.com/ocornut/imgui/issues/3800

This is a trivial change that removes a redundant declaration of GetMainViewport. The redundant declaration isn't harmful, but can trigger warnings (which turn into errors) when downstream developers use strict compilation settings (specifically: `-Wno-redundant-decls` in `g++`).