### PR TITLE
Improve on automatic circle segment count calculation

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -986,7 +986,7 @@ ImGuiStyle::ImGuiStyle()
     AntiAliasedLinesUseTex  = true;             // Enable anti-aliased lines/borders using textures where possible. Require backend to render with bilinear filtering.
     AntiAliasedFill         = true;             // Enable anti-aliased filled shapes (rounded rectangles, circles, etc.).
     CurveTessellationTol    = 1.25f;            // Tessellation tolerance when using PathBezierCurveTo() without a specific number of segments. Decrease for highly tessellated curves (higher quality, more polygons), increase to reduce quality.
-    CircleSegmentMaxError   = 1.60f;            // Maximum error (in pixels) allowed when using AddCircle()/AddCircleFilled() or drawing rounded corner rectangles with no explicit segment count specified. Decrease for higher quality but more geometry.
+    CircleSegmentMaxError   = 0.50f;            // Maximum error (in pixels) allowed when using AddCircle()/AddCircleFilled() or drawing rounded corner rectangles with no explicit segment count specified. Decrease for higher quality but more geometry.
 
     // Default theme
     ImGui::StyleColorsDark(this);

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -986,7 +986,7 @@ ImGuiStyle::ImGuiStyle()
     AntiAliasedLinesUseTex  = true;             // Enable anti-aliased lines/borders using textures where possible. Require backend to render with bilinear filtering.
     AntiAliasedFill         = true;             // Enable anti-aliased filled shapes (rounded rectangles, circles, etc.).
     CurveTessellationTol    = 1.25f;            // Tessellation tolerance when using PathBezierCurveTo() without a specific number of segments. Decrease for highly tessellated curves (higher quality, more polygons), increase to reduce quality.
-    CircleSegmentMaxError   = 0.50f;            // Maximum error (in pixels) allowed when using AddCircle()/AddCircleFilled() or drawing rounded corner rectangles with no explicit segment count specified. Decrease for higher quality but more geometry.
+    CircleTessellationMaxError = 0.25f;         // Maximum error (in pixels) allowed when using AddCircle()/AddCircleFilled() or drawing rounded corner rectangles with no explicit segment count specified. Decrease for higher quality but more geometry.
 
     // Default theme
     ImGui::StyleColorsDark(this);
@@ -3878,7 +3878,7 @@ void ImGui::NewFrame()
         virtual_space.Add(g.Viewports[n]->GetMainRect());
     g.DrawListSharedData.ClipRectFullscreen = virtual_space.ToVec4();
     g.DrawListSharedData.CurveTessellationTol = g.Style.CurveTessellationTol;
-    g.DrawListSharedData.SetCircleSegmentMaxError(g.Style.CircleSegmentMaxError);
+    g.DrawListSharedData.SetCircleTessellationMaxError(g.Style.CircleTessellationMaxError);
     g.DrawListSharedData.InitialFlags = ImDrawListFlags_None;
     if (g.Style.AntiAliasedLines)
         g.DrawListSharedData.InitialFlags |= ImDrawListFlags_AntiAliasedLines;
@@ -7055,7 +7055,7 @@ static void ImGui::ErrorCheckNewFrameSanityChecks()
     IM_ASSERT(g.IO.Fonts->Fonts.Size > 0                                && "Font Atlas not built. Did you call io.Fonts->GetTexDataAsRGBA32() / GetTexDataAsAlpha8()?");
     IM_ASSERT(g.IO.Fonts->Fonts[0]->IsLoaded()                          && "Font Atlas not built. Did you call io.Fonts->GetTexDataAsRGBA32() / GetTexDataAsAlpha8()?");
     IM_ASSERT(g.Style.CurveTessellationTol > 0.0f                       && "Invalid style setting!");
-    IM_ASSERT(g.Style.CircleSegmentMaxError > 0.0f                      && "Invalid style setting!");
+    IM_ASSERT(g.Style.CircleTessellationMaxError  > 0.0f                && "Invalid style setting!");
     IM_ASSERT(g.Style.Alpha >= 0.0f && g.Style.Alpha <= 1.0f            && "Invalid style setting!"); // Allows us to avoid a few clamps in color computations
     IM_ASSERT(g.Style.WindowMinSize.x >= 1.0f && g.Style.WindowMinSize.y >= 1.0f && "Invalid style setting.");
     IM_ASSERT(g.Style.WindowMenuButtonPosition == ImGuiDir_None || g.Style.WindowMenuButtonPosition == ImGuiDir_Left || g.Style.WindowMenuButtonPosition == ImGuiDir_Right);

--- a/imgui.h
+++ b/imgui.h
@@ -1723,7 +1723,7 @@ struct ImGuiStyle
     bool        AntiAliasedLinesUseTex;     // Enable anti-aliased lines/borders using textures where possible. Require backend to render with bilinear filtering. Latched at the beginning of the frame (copied to ImDrawList).
     bool        AntiAliasedFill;            // Enable anti-aliased edges around filled shapes (rounded rectangles, circles, etc.). Disable if you are really tight on CPU/GPU. Latched at the beginning of the frame (copied to ImDrawList).
     float       CurveTessellationTol;       // Tessellation tolerance when using PathBezierCurveTo() without a specific number of segments. Decrease for highly tessellated curves (higher quality, more polygons), increase to reduce quality.
-    float       CircleSegmentMaxError;      // Maximum error (in pixels) allowed when using AddCircle()/AddCircleFilled() or drawing rounded corner rectangles with no explicit segment count specified. Decrease for higher quality but more geometry.
+    float       CircleTessellationMaxError; // Maximum error (in pixels) allowed when using AddCircle()/AddCircleFilled() or drawing rounded corner rectangles with no explicit segment count specified. Decrease for higher quality but more geometry.
     ImVec4      Colors[ImGuiCol_COUNT];
 
     IMGUI_API ImGuiStyle();
@@ -2463,7 +2463,7 @@ struct ImDrawList
     IMGUI_API void  _OnChangedClipRect();
     IMGUI_API void  _OnChangedTextureID();
     IMGUI_API void  _OnChangedVtxOffset();
-    IMGUI_API int   _CalcCircleAutoSegmentCount(float radius, bool anti_aliased) const;
+    IMGUI_API int   _CalcCircleAutoSegmentCount(float radius) const;
 };
 
 // All draw data to render a Dear ImGui frame

--- a/imgui.h
+++ b/imgui.h
@@ -2463,6 +2463,7 @@ struct ImDrawList
     IMGUI_API void  _OnChangedClipRect();
     IMGUI_API void  _OnChangedTextureID();
     IMGUI_API void  _OnChangedVtxOffset();
+    IMGUI_API int   _CalcCircleAutoSegmentCount(float radius, bool anti_aliased) const;
 };
 
 // All draw data to render a Dear ImGui frame

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -6035,17 +6035,40 @@ void ImGui::ShowStyleEditor(ImGuiStyle* ref)
             {
                 ImGui::SetNextWindowPos(ImGui::GetCursorScreenPos());
                 ImGui::BeginTooltip();
-                ImVec2 p = ImGui::GetCursorScreenPos();
+                ImGui::TextUnformatted("N - number of segments");
+                ImGui::TextUnformatted("R - radius");
+                ImGui::Spacing();
                 ImDrawList* draw_list = ImGui::GetWindowDrawList();
-                float RAD_MIN = 10.0f, RAD_MAX = 80.0f;
-                float off_x = 10.0f;
-                for (int n = 0; n < 7; n++)
+                const float min_widget_width = ImGui::CalcTextSize("N: MM\nR: MM.MM").x;
+                float RAD_MIN = 5.0f, RAD_MAX = 80.0f;
+                for (int n = 0; n < 9; n++)
                 {
-                    const float rad = RAD_MIN + (RAD_MAX - RAD_MIN) * (float)n / (7.0f - 1.0f);
-                    draw_list->AddCircle(ImVec2(p.x + off_x + rad, p.y + RAD_MAX), rad, ImGui::GetColorU32(ImGuiCol_Text), 0);
-                    off_x += 10.0f + rad * 2.0f;
+                    const float rad = RAD_MIN + (RAD_MAX - RAD_MIN) * (float)n / (9.0f - 1.0f);
+
+                    const int segment_count              = draw_list->_CalcCircleAutoSegmentCount(rad, false);
+                    const int anti_aliased_segment_count = draw_list->_CalcCircleAutoSegmentCount(rad, true);
+
+                    ImGui::BeginGroup();
+                    ImGui::Text("R: %.f", rad);
+                    ImGui::Text("N: %d", draw_list->Flags & ImDrawListFlags_AntiAliasedLines ? anti_aliased_segment_count : segment_count);
+
+                    const float circle_diameter = rad * 2.0f;
+                    const float canvas_width    = IM_MAX(min_widget_width, circle_diameter);
+                    const float offset_x        = floorf(canvas_width * 0.5f);
+                    const float offset_y        = floorf(RAD_MAX);
+                    const ImVec2 p              = ImGui::GetCursorScreenPos();
+                    draw_list->AddCircle(ImVec2(p.x + offset_x, p.y + offset_y), rad, ImGui::GetColorU32(ImGuiCol_Text));
+
+                    ImGui::Dummy(ImVec2(canvas_width, RAD_MAX * 2));
+                    ImGui::Text("N: %d", draw_list->Flags & ImDrawListFlags_AntiAliasedFill ? anti_aliased_segment_count : segment_count);
+
+                    const ImVec2 p2             = ImGui::GetCursorScreenPos();
+                    draw_list->AddCircleFilled(ImVec2(p2.x + offset_x, p2.y + offset_y), rad, ImGui::GetColorU32(ImGuiCol_Text));
+
+                    ImGui::Dummy(ImVec2(canvas_width, RAD_MAX * 2));
+                    ImGui::EndGroup();
+                    ImGui::SameLine();
                 }
-                ImGui::Dummy(ImVec2(off_x, RAD_MAX * 2.0f));
                 ImGui::EndTooltip();
             }
             ImGui::SameLine();

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -6030,7 +6030,7 @@ void ImGui::ShowStyleEditor(ImGuiStyle* ref)
             if (style.CurveTessellationTol < 0.10f) style.CurveTessellationTol = 0.10f;
 
             // When editing the "Circle Segment Max Error" value, draw a preview of its effect on auto-tessellated circles.
-            ImGui::DragFloat("Circle Tessellation Max Error", &style.CircleTessellationMaxError , 0.01f, 0.10f, 10.0f, "%.2f", ImGuiSliderFlags_AlwaysClamp);
+            ImGui::DragFloat("Circle Tessellation Max Error", &style.CircleTessellationMaxError , 0.005f, 0.10f, 10.0f, "%.2f", ImGuiSliderFlags_AlwaysClamp);
             if (ImGui::IsItemActive())
             {
                 ImGui::SetNextWindowPos(ImGui::GetCursorScreenPos());

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -6030,7 +6030,7 @@ void ImGui::ShowStyleEditor(ImGuiStyle* ref)
             if (style.CurveTessellationTol < 0.10f) style.CurveTessellationTol = 0.10f;
 
             // When editing the "Circle Segment Max Error" value, draw a preview of its effect on auto-tessellated circles.
-            ImGui::DragFloat("Circle Segment Max Error", &style.CircleSegmentMaxError, 0.01f, 0.10f, 10.0f, "%.2f");
+            ImGui::DragFloat("Circle Tessellation Max Error", &style.CircleTessellationMaxError , 0.01f, 0.10f, 10.0f, "%.2f", ImGuiSliderFlags_AlwaysClamp);
             if (ImGui::IsItemActive())
             {
                 ImGui::SetNextWindowPos(ImGui::GetCursorScreenPos());
@@ -6045,12 +6045,11 @@ void ImGui::ShowStyleEditor(ImGuiStyle* ref)
                 {
                     const float rad = RAD_MIN + (RAD_MAX - RAD_MIN) * (float)n / (9.0f - 1.0f);
 
-                    const int segment_count              = draw_list->_CalcCircleAutoSegmentCount(rad, false);
-                    const int anti_aliased_segment_count = draw_list->_CalcCircleAutoSegmentCount(rad, true);
+                    const int segment_count = draw_list->_CalcCircleAutoSegmentCount(rad);
 
                     ImGui::BeginGroup();
                     ImGui::Text("R: %.f", rad);
-                    ImGui::Text("N: %d", draw_list->Flags & ImDrawListFlags_AntiAliasedLines ? anti_aliased_segment_count : segment_count);
+                    ImGui::Text("N: %d", segment_count);
 
                     const float circle_diameter = rad * 2.0f;
                     const float canvas_width    = IM_MAX(min_widget_width, circle_diameter);
@@ -6060,7 +6059,7 @@ void ImGui::ShowStyleEditor(ImGuiStyle* ref)
                     draw_list->AddCircle(ImVec2(p.x + offset_x, p.y + offset_y), rad, ImGui::GetColorU32(ImGuiCol_Text));
 
                     ImGui::Dummy(ImVec2(canvas_width, RAD_MAX * 2));
-                    ImGui::Text("N: %d", draw_list->Flags & ImDrawListFlags_AntiAliasedFill ? anti_aliased_segment_count : segment_count);
+                    ImGui::Text("N: %d", segment_count);
 
                     const ImVec2 p2             = ImGui::GetCursorScreenPos();
                     draw_list->AddCircleFilled(ImVec2(p2.x + offset_x, p2.y + offset_y), rad, ImGui::GetColorU32(ImGuiCol_Text));

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -376,7 +376,7 @@ ImDrawListSharedData::ImDrawListSharedData()
     }
 }
 
-void ImDrawListSharedData::SetCircleSegmentMaxError(float max_error)
+void ImDrawListSharedData::SetCircleTessellationMaxError(float max_error)
 {
     if (CircleSegmentMaxError == max_error)
         return;
@@ -384,8 +384,7 @@ void ImDrawListSharedData::SetCircleSegmentMaxError(float max_error)
     for (int i = 0; i < IM_ARRAYSIZE(CircleSegmentCounts); i++)
     {
         const float radius = (float)i;
-        CircleSegmentCounts[i]            = (ImU8)((i > 0) ? IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_CALC(radius, CircleSegmentMaxError) : 0);
-        AntiAliasedCircleSegmentCounts[i] = (ImU8)((i > 0) ? IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_CALC(radius, CircleSegmentMaxError * IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_AA_ERROR_SCALE_FACTOR) : 0);
+        CircleSegmentCounts[i] = (ImU8)((i > 0) ? IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_CALC(radius, CircleSegmentMaxError) : 0);
     }
 }
 
@@ -543,27 +542,17 @@ void ImDrawList::_OnChangedVtxOffset()
     curr_cmd->VtxOffset = _CmdHeader.VtxOffset;
 }
 
-int ImDrawList::_CalcCircleAutoSegmentCount(float radius, bool anti_aliased) const
+int ImDrawList::_CalcCircleAutoSegmentCount(float radius) const
 {
     int num_segments = 0;
 
-    const int  radius_idx      = (int)ImCeil(radius); // Use ceil to never reduce accuracy
+    const int  radius_idx = (int)ImCeil(radius); // Use ceil to never reduce accuracy
 
     // Automatic segment count
     if (radius_idx < IM_ARRAYSIZE(_Data->CircleSegmentCounts))
-    {
-        if (anti_aliased)
-            num_segments = _Data->AntiAliasedCircleSegmentCounts[radius_idx]; // Use cached value
-        else
-            num_segments = _Data->CircleSegmentCounts[radius_idx]; // Use cached value
-    }
+        num_segments = _Data->CircleSegmentCounts[radius_idx]; // Use cached value
     else
-    {
-        if (anti_aliased)
-            num_segments = IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_CALC(radius, _Data->CircleSegmentMaxError * IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_AA_ERROR_SCALE_FACTOR);
-        else
-            num_segments = IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_CALC(radius, _Data->CircleSegmentMaxError);
-    }
+        num_segments = IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_CALC(radius, _Data->CircleSegmentMaxError);
 
     return num_segments;
 }
@@ -1311,7 +1300,7 @@ void ImDrawList::AddCircle(const ImVec2& center, float radius, ImU32 col, int nu
     if (num_segments <= 0)
     {
         // Automatic segment count
-        num_segments = _CalcCircleAutoSegmentCount(radius, (Flags & ImDrawListFlags_AntiAliasedLines) != 0);
+        num_segments = _CalcCircleAutoSegmentCount(radius);
     }
     else
     {
@@ -1337,7 +1326,7 @@ void ImDrawList::AddCircleFilled(const ImVec2& center, float radius, ImU32 col, 
     if (num_segments <= 0)
     {
         // Automatic segment count
-        num_segments = _CalcCircleAutoSegmentCount(radius, (Flags & ImDrawListFlags_AntiAliasedFill) != 0);
+        num_segments = _CalcCircleAutoSegmentCount(radius);
     }
     else
     {

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -384,8 +384,8 @@ void ImDrawListSharedData::SetCircleSegmentMaxError(float max_error)
     for (int i = 0; i < IM_ARRAYSIZE(CircleSegmentCounts); i++)
     {
         const float radius = (float)i;
-        const int segment_count = (i > 0) ? IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_CALC(radius, CircleSegmentMaxError) : 0;
-        CircleSegmentCounts[i] = (ImU8)ImMin(segment_count, 255);
+        CircleSegmentCounts[i]            = (ImU8)((i > 0) ? IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_CALC(radius, CircleSegmentMaxError) : 0);
+        AntiAliasedCircleSegmentCounts[i] = (ImU8)((i > 0) ? IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_CALC(radius, CircleSegmentMaxError * IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_AA_ERROR_SCALE_FACTOR) : 0);
     }
 }
 
@@ -541,6 +541,31 @@ void ImDrawList::_OnChangedVtxOffset()
     }
     IM_ASSERT(curr_cmd->UserCallback == NULL);
     curr_cmd->VtxOffset = _CmdHeader.VtxOffset;
+}
+
+int ImDrawList::_CalcCircleAutoSegmentCount(float radius, bool anti_aliased) const
+{
+    int num_segments = 0;
+
+    const int  radius_idx      = (int)ImCeil(radius); // Use ceil to never reduce accuracy
+
+    // Automatic segment count
+    if (radius_idx < IM_ARRAYSIZE(_Data->CircleSegmentCounts))
+    {
+        if (anti_aliased)
+            num_segments = _Data->AntiAliasedCircleSegmentCounts[radius_idx]; // Use cached value
+        else
+            num_segments = _Data->CircleSegmentCounts[radius_idx]; // Use cached value
+    }
+    else
+    {
+        if (anti_aliased)
+            num_segments = IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_CALC(radius, _Data->CircleSegmentMaxError * IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_AA_ERROR_SCALE_FACTOR);
+        else
+            num_segments = IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_CALC(radius, _Data->CircleSegmentMaxError);
+    }
+
+    return num_segments;
 }
 
 // Render-level scissoring. This is passed down to your render function but not used for CPU-side coarse clipping. Prefer using higher-level ImGui::PushClipRect() to affect logic (hit-testing and widget culling)
@@ -1286,11 +1311,7 @@ void ImDrawList::AddCircle(const ImVec2& center, float radius, ImU32 col, int nu
     if (num_segments <= 0)
     {
         // Automatic segment count
-        const int radius_idx = (int)radius;
-        if (radius_idx < IM_ARRAYSIZE(_Data->CircleSegmentCounts))
-            num_segments = _Data->CircleSegmentCounts[radius_idx]; // Use cached value
-        else
-            num_segments = IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_CALC(radius, _Data->CircleSegmentMaxError);
+        num_segments = _CalcCircleAutoSegmentCount(radius, (Flags & ImDrawListFlags_AntiAliasedLines) != 0);
     }
     else
     {
@@ -1316,11 +1337,7 @@ void ImDrawList::AddCircleFilled(const ImVec2& center, float radius, ImU32 col, 
     if (num_segments <= 0)
     {
         // Automatic segment count
-        const int radius_idx = (int)radius;
-        if (radius_idx < IM_ARRAYSIZE(_Data->CircleSegmentCounts))
-            num_segments = _Data->CircleSegmentCounts[radius_idx]; // Use cached value
-        else
-            num_segments = IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_CALC(radius, _Data->CircleSegmentMaxError);
+        num_segments = _CalcCircleAutoSegmentCount(radius, (Flags & ImDrawListFlags_AntiAliasedFill) != 0);
     }
     else
     {

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -617,10 +617,36 @@ struct IMGUI_API ImChunkStream
 //-----------------------------------------------------------------------------
 
 // ImDrawList: Helper function to calculate a circle's segment count given its radius and a "maximum error" value.
-// FIXME: the minimum number of auto-segment may be undesirably high for very small radiuses (e.g. 1.0f)
-#define IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_MIN                     12
+//
+// Estimation of number of circle segment based on error is derived using method described in
+// this post (https://stackoverflow.com/a/2244088/15194693).
+// Number of segments (N) is calculated using equation:
+//
+//            +-                     -+
+//            |           pi          |
+//   N = ceil | --------------------- |     where r > 0, error <= r
+//            |  acos(1 - error / r)  |
+//            +-                     -+
+//
+// Note:
+//     Equation is significantly simpler that one in the post thanks for choosing segment
+//     that is perpendicular to X axis. Follow steps in the article from this starting condition
+//     and you will get this result.
+//
+// Rendering circles with an odd number of segments, while mathematically correct will produce
+// asymmetrical results on the raster grid. Therefore we're rounding N to next even number.
+// (7 became 8, 11 became 12, but 8 will still be 8).
+//
+// Error value is expressed in pixels and defaults to 0.5f, half a pixel. Which produce
+// non anti-aliased circles where segments cannot be spotted.
+// Anti-aliasing work on much finer grid than pixels which make segments visible. To mitigate this
+// issue error is scaled by IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_AA_ERROR_SCALE_FACTOR defaulting to 0.5f.
+// This make anti-aliased circles use 0.25f as an error value, making segments unnoticeable.
+//
+#define IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_MIN                     4
 #define IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_MAX                     512
-#define IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_CALC(_RAD,_MAXERROR)    ImClamp((int)((IM_PI * 2.0f) / ImAcos(((_RAD) - (_MAXERROR)) / (_RAD))), IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_MIN, IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_MAX)
+#define IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_AA_ERROR_SCALE_FACTOR   0.5f        // Anti-aliased geometry need better accuracy since it renders on more fine grined grid than pixels
+#define IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_CALC(_RAD,_MAXERROR)    ImClamp((((int)ImCeil(IM_PI / ImAcos(1 - ImMin((_MAXERROR), (_RAD)) / (_RAD))) + 1) / 2) * 2, IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_MIN, IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_MAX)
 
 // ImDrawList: You may set this to higher values (e.g. 2 or 3) to increase tessellation of fast rounded corners path.
 #ifndef IM_DRAWLIST_ARCFAST_TESSELLATION_MULTIPLIER
@@ -641,8 +667,9 @@ struct IMGUI_API ImDrawListSharedData
 
     // [Internal] Lookup tables
     ImVec2          ArcFastVtx[12 * IM_DRAWLIST_ARCFAST_TESSELLATION_MULTIPLIER];  // FIXME: Bake rounded corners fill/borders in atlas
-    ImU8            CircleSegmentCounts[64];    // Precomputed segment count for given radius before we calculate it dynamically (to avoid calculation overhead)
-    const ImVec4*   TexUvLines;                 // UV of anti-aliased lines in the atlas
+    ImU8            CircleSegmentCounts[64];                // Precomputed segment count for given radius before we calculate it dynamically (to avoid calculation overhead)
+    ImU8            AntiAliasedCircleSegmentCounts[64];     // Precomputed circle segment count anti-aliased primitives
+    const ImVec4*   TexUvLines;                             // UV of anti-aliased lines in the atlas
 
     ImDrawListSharedData();
     void SetCircleSegmentMaxError(float max_error);

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -637,15 +637,8 @@ struct IMGUI_API ImChunkStream
 // asymmetrical results on the raster grid. Therefore we're rounding N to next even number.
 // (7 became 8, 11 became 12, but 8 will still be 8).
 //
-// Error value is expressed in pixels and defaults to 0.5f, half a pixel. Which produce
-// non anti-aliased circles where segments cannot be spotted.
-// Anti-aliasing work on much finer grid than pixels which make segments visible. To mitigate this
-// issue error is scaled by IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_AA_ERROR_SCALE_FACTOR defaulting to 0.5f.
-// This make anti-aliased circles use 0.25f as an error value, making segments unnoticeable.
-//
 #define IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_MIN                     4
 #define IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_MAX                     512
-#define IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_AA_ERROR_SCALE_FACTOR   0.5f        // Anti-aliased geometry need better accuracy since it renders on more fine grined grid than pixels
 #define IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_CALC(_RAD,_MAXERROR)    ImClamp((((int)ImCeil(IM_PI / ImAcos(1 - ImMin((_MAXERROR), (_RAD)) / (_RAD))) + 1) / 2) * 2, IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_MIN, IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_MAX)
 
 // ImDrawList: You may set this to higher values (e.g. 2 or 3) to increase tessellation of fast rounded corners path.
@@ -668,11 +661,10 @@ struct IMGUI_API ImDrawListSharedData
     // [Internal] Lookup tables
     ImVec2          ArcFastVtx[12 * IM_DRAWLIST_ARCFAST_TESSELLATION_MULTIPLIER];  // FIXME: Bake rounded corners fill/borders in atlas
     ImU8            CircleSegmentCounts[64];                // Precomputed segment count for given radius before we calculate it dynamically (to avoid calculation overhead)
-    ImU8            AntiAliasedCircleSegmentCounts[64];     // Precomputed circle segment count anti-aliased primitives
     const ImVec4*   TexUvLines;                             // UV of anti-aliased lines in the atlas
 
     ImDrawListSharedData();
-    void SetCircleSegmentMaxError(float max_error);
+    void SetCircleTessellationMaxError(float max_error);
 };
 
 struct ImDrawDataBuilder


### PR DESCRIPTION
This PR improves on automatic number of circle segment calculation for anti-aliased and non anti-aliased shapes.

# The Old
After analyzing equation in `IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_CALC` few issues were discovered:
 - number of segments `N` was two times bigger than necessary (error was applied to half of an angle spanned by the segment)
    This is event somewhat acknowledged in the code, because small circles received too many segments:
    `FIXME: the minimum number of auto-segment may be undesirably high for very small radiuses (e.g. 1.0f)`.
 - N was floored, but should be ceiled, this was reducing quality but cannot be spotted due to first issue
 - `CircleSegmentMaxError` claim to be expressed in pixels, but default value 1.6 seems to not reflect that

# The New
Equation for number of circle segments was derived from scratch using method described in this [stackoverflow post](https://stackoverflow.com/a/2244088/15194693). Which lead to discoveries listed above about old method.

New method:
 - Defaults `CircleSegmentMaxError` to 0.5f, which is half of a pixel
 - N is ceiled up and rounded to next even value
 - N is different for anti-aliased and not anti-aliased shapes

## More details
Number of segments (N) is calculated using equation:

```
             /          pi         \
   N = ceil | --------------------- |     where r > 0, error <= r
             \ acos(1 - error / r) /
```
Note:
>    Equation is significantly simpler that one in the post thanks for choosing segment
>    that is perpendicular to X axis. Follow steps in the article from this starting condition
>    and you will get this result.

Rendering circles with an odd number of segments, while mathematically correct will produce
asymmetrical results on the raster grid. Therefore we're rounding `N` to next even number.
(7 became 8, 11 became 12, but 8 will still be 8).

Error value is expressed in pixels and defaults to 0.5f, half a pixel. Which produce
non anti-aliased circles where segments cannot be spotted.
Anti-aliasing work on much finer grid than pixels which make segments visible. To mitigate this
issue error is scaled by `IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_AA_ERROR_SCALE_FACTOR` defaulting to `0.5f`.
This make anti-aliased circles use `0.25f` as an error value, making segments unnoticeable.

## Derivation
`N` equation was derived by following steps in method described in this [stackoverflow post](https://stackoverflow.com/a/2244088/15194693). What I did differently is I choose different `A` and `B` points to make calculations simpler.

![image](https://user-images.githubusercontent.com/1197433/107850154-98f23e80-6e00-11eb-8ada-c5998c3ebdc6.png)


# Comparison
At previews you can see actual maximum error value used.

## Old vs. New
### Anti-Aliased
| Old |
| :- |
| ![image](https://user-images.githubusercontent.com/1197433/107850238-364d7280-6e01-11eb-9ad5-93f5c58a348e.png) |

| New |
| :- |
| ![image](https://user-images.githubusercontent.com/1197433/107850265-6dbc1f00-6e01-11eb-898e-ac0d52b535f4.png) |

### Non Anti-Aliased
Notice there are gaps on the circumference of the circle N 27 in the Old. They appear if mesh is too dense.
| Old |
| :- |
| ![image](https://user-images.githubusercontent.com/1197433/107850378-25e9c780-6e02-11eb-9f3e-f48eddfa9d14.png) |

| New |
| :- |
| ![image](https://user-images.githubusercontent.com/1197433/107850387-37cb6a80-6e02-11eb-8d03-19b665aa5a82.png) |

## New Method: AA vs. Non AA
### Maximum error: 0.5
Notice that you can spot line segments when circle is drawn with same number of segments for AA and not-AA circles.
| Non AA |
| :- |
| ![image](https://user-images.githubusercontent.com/1197433/107850543-701f7880-6e03-11eb-9115-c9a7833dacb7.png) |

| AA |
| :- |
| ![image](https://user-images.githubusercontent.com/1197433/107850551-7b72a400-6e03-11eb-9915-ba6a6066d473.png) |

### Maximum error: 0.25
Notice that non anti-aliased primitives has gaps due to too dense mesh (first circle), but anti-aliased drawing give the desired result.
| Non AA |
| :- |
| ![image](https://user-images.githubusercontent.com/1197433/107850581-b96fc800-6e03-11eb-8586-529574a127e4.png) |

| AA |
| :- |
| ![image](https://user-images.githubusercontent.com/1197433/107850591-cdb3c500-6e03-11eb-8e76-4202db7f1103.png) |





