### PR TITLE
Update example makefiles to check the new homebrew paths

### DIFF
--- a/examples/example_glfw_opengl2/Makefile
+++ b/examples/example_glfw_opengl2/Makefile
@@ -41,11 +41,11 @@ endif
 ifeq ($(UNAME_S), Darwin) #APPLE
 	ECHO_MESSAGE = "Mac OS X"
 	LIBS += -framework OpenGL -framework Cocoa -framework IOKit -framework CoreVideo
-	LIBS += -L/usr/local/lib -L/opt/local/lib
+	LIBS += -L/usr/local/lib -L/opt/local/lib -L/opt/homebrew/lib
 	#LIBS += -lglfw3
 	LIBS += -lglfw
 
-	CXXFLAGS += -I/usr/local/include -I/opt/local/include
+	CXXFLAGS += -I/usr/local/include -I/opt/local/include -I/opt/homebrew/include
 	CFLAGS = $(CXXFLAGS)
 endif
 

--- a/examples/example_glfw_opengl3/Makefile
+++ b/examples/example_glfw_opengl3/Makefile
@@ -80,11 +80,11 @@ endif
 ifeq ($(UNAME_S), Darwin) #APPLE
 	ECHO_MESSAGE = "Mac OS X"
 	LIBS += -framework OpenGL -framework Cocoa -framework IOKit -framework CoreVideo
-	LIBS += -L/usr/local/lib -L/opt/local/lib
+	LIBS += -L/usr/local/lib -L/opt/local/lib -L/opt/homebrew/lib
 	#LIBS += -lglfw3
 	LIBS += -lglfw
 
-	CXXFLAGS += -I/usr/local/include -I/opt/local/include
+	CXXFLAGS += -I/usr/local/include -I/opt/local/include -I/opt/homebrew/include
 	CFLAGS = $(CXXFLAGS)
 endif
 


### PR DESCRIPTION
Homebrew on Apple Silicon (i.e. Macbook Air/Pro M1) use
`/opt/homebrew` instead of `/usr/local`. This patch adds this path when
searching for GLFW.

SDL uses the `sdl2-config` helper tool, so that doesn't require any change.

This solves errors like this on Apple silicon where glfw IS installed:

```
c++ -I../.. -I../../backends -g -Wall -Wformat -I../libs/gl3w -DIMGUI_IMPL_OPENGL_LOADER_GL3W -I/usr/local/include -I/opt/local/include -c -o main.o main.cpp
main.cpp:40:10: fatal error: 'GLFW/glfw3.h' file not found
#include <GLFW/glfw3.h>
         ^~~~~~~~~~~~~~
1 error generated.
```
