### PR TITLE
Style Editor: export sizes settings

### DIFF
--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -5858,7 +5858,7 @@ static void ExportSize_ImVec2(const char* name, ImVec2& size_to_export, ImVec2& 
 // [Internal] export sizes style to current Log target
 static void ExportSizes(ImGuiStyle& style_to_export, ImGuiStyle& ref_style, bool export_only_modified)
 {
-    ImGui::LogText("auto& style = ImGui::GetStyle();" IM_NEWLINE);
+    ImGui::LogText("ImGuiStyle& style = ImGui::GetStyle();" IM_NEWLINE);
 
     {
         ImGui::LogText(IM_NEWLINE "// Main" IM_NEWLINE);

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -5829,112 +5829,126 @@ static void NodeFont(ImFont* font)
 }
 
 // [Internal] export colors style to current Log target
-static void ExportColors(ImGuiStyle& style_to_export, ImGuiStyle& ref_style, bool export_only_modified)
+static void ExportColors(ImGuiStyle* style_to_export, ImGuiStyle* ref_style, bool export_only_modified)
 {
+    IM_ASSERT(style_to_export != 0);
+    IM_ASSERT(ref_style != 0);
+
     ImGui::LogText("ImVec4* colors = ImGui::GetStyle().Colors;" IM_NEWLINE);
     for (auto i = 0; i < ImGuiCol_COUNT; i++)
     {
-        const auto& col = style_to_export.Colors[i];
-        const auto name = ImGui::GetStyleColorName(i);
-        if (!export_only_modified || memcmp(&col, &ref_style.Colors[i], sizeof(ImVec4)) != 0)
+        const ImVec4& col = style_to_export->Colors[i];
+        const char* name = ImGui::GetStyleColorName(i);
+        if (!export_only_modified || memcmp(&col, &ref_style->Colors[i], sizeof(ImVec4)) != 0)
             ImGui::LogText("colors[ImGuiCol_%s]%*s= ImVec4(%.2ff, %.2ff, %.2ff, %.2ff);" IM_NEWLINE, name, 23 - (int)strlen(name), "", col.x, col.y, col.z, col.w);
     }
 }
 
 // [Internal] export one size float style to current Log target
-static void ExportSize_Float(const char* name, float& size_to_export, float& ref_size, bool export_only_modified)
+static void ExportSize_Float(const char* name, float* size_to_export, float* ref_size, bool export_only_modified)
 {
-    if (!export_only_modified || memcmp(&size_to_export, &ref_size, sizeof(float)) != 0)
-        ImGui::LogText("style.%s%*s= %.2ff;" IM_NEWLINE, name, 25 - (int)strlen(name), "", size_to_export);
+    IM_ASSERT(name != 0);
+    IM_ASSERT(size_to_export != 0);
+    IM_ASSERT(ref_size != 0);
+
+    if (!export_only_modified || memcmp(size_to_export, ref_size, sizeof(float)) != 0)
+        ImGui::LogText("style.%s%*s= %.2ff;" IM_NEWLINE, name, 25 - (int)strlen(name), "", *size_to_export);
 }
 
 // [Internal] export one size ImVec2 style to current Log target
-static void ExportSize_ImVec2(const char* name, ImVec2& size_to_export, ImVec2& ref_size, bool export_only_modified)
+static void ExportSize_ImVec2(const char* name, ImVec2* size_to_export, ImVec2* ref_size, bool export_only_modified)
 {
-    if (!export_only_modified || memcmp(&size_to_export, &ref_size, sizeof(ImVec2)) != 0)
-        ImGui::LogText("style.%s%*s= ImVec2(%.2ff, %.2ff);" IM_NEWLINE, name, 25 - (int)strlen(name), "", size_to_export.x, size_to_export.y);
+    IM_ASSERT(name != 0);
+    IM_ASSERT(size_to_export != 0);
+    IM_ASSERT(ref_size != 0);
+
+    if (!export_only_modified || memcmp(size_to_export, ref_size, sizeof(ImVec2)) != 0)
+        ImGui::LogText("style.%s%*s= ImVec2(%.2ff, %.2ff);" IM_NEWLINE, name, 25 - (int)strlen(name), "", size_to_export->x, size_to_export->y);
 }
 
 // [Internal] export sizes style to current Log target
-static void ExportSizes(ImGuiStyle& style_to_export, ImGuiStyle& ref_style, bool export_only_modified)
+static void ExportSizes(ImGuiStyle* style_to_export, ImGuiStyle* ref_style, bool export_only_modified)
 {
+    IM_ASSERT(style_to_export != 0);
+    IM_ASSERT(ref_style != 0);
+
     ImGui::LogText("ImGuiStyle& style = ImGui::GetStyle();" IM_NEWLINE);
 
     {
         ImGui::LogText(IM_NEWLINE "// Main" IM_NEWLINE);
 
-        ExportSize_ImVec2("WindowPadding", style_to_export.WindowPadding, ref_style.WindowPadding, export_only_modified);
-        ExportSize_ImVec2("FramePadding", style_to_export.FramePadding, ref_style.FramePadding, export_only_modified);
-        ExportSize_ImVec2("ItemSpacing", style_to_export.ItemSpacing, ref_style.ItemSpacing, export_only_modified);
-        ExportSize_ImVec2("ItemInnerSpacing", style_to_export.ItemInnerSpacing, ref_style.ItemInnerSpacing, export_only_modified);
-        ExportSize_ImVec2("TouchExtraPadding", style_to_export.TouchExtraPadding, ref_style.TouchExtraPadding, export_only_modified);
-        ExportSize_Float("IndentSpacing", style_to_export.IndentSpacing, ref_style.IndentSpacing, export_only_modified);
-        ExportSize_Float("ScrollbarSize", style_to_export.ScrollbarSize, ref_style.ScrollbarSize, export_only_modified);
-        ExportSize_Float("GrabMinSize", style_to_export.GrabMinSize, ref_style.GrabMinSize, export_only_modified);
+        ExportSize_ImVec2("WindowPadding", &style_to_export->WindowPadding, &ref_style->WindowPadding, export_only_modified);
+        ExportSize_ImVec2("FramePadding", &style_to_export->FramePadding, &ref_style->FramePadding, export_only_modified);
+        ExportSize_ImVec2("ItemSpacing", &style_to_export->ItemSpacing, &ref_style->ItemSpacing, export_only_modified);
+        ExportSize_ImVec2("ItemInnerSpacing", &style_to_export->ItemInnerSpacing, &ref_style->ItemInnerSpacing, export_only_modified);
+        ExportSize_ImVec2("TouchExtraPadding", &style_to_export->TouchExtraPadding, &ref_style->TouchExtraPadding, export_only_modified);
+        ExportSize_Float("IndentSpacing", &style_to_export->IndentSpacing, &ref_style->IndentSpacing, export_only_modified);
+        ExportSize_Float("ScrollbarSize", &style_to_export->ScrollbarSize, &ref_style->ScrollbarSize, export_only_modified);
+        ExportSize_Float("GrabMinSize", &style_to_export->GrabMinSize, &ref_style->GrabMinSize, export_only_modified);
     }
 
     {
         ImGui::LogText(IM_NEWLINE "// Borders" IM_NEWLINE);
 
-        ExportSize_Float("WindowBorderSize", style_to_export.WindowBorderSize, ref_style.WindowBorderSize, export_only_modified);
-        ExportSize_Float("ChildBorderSize", style_to_export.ChildBorderSize, ref_style.ChildBorderSize, export_only_modified);
-        ExportSize_Float("PopupBorderSize", style_to_export.PopupBorderSize, ref_style.PopupBorderSize, export_only_modified);
-        ExportSize_Float("FrameBorderSize", style_to_export.FrameBorderSize, ref_style.FrameBorderSize, export_only_modified);
-        ExportSize_Float("TabBorderSize", style_to_export.TabBorderSize, ref_style.TabBorderSize, export_only_modified);
+        ExportSize_Float("WindowBorderSize", &style_to_export->WindowBorderSize, &ref_style->WindowBorderSize, export_only_modified);
+        ExportSize_Float("ChildBorderSize", &style_to_export->ChildBorderSize, &ref_style->ChildBorderSize, export_only_modified);
+        ExportSize_Float("PopupBorderSize", &style_to_export->PopupBorderSize, &ref_style->PopupBorderSize, export_only_modified);
+        ExportSize_Float("FrameBorderSize", &style_to_export->FrameBorderSize, &ref_style->FrameBorderSize, export_only_modified);
+        ExportSize_Float("TabBorderSize", &style_to_export->TabBorderSize, &ref_style->TabBorderSize, export_only_modified);
     }
 
     {
         ImGui::LogText(IM_NEWLINE "// Rounding" IM_NEWLINE);
 
-        ExportSize_Float("WindowRounding", style_to_export.WindowRounding, ref_style.WindowRounding, export_only_modified);
-        ExportSize_Float("ChildRounding", style_to_export.ChildRounding, ref_style.ChildRounding, export_only_modified);
-        ExportSize_Float("FrameRounding", style_to_export.FrameRounding, ref_style.FrameRounding, export_only_modified);
-        ExportSize_Float("PopupRounding", style_to_export.PopupRounding, ref_style.PopupRounding, export_only_modified);
-        ExportSize_Float("ScrollbarRounding", style_to_export.ScrollbarRounding, ref_style.ScrollbarRounding, export_only_modified);
-        ExportSize_Float("GrabRounding", style_to_export.GrabRounding, ref_style.GrabRounding, export_only_modified);
-        ExportSize_Float("TabRounding", style_to_export.TabRounding, ref_style.TabRounding, export_only_modified);
+        ExportSize_Float("WindowRounding", &style_to_export->WindowRounding, &ref_style->WindowRounding, export_only_modified);
+        ExportSize_Float("ChildRounding", &style_to_export->ChildRounding, &ref_style->ChildRounding, export_only_modified);
+        ExportSize_Float("FrameRounding", &style_to_export->FrameRounding, &ref_style->FrameRounding, export_only_modified);
+        ExportSize_Float("PopupRounding", &style_to_export->PopupRounding, &ref_style->PopupRounding, export_only_modified);
+        ExportSize_Float("ScrollbarRounding", &style_to_export->ScrollbarRounding, &ref_style->ScrollbarRounding, export_only_modified);
+        ExportSize_Float("GrabRounding", &style_to_export->GrabRounding, &ref_style->GrabRounding, export_only_modified);
+        ExportSize_Float("TabRounding", &style_to_export->TabRounding, &ref_style->TabRounding, export_only_modified);
     }
 
     {
         ImGui::LogText(IM_NEWLINE "// Alignment" IM_NEWLINE);
 
-        ExportSize_ImVec2("WindowTitleAlign", style_to_export.WindowTitleAlign, ref_style.WindowTitleAlign, export_only_modified);
+        ExportSize_ImVec2("WindowTitleAlign", &style_to_export->WindowTitleAlign, &ref_style->WindowTitleAlign, export_only_modified);
 
         // for this one we could just save ImGuiDir number, but its more redable to have ImGuiDir_ name
-        if (!export_only_modified || memcmp(&style_to_export.WindowMenuButtonPosition, &ref_style.WindowMenuButtonPosition, sizeof(ImGuiDir)) != 0)
+        if (!export_only_modified || memcmp(&style_to_export->WindowMenuButtonPosition, &ref_style->WindowMenuButtonPosition, sizeof(ImGuiDir)) != 0)
         {
             const char* dirName = 0;
-            switch (style_to_export.WindowMenuButtonPosition)
+            switch (style_to_export->WindowMenuButtonPosition)
             {
             case ImGuiDir_None: dirName = "ImGuiDir_None"; break;
             case ImGuiDir_Left: dirName = "ImGuiDir_Left"; break;
             case ImGuiDir_Right: dirName = "ImGuiDir_Right"; break;
             };
 
-            ImGui::LogText("style.%s%*s= %s;" IM_NEWLINE, "WindowMenuButtonPosition", 25 - (int)strlen("WindowMenuButtonPosition"), "", dirName);
+            ImGui::LogText("style->%s%*s= %s;" IM_NEWLINE, "WindowMenuButtonPosition", 25 - (int)strlen("WindowMenuButtonPosition"), "", dirName);
         }
 
         // for this one we could just save ImGuiDir number, but its more redable to have ImGuiDir_ name
-        if (!export_only_modified || memcmp(&style_to_export.ColorButtonPosition, &ref_style.ColorButtonPosition, sizeof(ImGuiDir)) != 0)
+        if (!export_only_modified || memcmp(&style_to_export->ColorButtonPosition, &ref_style->ColorButtonPosition, sizeof(ImGuiDir)) != 0)
         {
             const char* dirName = 0;
-            switch (style_to_export.ColorButtonPosition)
+            switch (style_to_export->ColorButtonPosition)
             {
             case ImGuiDir_Left: dirName = "ImGuiDir_Left"; break;
             case ImGuiDir_Right: dirName = "ImGuiDir_Right"; break;
             };
 
-            ImGui::LogText("style.%s%*s= %s;" IM_NEWLINE, "ColorButtonPosition", 25 - (int)strlen("ColorButtonPosition"), "", dirName);
+            ImGui::LogText("style->%s%*s= %s;" IM_NEWLINE, "ColorButtonPosition", 25 - (int)strlen("ColorButtonPosition"), "", dirName);
         }
 
-        ExportSize_ImVec2("ButtonTextAlign", style_to_export.ButtonTextAlign, ref_style.ButtonTextAlign, export_only_modified);
-        ExportSize_ImVec2("SelectableTextAlign", style_to_export.SelectableTextAlign, ref_style.SelectableTextAlign, export_only_modified);
+        ExportSize_ImVec2("ButtonTextAlign", &style_to_export->ButtonTextAlign, &ref_style->ButtonTextAlign, export_only_modified);
+        ExportSize_ImVec2("SelectableTextAlign", &style_to_export->SelectableTextAlign, &ref_style->SelectableTextAlign, export_only_modified);
     }
 
     {
         ImGui::LogText(IM_NEWLINE "// Safe Area Padding" IM_NEWLINE);
 
-        ExportSize_ImVec2("DisplaySafeAreaPadding", style_to_export.DisplaySafeAreaPadding, ref_style.DisplaySafeAreaPadding, export_only_modified);
+        ExportSize_ImVec2("DisplaySafeAreaPadding", &style_to_export->DisplaySafeAreaPadding, &ref_style->DisplaySafeAreaPadding, export_only_modified);
     }
 }
 
@@ -5981,8 +5995,8 @@ void ImGui::ShowStyleEditor(ImGuiStyle* ref)
 
     ImGui::Separator();
 
-    static auto output_dest = 0;
-    static auto output_only_modified = true;
+    static int output_dest = 0;
+    static bool output_only_modified = true;
     if (ImGui::Button("Export Sizes and Colors"))
     {
         if (output_dest == 0)
@@ -5990,11 +6004,11 @@ void ImGui::ShowStyleEditor(ImGuiStyle* ref)
         else
             ImGui::LogToTTY();
 
-        ExportColors(style, *ref, output_only_modified);
+        ExportColors(&style, ref, output_only_modified);
 
         ImGui::LogText(IM_NEWLINE);
 
-        ExportSizes(style, *ref, output_only_modified);
+        ExportSizes(&style, ref, output_only_modified);
 
         ImGui::LogFinish();
     }
@@ -6009,8 +6023,8 @@ void ImGui::ShowStyleEditor(ImGuiStyle* ref)
     {
         if (ImGui::BeginTabItem("Sizes"))
         {
-            static auto output_dest_sizes = 0;
-            static auto output_only_modified_sizes = true;
+            static int output_dest_sizes = 0;
+            static bool output_only_modified_sizes = true;
             if (ImGui::Button("Export"))
             {
                 if (output_dest_sizes == 0)
@@ -6018,7 +6032,7 @@ void ImGui::ShowStyleEditor(ImGuiStyle* ref)
                 else
                     ImGui::LogToTTY();
 
-                ExportSizes(style, *ref, output_only_modified_sizes);
+                ExportSizes(&style, ref, output_only_modified_sizes);
 
                 ImGui::LogFinish();
             }
@@ -6070,8 +6084,8 @@ void ImGui::ShowStyleEditor(ImGuiStyle* ref)
 
         if (ImGui::BeginTabItem("Colors"))
         {
-            static auto output_dest_colors = 0;
-            static auto output_only_modified_colors = true;
+            static int output_dest_colors = 0;
+            static bool output_only_modified_colors = true;
             if (ImGui::Button("Export"))
             {
                 if (output_dest_colors == 0)
@@ -6079,7 +6093,7 @@ void ImGui::ShowStyleEditor(ImGuiStyle* ref)
                 else
                     ImGui::LogToTTY();
 
-                ExportColors(style, *ref, output_only_modified_colors);
+                ExportColors(&style, ref, output_only_modified_colors);
 
                 ImGui::LogFinish();
             }

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -5828,6 +5828,116 @@ static void NodeFont(ImFont* font)
     ImGui::TreePop();
 }
 
+// [Internal] export colors style to current Log target
+static void ExportColors(ImGuiStyle& style_to_export, ImGuiStyle& ref_style, bool export_only_modified)
+{
+    ImGui::LogText("ImVec4* colors = ImGui::GetStyle().Colors;" IM_NEWLINE);
+    for (auto i = 0; i < ImGuiCol_COUNT; i++)
+    {
+        const auto& col = style_to_export.Colors[i];
+        const auto name = ImGui::GetStyleColorName(i);
+        if (!export_only_modified || memcmp(&col, &ref_style.Colors[i], sizeof(ImVec4)) != 0)
+            ImGui::LogText("colors[ImGuiCol_%s]%*s= ImVec4(%.2ff, %.2ff, %.2ff, %.2ff);" IM_NEWLINE, name, 23 - (int)strlen(name), "", col.x, col.y, col.z, col.w);
+    }
+}
+
+// [Internal] export one size float style to current Log target
+static void ExportSize_Float(const char* name, float& size_to_export, float& ref_size, bool export_only_modified)
+{
+    if (!export_only_modified || memcmp(&size_to_export, &ref_size, sizeof(float)) != 0)
+        ImGui::LogText("style.%s%*s= %.2ff;" IM_NEWLINE, name, 25 - (int)strlen(name), "", size_to_export);
+}
+
+// [Internal] export one size ImVec2 style to current Log target
+static void ExportSize_ImVec2(const char* name, ImVec2& size_to_export, ImVec2& ref_size, bool export_only_modified)
+{
+    if (!export_only_modified || memcmp(&size_to_export, &ref_size, sizeof(ImVec2)) != 0)
+        ImGui::LogText("style.%s%*s= ImVec2(%.2ff, %.2ff);" IM_NEWLINE, name, 25 - (int)strlen(name), "", size_to_export.x, size_to_export.y);
+}
+
+// [Internal] export sizes style to current Log target
+static void ExportSizes(ImGuiStyle& style_to_export, ImGuiStyle& ref_style, bool export_only_modified)
+{
+    ImGui::LogText("auto& style = ImGui::GetStyle();" IM_NEWLINE);
+
+    {
+        ImGui::LogText(IM_NEWLINE "// Main" IM_NEWLINE);
+
+        ExportSize_ImVec2("WindowPadding", style_to_export.WindowPadding, ref_style.WindowPadding, export_only_modified);
+        ExportSize_ImVec2("FramePadding", style_to_export.FramePadding, ref_style.FramePadding, export_only_modified);
+        ExportSize_ImVec2("ItemSpacing", style_to_export.ItemSpacing, ref_style.ItemSpacing, export_only_modified);
+        ExportSize_ImVec2("ItemInnerSpacing", style_to_export.ItemInnerSpacing, ref_style.ItemInnerSpacing, export_only_modified);
+        ExportSize_ImVec2("TouchExtraPadding", style_to_export.TouchExtraPadding, ref_style.TouchExtraPadding, export_only_modified);
+        ExportSize_Float("IndentSpacing", style_to_export.IndentSpacing, ref_style.IndentSpacing, export_only_modified);
+        ExportSize_Float("ScrollbarSize", style_to_export.ScrollbarSize, ref_style.ScrollbarSize, export_only_modified);
+        ExportSize_Float("GrabMinSize", style_to_export.GrabMinSize, ref_style.GrabMinSize, export_only_modified);
+    }
+
+    {
+        ImGui::LogText(IM_NEWLINE "// Borders" IM_NEWLINE);
+
+        ExportSize_Float("WindowBorderSize", style_to_export.WindowBorderSize, ref_style.WindowBorderSize, export_only_modified);
+        ExportSize_Float("ChildBorderSize", style_to_export.ChildBorderSize, ref_style.ChildBorderSize, export_only_modified);
+        ExportSize_Float("PopupBorderSize", style_to_export.PopupBorderSize, ref_style.PopupBorderSize, export_only_modified);
+        ExportSize_Float("FrameBorderSize", style_to_export.FrameBorderSize, ref_style.FrameBorderSize, export_only_modified);
+        ExportSize_Float("TabBorderSize", style_to_export.TabBorderSize, ref_style.TabBorderSize, export_only_modified);
+    }
+
+    {
+        ImGui::LogText(IM_NEWLINE "// Rounding" IM_NEWLINE);
+
+        ExportSize_Float("WindowRounding", style_to_export.WindowRounding, ref_style.WindowRounding, export_only_modified);
+        ExportSize_Float("ChildRounding", style_to_export.ChildRounding, ref_style.ChildRounding, export_only_modified);
+        ExportSize_Float("FrameRounding", style_to_export.FrameRounding, ref_style.FrameRounding, export_only_modified);
+        ExportSize_Float("PopupRounding", style_to_export.PopupRounding, ref_style.PopupRounding, export_only_modified);
+        ExportSize_Float("ScrollbarRounding", style_to_export.ScrollbarRounding, ref_style.ScrollbarRounding, export_only_modified);
+        ExportSize_Float("GrabRounding", style_to_export.GrabRounding, ref_style.GrabRounding, export_only_modified);
+        ExportSize_Float("TabRounding", style_to_export.TabRounding, ref_style.TabRounding, export_only_modified);
+    }
+
+    {
+        ImGui::LogText(IM_NEWLINE "// Alignment" IM_NEWLINE);
+
+        ExportSize_ImVec2("WindowTitleAlign", style_to_export.WindowTitleAlign, ref_style.WindowTitleAlign, export_only_modified);
+
+        // for this one we could just save ImGuiDir number, but its more redable to have ImGuiDir_ name
+        if (!export_only_modified || memcmp(&style_to_export.WindowMenuButtonPosition, &ref_style.WindowMenuButtonPosition, sizeof(ImGuiDir)) != 0)
+        {
+            const char* dirName = 0;
+            switch (style_to_export.WindowMenuButtonPosition)
+            {
+            case ImGuiDir_None: dirName = "ImGuiDir_None"; break;
+            case ImGuiDir_Left: dirName = "ImGuiDir_Left"; break;
+            case ImGuiDir_Right: dirName = "ImGuiDir_Right"; break;
+            };
+
+            ImGui::LogText("style.%s%*s= %s;" IM_NEWLINE, "WindowMenuButtonPosition", 25 - (int)strlen("WindowMenuButtonPosition"), "", dirName);
+        }
+
+        // for this one we could just save ImGuiDir number, but its more redable to have ImGuiDir_ name
+        if (!export_only_modified || memcmp(&style_to_export.ColorButtonPosition, &ref_style.ColorButtonPosition, sizeof(ImGuiDir)) != 0)
+        {
+            const char* dirName = 0;
+            switch (style_to_export.ColorButtonPosition)
+            {
+            case ImGuiDir_Left: dirName = "ImGuiDir_Left"; break;
+            case ImGuiDir_Right: dirName = "ImGuiDir_Right"; break;
+            };
+
+            ImGui::LogText("style.%s%*s= %s;" IM_NEWLINE, "ColorButtonPosition", 25 - (int)strlen("ColorButtonPosition"), "", dirName);
+        }
+
+        ExportSize_ImVec2("ButtonTextAlign", style_to_export.ButtonTextAlign, ref_style.ButtonTextAlign, export_only_modified);
+        ExportSize_ImVec2("SelectableTextAlign", style_to_export.SelectableTextAlign, ref_style.SelectableTextAlign, export_only_modified);
+    }
+
+    {
+        ImGui::LogText(IM_NEWLINE "// Safe Area Padding" IM_NEWLINE);
+
+        ExportSize_ImVec2("DisplaySafeAreaPadding", style_to_export.DisplaySafeAreaPadding, ref_style.DisplaySafeAreaPadding, export_only_modified);
+    }
+}
+
 void ImGui::ShowStyleEditor(ImGuiStyle* ref)
 {
     // You can pass in a reference ImGuiStyle structure to compare to, revert to and save to
@@ -5871,10 +5981,52 @@ void ImGui::ShowStyleEditor(ImGuiStyle* ref)
 
     ImGui::Separator();
 
+    static auto output_dest = 0;
+    static auto output_only_modified = true;
+    if (ImGui::Button("Export Sizes and Colors"))
+    {
+        if (output_dest == 0)
+            ImGui::LogToClipboard();
+        else
+            ImGui::LogToTTY();
+
+        ExportColors(style, *ref, output_only_modified);
+
+        ImGui::LogText(IM_NEWLINE);
+
+        ExportSizes(style, *ref, output_only_modified);
+
+        ImGui::LogFinish();
+    }
+    ImGui::SameLine(); ImGui::SetNextItemWidth(120); ImGui::Combo("##output_type_size_and_colors", &output_dest, "To Clipboard\0To TTY\0");
+    ImGui::SameLine(); ImGui::Checkbox("Only Modified##size_and_colors", &output_only_modified);
+    ImGui::SameLine();
+    HelpMarker("Export Sizes and Colors style");
+
+    ImGui::Separator();
+
     if (ImGui::BeginTabBar("##tabs", ImGuiTabBarFlags_None))
     {
         if (ImGui::BeginTabItem("Sizes"))
         {
+            static auto output_dest_sizes = 0;
+            static auto output_only_modified_sizes = true;
+            if (ImGui::Button("Export"))
+            {
+                if (output_dest_sizes == 0)
+                    ImGui::LogToClipboard();
+                else
+                    ImGui::LogToTTY();
+
+                ExportSizes(style, *ref, output_only_modified_sizes);
+
+                ImGui::LogFinish();
+            }
+            ImGui::SameLine(); ImGui::SetNextItemWidth(120); ImGui::Combo("##output_type", &output_dest_sizes, "To Clipboard\0To TTY\0");
+            ImGui::SameLine(); ImGui::Checkbox("Only Modified", &output_only_modified_sizes);
+
+            ImGui::Separator();
+
             ImGui::Text("Main");
             ImGui::SliderFloat2("WindowPadding", (float*)&style.WindowPadding, 0.0f, 20.0f, "%.0f");
             ImGui::SliderFloat2("FramePadding", (float*)&style.FramePadding, 0.0f, 20.0f, "%.0f");
@@ -5918,27 +6070,23 @@ void ImGui::ShowStyleEditor(ImGuiStyle* ref)
 
         if (ImGui::BeginTabItem("Colors"))
         {
-            static int output_dest = 0;
-            static bool output_only_modified = true;
+            static auto output_dest_colors = 0;
+            static auto output_only_modified_colors = true;
             if (ImGui::Button("Export"))
             {
-                if (output_dest == 0)
+                if (output_dest_colors == 0)
                     ImGui::LogToClipboard();
                 else
                     ImGui::LogToTTY();
-                ImGui::LogText("ImVec4* colors = ImGui::GetStyle().Colors;" IM_NEWLINE);
-                for (int i = 0; i < ImGuiCol_COUNT; i++)
-                {
-                    const ImVec4& col = style.Colors[i];
-                    const char* name = ImGui::GetStyleColorName(i);
-                    if (!output_only_modified || memcmp(&col, &ref->Colors[i], sizeof(ImVec4)) != 0)
-                        ImGui::LogText("colors[ImGuiCol_%s]%*s= ImVec4(%.2ff, %.2ff, %.2ff, %.2ff);" IM_NEWLINE,
-                            name, 23 - (int)strlen(name), "", col.x, col.y, col.z, col.w);
-                }
+
+                ExportColors(style, *ref, output_only_modified_colors);
+
                 ImGui::LogFinish();
             }
-            ImGui::SameLine(); ImGui::SetNextItemWidth(120); ImGui::Combo("##output_type", &output_dest, "To Clipboard\0To TTY\0");
-            ImGui::SameLine(); ImGui::Checkbox("Only Modified Colors", &output_only_modified);
+            ImGui::SameLine(); ImGui::SetNextItemWidth(120); ImGui::Combo("##output_type", &output_dest_colors, "To Clipboard\0To TTY\0");
+            ImGui::SameLine(); ImGui::Checkbox("Only Modified", &output_only_modified_colors);
+
+            ImGui::Separator();
 
             static ImGuiTextFilter filter;
             filter.Draw("Filter colors", ImGui::GetFontSize() * 16);


### PR DESCRIPTION
Hello,

i propose this PR for add the possibility to export sizes settings in more than just colors.

Because when we tune a theme, its a pain to gain the sizes settings. i made this PR for solve this :)
 
I Have added a button "Export" in Sizes tab (in a similar way to color export way)
I have also added an "Export Sizes & Colors" in the main window for have the ability to export sizes and colors in one time.

![7Ji49EESsA](https://user-images.githubusercontent.com/1434736/109387055-47b57500-78ff-11eb-98e0-86190a66c7d6.gif)

this is the result obtained with the defautl imgui theme :

```cpp
ImVec4* colors = ImGui::GetStyle().Colors;
colors[ImGuiCol_Text]                   = ImVec4(1.00f, 1.00f, 1.00f, 1.00f);
colors[ImGuiCol_TextDisabled]           = ImVec4(0.50f, 0.50f, 0.50f, 1.00f);
colors[ImGuiCol_WindowBg]               = ImVec4(0.06f, 0.06f, 0.06f, 0.94f);
colors[ImGuiCol_ChildBg]                = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
colors[ImGuiCol_PopupBg]                = ImVec4(0.08f, 0.08f, 0.08f, 0.94f);
colors[ImGuiCol_Border]                 = ImVec4(0.43f, 0.43f, 0.50f, 0.50f);
colors[ImGuiCol_BorderShadow]           = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
colors[ImGuiCol_FrameBg]                = ImVec4(0.16f, 0.29f, 0.48f, 0.54f);
colors[ImGuiCol_FrameBgHovered]         = ImVec4(0.26f, 0.59f, 0.98f, 0.40f);
colors[ImGuiCol_FrameBgActive]          = ImVec4(0.26f, 0.59f, 0.98f, 0.67f);
colors[ImGuiCol_TitleBg]                = ImVec4(0.04f, 0.04f, 0.04f, 1.00f);
colors[ImGuiCol_TitleBgActive]          = ImVec4(0.16f, 0.29f, 0.48f, 1.00f);
colors[ImGuiCol_TitleBgCollapsed]       = ImVec4(0.00f, 0.00f, 0.00f, 0.51f);
colors[ImGuiCol_MenuBarBg]              = ImVec4(0.14f, 0.14f, 0.14f, 1.00f);
colors[ImGuiCol_ScrollbarBg]            = ImVec4(0.02f, 0.02f, 0.02f, 0.53f);
colors[ImGuiCol_ScrollbarGrab]          = ImVec4(0.31f, 0.31f, 0.31f, 1.00f);
colors[ImGuiCol_ScrollbarGrabHovered]   = ImVec4(0.41f, 0.41f, 0.41f, 1.00f);
colors[ImGuiCol_ScrollbarGrabActive]    = ImVec4(0.51f, 0.51f, 0.51f, 1.00f);
colors[ImGuiCol_CheckMark]              = ImVec4(0.26f, 0.59f, 0.98f, 1.00f);
colors[ImGuiCol_SliderGrab]             = ImVec4(0.24f, 0.52f, 0.88f, 1.00f);
colors[ImGuiCol_SliderGrabActive]       = ImVec4(0.26f, 0.59f, 0.98f, 1.00f);
colors[ImGuiCol_Button]                 = ImVec4(0.26f, 0.59f, 0.98f, 0.40f);
colors[ImGuiCol_ButtonHovered]          = ImVec4(0.26f, 0.59f, 0.98f, 1.00f);
colors[ImGuiCol_ButtonActive]           = ImVec4(0.06f, 0.53f, 0.98f, 1.00f);
colors[ImGuiCol_Header]                 = ImVec4(0.26f, 0.59f, 0.98f, 0.31f);
colors[ImGuiCol_HeaderHovered]          = ImVec4(0.26f, 0.59f, 0.98f, 0.80f);
colors[ImGuiCol_HeaderActive]           = ImVec4(0.26f, 0.59f, 0.98f, 1.00f);
colors[ImGuiCol_Separator]              = ImVec4(0.43f, 0.43f, 0.50f, 0.50f);
colors[ImGuiCol_SeparatorHovered]       = ImVec4(0.10f, 0.40f, 0.75f, 0.78f);
colors[ImGuiCol_SeparatorActive]        = ImVec4(0.10f, 0.40f, 0.75f, 1.00f);
colors[ImGuiCol_ResizeGrip]             = ImVec4(0.26f, 0.59f, 0.98f, 0.20f);
colors[ImGuiCol_ResizeGripHovered]      = ImVec4(0.26f, 0.59f, 0.98f, 0.67f);
colors[ImGuiCol_ResizeGripActive]       = ImVec4(0.26f, 0.59f, 0.98f, 0.95f);
colors[ImGuiCol_Tab]                    = ImVec4(0.18f, 0.35f, 0.58f, 0.86f);
colors[ImGuiCol_TabHovered]             = ImVec4(0.26f, 0.59f, 0.98f, 0.80f);
colors[ImGuiCol_TabActive]              = ImVec4(0.20f, 0.41f, 0.68f, 1.00f);
colors[ImGuiCol_TabUnfocused]           = ImVec4(0.07f, 0.10f, 0.15f, 0.97f);
colors[ImGuiCol_TabUnfocusedActive]     = ImVec4(0.14f, 0.26f, 0.42f, 1.00f);
colors[ImGuiCol_PlotLines]              = ImVec4(0.61f, 0.61f, 0.61f, 1.00f);
colors[ImGuiCol_PlotLinesHovered]       = ImVec4(1.00f, 0.43f, 0.35f, 1.00f);
colors[ImGuiCol_PlotHistogram]          = ImVec4(0.90f, 0.70f, 0.00f, 1.00f);
colors[ImGuiCol_PlotHistogramHovered]   = ImVec4(1.00f, 0.60f, 0.00f, 1.00f);
colors[ImGuiCol_TableHeaderBg]          = ImVec4(0.19f, 0.19f, 0.20f, 1.00f);
colors[ImGuiCol_TableBorderStrong]      = ImVec4(0.31f, 0.31f, 0.35f, 1.00f);
colors[ImGuiCol_TableBorderLight]       = ImVec4(0.23f, 0.23f, 0.25f, 1.00f);
colors[ImGuiCol_TableRowBg]             = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
colors[ImGuiCol_TableRowBgAlt]          = ImVec4(1.00f, 1.00f, 1.00f, 0.06f);
colors[ImGuiCol_TextSelectedBg]         = ImVec4(0.26f, 0.59f, 0.98f, 0.35f);
colors[ImGuiCol_DragDropTarget]         = ImVec4(1.00f, 1.00f, 0.00f, 0.90f);
colors[ImGuiCol_NavHighlight]           = ImVec4(0.26f, 0.59f, 0.98f, 1.00f);
colors[ImGuiCol_NavWindowingHighlight]  = ImVec4(1.00f, 1.00f, 1.00f, 0.70f);
colors[ImGuiCol_NavWindowingDimBg]      = ImVec4(0.80f, 0.80f, 0.80f, 0.20f);
colors[ImGuiCol_ModalWindowDimBg]       = ImVec4(0.80f, 0.80f, 0.80f, 0.35f);

ImGuiStyle& style = ImGui::GetStyle();

// Main
style.WindowPadding            = ImVec2(8.00f, 8.00f);
style.FramePadding             = ImVec2(4.00f, 3.00f);
style.ItemSpacing              = ImVec2(8.00f, 4.00f);
style.ItemInnerSpacing         = ImVec2(4.00f, 4.00f);
style.TouchExtraPadding        = ImVec2(0.00f, 0.00f);
style.IndentSpacing            = 21.00f;
style.ScrollbarSize            = 14.00f;
style.GrabMinSize              = 10.00f;

// Borders
style.WindowBorderSize         = 1.00f;
style.ChildBorderSize          = 1.00f;
style.PopupBorderSize          = 1.00f;
style.FrameBorderSize          = 0.00f;
style.TabBorderSize            = 0.00f;

// Rounding
style.WindowRounding           = 0.00f;
style.ChildRounding            = 0.00f;
style.FrameRounding            = 0.00f;
style.PopupRounding            = 0.00f;
style.ScrollbarRounding        = 9.00f;
style.GrabRounding             = 0.00f;
style.TabRounding              = 4.00f;

// Alignment
style.WindowTitleAlign         = ImVec2(0.00f, 0.50f);
style.WindowMenuButtonPosition = ImGuiDir_Left;
style.ColorButtonPosition      = ImGuiDir_Right;
style.ButtonTextAlign          = ImVec2(0.50f, 0.50f);
style.SelectableTextAlign      = ImVec2(0.00f, 0.00f);

// Safe Area Padding
style.DisplaySafeAreaPadding   = ImVec2(3.00f, 3.00f);
```

i have used section in comments  (like Alignment, Rounding, etc..) for clarity, but not sure if its needed :)


