### PR TITLE
Enhanced ImGuiListClipper for drag&drop operations

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -2163,6 +2163,9 @@ struct ImGuiListClipper
     int     RangeStart[4];  // 1 for the user, rest for internal use
     int     RangeEnd[4];
     int     RangeCount;
+    int     YRangeMin[1];
+    int     YRangeMax[1];
+    int     YRangeCount;
     int     StepNo;
     int     ItemsFrozen;
     float   ItemsHeight;
@@ -2176,7 +2179,8 @@ struct ImGuiListClipper
     IMGUI_API void Begin(int items_count, float items_height = -1.0f);  // Automatically called by constructor if you passed 'items_count' or by Step() in Step 1.
     IMGUI_API void End();                                               // Automatically called on the last call of Step() that returns false.
     IMGUI_API void ForceDisplayRange(int item_start, int item_end);     // Optionally call before the first call to Step() if you need a range of items to be displayed regardless of visibility.
-    inline    void ForceDisplay(int item_start, int item_count = 1) { ForceDisplayRange(item_start, item_start + item_count); }  // Like ForceDisplayRange, but with a number insteaf of an end index.
+    inline    void ForceDisplay(int item_start, int item_count = 1) { ForceDisplayRange(item_start, item_start + item_count); }  // Like ForceDisplayRange, but with a number instead of an end index.
+    IMGUI_API void ForceDisplayYRange(float y_min, float y_max);        // Like ForceDisplayRange, but with y coordinates instead of item indices.
     IMGUI_API bool Step();                                              // Call until it returns false. The DisplayStart/DisplayEnd fields will be set and you can process/draw those items.
 
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS

--- a/imgui.h
+++ b/imgui.h
@@ -2143,7 +2143,7 @@ struct ImGuiStorage
 // Usage:
 //   ImGuiListClipper clipper;
 //   clipper.Begin(1000);         // We have 1000 elements, evenly spaced.
-//   clipper.ForceDisplay(42);    // Optional, force element with given index to be displayed (use f.e. if you need to update a tooltip for a drop source)
+//   clipper.ForceDisplay(42);    // Optional, force element with given index to be displayed (use f.e. if you need to update a tooltip for a drag&drop source)
 //   while (clipper.Step())
 //       for (int i = clipper.DisplayStart; i < clipper.DisplayEnd; i++)
 //           ImGui::Text("line number %d", i);
@@ -2160,9 +2160,9 @@ struct ImGuiListClipper
 
     // [Internal]
     int     ItemsCount;
-    int     ItemForced;
-    int     VisibleStart;
-    int     VisibleEnd;
+    int     RangeStart[4];  // 1 for the user, rest for internal use
+    int     RangeEnd[4];
+    int     RangeCount;
     int     StepNo;
     int     ItemsFrozen;
     float   ItemsHeight;
@@ -2175,7 +2175,8 @@ struct ImGuiListClipper
     // items_height: Use -1.0f to be calculated automatically on first step. Otherwise pass in the distance between your items, typically GetTextLineHeightWithSpacing() or GetFrameHeightWithSpacing().
     IMGUI_API void Begin(int items_count, float items_height = -1.0f);  // Automatically called by constructor if you passed 'items_count' or by Step() in Step 1.
     IMGUI_API void End();                                               // Automatically called on the last call of Step() that returns false.
-    IMGUI_API void ForceDisplay(int item_index);                        // Optionally call before the first call to Step() if you need a single item to be displayed, f.e. to update a drag&drop tooltip.
+    IMGUI_API void ForceDisplayRange(int item_start, int item_end);     // Optionally call before the first call to Step() if you need a range of items to be displayed regardless of visibility.
+    inline    void ForceDisplay(int item_start, int item_count = 1) { ForceDisplayRange(item_start, item_start + item_count); }  // Like ForceDisplayRange, but with a number insteaf of an end index.
     IMGUI_API bool Step();                                              // Call until it returns false. The DisplayStart/DisplayEnd fields will be set and you can process/draw those items.
 
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS

--- a/imgui.h
+++ b/imgui.h
@@ -2143,6 +2143,7 @@ struct ImGuiStorage
 // Usage:
 //   ImGuiListClipper clipper;
 //   clipper.Begin(1000);         // We have 1000 elements, evenly spaced.
+//   clipper.ForceDisplay(42);    // Optional, force element with given index to be displayed (use f.e. if you need to update a tooltip for a drop source)
 //   while (clipper.Step())
 //       for (int i = clipper.DisplayStart; i < clipper.DisplayEnd; i++)
 //           ImGui::Text("line number %d", i);
@@ -2159,6 +2160,9 @@ struct ImGuiListClipper
 
     // [Internal]
     int     ItemsCount;
+    int     ItemForced;
+    int     VisibleStart;
+    int     VisibleEnd;
     int     StepNo;
     int     ItemsFrozen;
     float   ItemsHeight;
@@ -2171,6 +2175,7 @@ struct ImGuiListClipper
     // items_height: Use -1.0f to be calculated automatically on first step. Otherwise pass in the distance between your items, typically GetTextLineHeightWithSpacing() or GetFrameHeightWithSpacing().
     IMGUI_API void Begin(int items_count, float items_height = -1.0f);  // Automatically called by constructor if you passed 'items_count' or by Step() in Step 1.
     IMGUI_API void End();                                               // Automatically called on the last call of Step() that returns false.
+    IMGUI_API void ForceDisplay(int item_index);                        // Optionally call before the first call to Step() if you need a single item to be displayed, f.e. to update a drag&drop tooltip.
     IMGUI_API bool Step();                                              // Call until it returns false. The DisplayStart/DisplayEnd fields will be set and you can process/draw those items.
 
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS


### PR DESCRIPTION
### Current limitation

When using the list clipper, only the visible subset of elements is actually calculated, which saves a lot of processing time in larger lists. However, if a drag&drop source is scrolled out and gets clipped, the tooltip no longer gets generated and jumps back to "...". If that is not good enough, the current workaround would be to detect if an item was displayed and fall back to an alternative with additional code which can complicate things.

### Solution

I enhanced the list clipper with a new method "ForceDisplay", with that the user can specify a single element that will be displayed even if it isn't visible. This allows the user to generate drag&drop tooltips (or possibly for other reasons) as if the element were visible. The forced element is optional (no change in functionality if it isn't used). It introduces another instance of Step() returning true only if the element is not handled by another step. The order of elements is also maintained, the additional step happens before or after the main step depending on element indices.

### Example test code

When running this example code, drag an element and scroll it out of the visible set with the mouse wheel. With the "Use ForceDisplay" checkbox checked, the tooltip gets continually updated, with it unchecked the tooltip reverts to "...". If you comment out the single call to ForceDisplay, the code works with the current ImGui version.

```c++
void TestForcedElement()
{
	const int  NumItems       = 100;
	static int draggedItem    = -1;
	int        itemsSubmitted = 0;

	static bool useForceDisplay = true;

	if (ImGui::GetDragDropPayload() == nullptr)
		draggedItem = -1;

	// instructions and test settings
	ImGui::SetNextWindowSize(ImVec2(320, 240), ImGuiCond_FirstUseEver);
	if (ImGui::Begin("Forced Element Settings"))
	{
		ImGui::PushTextWrapPos();
		ImGui::TextUnformatted("Drag any item while scrolling the list so that the dragged item is no longer visible.");
		ImGui::PopTextWrapPos();

		ImGui::Checkbox("Use ForceDisplay", &useForceDisplay);
	}
	ImGui::End();

	// test window, use drag&drop on items
	ImGui::SetNextWindowSize(ImVec2(320, 480), ImGuiCond_FirstUseEver );
	if (ImGui::Begin("Forced Element Test"))
	{
		ImGuiListClipper clipper;

		clipper.Begin(100);

#if 1	// deactivate this for unenhanced list clipper
		if (useForceDisplay)
			clipper.ForceDisplay(draggedItem);	// if >= 0, this item will be displayed regardless of visibility
#endif

		while (clipper.Step())
		{
			for (int i = clipper.DisplayStart; i < clipper.DisplayEnd; ++i)
			{
				char buffer[32];
				sprintf_s(buffer, "item #%d", i);

				ImGui::Selectable(buffer);

				if (ImGui::BeginDragDropSource())
				{
					int data = i;

					ImGui::SetDragDropPayload("Test Payload", &data, sizeof(data));
					ImGui::TextUnformatted(buffer);
					ImGui::EndDragDropSource();

					draggedItem = i;
				}

				itemsSubmitted++;
			}
		}
	}
	ImGui::End();

	// append metrics to test settings window
	if (ImGui::Begin("Forced Element Settings"))
	{
		if (ImGui::BeginTable("Metrics", 2))
		{
			if (ImGui::TableNextColumn()) ImGui::TextUnformatted("Number of Items:");
			if (ImGui::TableNextColumn()) ImGui::Text("%d", NumItems);

			if (ImGui::TableNextColumn()) ImGui::TextUnformatted("Items submitted:");
			if (ImGui::TableNextColumn()) ImGui::Text("%d", itemsSubmitted);

			if (ImGui::TableNextColumn()) ImGui::TextUnformatted("Dragged item index:");
			if (ImGui::TableNextColumn()) ImGui::Text("%d", draggedItem);

			ImGui::EndTable();
		}
	}
	ImGui::End();
}
```
