### PR TITLE
Backends: SDL2: Extend global mouse pos availability check

### DIFF
--- a/backends/imgui_impl_sdl.cpp
+++ b/backends/imgui_impl_sdl.cpp
@@ -177,8 +177,14 @@ static bool ImGui_ImplSDL2_Init(SDL_Window* window)
     g_MouseCursors[ImGuiMouseCursor_Hand] = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_HAND);
     g_MouseCursors[ImGuiMouseCursor_NotAllowed] = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_NO);
 
-    // Check and store if we are on Wayland
-    g_MouseCanUseGlobalState = strncmp(SDL_GetCurrentVideoDriver(), "wayland", 7) != 0;
+    // Check and store if we are on a SDL backend that supports global mouse position
+    const char* sdl_backend = SDL_GetCurrentVideoDriver();
+    g_MouseCanUseGlobalState =
+      strncmp(sdl_backend, "DIVE", 4) == 0 ||
+      strncmp(sdl_backend, "VMAN", 4) == 0 ||
+      strncmp(sdl_backend, "windows", 7) == 0 ||
+      strncmp(sdl_backend, "cocoa", 5) == 0 ||
+      strncmp(sdl_backend, "x11", 3) == 0;
 
 #ifdef _WIN32
     SDL_SysWMinfo wmInfo;
@@ -259,7 +265,7 @@ static void ImGui_ImplSDL2_UpdateMousePosAndButtons()
         {
             // SDL_GetMouseState() gives mouse position seemingly based on the last window entered/focused(?)
             // The creation of a new windows at runtime and SDL_CaptureMouse both seems to severely mess up with that, so we retrieve that position globally.
-            // Won't use this workaround when on Wayland, as there is no global mouse position.
+            // Won't use this workaround on SDL backends that have no global mouse position, like Wayland
             int wx, wy;
             SDL_GetWindowPosition(focused_window, &wx, &wy);
             SDL_GetGlobalMouseState(&mx, &my);


### PR DESCRIPTION
## Description

This extends the run-time check that tests if global mouse position is
available to cover all SDL backends that don't support global mouse
position, instead of just Wayland. This is done by using a "allow-list"
approach of known backends that do support global mouse position, as opposed to listing backends that don't support it.

The list of known backends was determined by looking through the SDL
source code and finding all backends that expose a `GetGlobalMouseState`
function. Example:

https://github.com/libsdl-org/SDL/blob/4acd1dcad41d154093ca14eb0adf35f4f99bd06a/src/video/windows/SDL_windowsmouse.c#L294

## Motivation

The main purpose of this change is to have working mouse input on platforms that don't support global mouse position, like Raspberry Pi (RPI backend in SDL) or other SBCs running Linux which might be using the KMS/DRM backend to run without an X server.

Some affected platforms like Android/iOS are easily detected via compile time defines. But for the aforementioned cases like Raspberry Pi and other SBCs, there's no easy way to detect them at build time, since they all appear as generic Linux platforms in terms of available defines etc. By doing a run-time check based on the SDL backend being used, as was already done for Wayland, we can make mouse input work on these platforms as well without having to introduce custom defines into the build system.

See #2837 for some more discussion/background.