### PR TITLE
Backends: DX9: programmable rendering pipeline version implement (Dear @Demonese)

### DIFF
--- a/backends/imgui_impl_dx9.cpp
+++ b/backends/imgui_impl_dx9.cpp
@@ -446,7 +446,7 @@ static bool ImGui_ImplDX9_CreateFontsTexture()
     unsigned char* pixels;
     int width, height, bytes_per_pixel;
     io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height, &bytes_per_pixel);
-
+    
     // Convert RGBA32 to BGRA32 (because RGBA32 is not well supported by DX9 devices)
 #ifndef IMGUI_USE_BGRA_PACKED_COLOR
     if (io.Fonts->TexPixelsUseColors)
@@ -471,12 +471,12 @@ static bool ImGui_ImplDX9_CreateFontsTexture()
     
     // Store our identifier
     io.Fonts->SetTexID((ImTextureID)g_pFontTexture);
-
+    
 #ifndef IMGUI_USE_BGRA_PACKED_COLOR
     if (io.Fonts->TexPixelsUseColors)
         ImGui::MemFree(pixels);
 #endif
-
+    
     return true;
 }
 


### PR DESCRIPTION
## 1. BGRA color packing (also fix a bug)

DX9 using B8G8R8A8 color packing (D3DCOLOR). I notice that imgui_impl_dx9 do color packing converting but in core library there is a IMGUI_USE_BGRA_PACKED_COLOR macro. 
So I think we can avoid color packing converting:
* before:
```c++
vtx_dst->col = (vtx_src->col & 0xFF00FF00) | ((vtx_src->col & 0xFF0000) >> 16) | ((vtx_src->col & 0xFF) << 16);     // RGBA --> ARGB for DirectX9
```
* after:
```c++
#ifndef IMGUI_USE_BGRA_PACKED_COLOR
    vtx_dst->col = (vtx_src->col & 0xFF00FF00) | ((vtx_src->col & 0xFF0000) >> 16) | ((vtx_src->col & 0xFF) << 16);     // RGBA --> ARGB for DirectX9
#else
    vtx_dst->col = vtx_src->col;
#endif
```
This change will also fix a bug (default dark theme):
* before:
![image](https://user-images.githubusercontent.com/40131112/109278856-fb612b00-7853-11eb-8a29-bdaca118e7bf.png)
* after:
![image](https://user-images.githubusercontent.com/40131112/109279192-6c084780-7854-11eb-8dc4-e74900862add.png)

## 2. Bug fix

I think we forget to validate device and texture before drawing. My game crashes in some cases because of this.
```c++
// Render function.
void ImGui_ImplDX9_RenderDrawData(ImDrawData* draw_data)
{
    // Avoid rendering when device or texture is invalid
    if (!g_pd3dDevice || !g_FontTexture)
        return;
```

## 3. ~~The ordering of state recovery~~

~~I don't known why, but this did fix a bug in my game.
(see commits)~~

## 4. Static texture

We can create static texture to improve performance.
```c++
// Create a texture without D3DUSAGE_DYNAMIC (static texture)
// https://github.com/Microsoft/DirectXTex

// 1. Create staging texture and write pixel data
IDirect3DTexture9* texture_staging = NULL;
struct com_helper
{
    // This is a helper to manage COM object
    // We can also using Microsoft::WRL::ComPtr (wrl.h) or CComPtr (ATL)
    IDirect3DTexture9*& ptr;
    com_helper(IDirect3DTexture9*& tex) : ptr(tex) {}
    ~com_helper() { if (ptr) { ptr->Release(); ptr = NULL; } }
} texture_staging_ref(texture_staging);
if (D3D_OK != g_pd3dDevice->CreateTexture(width, height, 1, D3DUSAGE_DYNAMIC, D3DFMT_A8R8G8B8, D3DPOOL_SYSTEMMEM, &texture_staging, NULL))
    return false;
D3DLOCKED_RECT tex_locked_rect;
if (D3D_OK != texture_staging->LockRect(0, &tex_locked_rect, NULL, 0))
    return false;
for (int y = 0; y < height; y++)
    memcpy((unsigned char*)tex_locked_rect.pBits + tex_locked_rect.Pitch * y, pixels + (width * bytes_per_pixel) * y, (width * bytes_per_pixel));
if (D3D_OK != texture_staging->UnlockRect(0))
    return false;

// 2. Upload to graphic card memory
g_FontTexture = NULL;
if (D3D_OK != g_pd3dDevice->CreateTexture(width, height, 1, 0, D3DFMT_A8R8G8B8, D3DPOOL_DEFAULT, &g_FontTexture, NULL))
    return false;
if (D3D_OK != g_pd3dDevice->UpdateTexture(texture_staging, g_FontTexture))
    return false;
```

Thanks Dear-ImGui
