### PR TITLE
Fixes two static code analysis warnings

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -1134,10 +1134,15 @@ void ImGuiIO::AddInputCharacterUTF16(ImWchar16 c)
     {
         if ((c & 0xFC00) != 0xDC00) // Invalid low surrogate
             InputQueueCharacters.push_back(IM_UNICODE_CODEPOINT_INVALID);
-        else if (IM_UNICODE_CODEPOINT_MAX == (0xFFFF)) // Codepoint will not fit in ImWchar (extra parenthesis around 0xFFFF somehow fixes -Wunreachable-code with Clang)
-            cp = IM_UNICODE_CODEPOINT_INVALID;
         else
+        {
+          #if IM_UNICODE_CODEPOINT_MAX == 0xFFFF
+            cp = IM_UNICODE_CODEPOINT_INVALID;
+          #else
             cp = (ImWchar)(((InputQueueSurrogate - 0xD800) << 10) + (c - 0xDC00) + 0x10000);
+          #endif
+        }
+
         InputQueueSurrogate = 0;
     }
     InputQueueCharacters.push_back(cp);
@@ -4536,6 +4541,8 @@ static void FindHoveredWindow()
     for (int i = g.Windows.Size - 1; i >= 0; i--)
     {
         ImGuiWindow* window = g.Windows[i];
+        assert(window != NULL);
+
         if (!window->Active || window->Hidden)
             continue;
         if (window->Flags & ImGuiWindowFlags_NoMouseInputs)


### PR DESCRIPTION
This change fixes two warnings that were found with the static code analyzer that we use internally at Microsoft (based on MSVC 2019). You can reproduce this by opening the code with VS 2019 and just wait for the inline static analysis to show up (green squiggly lines).

`if (IM_UNICODE_CODEPOINT_MAX == (0xFFFF))`

About this line it complained that this condition is between two constants. I assume that is the same reason why you were seeing an "unreachable code" warning with Clang.

The fix is simply to move this check to the preprocessor.

`if (hovered_window_ignoring_moving_window == NULL && (!g.MovingWindow || window->RootWindow != g.MovingWindow->RootWindow))`

![image](https://user-images.githubusercontent.com/36191331/111641280-4809a780-87fd-11eb-96b3-76211d5e6058.png)

In this line it complained that there might be a nullptr access. I don't know why it tripped over this line in particular, the fix is simply to add an assert, to let it know that `window` can be considered safe to access.