### PR TITLE
Fix unused variable warning in ImGui::EndListBox()

### DIFF
--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -6220,6 +6220,7 @@ void ImGui::EndListBox()
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
     IM_ASSERT((window->Flags & ImGuiWindowFlags_ChildWindow) && "Mismatched BeginListBox/EndListBox calls. Did you test the return value of BeginListBox?");
+    IM_UNUSED(window);
 
     EndChildFrame();
     EndGroup(); // This is only required to be able to do IsItemXXX query on the whole ListBox including label


### PR DESCRIPTION
This commit fixed an unused variable warning in function ImGui::EndListBox().

**Compiler log:**
```
[  0%] Building CXX object External/imgui/CMakeFiles/imgui.dir/imgui_widgets.cpp.o
/home/even/Projects/cherrysoda-engine/External/imgui/imgui_widgets.cpp: In function ‘void ImGui::EndListBox()’:
/home/even/Projects/cherrysoda-engine/External/imgui/imgui_widgets.cpp:6198:18: warning: unused variable ‘window’ [-Wunused-variable]
 6198 |     ImGuiWindow* window = g.CurrentWindow;
      |                  ^~~~~~
[100%] Linking CXX static library ../../lib/libimgui.a
```

**Compiler version:** gcc (GCC) 10.2.0
**Platform:** Linux 5.11.2-1-MANJARO x86_64

