### PR TITLE
Backends: Win32: Add IMGUI_IMPL_WIN32_ENABLE_PEEKMESSAGE

### DIFF
--- a/backends/imgui_impl_win32.cpp
+++ b/backends/imgui_impl_win32.cpp
@@ -23,6 +23,7 @@
 
 // Configuration flags to add in your imconfig.h file:
 //#define IMGUI_IMPL_WIN32_DISABLE_GAMEPAD              // Disable gamepad support (this used to be meaningful before <1.81) but we know load XInput dynamically so the option is less relevant now.
+//#define IMGUI_IMPL_WIN32_ENABLE_PEEKMESSAGE           // Enable PeekMessage in the Multi-viewport if main window call PeekMessage itself only
 
 // Using XInput for gamepad (will load DLL dynamically)
 #ifndef IMGUI_IMPL_WIN32_DISABLE_GAMEPAD
@@ -728,6 +729,16 @@ static void ImGui_ImplWin32_UpdateWindow(ImGuiViewport* viewport)
         ::ShowWindow(data->Hwnd, SW_SHOWNA); // This is necessary when we alter the style
         viewport->PlatformRequestMove = viewport->PlatformRequestResize = true;
     }
+
+    // To call PeekMessage if calling PeekMessage main window in the main loop only
+#ifdef IMGUI_IMPL_WIN32_ENABLE_PEEKMESSAGE
+    MSG msg;
+    if (::PeekMessage(&msg, data->Hwnd, 0, 0, PM_REMOVE))
+    {
+        ::TranslateMessage(&msg);
+        ::DispatchMessage(&msg);
+    }
+#endif
 }
 
 static ImVec2 ImGui_ImplWin32_GetWindowPos(ImGuiViewport* viewport)


### PR DESCRIPTION
This is an optional PR.
It affect some win32 programs that PeekMessage main HWND only.
(Some windows have their message flow)

We can reproduce that we modify this line
https://github.com/ocornut/imgui/blob/fe6369b03dab08c6636e32f57757e72c047e7cf1/examples/example_win32_directx9/main.cpp#L88
to
```
if (::PeekMessage(&msg, hwnd, 0U, 0U, PM_REMOVE) || ::PeekMessage(&msg, NULL, 96, 96, PM_REMOVE)) 
```

The message-id 96 is an internal Windows Message.
If skip the message, the program can't receive WM_QUIT.