### PR TITLE
Add support for multiple GLFW contexts

### DIFF
--- a/backends/imgui_impl_glfw.cpp
+++ b/backends/imgui_impl_glfw.cpp
@@ -90,7 +90,7 @@ static GLFWwindow* g_DefaultWindow = NULL;
 
 static State* ImGui_ImplGlfw_InitWindowState(GLFWwindow* window)
 {
-    State* state = (State*)ImGui::MemAlloc(sizeof(State));
+    State* state = IM_NEW(State)();
     const ImGuiID window_hash = ImHashData(&window, sizeof(void*), 0);
     g_StateStorage.SetVoidPtr(window_hash, state);
     return state;
@@ -295,7 +295,7 @@ void ImGui_ImplGlfw_Shutdown(GLFWwindow* window)
     }
     state->ClientApi = GlfwClientApi_Unknown;
 
-    ImGui::MemFree(state);
+    IM_DELETE(state);
 }
 
 static void ImGui_ImplGlfw_UpdateMousePosAndButtons(GLFWwindow* window)

--- a/backends/imgui_impl_glfw.h
+++ b/backends/imgui_impl_glfw.h
@@ -24,8 +24,8 @@ struct GLFWwindow;
 IMGUI_IMPL_API bool     ImGui_ImplGlfw_InitForOpenGL(GLFWwindow* window, bool install_callbacks);
 IMGUI_IMPL_API bool     ImGui_ImplGlfw_InitForVulkan(GLFWwindow* window, bool install_callbacks);
 IMGUI_IMPL_API bool     ImGui_ImplGlfw_InitForOther(GLFWwindow* window, bool install_callbacks);
-IMGUI_IMPL_API void     ImGui_ImplGlfw_Shutdown();
-IMGUI_IMPL_API void     ImGui_ImplGlfw_NewFrame();
+IMGUI_IMPL_API void     ImGui_ImplGlfw_Shutdown(GLFWwindow* window = NULL);
+IMGUI_IMPL_API void     ImGui_ImplGlfw_NewFrame(GLFWwindow* window = NULL);
 
 // GLFW callbacks
 // - When calling Init with 'install_callbacks=true': GLFW callbacks will be installed for you. They will call user's previously installed callbacks, if any.


### PR DESCRIPTION
I have the same situation as #3012 where I am integrating into a large existing code base that manages multiple windows via `glfwCreateWindow` and `glfwMakeContextCurrent`. ImGui is currently _very_ close to supporting this out of the box, the only issue is the global state in `imgui_impl_glfw.cpp`.

The first patch removes the global `g_Window` in favor of `glfwGetCurrentContext()`. This allows the user to manage their own glfw and imgui contexts and the imgui glfw backend will use which ever one is currently active.

The second patch encapsulates the other cross-frame state and keeps an instance of it per glfw window in a `ImguiStorage` global. I'm not sure if this is the best data structure to use.

The more general solution would probably be related to the Viewports work but it was not obvious to me how to achieve my integration with that branch.