### PR TITLE
Fix valid unicode in clipboard paste being filtered by special key filter

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -1000,7 +1000,8 @@ enum ImGuiInputTextFlags_
     ImGuiInputTextFlags_CallbackEdit        = 1 << 19,  // Callback on any edit (note that InputText() already returns true on edit, the callback is useful mainly to manipulate the underlying buffer while focus is active)
     // [Internal]
     ImGuiInputTextFlags_Multiline           = 1 << 20,  // For internal use by InputTextMultiline()
-    ImGuiInputTextFlags_NoMarkEdited        = 1 << 21   // For internal use by functions using InputText() before reformatting data
+    ImGuiInputTextFlags_NoMarkEdited        = 1 << 21,   // For internal use by functions using InputText() before reformatting data
+    ImGuiInputTextFlags_FromClipboard       = 1 << 22   // For internal use during reformatting data
 
     // Obsolete names (will be removed soon)
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -3790,7 +3790,7 @@ static bool InputTextFilterCharacter(unsigned int* p_char, ImGuiInputTextFlags f
         return false;
 
     // Filter private Unicode range. GLFW on OSX seems to send private characters for special keys like arrow keys (FIXME)
-    if (c >= 0xE000 && c <= 0xF8FF)
+    if ( !(flags & ImGuiInputTextFlags_FromClipboard) && c >= 0xE000 && c <= 0xF8FF)
         return false;
 
     // Filter Unicode ranges we are not handling in this build.
@@ -4250,7 +4250,7 @@ bool ImGui::InputTextEx(const char* label, const char* hint, char* buf, int buf_
                     s += ImTextCharFromUtf8(&c, s, NULL);
                     if (c == 0)
                         break;
-                    if (!InputTextFilterCharacter(&c, flags, callback, callback_user_data))
+                    if (!InputTextFilterCharacter(&c, flags | ImGuiInputTextFlags_FromClipboard, callback, callback_user_data))
                         continue;
                     clipboard_filtered[clipboard_filtered_len++] = (ImWchar)c;
                 }


### PR DESCRIPTION
Note: This PR is based on `docking` branch, but I can create a master branch PR if required.

Currently pasting a valid unicode character (such as when using an icon font) can result in it being filtered by the lines:

```C++
    // Filter private Unicode range. GLFW on OSX seems to send private characters for special keys like arrow keys (FIXME)
    if (c >= 0xE000 && c <= 0xF8FF)
        return false;
```

Since pastes originate from the clipboard, they are likely valid unicode and do not originate from these special keys, thus my proposed solution is a flag which hints the data source is from a clipboard, rather than from key presses:

```C++
    // Filter private Unicode range. GLFW on OSX seems to send private characters for special keys like arrow keys (FIXME)
    if ( !(flags & ImGuiInputTextFlags_FromClipboard) && c >= 0xE000 && c <= 0xF8FF)
        return false;
```

This is a 3 line change (actually 4 since there is a separator needed on the last flag), with limited surface area. Since it's fairly simple it may be easiest for you to modify the code directly rather than accept this PR.
