### PR TITLE
Fix unreferenced formal parameter warning in SanitizeFormatString()

### DIFF
--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -2082,6 +2082,7 @@ static const char* ImAtoi(const char* src, TYPE* output)
 // - stb_sprintf.h supports several new modifiers which format numbers in a way that also makes them incompatible atof/atoi.
 static void SanitizeFormatString(const char* fmt, char* fmt_out, size_t fmt_out_size)
 {
+    IM_UNUSED(fmt_out_size);
     const char* fmt_end = ImParseFormatFindEnd(fmt);
     IM_ASSERT((size_t)(fmt_end - fmt + 1) < fmt_out_size); // Format is too long, let us know if this happens to you!
     while (fmt < fmt_end)


### PR DESCRIPTION
This commit fixed an unreferenced formal parameter warning in function SanitizeFormatString().

Compiler log:
```
>------ Build All started: Project: cmake_study-master, Configuration: x64-Release ------
  [1/3] Building CXX object lib\imgui\CMakeFiles\imgui.dir\imgui_widgets.cpp.obj
  FAILED: lib/imgui/CMakeFiles/imgui.dir/imgui_widgets.cpp.obj 
  C:\PROGRA~2\MICROS~1\2019\ENTERP~1\VC\Tools\MSVC\1428~1.299\bin\Hostx64\x64\cl.exe  /nologo /TP  -I..\..\..\include -I..\..\..\lib -I..\..\..\lib\doctest -I..\..\..\lib\SFML\include -I..\..\..\lib\imgui /DWIN32 /D_WINDOWS  /GR /EHsc /MD /Zi /O2 /Ob1 /DNDEBUG /MP /W4 /WX -std:c++17 /showIncludes /Folib\imgui\CMakeFiles\imgui.dir\imgui_widgets.cpp.obj /Fdlib\imgui\CMakeFiles\imgui.dir\imgui.pdb /FS -c ..\..\..\lib\imgui\imgui_widgets.cpp
C:\Users\utilf\Downloads\cmake_study-master\lib\imgui\imgui_widgets.cpp(2083): error C2220: the following warning is treated as an error
C:\Users\utilf\Downloads\cmake_study-master\lib\imgui\imgui_widgets.cpp(2083): warning C4100: 'fmt_out_size': unreferenced formal parameter
  ninja: build stopped: subcommand failed.

Build All failed.
```

**Compiler version**: Visual Studio 2019 16.9.2
**Platform**: Windows 10 Pro x64