### PR TITLE
Examples: Win32: Let the CPU and GPU chill when minimized

### DIFF
--- a/examples/example_win32_directx10/main.cpp
+++ b/examples/example_win32_directx10/main.cpp
@@ -13,6 +13,7 @@
 static ID3D10Device*            g_pd3dDevice = NULL;
 static IDXGISwapChain*          g_pSwapChain = NULL;
 static ID3D10RenderTargetView*  g_mainRenderTargetView = NULL;
+static bool                     g_wndMinimized = false;
 
 // Forward declarations of helper functions
 bool CreateDeviceD3D(HWND hWnd);
@@ -96,6 +97,13 @@ int main(int, char**)
         }
         if (done)
             break;
+
+        // Don't render if the window is minimized
+        if (g_wndMinimized)
+        {
+            Sleep(1); // Let the processor sleep a bit
+            continue;
+        }
 
         // Start the Dear ImGui frame
         ImGui_ImplDX10_NewFrame();
@@ -228,6 +236,14 @@ LRESULT WINAPI WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
             CleanupRenderTarget();
             g_pSwapChain->ResizeBuffers(0, (UINT)LOWORD(lParam), (UINT)HIWORD(lParam), DXGI_FORMAT_UNKNOWN, 0);
             CreateRenderTarget();
+        }
+        if (wParam == SIZE_MINIMIZED)
+        {
+            g_wndMinimized = true;
+        }
+        else if (wParam == SIZE_RESTORED)
+        {
+            g_wndMinimized = false;
         }
         return 0;
     case WM_SYSCOMMAND:

--- a/examples/example_win32_directx10/main.cpp
+++ b/examples/example_win32_directx10/main.cpp
@@ -237,14 +237,7 @@ LRESULT WINAPI WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
             g_pSwapChain->ResizeBuffers(0, (UINT)LOWORD(lParam), (UINT)HIWORD(lParam), DXGI_FORMAT_UNKNOWN, 0);
             CreateRenderTarget();
         }
-        if (wParam == SIZE_MINIMIZED)
-        {
-            g_wndMinimized = true;
-        }
-        else if (wParam == SIZE_RESTORED)
-        {
-            g_wndMinimized = false;
-        }
+        g_wndMinimized = (wParam == SIZE_MINIMIZED);
         return 0;
     case WM_SYSCOMMAND:
         if ((wParam & 0xfff0) == SC_KEYMENU) // Disable ALT application menu

--- a/examples/example_win32_directx11/main.cpp
+++ b/examples/example_win32_directx11/main.cpp
@@ -13,6 +13,7 @@ static ID3D11Device*            g_pd3dDevice = NULL;
 static ID3D11DeviceContext*     g_pd3dDeviceContext = NULL;
 static IDXGISwapChain*          g_pSwapChain = NULL;
 static ID3D11RenderTargetView*  g_mainRenderTargetView = NULL;
+static bool                     g_wndMinimized = false;
 
 // Forward declarations of helper functions
 bool CreateDeviceD3D(HWND hWnd);
@@ -91,6 +92,13 @@ int main(int, char**)
         {
             ::TranslateMessage(&msg);
             ::DispatchMessage(&msg);
+            continue;
+        }
+        
+        // Don't render if the window is minimized
+        if (g_wndMinimized)
+        {
+            Sleep(1); // Let the processor sleep a bit
             continue;
         }
 
@@ -229,6 +237,14 @@ LRESULT WINAPI WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
             CleanupRenderTarget();
             g_pSwapChain->ResizeBuffers(0, (UINT)LOWORD(lParam), (UINT)HIWORD(lParam), DXGI_FORMAT_UNKNOWN, 0);
             CreateRenderTarget();
+        }
+        if (wParam == SIZE_MINIMIZED)
+        {
+            g_wndMinimized = true;
+        }
+        else if (wParam == SIZE_RESTORED)
+        {
+            g_wndMinimized = false;
         }
         return 0;
     case WM_SYSCOMMAND:

--- a/examples/example_win32_directx11/main.cpp
+++ b/examples/example_win32_directx11/main.cpp
@@ -241,14 +241,7 @@ LRESULT WINAPI WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
             g_pSwapChain->ResizeBuffers(0, (UINT)LOWORD(lParam), (UINT)HIWORD(lParam), DXGI_FORMAT_UNKNOWN, 0);
             CreateRenderTarget();
         }
-        if (wParam == SIZE_MINIMIZED)
-        {
-            g_wndMinimized = true;
-        }
-        else if (wParam == SIZE_RESTORED)
-        {
-            g_wndMinimized = false;
-        }
+        g_wndMinimized = (wParam == SIZE_MINIMIZED);
         return 0;
     case WM_SYSCOMMAND:
         if ((wParam & 0xfff0) == SC_KEYMENU) // Disable ALT application menu

--- a/examples/example_win32_directx12/main.cpp
+++ b/examples/example_win32_directx12/main.cpp
@@ -46,6 +46,7 @@ static IDXGISwapChain3*             g_pSwapChain = NULL;
 static HANDLE                       g_hSwapChainWaitableObject = NULL;
 static ID3D12Resource*              g_mainRenderTargetResource[NUM_BACK_BUFFERS] = {};
 static D3D12_CPU_DESCRIPTOR_HANDLE  g_mainRenderTargetDescriptor[NUM_BACK_BUFFERS] = {};
+static bool                         g_wndMinimized = false;
 
 // Forward declarations of helper functions
 bool CreateDeviceD3D(HWND hWnd);
@@ -135,6 +136,13 @@ int main(int, char**)
         }
         if (done)
             break;
+
+        // Don't render if the window is minimized
+        if (g_wndMinimized)
+        {
+            Sleep(1); // Let the processor sleep a bit
+            continue;
+        }
 
         // Start the Dear ImGui frame
         ImGui_ImplDX12_NewFrame();
@@ -478,6 +486,7 @@ LRESULT WINAPI WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
             CreateRenderTarget();
             ImGui_ImplDX12_CreateDeviceObjects();
         }
+        g_wndMinimized = (wParam == SIZE_MINIMIZED);
         return 0;
     case WM_SYSCOMMAND:
         if ((wParam & 0xfff0) == SC_KEYMENU) // Disable ALT application menu

--- a/examples/example_win32_directx9/main.cpp
+++ b/examples/example_win32_directx9/main.cpp
@@ -12,6 +12,7 @@
 static LPDIRECT3D9              g_pD3D = NULL;
 static LPDIRECT3DDEVICE9        g_pd3dDevice = NULL;
 static D3DPRESENT_PARAMETERS    g_d3dpp = {};
+static bool                     g_wndMinimized = false;
 
 // Forward declarations of helper functions
 bool CreateDeviceD3D(HWND hWnd);
@@ -94,6 +95,13 @@ int main(int, char**)
         }
         if (done)
             break;
+
+        // Don't render if the window is minimized
+        if (g_wndMinimized)
+        {
+            Sleep(1); // Let the processor sleep a bit
+            continue;
+        }
 
         // Start the Dear ImGui frame
         ImGui_ImplDX9_NewFrame();
@@ -223,6 +231,7 @@ LRESULT WINAPI WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
             g_d3dpp.BackBufferHeight = HIWORD(lParam);
             ResetDevice();
         }
+        g_wndMinimized = (wParam == SIZE_MINIMIZED);
         return 0;
     case WM_SYSCOMMAND:
         if ((wParam & 0xfff0) == SC_KEYMENU) // Disable ALT application menu


### PR DESCRIPTION
When the window is minimized, in the task manager i see 100% GPU usage and 10% CPU usage
When the window is restored, i see 7% GPU usage and 0,5% CPU usage

So i added SIZE_MINIMIZED handling, to prevent CPU and GPU usage when the window is minimized