### PR TITLE
Enable FreeType bitmap glyphs

### DIFF
--- a/misc/freetype/imgui_freetype.h
+++ b/misc/freetype/imgui_freetype.h
@@ -26,7 +26,8 @@ enum ImGuiFreeTypeBuilderFlags
     ImGuiFreeTypeBuilderFlags_Bold          = 1 << 5,   // Styling: Should we artificially embolden the font?
     ImGuiFreeTypeBuilderFlags_Oblique       = 1 << 6,   // Styling: Should we slant the font, emulating italic style?
     ImGuiFreeTypeBuilderFlags_Monochrome    = 1 << 7,   // Disable anti-aliasing. Combine this with MonoHinting for best results!
-    ImGuiFreeTypeBuilderFlags_LoadColor     = 1 << 8    // Enable FreeType color-layered glyphs
+    ImGuiFreeTypeBuilderFlags_LoadColor     = 1 << 8,   // Enable FreeType color-layered glyphs
+    ImGuiFreeTypeBuilderFlags_Bitmap        = 1 << 9    // Enable FreeType bitmap glyphs
 };
 
 namespace ImGuiFreeType


### PR DESCRIPTION
This PR is support TTF bitmap for CJK.
We need it because the font is not clear when screen resolution is 1080P or below.
the freetype support bitmap, the stb_truetype don't support it yet.

Before :
![B](https://user-images.githubusercontent.com/52752725/110063902-f8f85700-7da6-11eb-8c0b-cd9cfdbe8718.PNG)

Before : (Monochrome)
![C](https://user-images.githubusercontent.com/52752725/110065414-019e5c80-7daa-11eb-8fa8-e7079d4cb5bf.PNG)

After :
![A](https://user-images.githubusercontent.com/52752725/110063914-ff86ce80-7da6-11eb-9c17-087dcb1a2448.PNG)

Example code :
```
    ImFontConfig font_config;
    font_config.SizePixels = 13.0f;
    font_config.FontBuilderFlags = ImGuiFreeTypeBuilderFlags_Bitmap;
    io.Fonts->AddFontFromFileTTF("C:\\Windows\\Fonts\\msgothic.ttc", 13.0f, &font_config, io.Fonts->GetGlyphRangesJapanese());
```