### PR TITLE
Fix GL_INVALID_ENUM error in imgui_impl_opengl3 when calling glGetIntegerv on GL_CLIP_ORIGIN

### DIFF
--- a/backends/imgui_impl_opengl3.cpp
+++ b/backends/imgui_impl_opengl3.cpp
@@ -13,6 +13,7 @@
 
 // CHANGELOG
 // (minor and older changes stripped away, please see git history for details)
+//  2021-04-02: OpenGL: Don't try to read GL_CLIP_ORIGIN unless we're OpenGL 4.5 or greater.
 //  2021-02-18: OpenGL: Change blending equation to preserve alpha in output buffer.
 //  2021-01-03: OpenGL: Backup, setup and restore GL_STENCIL_TEST state.
 //  2020-10-23: OpenGL: Backup, setup and restore GL_PRIMITIVE_RESTART state.
@@ -263,10 +264,13 @@ static void ImGui_ImplOpenGL3_SetupRenderState(ImDrawData* draw_data, int fb_wid
 
     // Support for GL 4.5 rarely used glClipControl(GL_UPPER_LEFT)
 #if defined(GL_CLIP_ORIGIN) && !defined(__APPLE__)
-    bool clip_origin_lower_left = true;
-    GLenum current_clip_origin = 0; glGetIntegerv(GL_CLIP_ORIGIN, (GLint*)&current_clip_origin);
-    if (current_clip_origin == GL_UPPER_LEFT)
-        clip_origin_lower_left = false;
+    if (g_GlVersion >= 450)
+    {
+        bool clip_origin_lower_left = true;
+        GLenum current_clip_origin = 0; glGetIntegerv(GL_CLIP_ORIGIN, (GLint*)&current_clip_origin);
+        if (current_clip_origin == GL_UPPER_LEFT)
+            clip_origin_lower_left = false;
+    }
 #endif
 
     // Setup viewport, orthographic projection matrix

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -62,7 +62,7 @@ Other Changes:
 - Examples: Vulkan: Rebuild swapchain on VK_SUBOPTIMAL_KHR. (#3881)
 - Examples: SDL2: Link with shell32.lib required by SDL2main.lib since SDL 2.0.12. [#3988]
 - Docs: Improvements to minor mistakes in documentation comments (#3923) [@ANF-Studios]
-- Examples: OpenGL: Don't try to read GL_CLIP_ORIGIN unless we're OpenGL 4.5 or greater. (issue??) [name??]
+- Examples: OpenGL: Don't try to read GL_CLIP_ORIGIN unless we're OpenGL 4.5 or greater. (#3998) [@s7jones]
 
 
 -----------------------------------------------------------------------

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -62,6 +62,7 @@ Other Changes:
 - Examples: Vulkan: Rebuild swapchain on VK_SUBOPTIMAL_KHR. (#3881)
 - Examples: SDL2: Link with shell32.lib required by SDL2main.lib since SDL 2.0.12. [#3988]
 - Docs: Improvements to minor mistakes in documentation comments (#3923) [@ANF-Studios]
+- Examples: OpenGL: Don't try to read GL_CLIP_ORIGIN unless we're OpenGL 4.5 or greater. (issue??) [name??]
 
 
 -----------------------------------------------------------------------


### PR DESCRIPTION
On OpenGL 3.20 with GLEW I have found that GL_CLIP_ORIGIN is defined and therefore the code block is run but it is invalid to call glGetIntegerv on GL_CLIP_ORIGIN in OpenGL 3.20 (Intel HD 4000).

The resulting invalid call causes a GL_INVALID_ENUM to be returned.

This fix adds a runtime check to ensure that we're using OpenGL 4.5 before using the clip control functionality.