### PR TITLE
Changed default Windows clipboard handler to expand LF to CRLF to fix clipboard corruption on some systems

### DIFF
--- a/backends/imgui_impl_allegro5.cpp
+++ b/backends/imgui_impl_allegro5.cpp
@@ -43,8 +43,9 @@
 #include <allegro5/allegro_primitives.h>
 #ifdef _WIN32
 #include <allegro5/allegro_windows.h>
-#endif
+#else // Never use Allegro's clipboard implementation on Windows since it has issues on some systems.
 #define ALLEGRO_HAS_CLIPBOARD   (ALLEGRO_VERSION_INT >= ((5 << 24) | (1 << 16) | (12 << 8)))    // Clipboard only supported from Allegro 5.1.12
+#endif
 
 // Visual Studio warnings
 #ifdef _MSC_VER

--- a/backends/imgui_impl_glfw.cpp
+++ b/backends/imgui_impl_glfw.cpp
@@ -78,6 +78,7 @@ static GLFWscrollfun        g_PrevUserCallbackScroll = NULL;
 static GLFWkeyfun           g_PrevUserCallbackKey = NULL;
 static GLFWcharfun          g_PrevUserCallbackChar = NULL;
 
+#if !defined(_WIN32)
 static const char* ImGui_ImplGlfw_GetClipboardText(void* user_data)
 {
     return glfwGetClipboardString((GLFWwindow*)user_data);
@@ -87,6 +88,7 @@ static void ImGui_ImplGlfw_SetClipboardText(void* user_data, const char* text)
 {
     glfwSetClipboardString((GLFWwindow*)user_data, text);
 }
+#endif
 
 void ImGui_ImplGlfw_MouseButtonCallback(GLFWwindow* window, int button, int action, int mods)
 {
@@ -173,9 +175,11 @@ static bool ImGui_ImplGlfw_Init(GLFWwindow* window, bool install_callbacks, Glfw
     io.KeyMap[ImGuiKey_Y] = GLFW_KEY_Y;
     io.KeyMap[ImGuiKey_Z] = GLFW_KEY_Z;
 
+#if !defined(_WIN32) // The glfwSetClipboardString Windows implementation has problems on some systems
     io.SetClipboardTextFn = ImGui_ImplGlfw_SetClipboardText;
     io.GetClipboardTextFn = ImGui_ImplGlfw_GetClipboardText;
     io.ClipboardUserData = g_Window;
+#endif
 #if defined(_WIN32)
     io.ImeWindowHandle = (void*)glfwGetWin32Window(g_Window);
 #endif

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -68,6 +68,7 @@ Other Changes:
 - Examples: Vulkan: Prefer using discrete GPU if there are more than one available. (#4012) [@rokups]
 - Examples: SDL2: Link with shell32.lib required by SDL2main.lib since SDL 2.0.12. [#3988]
 - Docs: Improvements to minor mistakes in documentation comments (#3923) [@ANF-Studios]
+- Misc: Changed default Windows clipboard handler to expand LF to CRLF to fix clipboard corruption on some systems. (#4029) [@PathogenDavid]
 
 
 -----------------------------------------------------------------------


### PR DESCRIPTION
✨ CRLF: Because Teletype machines are still relevant in 2021 ✨

# Background

This PR fixes the clipboard corruption bug described in https://github.com/ocornut/imgui/issues/4029

In short: For whatever reason, that user's clipboard gets corrupted when copying text containing non-CRLF newlines. Unfortunately, even after configuring my system to use Russian I was unable to reproduce the issue locally so we're not 100% sure what causes this.

Regardless though, [the Windows documentation](https://docs.microsoft.com/en-us/windows/win32/dataxchg/standard-clipboard-formats) *does* state that the `CF_UNICODETEXT` clipboard format is expected to use CRLF newlines, so using CRLF newlines is the technically correct thing to do:

> Unicode text format. **Each line ends with a carriage return/linefeed (CR-LF) combination.** A null character signals the end of the data.

As a random anecdotal sample: [SDL's `WIN_SetClipboardText` function](https://github.com/libsdl-org/SDL/blob/bd06538778102f72bad8393ef07da5a1ec444217/src/video/windows/SDL_windowsclipboard.c#L81-L87) expands LF to CRLF as well.

# Changes

The changes to the existing implementation are essentially:

1. Scan the input string and count LF newlines that are not a part of a CRLF newline.
2. Over-allocate the clipboard text buffer by the number of bare LF newlines to make room for the CRs to be added later.
3. After the UTF8 -> UTF16 widening, convert the bare LF newlines to CRLF.

The widening is implemented by iterating over the string backwards and copying it to the end of the buffer to avoid the need for allocating an extra buffer. It's also skipped if the copied text did not contain any newlines. (If that chubby for loop grosses you out too much, I can rewrite it to be simpler at the expense of double-allocating the clipboard buffer.)

# Performance

Since this bug seems to be extremely niche I took some basic performance metrics to see how the changes affected things. Unsurprisingly, the performance impact is negligible for a function called so rarely (and usually with very little data.) The results on my machine are summarized below:

Sample Data | Current Implementation | This PR's Implementation
-----|-----|-----
"Hello, world!" | 0.073100 ms | 0.491900 ms
`imgui.cpp` with CRLF line endings (566 KB) | 1.428400 ms | 8.495800 ms
`imgui.cpp` with LF line endings (555 KB) | 1.161600 ms | 11.585000 ms
The complete works of William Shakespeare (10.8 MB) | 28.956500 ms | 90.826100 ms

Since this isn't a proper microbenchmark, those results tend to be pretty noisy. Either way I don't think people are regularly copying the entirety of the complete works of William Shakespeare from a Dear ImGui app, so I don't think the performance regression will hurt anyone 😅

You can find these source of these quick-and-dirty benchmarks in my [`GH-4029` branch](https://github.com/PathogenDavid/imgui/tree/GH-4029) in the `example_glfw_opengl3` project.

# GLFW

[GLFW's `_glfwPlatformSetClipboardString` implementation](https://github.com/glfw/glfw/blob/b925a54ef11adab250e4e9592afe918c1f8caebb/src/win32_window.c#L2200) also has this issue.

As such, I've modified `imgui_impl_glfw.cpp` to use Dear ImGui's built-in clipboard handling when building for Windows. I did this mainly because our GLFW backend appears to prefer keeping backwards compatibility with older versions of GLFW and the GLFW clipboard implementation offers little value over our own.

(If I get around to submitting a PR to GLFW we could put it behind a version gate on Windows once it's merged and released.)

# Allegro

[Allegro's `win_set_clipboard_text` implementation](https://github.com/liballeg/allegro5/blob/4aa54e6c994af21bc63d8b593673ab3df62390f8/src/win/wclipboard.c#L85-L86) also has this issue. The linked comment suggests they might be resistant to changing this.

As such, I disabled the use of Allegro's clipboard in `imgui_impl_allegro5.cpp` on Windows as well.