### PR TITLE
ImGui::SetWindowFocus(nullptr) can cause crash

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -6945,6 +6945,7 @@ void ImGui::FocusWindow(ImGuiWindow* window)
         g.NavFocusScopeId = 0;
         g.NavIdIsAlive = false;
         g.NavLayer = ImGuiNavLayer_Main;
+        NavUpdateAnyRequestFlag();
         //IMGUI_DEBUG_LOG("FocusWindow(\"%s\")\n", window ? window->Name : NULL);
     }
 


### PR DESCRIPTION
Steps to reproduce: 
1. put `ImGui::SetWindowFocus(nullptr);` before `if (!ImGui::Begin("Dear ImGui Demo"` in demo
2. start demo
3. dock two windows together
4. click on docked windows
5. observe crash in `ImGui::ItemAdd`

Note: VS2019, win10, latest docking branch version
Note: crashes because `NavAnyRequest` is true, but `NavWindow` is null
Note: SetWindowFocus does not update `NavAnyRequest`