### PR TITLE
scalable fonts & shadows

### DIFF
--- a/backends/imgui_impl_dx11.cpp
+++ b/backends/imgui_impl_dx11.cpp
@@ -343,6 +343,10 @@ bool    ImGui_ImplDX11_CreateDeviceObjects()
     if (g_pFontSampler)
         ImGui_ImplDX11_InvalidateDeviceObjects();
 
+#ifndef IMGUI_DISABLE_SDF
+    bool sdf = (ImGui::GetIO().BackendFlags & ImGuiBackendFlags_SignedDistanceFonts) | (ImGui::GetIO().BackendFlags & ImGuiBackendFlags_SignedDistanceShapes);
+#endif
+
     // By using D3DCompile() from <d3dcompiler.h> / d3dcompiler.lib, we introduce a dependency to a given version of d3dcompiler_XX.dll (see D3DCOMPILER_DLL_A)
     // If you would like to use this DX11 sample code but remove this dependency you can:
     //  1) compile once, save the compiled shader blobs into a file or source code and pass them to CreateVertexShader()/CreatePixelShader() [preferred solution]
@@ -351,7 +355,7 @@ bool    ImGui_ImplDX11_CreateDeviceObjects()
 
     // Create the vertex shader
     {
-        static const char* vertexShader =
+        static const char* vertexShaderDirect =
             "cbuffer vertexBuffer : register(b0) \
             {\
               float4x4 ProjectionMatrix; \
@@ -379,9 +383,63 @@ bool    ImGui_ImplDX11_CreateDeviceObjects()
               return output;\
             }";
 
+#ifndef IMGUI_DISABLE_SDF
+        static const char* vertexShaderSDF =
+            "cbuffer vertexBuffer : register(b0) \
+            {\
+              float4x4 ProjectionMatrix; \
+            };\
+            struct VS_INPUT\
+            {\
+              float2 pos : POSITION;\
+              float2 uv  : TEXCOORD0;\
+              float4 innerColor : COLOR0;\
+              float4 startOuterColor : COLOR1;\
+              float4 endOuterColor : COLOR2;\
+              float a : COLOR3; \
+              float b : COLOR4; \
+              float w : COLOR5; \
+            };\
+            \
+            struct PS_INPUT\
+            {\
+              float4 pos : SV_POSITION;\
+              float2 uv  : TEXCOORD0;\
+              float4 innerColor : COLOR0;\
+              float4 startOuterColor : COLOR1;\
+              float4 endOuterColor : COLOR2;\
+              nointerpolation float a : COLOR3; \
+              nointerpolation float b : COLOR4; \
+              nointerpolation float w : COLOR5; \
+            };\
+            \
+            PS_INPUT main(VS_INPUT input)\
+            {\
+              PS_INPUT output;\
+              output.pos = mul(ProjectionMatrix, float4(input.pos.xy, 0.f, 1.f));\
+              output.uv  = input.uv;\
+              output.innerColor = input.innerColor;\
+              output.startOuterColor = input.startOuterColor;\
+              output.endOuterColor = input.endOuterColor;\
+              output.a = input.a;\
+              output.b = input.b;\
+              output.w = input.w;\
+              return output;\
+            }";
+
+        const char* vertexShader = sdf ? vertexShaderSDF : vertexShaderDirect;
+#else
+        const char* vertexShader = vertexShaderDirect;
+#endif
+
         ID3DBlob* vertexShaderBlob;
-        if (FAILED(D3DCompile(vertexShader, strlen(vertexShader), NULL, NULL, NULL, "main", "vs_4_0", 0, 0, &vertexShaderBlob, NULL)))
+        ID3DBlob* pError;
+        if (FAILED(D3DCompile(vertexShader, strlen(vertexShader), NULL, NULL, NULL, "main", "vs_4_0", 0, 0, &vertexShaderBlob, &pError))) {
+            if (pError) {
+                fprintf(stderr, "VertexShader: %s\n", (char*)pError->GetBufferPointer());
+            }
             return false; // NB: Pass ID3DBlob* pErrorBlob to D3DCompile() to get error showing in (const char*)pErrorBlob->GetBufferPointer(). Make sure to Release() the blob!
+        }
         if (g_pd3dDevice->CreateVertexShader(vertexShaderBlob->GetBufferPointer(), vertexShaderBlob->GetBufferSize(), NULL, &g_pVertexShader) != S_OK)
         {
             vertexShaderBlob->Release();
@@ -391,12 +449,24 @@ bool    ImGui_ImplDX11_CreateDeviceObjects()
         // Create the input layout
         D3D11_INPUT_ELEMENT_DESC local_layout[] =
         {
-            { "POSITION", 0, DXGI_FORMAT_R32G32_FLOAT,   0, (UINT)IM_OFFSETOF(ImDrawVert, pos), D3D11_INPUT_PER_VERTEX_DATA, 0 },
-            { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT,   0, (UINT)IM_OFFSETOF(ImDrawVert, uv),  D3D11_INPUT_PER_VERTEX_DATA, 0 },
-            { "COLOR",    0, DXGI_FORMAT_R8G8B8A8_UNORM, 0, (UINT)IM_OFFSETOF(ImDrawVert, col), D3D11_INPUT_PER_VERTEX_DATA, 0 },
+            { "POSITION", 0, DXGI_FORMAT_R32G32_FLOAT,   0, (UINT)IM_OFFSETOF(ImDrawVert, pos),  D3D11_INPUT_PER_VERTEX_DATA, 0 },
+            { "COLOR",    0, DXGI_FORMAT_R8G8B8A8_UNORM, 0, (UINT)IM_OFFSETOF(ImDrawVert, col),  D3D11_INPUT_PER_VERTEX_DATA, 0 },
+            { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT,   0, (UINT)IM_OFFSETOF(ImDrawVert, uv),   D3D11_INPUT_PER_VERTEX_DATA, 0 },
+#ifndef IMGUI_DISABLE_SDF
+            { "COLOR",    1, DXGI_FORMAT_R8G8B8A8_UNORM, 0, (UINT)IM_OFFSETOF(ImDrawVert, startOuterColor),  D3D11_INPUT_PER_VERTEX_DATA, 0 },
+            { "COLOR",    2, DXGI_FORMAT_R8G8B8A8_UNORM, 0, (UINT)IM_OFFSETOF(ImDrawVert, endOuterColor),  D3D11_INPUT_PER_VERTEX_DATA, 0 },
+            { "COLOR",    3, DXGI_FORMAT_R32_FLOAT,      0, (UINT)IM_OFFSETOF(ImDrawVert, a), D3D11_INPUT_PER_VERTEX_DATA, 0 },
+            { "COLOR",    4, DXGI_FORMAT_R32_FLOAT,      0, (UINT)IM_OFFSETOF(ImDrawVert, b), D3D11_INPUT_PER_VERTEX_DATA, 0 },
+            { "COLOR",    5, DXGI_FORMAT_R32_FLOAT,      0, (UINT)IM_OFFSETOF(ImDrawVert, w), D3D11_INPUT_PER_VERTEX_DATA, 0 },
+#endif
         };
+#ifndef IMGUI_DISABLE_SDF
+        if (g_pd3dDevice->CreateInputLayout(local_layout, sdf ? 8 : 3, vertexShaderBlob->GetBufferPointer(), vertexShaderBlob->GetBufferSize(), &g_pInputLayout) != S_OK)
+#else
         if (g_pd3dDevice->CreateInputLayout(local_layout, 3, vertexShaderBlob->GetBufferPointer(), vertexShaderBlob->GetBufferSize(), &g_pInputLayout) != S_OK)
+#endif
         {
+            assert(false);
             vertexShaderBlob->Release();
             return false;
         }
@@ -416,7 +486,7 @@ bool    ImGui_ImplDX11_CreateDeviceObjects()
 
     // Create the pixel shader
     {
-        static const char* pixelShader =
+        static const char* pixelShaderDirect =
             "struct PS_INPUT\
             {\
             float4 pos : SV_POSITION;\
@@ -432,9 +502,61 @@ bool    ImGui_ImplDX11_CreateDeviceObjects()
             return out_col; \
             }";
 
+#ifndef IMGUI_DISABLE_SDF
+        static const char* pixelShaderSDF =
+            "struct PS_INPUT\
+            {\
+            float4 pos : SV_POSITION;\
+            float2 uv  : TEXCOORD0;\
+            float4 innerColor : COLOR0;\
+            float4 startOuterColor : COLOR1;\
+            float4 endOuterColor : COLOR2;\
+            nointerpolation float a : COLOR3; \
+            nointerpolation float b : COLOR4; \
+            nointerpolation float w : COLOR5; \
+            }; \
+            sampler sampler0; \
+            Texture2D texture0; \
+            \
+            float stretch(float low, float high, float x) {\n"
+            "    return clamp((x-low)/(high-low), 0.0, 1.0);\
+            }\
+            [earlydepthstencil] float4 main(PS_INPUT input) : SV_Target {\
+                if (input.a == 0.0) \
+                    return input.innerColor * texture0.Sample(sampler0, input.uv); \
+                float distance;\
+                if (input.a >= 2.0) {\
+                    input.a = input.a - 2.0;\
+                    distance = 1.0 - clamp(length(input.uv), 0.0, 1.0);\
+                } else {\
+                    distance = texture0.Sample(sampler0, input.uv).a;\
+                }\
+                if (distance >= input.a + input.w) return input.innerColor;\
+                if (distance <= input.b - input.w) discard; \
+                float m = stretch(input.a - input.w, min(1.0, input.a + input.w), distance);\
+                if (input.a <= input.b) \
+                    return float4(input.innerColor.rgb, input.innerColor.a * m);\
+                float outerMix = stretch(input.b, input.a, distance);\
+                float4 outer = lerp(input.endOuterColor, input.startOuterColor, outerMix);\
+                outer.a *= stretch(input.b - input.w, input.b + input.w, distance);\
+                float ia = m * input.innerColor.a;\
+                float oa = (1 - m) * outer.a;\
+                float a = ia + oa;\
+                return float4((input.innerColor.rgb * ia + outer.rgb * oa) / a, a);\
+            }";
+        const char* pixelShader = sdf ? pixelShaderSDF : pixelShaderDirect;
+#else
+        const char* pixelShader = pixelShaderDirect;
+#endif
+
         ID3DBlob* pixelShaderBlob;
-        if (FAILED(D3DCompile(pixelShader, strlen(pixelShader), NULL, NULL, NULL, "main", "ps_4_0", 0, 0, &pixelShaderBlob, NULL)))
+        ID3DBlob* pError;
+        if (FAILED(D3DCompile(pixelShader, strlen(pixelShader), NULL, NULL, NULL, "main", "ps_4_0", 0, 0, &pixelShaderBlob, &pError))) {
+            if (pError) {
+                fprintf(stderr, "PixelShader: %s\n", (char*)pError->GetBufferPointer());
+            }
             return false; // NB: Pass ID3DBlob* pErrorBlob to D3DCompile() to get error showing in (const char*)pErrorBlob->GetBufferPointer(). Make sure to Release() the blob!
+        }
         if (g_pd3dDevice->CreatePixelShader(pixelShaderBlob->GetBufferPointer(), pixelShaderBlob->GetBufferSize(), NULL, &g_pPixelShader) != S_OK)
         {
             pixelShaderBlob->Release();
@@ -508,12 +630,15 @@ void    ImGui_ImplDX11_InvalidateDeviceObjects()
     if (g_pVertexShader) { g_pVertexShader->Release(); g_pVertexShader = NULL; }
 }
 
-bool    ImGui_ImplDX11_Init(ID3D11Device* device, ID3D11DeviceContext* device_context)
+bool    ImGui_ImplDX11_Init(ID3D11Device* device, ID3D11DeviceContext* device_context, ImGuiBackendFlags flags)
 {
     // Setup backend capabilities flags
     ImGuiIO& io = ImGui::GetIO();
     io.BackendRendererName = "imgui_impl_dx11";
     io.BackendFlags |= ImGuiBackendFlags_RendererHasVtxOffset;  // We can honor the ImDrawCmd::VtxOffset field, allowing for large meshes.
+    io.BackendFlags |= (flags & ImGuiBackendFlags_SignedDistanceFonts);
+    io.BackendFlags |= (flags & ImGuiBackendFlags_SignedDistanceShapes);
+    io.BackendFlags |= ImGuiBackendFlags_ProvocingVertexFirst;
 
     // Get factory from device
     IDXGIDevice* pDXGIDevice = NULL;

--- a/backends/imgui_impl_dx11.h
+++ b/backends/imgui_impl_dx11.h
@@ -15,7 +15,7 @@
 struct ID3D11Device;
 struct ID3D11DeviceContext;
 
-IMGUI_IMPL_API bool     ImGui_ImplDX11_Init(ID3D11Device* device, ID3D11DeviceContext* device_context);
+IMGUI_IMPL_API bool     ImGui_ImplDX11_Init(ID3D11Device* device, ID3D11DeviceContext* device_context, ImGuiBackendFlags flags = ImGuiBackendFlags_DefaultFast);
 IMGUI_IMPL_API void     ImGui_ImplDX11_Shutdown();
 IMGUI_IMPL_API void     ImGui_ImplDX11_NewFrame();
 IMGUI_IMPL_API void     ImGui_ImplDX11_RenderDrawData(ImDrawData* draw_data);

--- a/backends/imgui_impl_metal.h
+++ b/backends/imgui_impl_metal.h
@@ -14,7 +14,7 @@
 @class MTLRenderPassDescriptor;
 @protocol MTLDevice, MTLCommandBuffer, MTLRenderCommandEncoder;
 
-IMGUI_IMPL_API bool ImGui_ImplMetal_Init(id<MTLDevice> device);
+IMGUI_IMPL_API bool ImGui_ImplMetal_Init(id<MTLDevice> device, ImGuiBackendFlags flags = ImGuiBackendFlags_DefaultFast);
 IMGUI_IMPL_API void ImGui_ImplMetal_Shutdown();
 IMGUI_IMPL_API void ImGui_ImplMetal_NewFrame(MTLRenderPassDescriptor* renderPassDescriptor);
 IMGUI_IMPL_API void ImGui_ImplMetal_RenderDrawData(ImDrawData* draw_data,

--- a/backends/imgui_impl_metal.mm
+++ b/backends/imgui_impl_metal.mm
@@ -76,11 +76,14 @@ static MetalContext *g_sharedMetalContext = nil;
 
 #pragma mark - ImGui API implementation
 
-bool ImGui_ImplMetal_Init(id<MTLDevice> device)
+bool ImGui_ImplMetal_Init(id<MTLDevice> device, ImGuiBackendFlags flags)
 {
     ImGuiIO& io = ImGui::GetIO();
     io.BackendRendererName = "imgui_impl_metal";
     io.BackendFlags |= ImGuiBackendFlags_RendererHasVtxOffset;  // We can honor the ImDrawCmd::VtxOffset field, allowing for large meshes.
+    io.BackendFlags |= (flags & ImGuiBackendFlags_SignedDistanceFonts);
+    io.BackendFlags |= (flags & ImGuiBackendFlags_SignedDistanceShapes);
+    io.BackendFlags |= ImGuiBackendFlags_ProvocingVertexFirst;
 
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -313,7 +316,7 @@ void ImGui_ImplMetal_DestroyDeviceObjects()
 {
     NSError *error = nil;
 
-    NSString *shaderSource = @""
+    NSString *shaderSourceDirect = @""
     "#include <metal_stdlib>\n"
     "using namespace metal;\n"
     "\n"
@@ -349,6 +352,90 @@ void ImGui_ImplMetal_DestroyDeviceObjects()
     "    return half4(in.color) * texColor;\n"
     "}\n";
 
+#ifndef IMGUI_DISABLE_SDF
+    NSString *shaderSourceSDF = @""
+    "#include <metal_stdlib>\n"
+    "using namespace metal;\n"
+    "\n"
+    "struct Uniforms {\n"
+    "    float4x4 projectionMatrix;\n"
+    "};\n"
+    "\n"
+    "struct VertexIn {\n"
+    "    float2 position        [[attribute(0)]];\n"
+    "    float2 texCoords       [[attribute(1)]];\n"
+    "    uchar4 innerColor      [[attribute(2)]];\n"
+    "    uchar4 startOuterColor [[attribute(3)]];\n"
+    "    uchar4 endOuterColor   [[attribute(4)]];\n"
+    "    float a                [[attribute(5)]];\n"
+    "    float b                [[attribute(6)]];\n"
+    "    float w                [[attribute(7)]];\n"
+    "};\n"
+    "\n"
+    "struct VertexOut {\n"
+    "    float4 position [[position]];\n"
+    "    float2 texCoords;\n"
+    "    float4 innerColor;\n"
+    "    float4 startOuterColor;\n"
+    "    float4 endOuterColor;\n"
+    "    float a                [[flat]];\n"
+    "    float b                [[flat]];\n"
+    "    float w                [[flat]];\n"
+    "};\n"
+    "\n"
+    "vertex VertexOut vertex_main(VertexIn in                 [[stage_in]],\n"
+    "                             constant Uniforms &uniforms [[buffer(1)]]) {\n"
+    "    VertexOut out;\n"
+    "    out.position = uniforms.projectionMatrix * float4(in.position, 0, 1);\n"
+    "    out.texCoords = in.texCoords;\n"
+    "    out.innerColor = float4(in.innerColor) / float4(255.0);\n"
+    "    out.startOuterColor = float4(in.startOuterColor) / float4(255.0);\n"
+    "    out.endOuterColor = float4(in.endOuterColor) / float4(255.0);\n"
+    "    out.a = in.a;\n"
+    "    out.b = in.b;\n"
+    "    out.w = in.w;\n"
+    "    return out;\n"
+    "}\n"
+    "\n"
+    "float stretch(float low, float high, float x) {\n"
+    "  return clamp((x-low)/(high-low), 0.0, 1.0);\n"
+    "}\n"
+    "[[early_fragment_tests]] fragment float4 fragment_main(VertexOut in [[stage_in]],\n"
+    "                             texture2d<half, access::sample> texture [[texture(0)]]) {\n"
+    "    constexpr sampler linearSampler(coord::normalized, min_filter::linear, mag_filter::linear, mip_filter::linear);\n"
+    "    if (in.a == 0) {\n"
+    "        half4 c = texture.sample(linearSampler, in.texCoords);\n"
+    "        return float4(c) * in.innerColor;\n"
+    "    }\n"
+    "    float distance;\n"
+    "    if (in.a >= 2.0) {\n"
+    "        in.a = in.a - 2.0;\n"
+    "        distance = 1.0 - clamp(length(in.texCoords), 0.0, 1.0);\n"
+    "    } else {\n"
+    "        distance = texture.sample(linearSampler, in.texCoords).a;\n"
+    "    }\n"
+    "    if (distance >= in.a + in.w) {\n"
+    "        return in.innerColor;\n"
+    "    }\n"
+    "  if (distance <= in.b - in.w) { discard_fragment(); return float4(0.0, 0.0, 0.0, 0.0); } \n"
+    "  float m = stretch(in.a - in.w, min(1.0, in.a + in.w), distance); \n"
+    "  if (in.a <= in.b) {\n"
+    "    return float4(in.innerColor.rgb, in.innerColor.a * m);\n"
+    "  }\n"
+    "  float outerMix = stretch(in.b, in.a, distance); \n"
+    "  float4 outer = mix(in.endOuterColor, in.startOuterColor, outerMix); \n"
+    "  outer.a *= stretch(in.b - in.w, in.b + in.w, distance); \n"
+    "  float ia = m * in.innerColor.a;\n"
+    "  float oa = (1 - m) * outer.a;\n"
+    "  float a = ia + oa;\n"
+    "  return float4((in.innerColor.rgb * ia + outer.rgb * oa) / a, a);\n"
+    "}\n";
+
+    NSString* shaderSource = sdf ? shaderSourceSDF : shaderSourceDirect;
+#else
+    NSString* shaderSource = shaderSourceDirect;
+#endif
+
     id<MTLLibrary> library = [device newLibraryWithSource:shaderSource options:nil error:&error];
     if (library == nil)
     {
@@ -375,6 +462,23 @@ void ImGui_ImplMetal_DestroyDeviceObjects()
     vertexDescriptor.attributes[2].offset = IM_OFFSETOF(ImDrawVert, col);
     vertexDescriptor.attributes[2].format = MTLVertexFormatUChar4; // color
     vertexDescriptor.attributes[2].bufferIndex = 0;
+#ifndef IMGUI_DISABLE_SDF
+    vertexDescriptor.attributes[3].offset = IM_OFFSETOF(ImDrawVert, startOuterColor);
+    vertexDescriptor.attributes[3].format = MTLVertexFormatUChar4; // color
+    vertexDescriptor.attributes[3].bufferIndex = 0;
+    vertexDescriptor.attributes[4].offset = IM_OFFSETOF(ImDrawVert, endOuterColor);
+    vertexDescriptor.attributes[4].format = MTLVertexFormatUChar4; // color
+    vertexDescriptor.attributes[4].bufferIndex = 0;
+    vertexDescriptor.attributes[5].offset = IM_OFFSETOF(ImDrawVert, a);
+    vertexDescriptor.attributes[5].format = MTLVertexFormatFloat;
+    vertexDescriptor.attributes[5].bufferIndex = 0;
+    vertexDescriptor.attributes[6].offset = IM_OFFSETOF(ImDrawVert, b);
+    vertexDescriptor.attributes[6].format = MTLVertexFormatFloat;
+    vertexDescriptor.attributes[6].bufferIndex = 0;
+    vertexDescriptor.attributes[7].offset = IM_OFFSETOF(ImDrawVert, w);
+    vertexDescriptor.attributes[7].format = MTLVertexFormatFloat;
+    vertexDescriptor.attributes[7].bufferIndex = 0;
+#endif
     vertexDescriptor.layouts[0].stepRate = 1;
     vertexDescriptor.layouts[0].stepFunction = MTLVertexStepFunctionPerVertex;
     vertexDescriptor.layouts[0].stride = sizeof(ImDrawVert);

--- a/backends/imgui_impl_opengl3.cpp
+++ b/backends/imgui_impl_opengl3.cpp
@@ -148,12 +148,15 @@ static GLuint       g_GlVersion = 0;                // Extracted at runtime usin
 static char         g_GlslVersionString[32] = "";   // Specified by user or detected based on compile time GL settings.
 static GLuint       g_FontTexture = 0;
 static GLuint       g_ShaderHandle = 0, g_VertHandle = 0, g_FragHandle = 0;
-static GLint        g_AttribLocationTex = 0, g_AttribLocationProjMtx = 0;                                // Uniforms location
-static GLuint       g_AttribLocationVtxPos = 0, g_AttribLocationVtxUV = 0, g_AttribLocationVtxColor = 0; // Vertex attributes location
+static GLint        g_AttribLocationTex = 0, g_AttribLocationProjMtx = 0;                                     // Uniforms location
+static GLuint       g_AttribLocationVtxPos = 0, g_AttribLocationVtxUV = 0, g_AttribLocationVtxInnerColor = 0; // Vertex attributes location
+#ifndef IMGUI_DISABLE_SDF
+static GLuint       g_AttribLocationVtxStartOuterColor = 0, g_AttribLocationVtxEndOuterColor = 0, g_AttribLocationVtxW = 0, g_AttribLocationVtxA = 0, g_AttribLocationVtxB = 0; // Vertex attributes location
+#endif
 static unsigned int g_VboHandle = 0, g_ElementsHandle = 0;
 
 // Functions
-bool    ImGui_ImplOpenGL3_Init(const char* glsl_version)
+bool    ImGui_ImplOpenGL3_Init(const char* glsl_version, ImGuiBackendFlags flags)
 {
     // Query for GL version (e.g. 320 for GL 3.2)
 #if !defined(IMGUI_IMPL_OPENGL_ES2)
@@ -179,6 +182,13 @@ bool    ImGui_ImplOpenGL3_Init(const char* glsl_version)
     if (g_GlVersion >= 320)
         io.BackendFlags |= ImGuiBackendFlags_RendererHasVtxOffset;  // We can honor the ImDrawCmd::VtxOffset field, allowing for large meshes.
 #endif
+#ifndef IMGUI_DISABLE_SDF
+    if (g_GlVersion >= 130) {
+      io.BackendFlags |= (flags & ImGuiBackendFlags_SignedDistanceFonts);
+      io.BackendFlags |= (flags & ImGuiBackendFlags_SignedDistanceShapes);
+    }
+#endif
+
 
     // Store GLSL version string so we can refer to it later in case we recreate shaders.
     // Note: GLSL version is NOT the same as GL version. Leave this to NULL if unsure.
@@ -309,10 +319,30 @@ static void ImGui_ImplOpenGL3_SetupRenderState(ImDrawData* draw_data, int fb_wid
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, g_ElementsHandle);
     glEnableVertexAttribArray(g_AttribLocationVtxPos);
     glEnableVertexAttribArray(g_AttribLocationVtxUV);
-    glEnableVertexAttribArray(g_AttribLocationVtxColor);
+    glEnableVertexAttribArray(g_AttribLocationVtxInnerColor);
+
+#ifndef IMGUI_DISABLE_SDF
+    bool sdf = (ImGui::GetIO().BackendFlags & ImGuiBackendFlags_SignedDistanceFonts) | (ImGui::GetIO().BackendFlags & ImGuiBackendFlags_SignedDistanceShapes);
+    if (sdf) {
+      glEnableVertexAttribArray(g_AttribLocationVtxStartOuterColor);
+      glEnableVertexAttribArray(g_AttribLocationVtxEndOuterColor);
+      glEnableVertexAttribArray(g_AttribLocationVtxA);
+      glEnableVertexAttribArray(g_AttribLocationVtxB);
+      glEnableVertexAttribArray(g_AttribLocationVtxW);
+    }
+#endif
     glVertexAttribPointer(g_AttribLocationVtxPos,   2, GL_FLOAT,         GL_FALSE, sizeof(ImDrawVert), (GLvoid*)IM_OFFSETOF(ImDrawVert, pos));
     glVertexAttribPointer(g_AttribLocationVtxUV,    2, GL_FLOAT,         GL_FALSE, sizeof(ImDrawVert), (GLvoid*)IM_OFFSETOF(ImDrawVert, uv));
-    glVertexAttribPointer(g_AttribLocationVtxColor, 4, GL_UNSIGNED_BYTE, GL_TRUE,  sizeof(ImDrawVert), (GLvoid*)IM_OFFSETOF(ImDrawVert, col));
+    glVertexAttribPointer(g_AttribLocationVtxInnerColor, 4, GL_UNSIGNED_BYTE, GL_TRUE,  sizeof(ImDrawVert), (GLvoid*)IM_OFFSETOF(ImDrawVert, col));
+#ifndef IMGUI_DISABLE_SDF
+    if (sdf) {
+      glVertexAttribPointer(g_AttribLocationVtxStartOuterColor, 4, GL_UNSIGNED_BYTE, GL_TRUE,  sizeof(ImDrawVert), (GLvoid*)IM_OFFSETOF(ImDrawVert, startOuterColor));
+      glVertexAttribPointer(g_AttribLocationVtxEndOuterColor, 4, GL_UNSIGNED_BYTE, GL_TRUE,  sizeof(ImDrawVert), (GLvoid*)IM_OFFSETOF(ImDrawVert, endOuterColor));
+      glVertexAttribPointer(g_AttribLocationVtxA,  1, GL_FLOAT,         GL_FALSE, sizeof(ImDrawVert), (GLvoid*)IM_OFFSETOF(ImDrawVert, a));
+      glVertexAttribPointer(g_AttribLocationVtxB,  1, GL_FLOAT,         GL_FALSE, sizeof(ImDrawVert), (GLvoid*)IM_OFFSETOF(ImDrawVert, b));
+      glVertexAttribPointer(g_AttribLocationVtxW,  1, GL_FLOAT,         GL_FALSE, sizeof(ImDrawVert), (GLvoid*)IM_OFFSETOF(ImDrawVert, w));
+    }
+#endif
 }
 
 // OpenGL3 Render function.
@@ -458,7 +488,7 @@ bool ImGui_ImplOpenGL3_CreateFontsTexture()
 {
     // Build texture atlas
     ImGuiIO& io = ImGui::GetIO();
-    unsigned char* pixels;
+    unsigned char* pixels = NULL;
     int width, height;
     io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);   // Load as RGBA 32-bit (75% of the memory is wasted, but default font is so small) because it is more likely to be compatible with user's existing shaders. If your ImTextureId represent a higher-level concept than just a GL texture id, consider calling GetTexDataAsAlpha8() instead to save on GPU memory.
 
@@ -541,64 +571,79 @@ bool    ImGui_ImplOpenGL3_CreateDeviceObjects()
     glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &last_vertex_array);
 #endif
 
+#ifndef IMGUI_DISABLE_SDF
+    bool sdf = (ImGui::GetIO().BackendFlags & ImGuiBackendFlags_SignedDistanceFonts) | (ImGui::GetIO().BackendFlags & ImGuiBackendFlags_SignedDistanceShapes);
+#endif
+
     // Parse GLSL version string
     int glsl_version = 130;
     sscanf(g_GlslVersionString, "#version %d", &glsl_version);
 
+    // needed flat qualifier for SDF is not available in 120
     const GLchar* vertex_shader_glsl_120 =
         "uniform mat4 ProjMtx;\n"
         "attribute vec2 Position;\n"
         "attribute vec2 UV;\n"
-        "attribute vec4 Color;\n"
+        "attribute vec4 InnerColor;\n"
         "varying vec2 Frag_UV;\n"
         "varying vec4 Frag_Color;\n"
         "void main()\n"
         "{\n"
         "    Frag_UV = UV;\n"
-        "    Frag_Color = Color;\n"
+        "    Frag_Color = InnerColor;\n"
         "    gl_Position = ProjMtx * vec4(Position.xy,0,1);\n"
         "}\n";
 
+#define LAYOUT(location, definition) "#if defined(__VERSION__) >= 300\nlayout (location = " location ") " definition ";\n#else\n" definition ";\n#endif\n"
+
+#ifndef IMGUI_DISABLE_SDF
     const GLchar* vertex_shader_glsl_130 =
+        "#ifdef GL_ES\n"
+        "precision mediump float;\n"
+        "#endif\n"
+        LAYOUT("0", "in vec2 Position")
+        LAYOUT("1", "in vec2 UV")
+        LAYOUT("2", "in float a")
+        LAYOUT("3", "in float b")
+        LAYOUT("4", "in float w") // for anti-aliasing
+        LAYOUT("5", "in vec4 InnerColor")      // until a
+        LAYOUT("6", "in vec4 StartOuterColor") // after a
+        LAYOUT("7", "in vec4 EndOuterColor")   // at b
         "uniform mat4 ProjMtx;\n"
-        "in vec2 Position;\n"
-        "in vec2 UV;\n"
-        "in vec4 Color;\n"
         "out vec2 Frag_UV;\n"
-        "out vec4 Frag_Color;\n"
+        "out vec4 Frag_InnerColor;\n"      // until a
+        "out vec4 Frag_StartOuterColor;\n" // after a
+        "out vec4 Frag_EndOuterColor;\n"   // at b
+        "flat out float Frag_a;\n"
+        "flat out float Frag_b;\n"
+        "flat out float Frag_w;\n" // for anti-aliasing
         "void main()\n"
         "{\n"
         "    Frag_UV = UV;\n"
-        "    Frag_Color = Color;\n"
+        "    Frag_InnerColor = InnerColor;\n"
+        "    Frag_StartOuterColor = StartOuterColor;\n"
+        "    Frag_EndOuterColor = EndOuterColor;\n"
+        "    Frag_a = a;\n"
+        "    Frag_b = b;\n"
+        "    Frag_w = w;\n"
         "    gl_Position = ProjMtx * vec4(Position.xy,0,1);\n"
         "}\n";
+#endif
 
     const GLchar* vertex_shader_glsl_300_es =
+        "#ifdef GL_ES\n"
         "precision mediump float;\n"
-        "layout (location = 0) in vec2 Position;\n"
-        "layout (location = 1) in vec2 UV;\n"
-        "layout (location = 2) in vec4 Color;\n"
+        "#endif\n"
+        LAYOUT("0", "in vec2 Position")
+        LAYOUT("1", "in vec2 UV")
+        LAYOUT("2", "in vec4 InnerColor")
         "uniform mat4 ProjMtx;\n"
         "out vec2 Frag_UV;\n"
-        "out vec4 Frag_Color;\n"
+        "out vec4 Frag_InnerColor;\n"
         "void main()\n"
         "{\n"
         "    Frag_UV = UV;\n"
-        "    Frag_Color = Color;\n"
-        "    gl_Position = ProjMtx * vec4(Position.xy,0,1);\n"
-        "}\n";
-
-    const GLchar* vertex_shader_glsl_410_core =
-        "layout (location = 0) in vec2 Position;\n"
-        "layout (location = 1) in vec2 UV;\n"
-        "layout (location = 2) in vec4 Color;\n"
-        "uniform mat4 ProjMtx;\n"
-        "out vec2 Frag_UV;\n"
-        "out vec4 Frag_Color;\n"
-        "void main()\n"
-        "{\n"
-        "    Frag_UV = UV;\n"
-        "    Frag_Color = Color;\n"
+        "    Frag_InnerColor = InnerColor;\n"
         "    gl_Position = ProjMtx * vec4(Position.xy,0,1);\n"
         "}\n";
 
@@ -614,35 +659,69 @@ bool    ImGui_ImplOpenGL3_CreateDeviceObjects()
         "    gl_FragColor = Frag_Color * texture2D(Texture, Frag_UV.st);\n"
         "}\n";
 
+#ifndef IMGUI_DISABLE_SDF
     const GLchar* fragment_shader_glsl_130 =
+        "#ifdef GL_ES\n"
+        "precision mediump float;\n"
+        "#endif\n"
         "uniform sampler2D Texture;\n"
         "in vec2 Frag_UV;\n"
-        "in vec4 Frag_Color;\n"
-        "out vec4 Out_Color;\n"
+        "in vec4 Frag_InnerColor;\n"      // until a
+        "in vec4 Frag_StartOuterColor;\n" // after a
+        "in vec4 Frag_EndOuterColor;\n"   // at b
+        "flat in float Frag_a;\n"
+        "flat in float Frag_b;\n"
+        "flat in float Frag_w;\n" // for anti-aliasing
+        LAYOUT("0", "out vec4 Out_Color")
+        //"float median(float r, float g, float b) { return max(min(r, g), min(max(r, g), b)); }\n"
+        "float stretch(float low, float high, float x) {\n"
+        "  return clamp((x-low)/(high-low), 0.0, 1.0);\n"
+        "}\n"
         "void main()\n"
         "{\n"
-        "    Out_Color = Frag_Color * texture(Texture, Frag_UV.st);\n"
+         "  if (Frag_a == 0.0) {\n"
+        "    Out_Color = texture(Texture, Frag_UV.st) * Frag_InnerColor;\n"
+        "    return;\n"
+        "  }\n"
+        "  float a = Frag_a;\n"
+        "  float distance;\n"
+        "  if (a >= 2.0) {\n"
+        "     a = a - 2.0;\n"
+        "     distance = 1.0 - (Frag_UV.s > 0.0 && Frag_UV.t > 0.0 ? clamp(length(Frag_UV.st), 0.0, 1.0) : max(Frag_UV.s, Frag_UV.t));\n"
+        "  } else {\n"
+        "     distance = texture(Texture, Frag_UV.st).a;\n"
+        "  }\n"
+        "  if (distance >= a + Frag_w) {\n"
+        "    Out_Color = Frag_InnerColor;\n"
+        "    return;\n"
+        "  }\n"
+        "  if (distance <= Frag_b - Frag_w) discard; \n"
+        "  float m = stretch(a - Frag_w, min(1.0, a + Frag_w), distance); \n"
+        "  if (a <= Frag_b) {\n"
+        "    Out_Color = vec4(Frag_InnerColor.rgb, Frag_InnerColor.a * m);\n"
+        "    return;\n"
+        "  }\n"
+        "  float outerMix = stretch(Frag_b, a, distance); \n"
+        "  vec4 outer = mix(Frag_EndOuterColor, Frag_StartOuterColor, outerMix); \n"
+        "  outer.a *= stretch(Frag_b - Frag_w, Frag_b + Frag_w, distance); \n"
+        "  float ia = m * Frag_InnerColor.a;\n"
+        "  float oa = (1.0 - m) * outer.a;\n"
+        "  a = ia + oa;\n"
+        "  Out_Color = vec4((Frag_InnerColor.rgb * ia + outer.rgb * oa) / a, a);\n"
         "}\n";
+#endif
 
     const GLchar* fragment_shader_glsl_300_es =
+        "#ifdef GL_ES\n"
         "precision mediump float;\n"
+        "#endif\n"
         "uniform sampler2D Texture;\n"
         "in vec2 Frag_UV;\n"
-        "in vec4 Frag_Color;\n"
-        "layout (location = 0) out vec4 Out_Color;\n"
+        "in vec4 Frag_InnerColor;\n"
+        LAYOUT("0", "out vec4 Out_Color")
         "void main()\n"
         "{\n"
-        "    Out_Color = Frag_Color * texture(Texture, Frag_UV.st);\n"
-        "}\n";
-
-    const GLchar* fragment_shader_glsl_410_core =
-        "in vec2 Frag_UV;\n"
-        "in vec4 Frag_Color;\n"
-        "uniform sampler2D Texture;\n"
-        "layout (location = 0) out vec4 Out_Color;\n"
-        "void main()\n"
-        "{\n"
-        "    Out_Color = Frag_Color * texture(Texture, Frag_UV.st);\n"
+        "    Out_Color = Frag_InnerColor * texture(Texture, Frag_UV.st);\n"
         "}\n";
 
     // Select shaders matching our GLSL versions
@@ -653,20 +732,17 @@ bool    ImGui_ImplOpenGL3_CreateDeviceObjects()
         vertex_shader = vertex_shader_glsl_120;
         fragment_shader = fragment_shader_glsl_120;
     }
-    else if (glsl_version >= 410)
-    {
-        vertex_shader = vertex_shader_glsl_410_core;
-        fragment_shader = fragment_shader_glsl_410_core;
-    }
-    else if (glsl_version == 300)
-    {
-        vertex_shader = vertex_shader_glsl_300_es;
-        fragment_shader = fragment_shader_glsl_300_es;
-    }
-    else
+#ifndef IMGUI_DISABLE_SDF
+    else if (sdf)
     {
         vertex_shader = vertex_shader_glsl_130;
         fragment_shader = fragment_shader_glsl_130;
+    }
+#endif
+    else
+    {
+        vertex_shader = vertex_shader_glsl_300_es;
+        fragment_shader = fragment_shader_glsl_300_es;
     }
 
     // Create shaders
@@ -692,7 +768,16 @@ bool    ImGui_ImplOpenGL3_CreateDeviceObjects()
     g_AttribLocationProjMtx = glGetUniformLocation(g_ShaderHandle, "ProjMtx");
     g_AttribLocationVtxPos = (GLuint)glGetAttribLocation(g_ShaderHandle, "Position");
     g_AttribLocationVtxUV = (GLuint)glGetAttribLocation(g_ShaderHandle, "UV");
-    g_AttribLocationVtxColor = (GLuint)glGetAttribLocation(g_ShaderHandle, "Color");
+    g_AttribLocationVtxInnerColor = (GLuint)glGetAttribLocation(g_ShaderHandle, "InnerColor");
+#ifndef IMGUI_DISABLE_SDF
+    if (sdf) {
+      g_AttribLocationVtxStartOuterColor = (GLuint)glGetAttribLocation(g_ShaderHandle, "StartOuterColor");
+      g_AttribLocationVtxEndOuterColor = (GLuint)glGetAttribLocation(g_ShaderHandle, "EndOuterColor");
+      g_AttribLocationVtxW = (GLuint)glGetAttribLocation(g_ShaderHandle, "w");
+      g_AttribLocationVtxA = (GLuint)glGetAttribLocation(g_ShaderHandle, "a");
+      g_AttribLocationVtxB = (GLuint)glGetAttribLocation(g_ShaderHandle, "b");
+    }
+#endif
 
     // Create buffers
     glGenBuffers(1, &g_VboHandle);

--- a/backends/imgui_impl_opengl3.h
+++ b/backends/imgui_impl_opengl3.h
@@ -25,7 +25,7 @@
 #include "imgui.h"      // IMGUI_IMPL_API
 
 // Backend API
-IMGUI_IMPL_API bool     ImGui_ImplOpenGL3_Init(const char* glsl_version = NULL);
+IMGUI_IMPL_API bool     ImGui_ImplOpenGL3_Init(const char* glsl_version = NULL, ImGuiBackendFlags flags = ImGuiBackendFlags_DefaultFast);
 IMGUI_IMPL_API void     ImGui_ImplOpenGL3_Shutdown();
 IMGUI_IMPL_API void     ImGui_ImplOpenGL3_NewFrame();
 IMGUI_IMPL_API void     ImGui_ImplOpenGL3_RenderDrawData(ImDrawData* draw_data);

--- a/examples/example_glfw_opengl3/Makefile
+++ b/examples/example_glfw_opengl3/Makefile
@@ -24,7 +24,7 @@ UNAME_S := $(shell uname -s)
 LINUX_GL_LIBS = -lGL
 
 CXXFLAGS = -I$(IMGUI_DIR) -I$(IMGUI_DIR)/backends
-CXXFLAGS += -g -Wall -Wformat
+CXXFLAGS += -g -Wall -Wformat -fPIE
 LIBS =
 
 ##---------------------------------------------------------------------

--- a/examples/example_glfw_opengl3/main.cpp
+++ b/examples/example_glfw_opengl3/main.cpp
@@ -7,6 +7,7 @@
 #include "imgui_impl_glfw.h"
 #include "imgui_impl_opengl3.h"
 #include <stdio.h>
+#include "../sdf_demo.h"
 
 #if defined(IMGUI_IMPL_OPENGL_ES2)
 #include <GLES2/gl2.h>
@@ -123,9 +124,15 @@ int main(int, char**)
     ImGui::StyleColorsDark();
     //ImGui::StyleColorsClassic();
 
+    ImGuiStyle& style = ImGui::GetStyle();
+    style.WindowRounding = 12;
+    style.FrameRounding = 12;
+    style.WindowBorderSize = 0;
+
     // Setup Platform/Renderer backends
     ImGui_ImplGlfw_InitForOpenGL(window, true);
-    ImGui_ImplOpenGL3_Init(glsl_version);
+    // default (if no argument is given) is ImGuiBackendFlags_DefaultFast (no signed distance fonts nor shapes, this is what current users expect)
+    ImGui_ImplOpenGL3_Init(glsl_version, ImGuiBackendFlags_DefaultDesktop);
 
     // Load Fonts
     // - If no fonts are loaded, dear imgui will use the default font. You can also load multiple fonts and use ImGui::PushFont()/PopFont() to select them.
@@ -134,13 +141,33 @@ int main(int, char**)
     // - The fonts will be rasterized at a given size (w/ oversampling) and stored into a texture when calling ImFontAtlas::Build()/GetTexDataAsXXXX(), which ImGui_ImplXXXX_NewFrame below will call.
     // - Read 'docs/FONTS.md' for more instructions and details.
     // - Remember that in C/C++ if you want to include a backslash \ in a string literal you need to write a double backslash \\ !
+    ImFontConfig config;
+    config.SignedDistanceFont = true;
     //io.Fonts->AddFontDefault();
-    //io.Fonts->AddFontFromFileTTF("../../misc/fonts/Roboto-Medium.ttf", 16.0f);
-    //io.Fonts->AddFontFromFileTTF("../../misc/fonts/Cousine-Regular.ttf", 15.0f);
-    //io.Fonts->AddFontFromFileTTF("../../misc/fonts/DroidSans.ttf", 16.0f);
-    //io.Fonts->AddFontFromFileTTF("../../misc/fonts/ProggyTiny.ttf", 10.0f);
+    io.Fonts->AddFontFromFileTTF("../../misc/fonts/Roboto-Medium.ttf", 16.0f, &config);
+    io.Fonts->AddFontFromFileTTF("../../misc/fonts/Cousine-Regular.ttf", 15.0f, &config);
+    io.Fonts->AddFontFromFileTTF("../../misc/fonts/DroidSans.ttf", 16.0f, &config);
+    io.Fonts->AddFontFromFileTTF("../../misc/fonts/ProggyTiny.ttf", 10.0f, &config);
+    io.Fonts->AddFontDefault(&config);
+
+    io.Fonts->AddFontFromFileTTF("../../misc/fonts/Roboto-Medium.ttf", 16.0f);
+    io.Fonts->AddFontFromFileTTF("../../misc/fonts/Cousine-Regular.ttf", 15.0f);
+    io.Fonts->AddFontFromFileTTF("../../misc/fonts/DroidSans.ttf", 16.0f);
+    io.Fonts->AddFontFromFileTTF("../../misc/fonts/ProggyTiny.ttf", 10.0f);
+    io.Fonts->AddFontDefault();
+
+    io.Fonts->AddFontFromFileTTF("../../misc/fonts/Roboto-Medium.ttf", 32.0f, &config);
+    io.Fonts->AddFontFromFileTTF("../../misc/fonts/Cousine-Regular.ttf", 32.0f, &config);
+    io.Fonts->AddFontFromFileTTF("../../misc/fonts/DroidSans.ttf", 32.0f, &config);
+    io.Fonts->AddFontFromFileTTF("../../misc/fonts/ProggyTiny.ttf", 32.0f, &config);
+
+    io.Fonts->AddFontFromFileTTF("../../misc/fonts/Roboto-Medium.ttf", 32.0f);
+    io.Fonts->AddFontFromFileTTF("../../misc/fonts/Cousine-Regular.ttf", 32.0f);
+    io.Fonts->AddFontFromFileTTF("../../misc/fonts/DroidSans.ttf", 32.0f);
+    io.Fonts->AddFontFromFileTTF("../../misc/fonts/ProggyTiny.ttf", 32.0f);
     //ImFont* font = io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\ArialUni.ttf", 18.0f, NULL, io.Fonts->GetGlyphRangesJapanese());
     //IM_ASSERT(font != NULL);
+    
 
     // Our state
     bool show_demo_window = true;
@@ -186,6 +213,9 @@ int main(int, char**)
             ImGui::Text("counter = %d", counter);
 
             ImGui::Text("Application average %.3f ms/frame (%.1f FPS)", 1000.0f / ImGui::GetIO().Framerate, ImGui::GetIO().Framerate);
+
+            SDFDemo();
+            
             ImGui::End();
         }
 

--- a/examples/example_glfw_opengl3/main.cpp
+++ b/examples/example_glfw_opengl3/main.cpp
@@ -121,7 +121,7 @@ int main(int, char**)
     //io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;      // Enable Gamepad Controls
 
     // Setup Dear ImGui style
-    ImGui::StyleColorsDark();
+    ImGui::StyleColorsLight();
     //ImGui::StyleColorsClassic();
 
     ImGuiStyle& style = ImGui::GetStyle();

--- a/examples/example_glfw_opengl3/main.cpp
+++ b/examples/example_glfw_opengl3/main.cpp
@@ -128,6 +128,7 @@ int main(int, char**)
     style.WindowRounding = 12;
     style.FrameRounding = 12;
     style.WindowBorderSize = 0;
+    style.FrameShadowSize = 3;
 
     // Setup Platform/Renderer backends
     ImGui_ImplGlfw_InitForOpenGL(window, true);

--- a/examples/example_win32_directx11/main.cpp
+++ b/examples/example_win32_directx11/main.cpp
@@ -55,7 +55,7 @@ int main(int, char**)
     //io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;      // Enable Gamepad Controls
 
     // Setup Dear ImGui style
-    ImGui::StyleColorsDark();
+    ImGui::StyleColorsLight();
     //ImGui::StyleColorsClassic();
     //
     ImGuiStyle& style = ImGui::GetStyle();

--- a/examples/example_win32_directx11/main.cpp
+++ b/examples/example_win32_directx11/main.cpp
@@ -2,11 +2,16 @@
 // If you are new to Dear ImGui, read documentation from the docs/ folder + read the top of imgui.cpp.
 // Read online: https://github.com/ocornut/imgui/tree/master/docs
 
+#define _USE_MATH_DEFINES
+#include <math.h>
+
 #include "imgui.h"
 #include "imgui_impl_win32.h"
 #include "imgui_impl_dx11.h"
 #include <d3d11.h>
 #include <tchar.h>
+
+#include "../sdf_demo.h"
 
 // Data
 static ID3D11Device*            g_pd3dDevice = NULL;
@@ -55,7 +60,7 @@ int main(int, char**)
 
     // Setup Platform/Renderer backends
     ImGui_ImplWin32_Init(hwnd);
-    ImGui_ImplDX11_Init(g_pd3dDevice, g_pd3dDeviceContext);
+    ImGui_ImplDX11_Init(g_pd3dDevice, g_pd3dDeviceContext, ImGuiBackendFlags_DefaultDesktop);
 
     // Load Fonts
     // - If no fonts are loaded, dear imgui will use the default font. You can also load multiple fonts and use ImGui::PushFont()/PopFont() to select them.
@@ -64,11 +69,30 @@ int main(int, char**)
     // - The fonts will be rasterized at a given size (w/ oversampling) and stored into a texture when calling ImFontAtlas::Build()/GetTexDataAsXXXX(), which ImGui_ImplXXXX_NewFrame below will call.
     // - Read 'docs/FONTS.md' for more instructions and details.
     // - Remember that in C/C++ if you want to include a backslash \ in a string literal you need to write a double backslash \\ !
+    ImFontConfig config;
+    config.SignedDistanceFont = true;
     //io.Fonts->AddFontDefault();
-    //io.Fonts->AddFontFromFileTTF("../../misc/fonts/Roboto-Medium.ttf", 16.0f);
-    //io.Fonts->AddFontFromFileTTF("../../misc/fonts/Cousine-Regular.ttf", 15.0f);
-    //io.Fonts->AddFontFromFileTTF("../../misc/fonts/DroidSans.ttf", 16.0f);
-    //io.Fonts->AddFontFromFileTTF("../../misc/fonts/ProggyTiny.ttf", 10.0f);
+    io.Fonts->AddFontFromFileTTF("../../misc/fonts/Roboto-Medium.ttf", 16.0f, &config);
+    io.Fonts->AddFontFromFileTTF("../../misc/fonts/Cousine-Regular.ttf", 15.0f, &config);
+    io.Fonts->AddFontFromFileTTF("../../misc/fonts/DroidSans.ttf", 16.0f, &config);
+    io.Fonts->AddFontFromFileTTF("../../misc/fonts/ProggyTiny.ttf", 10.0f, &config);
+    io.Fonts->AddFontDefault(&config);
+
+    io.Fonts->AddFontFromFileTTF("../../misc/fonts/Roboto-Medium.ttf", 16.0f);
+    io.Fonts->AddFontFromFileTTF("../../misc/fonts/Cousine-Regular.ttf", 15.0f);
+    io.Fonts->AddFontFromFileTTF("../../misc/fonts/DroidSans.ttf", 16.0f);
+    io.Fonts->AddFontFromFileTTF("../../misc/fonts/ProggyTiny.ttf", 10.0f);
+    io.Fonts->AddFontDefault();
+
+    io.Fonts->AddFontFromFileTTF("../../misc/fonts/Roboto-Medium.ttf", 32.0f, &config);
+    io.Fonts->AddFontFromFileTTF("../../misc/fonts/Cousine-Regular.ttf", 32.0f, &config);
+    io.Fonts->AddFontFromFileTTF("../../misc/fonts/DroidSans.ttf", 32.0f, &config);
+    io.Fonts->AddFontFromFileTTF("../../misc/fonts/ProggyTiny.ttf", 32.0f, &config);
+
+    io.Fonts->AddFontFromFileTTF("../../misc/fonts/Roboto-Medium.ttf", 32.0f);
+    io.Fonts->AddFontFromFileTTF("../../misc/fonts/Cousine-Regular.ttf", 32.0f);
+    io.Fonts->AddFontFromFileTTF("../../misc/fonts/DroidSans.ttf", 32.0f);
+    io.Fonts->AddFontFromFileTTF("../../misc/fonts/ProggyTiny.ttf", 32.0f);
     //ImFont* font = io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\ArialUni.ttf", 18.0f, NULL, io.Fonts->GetGlyphRangesJapanese());
     //IM_ASSERT(font != NULL);
 
@@ -126,6 +150,9 @@ int main(int, char**)
             ImGui::Text("counter = %d", counter);
 
             ImGui::Text("Application average %.3f ms/frame (%.1f FPS)", 1000.0f / ImGui::GetIO().Framerate, ImGui::GetIO().Framerate);
+
+            SDFDemo();
+
             ImGui::End();
         }
 

--- a/examples/example_win32_directx11/main.cpp
+++ b/examples/example_win32_directx11/main.cpp
@@ -57,6 +57,12 @@ int main(int, char**)
     // Setup Dear ImGui style
     ImGui::StyleColorsDark();
     //ImGui::StyleColorsClassic();
+    //
+    ImGuiStyle& style = ImGui::GetStyle();
+    style.WindowRounding = 12;
+    style.FrameRounding = 12;
+    style.WindowBorderSize = 0;
+    style.FrameShadowSize = 3;
 
     // Setup Platform/Renderer backends
     ImGui_ImplWin32_Init(hwnd);

--- a/examples/sdf_demo.h
+++ b/examples/sdf_demo.h
@@ -108,6 +108,7 @@ void SDFDemo() {
   ImGui::Checkbox("top-left", &rounded_top_left);
   ImGui::SameLine();
   ImGui::Checkbox("top-right", &rounded_top_right);
+  ImGui::Checkbox("bottom-left", &rounded_bottom_left);
   ImGui::SameLine();
   ImGui::Checkbox("bottom-right", &rounded_bottom_right);
   ImGui::EndGroup();

--- a/examples/sdf_demo.h
+++ b/examples/sdf_demo.h
@@ -25,7 +25,7 @@ ImVec2 ImRotationCenter()
 
 void ImRotateEnd(float rad, ImVec2 center = ImRotationCenter())
 {
-	float s=sin(rad), c=cos(rad);
+	float s=sinf(rad), c=cosf(rad);
 	center = ImRotate(center, s, c) - center;
 
 	auto& buf = ImGui::GetWindowDrawList()->VtxBuffer;
@@ -41,10 +41,10 @@ void SDFDemo() {
   ImGui::SetWindowFontScale(1);
   ImGui::TextWrapped("Signed distance tester. You can choose multiple fonts in the style manager, supporting both signed distance fonts and regular fonts at the same time. Because of additional shader support that is needed, this is only enabled if the backend enables the new SignedDistance flags.");
   static float scale = 3.0f;
-  static ImVec4 text_inner_color = ImVec4(1.0f, 1.0f, 1.0f, 1.0f);
+  static ImVec4 text_inner_color = ImVec4(1.0f, 1.0f, 1.0f, 0.0f);
   static ImVec4 text_outline_start = ImVec4(1.0f, .0f, .0f, 1.0f);
   static ImVec4 text_outline_end = ImVec4(1.0f, .0f, .0f, 0.0f);
-  static float outline_width = .6;
+  static float outline_width = .6f;
   static float rotate = 0.1f;
 
   ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 50);
@@ -62,7 +62,7 @@ void SDFDemo() {
   ImGui::PopStyleVar(1);
   ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 50);
 
-  ImRotateEnd(rotate + M_PI/2);
+  ImRotateEnd(rotate + float(M_PI/2));
   ImGui::SetWindowFontScale(1);
 
   ImGui::SliderFloat("scale", &scale, 0.2f, 10.0f);
@@ -71,10 +71,10 @@ void SDFDemo() {
   ImGui::ColorEdit4("outline end", (float*)&text_outline_end);
   ImGui::SliderFloat("outline width", &outline_width, 0.0f, .99f);
   static bool animate_rotation = false;
-  ImGui::SliderFloat("rotate", &rotate, 0.0f, 2*M_PI);
+  ImGui::SliderFloat("rotate", &rotate, 0.0f, float(2*M_PI));
   ImGui::Checkbox("Animate rotation", &animate_rotation);
   if (animate_rotation)
-    rotate = 0.05f*ImGui::GetTime();
+    rotate = 0.05f*float(ImGui::GetTime());
 
   ImGui::Separator();
   ImGui::SetWindowFontScale(1.5f);
@@ -88,27 +88,26 @@ void SDFDemo() {
 
   static ImVec4 color = ImColor(IM_COL32(0xff, 0x98, 0x07, 0xff)); //ImGui::GetColorU32(ImGuiCol_Text));
   ImGui::ColorEdit4("inner color", (float*)&color); // Edit 3 floats representing a color
-  static ImVec4 shadowStart = ImVec4(1.0f, 1.0f, 1.0f, .25f);
+  static ImVec4 shadowStart = ImVec4(.0f, .0f, .0f, .25f);
   ImGui::ColorEdit4("shadow start", (float*)&shadowStart); // Edit 3 floats representing a color
-  static ImVec4 shadowEnd = ImVec4(1.0f, 1.0f, 1.0f, 0.0f);
+  static ImVec4 shadowEnd = ImVec4(.0f, .0f, .0f, 0.0f);
   ImGui::ColorEdit4("shadow end", (float*)&shadowEnd); // Edit 3 floats representing a color
 
-  static int shadow = 50;
-  ImGui::SliderInt("shadow", &shadow, 0, 100);
+  static float shadow = 50;
+  ImGui::SliderFloat("shadow", &shadow, 0.0f, 100.0f);
 
   static bool rounded_top_left = true;
   static bool rounded_top_right = true;
   static bool rounded_bottom_left = true;
   static bool rounded_bottom_right = false;
-  static int radius = 100;
-  ImGui::SliderInt("radius", &radius, 0, 200);
+  static float radius = 100.0f;
+  ImGui::SliderFloat("radius", &radius, 0.0f, 200.0f);
   ImGui::Text("Rounded:");
   ImGui::SameLine();
   ImGui::BeginGroup();
   ImGui::Checkbox("top-left", &rounded_top_left);
   ImGui::SameLine();
   ImGui::Checkbox("top-right", &rounded_top_right);
-  ImGui::Checkbox("bottom-left", &rounded_bottom_left);
   ImGui::SameLine();
   ImGui::Checkbox("bottom-right", &rounded_bottom_right);
   ImGui::EndGroup();
@@ -131,10 +130,10 @@ void SDFDemo() {
     flags |= ImDrawFlags_RoundCornersBottomLeft;
   if (rounded_bottom_right)
     flags |= ImDrawFlags_RoundCornersBottomRight;
-  int radiusCopy = radius;
+  float radiusCopy = radius;
   if (flags == 0)
-    radiusCopy = 0;
-  drawList->AddRectFilled(ImVec2(pos.x + 100, pos.y), ImVec2(pos.x + w + 100, pos.y + h), ImColor(color), radiusCopy, flags, shadow, ImColor(shadowStart), ImColor(shadowEnd));
+    radiusCopy = 0.0f;
+  drawList->AddRectFilled(ImVec2(pos.x + 100.0f, pos.y), ImVec2(pos.x + w + 100.0f, pos.y + h), ImColor(color), radiusCopy, flags, shadow, ImColor(shadowStart), ImColor(shadowEnd));
 
   ImGui::SetCursorPosY(ImGui::GetCursorPosY() + h + 50);
 }

--- a/examples/sdf_demo.h
+++ b/examples/sdf_demo.h
@@ -1,0 +1,137 @@
+// Rotate from https://gist.github.com/carasuca/e72aacadcf6cf8139de46f97158f790f
+#include <math.h>
+static inline ImVec2 ImMin(const ImVec2& lhs, const ImVec2& rhs)                { return ImVec2(lhs.x < rhs.x ? lhs.x : rhs.x, lhs.y < rhs.y ? lhs.y : rhs.y); }
+static inline ImVec2 ImMax(const ImVec2& lhs, const ImVec2& rhs)                { return ImVec2(lhs.x >= rhs.x ? lhs.x : rhs.x, lhs.y >= rhs.y ? lhs.y : rhs.y); }
+static inline ImVec2 ImRotate(const ImVec2& v, float cos_a, float sin_a)        { return ImVec2(v.x * cos_a - v.y * sin_a, v.x * sin_a + v.y * cos_a); }
+static inline ImVec2 operator+(const ImVec2& lhs, const ImVec2& rhs)            { return ImVec2(lhs.x + rhs.x, lhs.y + rhs.y); }
+static inline ImVec2 operator-(const ImVec2& lhs, const ImVec2& rhs)            { return ImVec2(lhs.x - rhs.x, lhs.y - rhs.y); }
+static inline ImVec2 operator*(const float& lhs, const ImVec2& rhs)            { return ImVec2(lhs * rhs.x, lhs * rhs.y); }
+int rotation_start_index; 
+void ImRotateStart() 
+{ 
+	rotation_start_index = ImGui::GetWindowDrawList()->VtxBuffer.Size; 
+}
+
+ImVec2 ImRotationCenter()
+{
+	ImVec2 l(FLT_MAX, FLT_MAX), u(-FLT_MAX, -FLT_MAX); // bounds
+
+	const auto& buf = ImGui::GetWindowDrawList()->VtxBuffer;
+	for (int i = rotation_start_index; i < buf.Size; i++)
+		l = ImMin(l, buf[i].pos), u = ImMax(u, buf[i].pos);
+
+	return ImVec2((l.x+u.x)/2, (l.y+u.y)/2); // or use _ClipRectStack?
+}
+
+void ImRotateEnd(float rad, ImVec2 center = ImRotationCenter())
+{
+	float s=sin(rad), c=cos(rad);
+	center = ImRotate(center, s, c) - center;
+
+	auto& buf = ImGui::GetWindowDrawList()->VtxBuffer;
+	for (int i = rotation_start_index; i < buf.Size; i++)
+		buf[i].pos = ImRotate(buf[i].pos, s, c) - center;
+}
+
+
+void SDFDemo() {
+  ImGui::Separator();
+  ImGui::SetWindowFontScale(1.5f);
+  ImGui::Text("Fonts");
+  ImGui::SetWindowFontScale(1);
+  ImGui::TextWrapped("Signed distance tester. You can choose multiple fonts in the style manager, supporting both signed distance fonts and regular fonts at the same time. Because of additional shader support that is needed, this is only enabled if the backend enables the new SignedDistance flags.");
+  static float scale = 3.0f;
+  static ImVec4 text_outline_start = ImVec4(1.0f, .0f, .0f, 1.0f);
+  static ImVec4 text_outline_end = ImVec4(1.0f, .0f, .0f, 0.0f);
+  static float outline_width = .99f;
+  static float rotate = 0.1f;
+
+  ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 50);
+  ImGui::SetWindowFontScale(scale);
+  ImRotateStart();
+
+  ImGui::TextWrapped("Some scaled text.");
+
+  ImGui::PushStyleVar(ImGuiStyleVar_FontShadowSize, outline_width);
+  ImGui::PushStyleColor(ImGuiCol_FontShadowStart, text_outline_start);
+  ImGui::PushStyleColor(ImGuiCol_FontShadowEnd, text_outline_end);
+  ImGui::TextWrapped("Additional styles are supported.");
+  ImGui::PopStyleColor(2);
+  ImGui::PopStyleVar(1);
+  ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 50);
+
+  ImRotateEnd(rotate + M_PI/2);
+  ImGui::SetWindowFontScale(1);
+
+  ImGui::SliderFloat("scale", &scale, 0.2f, 10.0f);
+  ImGui::ColorEdit4("outline start", (float*)&text_outline_start);
+  ImGui::ColorEdit4("outline end", (float*)&text_outline_end);
+  ImGui::SliderFloat("outline width", &outline_width, 0.0f, .99f);
+  static bool animate_rotation = false;
+  ImGui::SliderFloat("rotate", &rotate, 0.0f, 2*M_PI);
+  ImGui::Checkbox("Animate rotation", &animate_rotation);
+  if (animate_rotation)
+    rotate = 0.05f*ImGui::GetTime();
+
+  ImGui::Separator();
+  ImGui::SetWindowFontScale(1.5f);
+  ImGui::Text("Shapes");
+  ImGui::SetWindowFontScale(1);
+  ImGui::TextWrapped("To support text effects, additional information needs be encoded in ImDrawVert. This same information can easily be supported for drawing outlines and shadow for regular shapes. A rounded rectangle with shadow can be drawn with 18 triangles (size of shadow or rounding does not have an impact). See the DrawCmd in Metrics/Debugger window how these rectangles are drawn (especially ones with some round corners, and some straight corners).");
+
+  ImGui::TextWrapped("Support for these new rounded rectangles is enabled if the flag SignedDistanceShapes is set by the backend. If enabled, AddRect and AddRectFilled are using these new implementation of shapes. This causes the number of vertices and triangles to drop significantly when using rounded frames.");
+
+  ImGui::TextWrapped("Because AddRect and AddRectFilled are extended with additional functionality, window and frame shadows can easily be added. To support styling additional variables are introduced: WindowShadowSize and FrameShadowSize (see 'Style' tab).");
+
+  static ImVec4 color = ImColor(IM_COL32(0xff, 0x98, 0x07, 0xff)); //ImGui::GetColorU32(ImGuiCol_Text));
+  ImGui::ColorEdit4("inner color", (float*)&color); // Edit 3 floats representing a color
+  static ImVec4 shadowStart = ImVec4(1.0f, 1.0f, 1.0f, .25f);
+  ImGui::ColorEdit4("shadow start", (float*)&shadowStart); // Edit 3 floats representing a color
+  static ImVec4 shadowEnd = ImVec4(1.0f, 1.0f, 1.0f, 0.0f);
+  ImGui::ColorEdit4("shadow end", (float*)&shadowEnd); // Edit 3 floats representing a color
+
+  static int shadow = 50;
+  ImGui::SliderInt("shadow", &shadow, 0, 100);
+
+  static bool rounded_top_left = true;
+  static bool rounded_top_right = true;
+  static bool rounded_bottom_left = true;
+  static bool rounded_bottom_right = false;
+  static int radius = 100;
+  ImGui::SliderInt("radius", &radius, 0, 200);
+  ImGui::Text("Rounded:");
+  ImGui::SameLine();
+  ImGui::BeginGroup();
+  ImGui::Checkbox("top-left", &rounded_top_left);
+  ImGui::SameLine();
+  ImGui::Checkbox("top-right", &rounded_top_right);
+  ImGui::Checkbox("bottom-left", &rounded_bottom_left);
+  ImGui::SameLine();
+  ImGui::Checkbox("bottom-right", &rounded_bottom_right);
+  ImGui::EndGroup();
+
+  int w = 300;
+  int h = 200;
+
+  ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 50);
+
+  auto pos = ImGui::GetCursorScreenPos();
+
+  //pos.y += 100;
+  ImDrawList* drawList = ImGui::GetWindowDrawList();
+  ImDrawFlags flags = 0;
+  if (rounded_top_left)
+    flags |= ImDrawFlags_RoundCornersTopLeft;
+  if (rounded_top_right)
+    flags |= ImDrawFlags_RoundCornersTopRight;
+  if (rounded_bottom_left)
+    flags |= ImDrawFlags_RoundCornersBottomLeft;
+  if (rounded_bottom_right)
+    flags |= ImDrawFlags_RoundCornersBottomRight;
+  int radiusCopy = radius;
+  if (flags == 0)
+    radiusCopy = 0;
+  drawList->AddRectFilled(ImVec2(pos.x + 100, pos.y), ImVec2(pos.x + w + 100, pos.y + h), ImColor(color), radiusCopy, flags, shadow, ImColor(shadowStart), ImColor(shadowEnd));
+
+  ImGui::SetCursorPosY(ImGui::GetCursorPosY() + h + 50);
+}

--- a/examples/sdf_demo.h
+++ b/examples/sdf_demo.h
@@ -77,7 +77,7 @@ void SDFDemo() {
   ImGui::SetWindowFontScale(1.5f);
   ImGui::Text("Shapes");
   ImGui::SetWindowFontScale(1);
-  ImGui::TextWrapped("To support text effects, additional information needs be encoded in ImDrawVert. This same information can easily be supported for drawing outlines and shadow for regular shapes. A rounded rectangle with shadow can be drawn with 18 triangles (size of shadow or rounding does not have an impact). See the DrawCmd in Metrics/Debugger window how these rectangles are drawn (especially ones with some round corners, and some straight corners).");
+  ImGui::TextWrapped("To support text effects, additional information needs be encoded in ImDrawVert. This same information can easily be used for drawing outlines and shadow for regular shapes. A rounded rectangle with shadow can be drawn with 18 triangles (size of shadow or rounding does not have an impact). See the DrawCmd in Metrics/Debugger window how these rectangles are drawn (especially ones with some round corners, and some straight corners).");
 
   ImGui::TextWrapped("Support for these new rounded rectangles is enabled if the flag SignedDistanceShapes is set by the backend. If enabled, AddRect and AddRectFilled are using these new implementation of shapes. This causes the number of vertices and triangles to drop significantly when using rounded frames.");
 

--- a/examples/sdf_demo.h
+++ b/examples/sdf_demo.h
@@ -41,9 +41,10 @@ void SDFDemo() {
   ImGui::SetWindowFontScale(1);
   ImGui::TextWrapped("Signed distance tester. You can choose multiple fonts in the style manager, supporting both signed distance fonts and regular fonts at the same time. Because of additional shader support that is needed, this is only enabled if the backend enables the new SignedDistance flags.");
   static float scale = 3.0f;
+  static ImVec4 text_inner_color = ImVec4(1.0f, 1.0f, 1.0f, 1.0f);
   static ImVec4 text_outline_start = ImVec4(1.0f, .0f, .0f, 1.0f);
   static ImVec4 text_outline_end = ImVec4(1.0f, .0f, .0f, 0.0f);
-  static float outline_width = .99f;
+  static float outline_width = .6;
   static float rotate = 0.1f;
 
   ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 50);
@@ -53,10 +54,11 @@ void SDFDemo() {
   ImGui::TextWrapped("Some scaled text.");
 
   ImGui::PushStyleVar(ImGuiStyleVar_FontShadowSize, outline_width);
+  ImGui::PushStyleColor(ImGuiCol_Text, text_inner_color);
   ImGui::PushStyleColor(ImGuiCol_FontShadowStart, text_outline_start);
   ImGui::PushStyleColor(ImGuiCol_FontShadowEnd, text_outline_end);
   ImGui::TextWrapped("Additional styles are supported.");
-  ImGui::PopStyleColor(2);
+  ImGui::PopStyleColor(3);
   ImGui::PopStyleVar(1);
   ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 50);
 
@@ -64,6 +66,7 @@ void SDFDemo() {
   ImGui::SetWindowFontScale(1);
 
   ImGui::SliderFloat("scale", &scale, 0.2f, 10.0f);
+  ImGui::ColorEdit4("text color", (float*)&text_inner_color);
   ImGui::ColorEdit4("outline start", (float*)&text_outline_start);
   ImGui::ColorEdit4("outline end", (float*)&text_outline_end);
   ImGui::SliderFloat("outline width", &outline_width, 0.0f, .99f);

--- a/imconfig.h
+++ b/imconfig.h
@@ -118,3 +118,6 @@ namespace ImGui
     void MyFunction(const char* name, const MyMatrix44& v);
 }
 */
+
+//---- Disables signed distance fonts and shapes. If no scalable fonts, text effects, or shadows are used, this can be used to speed up the rendering
+//#define IMGUI_DISABLE_SDF

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -978,6 +978,7 @@ ImGuiStyle::ImGuiStyle()
     WindowPadding           = ImVec2(8,8);      // Padding within a window
     WindowRounding          = 0.0f;             // Radius of window corners rounding. Set to 0.0f to have rectangular windows. Large values tend to lead to variety of artifacts and are not recommended.
     WindowBorderSize        = 1.0f;             // Thickness of border around windows. Generally set to 0.0f or 1.0f. Other values not well tested.
+    WindowShadowSize        = 5.0f;             // Thickness of shadow behind windows in pixels.
     WindowMinSize           = ImVec2(32,32);    // Minimum window size
     WindowTitleAlign        = ImVec2(0.0f,0.5f);// Alignment for title bar text
     WindowMenuButtonPosition= ImGuiDir_Left;    // Position of the collapsing/docking button in the title bar (left/right). Defaults to ImGuiDir_Left.
@@ -988,6 +989,7 @@ ImGuiStyle::ImGuiStyle()
     FramePadding            = ImVec2(4,3);      // Padding within a framed rectangle (used by most widgets)
     FrameRounding           = 0.0f;             // Radius of frame corners rounding. Set to 0.0f to have rectangular frames (used by most widgets).
     FrameBorderSize         = 0.0f;             // Thickness of border around frames. Generally set to 0.0f or 1.0f. Other values not well tested.
+    FrameShadowSize         = 0.0f;             // Thickness of shadow behind frames in pixels.
     ItemSpacing             = ImVec2(8,4);      // Horizontal and vertical spacing between widgets/lines
     ItemInnerSpacing        = ImVec2(4,4);      // Horizontal and vertical spacing between within elements of a composed widget (e.g. a slider and its label)
     CellPadding             = ImVec2(4,2);      // Padding within a table cell
@@ -1024,11 +1026,13 @@ void ImGuiStyle::ScaleAllSizes(float scale_factor)
 {
     WindowPadding = ImFloor(WindowPadding * scale_factor);
     WindowRounding = ImFloor(WindowRounding * scale_factor);
+    WindowShadowSize = ImFloor(WindowShadowSize * scale_factor);
     WindowMinSize = ImFloor(WindowMinSize * scale_factor);
     ChildRounding = ImFloor(ChildRounding * scale_factor);
     PopupRounding = ImFloor(PopupRounding * scale_factor);
     FramePadding = ImFloor(FramePadding * scale_factor);
     FrameRounding = ImFloor(FrameRounding * scale_factor);
+    FrameShadowSize = ImFloor(FrameShadowSize * scale_factor);
     ItemSpacing = ImFloor(ItemSpacing * scale_factor);
     ItemInnerSpacing = ImFloor(ItemInnerSpacing * scale_factor);
     CellPadding = ImFloor(CellPadding * scale_factor);
@@ -2499,6 +2503,7 @@ static const ImGuiStyleVarInfo GStyleVarInfo[] =
     { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImGuiStyle, WindowPadding) },       // ImGuiStyleVar_WindowPadding
     { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImGuiStyle, WindowRounding) },      // ImGuiStyleVar_WindowRounding
     { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImGuiStyle, WindowBorderSize) },    // ImGuiStyleVar_WindowBorderSize
+    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImGuiStyle, WindowShadowSize) },    // ImGuiStyleVar_WindowShadowSize
     { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImGuiStyle, WindowMinSize) },       // ImGuiStyleVar_WindowMinSize
     { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImGuiStyle, WindowTitleAlign) },    // ImGuiStyleVar_WindowTitleAlign
     { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImGuiStyle, ChildRounding) },       // ImGuiStyleVar_ChildRounding
@@ -2508,6 +2513,7 @@ static const ImGuiStyleVarInfo GStyleVarInfo[] =
     { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImGuiStyle, FramePadding) },        // ImGuiStyleVar_FramePadding
     { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImGuiStyle, FrameRounding) },       // ImGuiStyleVar_FrameRounding
     { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImGuiStyle, FrameBorderSize) },     // ImGuiStyleVar_FrameBorderSize
+    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImGuiStyle, FrameShadowSize) },     // ImGuiStyleVar_FrameShadowSize
     { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImGuiStyle, ItemSpacing) },         // ImGuiStyleVar_ItemSpacing
     { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImGuiStyle, ItemInnerSpacing) },    // ImGuiStyleVar_ItemInnerSpacing
     { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImGuiStyle, IndentSpacing) },       // ImGuiStyleVar_IndentSpacing
@@ -2519,6 +2525,7 @@ static const ImGuiStyleVarInfo GStyleVarInfo[] =
     { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImGuiStyle, TabRounding) },         // ImGuiStyleVar_TabRounding
     { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImGuiStyle, ButtonTextAlign) },     // ImGuiStyleVar_ButtonTextAlign
     { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImGuiStyle, SelectableTextAlign) }, // ImGuiStyleVar_SelectableTextAlign
+    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImGuiStyle, FontShadowSize) },      // ImGuiStyleVar_FontShadowSize
 };
 
 static const ImGuiStyleVarInfo* GetStyleVarInfo(ImGuiStyleVar idx)
@@ -2580,6 +2587,8 @@ const char* ImGui::GetStyleColorName(ImGuiCol idx)
     case ImGuiCol_Text: return "Text";
     case ImGuiCol_TextDisabled: return "TextDisabled";
     case ImGuiCol_WindowBg: return "WindowBg";
+    case ImGuiCol_WindowShadowStart: return "WindowShadowStart";
+    case ImGuiCol_WindowShadowEnd: return "WindowShadowEnd";
     case ImGuiCol_ChildBg: return "ChildBg";
     case ImGuiCol_PopupBg: return "PopupBg";
     case ImGuiCol_Border: return "Border";
@@ -2587,6 +2596,8 @@ const char* ImGui::GetStyleColorName(ImGuiCol idx)
     case ImGuiCol_FrameBg: return "FrameBg";
     case ImGuiCol_FrameBgHovered: return "FrameBgHovered";
     case ImGuiCol_FrameBgActive: return "FrameBgActive";
+    case ImGuiCol_FrameShadowStart: return "FrameShadowStart";
+    case ImGuiCol_FrameShadowEnd: return "FrameShadowEnd";
     case ImGuiCol_TitleBg: return "TitleBg";
     case ImGuiCol_TitleBgActive: return "TitleBgActive";
     case ImGuiCol_TitleBgCollapsed: return "TitleBgCollapsed";
@@ -2630,6 +2641,8 @@ const char* ImGui::GetStyleColorName(ImGuiCol idx)
     case ImGuiCol_NavWindowingHighlight: return "NavWindowingHighlight";
     case ImGuiCol_NavWindowingDimBg: return "NavWindowingDimBg";
     case ImGuiCol_ModalWindowDimBg: return "ModalWindowDimBg";
+    case ImGuiCol_FontShadowStart: return "FontShadowStart";
+    case ImGuiCol_FontShadowEnd: return "FontShadowEnd";
     }
     IM_ASSERT(0);
     return "Unknown";
@@ -2676,7 +2689,7 @@ void ImGui::RenderText(ImVec2 pos, const char* text, const char* text_end, bool 
 
     if (text != text_display_end)
     {
-        window->DrawList->AddText(g.Font, g.FontSize, pos, GetColorU32(ImGuiCol_Text), text, text_display_end);
+        window->DrawList->AddText(g.Font, g.FontSize, pos, GetColorU32(ImGuiCol_Text), text, text_display_end, 0.0f, NULL, g.Style.FontShadowSize, GetColorU32(ImGuiCol_FontShadowStart), GetColorU32(ImGuiCol_FontShadowEnd));
         if (g.LogEnabled)
             LogRenderedText(&pos, text, text_display_end);
     }
@@ -2692,7 +2705,7 @@ void ImGui::RenderTextWrapped(ImVec2 pos, const char* text, const char* text_end
 
     if (text != text_end)
     {
-        window->DrawList->AddText(g.Font, g.FontSize, pos, GetColorU32(ImGuiCol_Text), text, text_end, wrap_width);
+        window->DrawList->AddText(g.Font, g.FontSize, pos, GetColorU32(ImGuiCol_Text), text, text_end, wrap_width, NULL, g.Style.FontShadowSize, GetColorU32(ImGuiCol_FontShadowStart), GetColorU32(ImGuiCol_FontShadowEnd));
         if (g.LogEnabled)
             LogRenderedText(&pos, text, text_end);
     }
@@ -2717,14 +2730,15 @@ void ImGui::RenderTextClippedEx(ImDrawList* draw_list, const ImVec2& pos_min, co
     if (align.y > 0.0f) pos.y = ImMax(pos.y, pos.y + (pos_max.y - pos.y - text_size.y) * align.y);
 
     // Render
+    ImGuiContext& g = *GImGui;
     if (need_clipping)
     {
         ImVec4 fine_clip_rect(clip_min->x, clip_min->y, clip_max->x, clip_max->y);
-        draw_list->AddText(NULL, 0.0f, pos, GetColorU32(ImGuiCol_Text), text, text_display_end, 0.0f, &fine_clip_rect);
+        draw_list->AddText(NULL, 0.0f, pos, GetColorU32(ImGuiCol_Text), text, text_display_end, 0.0f, &fine_clip_rect, g.Style.FontShadowSize, GetColorU32(ImGuiCol_FontShadowStart), GetColorU32(ImGuiCol_FontShadowEnd));
     }
     else
     {
-        draw_list->AddText(NULL, 0.0f, pos, GetColorU32(ImGuiCol_Text), text, text_display_end, 0.0f, NULL);
+        draw_list->AddText(NULL, 0.0f, pos, GetColorU32(ImGuiCol_Text), text, text_display_end, 0.0f, NULL, g.Style.FontShadowSize, GetColorU32(ImGuiCol_FontShadowStart), GetColorU32(ImGuiCol_FontShadowEnd));
     }
 }
 
@@ -2785,7 +2799,9 @@ void ImGui::RenderTextEllipsis(ImDrawList* draw_list, const ImVec2& pos_min, con
         {
             // Full ellipsis size without free spacing after it.
             const float spacing_between_dots = 1.0f * (draw_list->_Data->FontSize / font->FontSize);
-            ellipsis_glyph_width = glyph->X1 - glyph->X0 + spacing_between_dots;
+            const bool sdf = ImGui::GetIO().BackendFlags & ImGuiBackendFlags_SignedDistanceFonts;
+            const float xy_padding = sdf ? float(IMGUI_SDF_PADDING) : 0.0f;
+            ellipsis_glyph_width = glyph->X1 - glyph->X0 + spacing_between_dots - 2*xy_padding;
             ellipsis_total_width = ellipsis_glyph_width * (float)ellipsis_char_count - spacing_between_dots;
         }
 
@@ -2811,7 +2827,8 @@ void ImGui::RenderTextEllipsis(ImDrawList* draw_list, const ImVec2& pos_min, con
         if (ellipsis_x + ellipsis_total_width <= ellipsis_max_x)
             for (int i = 0; i < ellipsis_char_count; i++)
             {
-                font->RenderChar(draw_list, font_size, ImVec2(ellipsis_x, pos_min.y), GetColorU32(ImGuiCol_Text), ellipsis_char);
+                ImGuiContext& g = *GImGui;
+                font->RenderChar(draw_list, font_size, ImVec2(ellipsis_x, pos_min.y), GetColorU32(ImGuiCol_Text), ellipsis_char, g.Style.FontShadowSize, GetColorU32(ImGuiCol_FontShadowStart), GetColorU32(ImGuiCol_FontShadowEnd));
                 ellipsis_x += ellipsis_glyph_width;
             }
     }
@@ -2829,11 +2846,10 @@ void ImGui::RenderFrame(ImVec2 p_min, ImVec2 p_max, ImU32 fill_col, bool border,
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
-    window->DrawList->AddRectFilled(p_min, p_max, fill_col, rounding);
+    window->DrawList->AddRectFilled(p_min, p_max, fill_col, rounding, 0, g.Style.FrameShadowSize, GetColorU32(ImGuiCol_FrameShadowStart), GetColorU32(ImGuiCol_FrameShadowEnd));
     const float border_size = g.Style.FrameBorderSize;
     if (border && border_size > 0.0f)
     {
-        window->DrawList->AddRect(p_min + ImVec2(1, 1), p_max + ImVec2(1, 1), GetColorU32(ImGuiCol_BorderShadow), rounding, 0, border_size);
         window->DrawList->AddRect(p_min, p_max, GetColorU32(ImGuiCol_Border), rounding, 0, border_size);
     }
 }
@@ -2842,10 +2858,10 @@ void ImGui::RenderFrameBorder(ImVec2 p_min, ImVec2 p_max, float rounding)
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
+    window->DrawList->AddRectFilled(p_min, p_max, IM_COL32_BLACK_TRANS, rounding, 0, g.Style.FrameShadowSize, GetColorU32(ImGuiCol_FrameShadowStart), GetColorU32(ImGuiCol_FrameShadowEnd));
     const float border_size = g.Style.FrameBorderSize;
     if (border_size > 0.0f)
     {
-        window->DrawList->AddRect(p_min + ImVec2(1, 1), p_max + ImVec2(1, 1), GetColorU32(ImGuiCol_BorderShadow), rounding, 0, border_size);
         window->DrawList->AddRect(p_min, p_max, GetColorU32(ImGuiCol_Border), rounding, 0, border_size);
     }
 }
@@ -3939,6 +3955,12 @@ void ImGui::NewFrame()
         g.DrawListSharedData.InitialFlags |= ImDrawListFlags_AntiAliasedFill;
     if (g.IO.BackendFlags & ImGuiBackendFlags_RendererHasVtxOffset)
         g.DrawListSharedData.InitialFlags |= ImDrawListFlags_AllowVtxOffset;
+    if (g.IO.BackendFlags & ImGuiBackendFlags_SignedDistanceFonts)
+        g.DrawListSharedData.InitialFlags |= ImDrawListFlags_SignedDistanceFonts;
+    if (g.IO.BackendFlags & ImGuiBackendFlags_SignedDistanceShapes)
+        g.DrawListSharedData.InitialFlags |= ImDrawListFlags_SignedDistanceShapes;
+    if (g.IO.BackendFlags & ImGuiBackendFlags_ProvocingVertexFirst)
+        g.DrawListSharedData.InitialFlags |= ImDrawListFlags_ProvocingVertexFirst;
 
     // Mark rendering data as invalid to prevent user who may have a handle on it to use it.
     for (int n = 0; n < g.Viewports.Size; n++)
@@ -5546,7 +5568,10 @@ void ImGui::RenderWindowDecorations(ImGuiWindow* window, const ImRect& title_bar
             }
             if (override_alpha)
                 bg_col = (bg_col & ~IM_COL32_A_MASK) | (IM_F32_TO_INT8_SAT(alpha) << IM_COL32_A_SHIFT);
-            window->DrawList->AddRectFilled(window->Pos + ImVec2(0, window->TitleBarHeight()), window->Pos + window->Size, bg_col, window_rounding, (flags & ImGuiWindowFlags_NoTitleBar) ? 0 : ImDrawFlags_RoundCornersBottom);
+            // one smaller to avoid rendering artifacts in anti-aliasing.
+            const float window_border_size_smaller = ImMax(0.0f, window_border_size-1);
+            ImVec2 border = ImVec2(window_border_size_smaller, window_border_size_smaller);
+            window->DrawList->AddRectFilled(window->Pos - border, window->Pos + window->Size + border, bg_col, window_rounding + window_border_size_smaller, 0, (flags & ImGuiWindowFlags_Modal) || (flags & ImGuiWindowFlags_ChildWindow) ? 0 : g.Style.WindowShadowSize, GetColorU32(ImGuiCol_WindowShadowStart), GetColorU32(ImGuiCol_WindowShadowEnd));
         }
 
         // Title bar

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -2824,13 +2824,14 @@ void ImGui::RenderTextEllipsis(ImDrawList* draw_list, const ImVec2& pos_min, con
         // Render text, render ellipsis
         RenderTextClippedEx(draw_list, pos_min, ImVec2(clip_max_x, pos_max.y), text, text_end_ellipsis, &text_size, ImVec2(0.0f, 0.0f));
         float ellipsis_x = pos_min.x + text_size_clipped_x;
-        if (ellipsis_x + ellipsis_total_width <= ellipsis_max_x)
+        if (ellipsis_x + ellipsis_total_width <= ellipsis_max_x) {
+            bool globalSDF = ImGui::GetIO().BackendFlags & ImGuiBackendFlags_SignedDistanceFonts;
             for (int i = 0; i < ellipsis_char_count; i++)
             {
-                ImGuiContext& g = *GImGui;
-                font->RenderChar(draw_list, font_size, ImVec2(ellipsis_x, pos_min.y), GetColorU32(ImGuiCol_Text), ellipsis_char, g.Style.FontShadowSize, GetColorU32(ImGuiCol_FontShadowStart), GetColorU32(ImGuiCol_FontShadowEnd));
+                font->RenderChar(draw_list, font_size, ImVec2(ellipsis_x, pos_min.y), GetColorU32(ImGuiCol_Text), ellipsis_char, globalSDF && font->SignedDistanceFont, g.Style.FontShadowSize, GetColorU32(ImGuiCol_FontShadowStart), GetColorU32(ImGuiCol_FontShadowEnd));
                 ellipsis_x += ellipsis_glyph_width;
             }
+         }
     }
     else
     {

--- a/imgui.h
+++ b/imgui.h
@@ -2259,8 +2259,6 @@ typedef unsigned short ImDrawIdx;
 #define IMGUI_SDF_DETAIL 40
 // so outlines are more or less the same size around the font
 #define IMGUI_SDF_PADDING (IMGUI_SDF_DETAIL/10)
-// the higher the sharper for lower font sizes, value of 2 matches the regular font rendering
-#define IMGUI_SDF_SHARPENING 2
 
 #ifndef IMGUI_OVERRIDE_DRAWVERT_STRUCT_LAYOUT
 struct ImDrawVert

--- a/imgui.h
+++ b/imgui.h
@@ -1392,7 +1392,12 @@ enum ImGuiBackendFlags_
     ImGuiBackendFlags_HasGamepad            = 1 << 0,   // Backend Platform supports gamepad and currently has one connected.
     ImGuiBackendFlags_HasMouseCursors       = 1 << 1,   // Backend Platform supports honoring GetMouseCursor() value to change the OS cursor shape.
     ImGuiBackendFlags_HasSetMousePos        = 1 << 2,   // Backend Platform supports io.WantSetMousePos requests to reposition the OS mouse position (only used if ImGuiConfigFlags_NavEnableSetMousePos is set).
-    ImGuiBackendFlags_RendererHasVtxOffset  = 1 << 3    // Backend Renderer supports ImDrawCmd::VtxOffset. This enables output of large meshes (64K+ vertices) while still using 16-bit indices.
+    ImGuiBackendFlags_RendererHasVtxOffset  = 1 << 3,   // Backend Renderer supports ImDrawCmd::VtxOffset. This enables output of large meshes (64K+ vertices) while still using 16-bit indices.
+    ImGuiBackendFlags_SignedDistanceFonts   = 1 << 5,  // Enable/disabled signed distance font rendering (scaling).
+    ImGuiBackendFlags_SignedDistanceShapes  = 1 << 6,  // Enable/disabled signed distance rendering of (rounded) rectangles.
+    ImGuiBackendFlags_ProvocingVertexFirst  = 1 << 7,  // Needed for DirectX if the signed distance fields operations are enabled.
+    ImGuiBackendFlags_DefaultFast          = ImGuiBackendFlags_None, // Minimal shader, minimal effects
+    ImGuiBackendFlags_DefaultDesktop       = (1 << 8) - 1, // Full desktop backend: SignedDistanceFonts, SignedDistanceShapes
 };
 
 // Enumeration for PushStyleColor() / PopStyleColor()
@@ -1401,6 +1406,8 @@ enum ImGuiCol_
     ImGuiCol_Text,
     ImGuiCol_TextDisabled,
     ImGuiCol_WindowBg,              // Background of normal windows
+    ImGuiCol_WindowShadowStart,     // Start color of shadows of normal windows
+    ImGuiCol_WindowShadowEnd,       // End color of shadows of normal windows
     ImGuiCol_ChildBg,               // Background of child windows
     ImGuiCol_PopupBg,               // Background of popups, menus, tooltips windows
     ImGuiCol_Border,
@@ -1408,6 +1415,8 @@ enum ImGuiCol_
     ImGuiCol_FrameBg,               // Background of checkbox, radio button, plot, slider, text input
     ImGuiCol_FrameBgHovered,
     ImGuiCol_FrameBgActive,
+    ImGuiCol_FrameShadowStart,      // Start color of shadows of frames
+    ImGuiCol_FrameShadowEnd,        // End color of shadows of frames
     ImGuiCol_TitleBg,
     ImGuiCol_TitleBgActive,
     ImGuiCol_TitleBgCollapsed,
@@ -1451,6 +1460,8 @@ enum ImGuiCol_
     ImGuiCol_NavWindowingHighlight, // Highlight window when using CTRL+TAB
     ImGuiCol_NavWindowingDimBg,     // Darken/colorize entire screen behind the CTRL+TAB window list, when active
     ImGuiCol_ModalWindowDimBg,      // Darken/colorize entire screen behind a modal window, when one is active
+    ImGuiCol_FontShadowStart,       // Start color of shadows of fonts
+    ImGuiCol_FontShadowEnd,         // End color of shadows of fonts
     ImGuiCol_COUNT
 };
 
@@ -1468,6 +1479,7 @@ enum ImGuiStyleVar_
     ImGuiStyleVar_WindowPadding,       // ImVec2    WindowPadding
     ImGuiStyleVar_WindowRounding,      // float     WindowRounding
     ImGuiStyleVar_WindowBorderSize,    // float     WindowBorderSize
+    ImGuiStyleVar_WindowShadowSize,    // float     WindowShadowSize
     ImGuiStyleVar_WindowMinSize,       // ImVec2    WindowMinSize
     ImGuiStyleVar_WindowTitleAlign,    // ImVec2    WindowTitleAlign
     ImGuiStyleVar_ChildRounding,       // float     ChildRounding
@@ -1477,6 +1489,7 @@ enum ImGuiStyleVar_
     ImGuiStyleVar_FramePadding,        // ImVec2    FramePadding
     ImGuiStyleVar_FrameRounding,       // float     FrameRounding
     ImGuiStyleVar_FrameBorderSize,     // float     FrameBorderSize
+    ImGuiStyleVar_FrameShadowSize,     // float     FrameShadowSize
     ImGuiStyleVar_ItemSpacing,         // ImVec2    ItemSpacing
     ImGuiStyleVar_ItemInnerSpacing,    // ImVec2    ItemInnerSpacing
     ImGuiStyleVar_IndentSpacing,       // float     IndentSpacing
@@ -1488,6 +1501,7 @@ enum ImGuiStyleVar_
     ImGuiStyleVar_TabRounding,         // float     TabRounding
     ImGuiStyleVar_ButtonTextAlign,     // ImVec2    ButtonTextAlign
     ImGuiStyleVar_SelectableTextAlign, // ImVec2    SelectableTextAlign
+    ImGuiStyleVar_FontShadowSize,      // float     FontShadowSize
     ImGuiStyleVar_COUNT
 };
 
@@ -1709,6 +1723,7 @@ struct ImGuiStyle
     ImVec2      WindowPadding;              // Padding within a window.
     float       WindowRounding;             // Radius of window corners rounding. Set to 0.0f to have rectangular windows. Large values tend to lead to variety of artifacts and are not recommended.
     float       WindowBorderSize;           // Thickness of border around windows. Generally set to 0.0f or 1.0f. (Other values are not well tested and more CPU/GPU costly).
+    float       WindowShadowSize;           // Shadow of windows in number of pixels. Only used with signed distance enabled backend.
     ImVec2      WindowMinSize;              // Minimum window size. This is a global setting. If you want to constraint individual windows, use SetNextWindowSizeConstraints().
     ImVec2      WindowTitleAlign;           // Alignment for title bar text. Defaults to (0.0f,0.5f) for left-aligned,vertically centered.
     ImGuiDir    WindowMenuButtonPosition;   // Side of the collapsing/docking button in the title bar (None/Left/Right). Defaults to ImGuiDir_Left.
@@ -1719,6 +1734,7 @@ struct ImGuiStyle
     ImVec2      FramePadding;               // Padding within a framed rectangle (used by most widgets).
     float       FrameRounding;              // Radius of frame corners rounding. Set to 0.0f to have rectangular frame (used by most widgets).
     float       FrameBorderSize;            // Thickness of border around frames. Generally set to 0.0f or 1.0f. (Other values are not well tested and more CPU/GPU costly).
+    float       FrameShadowSize;            // Shadow of frames in number of pixels. Only used with signed distance enabled backend.
     ImVec2      ItemSpacing;                // Horizontal and vertical spacing between widgets/lines.
     ImVec2      ItemInnerSpacing;           // Horizontal and vertical spacing between within elements of a composed widget (e.g. a slider and its label).
     ImVec2      CellPadding;                // Padding within a table cell
@@ -1744,6 +1760,7 @@ struct ImGuiStyle
     bool        AntiAliasedFill;            // Enable anti-aliased edges around filled shapes (rounded rectangles, circles, etc.). Disable if you are really tight on CPU/GPU. Latched at the beginning of the frame (copied to ImDrawList).
     float       CurveTessellationTol;       // Tessellation tolerance when using PathBezierCurveTo() without a specific number of segments. Decrease for highly tessellated curves (higher quality, more polygons), increase to reduce quality.
     float       CircleTessellationMaxError; // Maximum error (in pixels) allowed when using AddCircle()/AddCircleFilled() or drawing rounded corner rectangles with no explicit segment count specified. Decrease for higher quality but more geometry.
+    float       FontShadowSize;             // Shadow size of font (in SDF_WIDTH / SDF_DETAIL units, max is SDF_WIDTH-1)
     ImVec4      Colors[ImGuiCol_COUNT];
 
     IMGUI_API ImGuiStyle();
@@ -2239,12 +2256,33 @@ typedef unsigned short ImDrawIdx;
 #endif
 
 // Vertex layout
+#define IMGUI_SDF_DETAIL 40
+// so outlines are more or less the same size around the font
+#define IMGUI_SDF_PADDING (IMGUI_SDF_DETAIL/10)
+// the higher the sharper for lower font sizes, value of 2 matches the regular font rendering
+#define IMGUI_SDF_SHARPENING 2
+
 #ifndef IMGUI_OVERRIDE_DRAWVERT_STRUCT_LAYOUT
 struct ImDrawVert
 {
     ImVec2  pos;
     ImVec2  uv;
     ImU32   col;
+#ifndef IMGUI_DISABLE_SDF
+    // signed distance support
+    ImU32   startOuterColor = IM_COL32(0x0, 0x0, 0x0, 0x0); // 4 bytes = 24
+    ImU32   endOuterColor = IM_COL32(0x0, 0x0, 0x0, 0x0); // 4 bytes = 28
+    float   a = 0.0;   // threshold [0-1] between outer and inner; 4 bytes = 32
+    float   b = 0.0;   // threshold [0-1] between outer and discard; 4 bytes = 36
+    float   w = 0.0;   // anti-aliasing width [0-1]; 4 bytes = 40
+    void simple() {
+      a = 0.0f;
+      b = 0.0f;
+      w = 0.0f;
+      startOuterColor = IM_COL32(0x0, 0x0, 0x0, 0x0);
+      endOuterColor = IM_COL32(0x0, 0x0, 0x0, 0x0);
+    }
+#endif
 };
 #else
 // You can override the vertex format layout by defining IMGUI_OVERRIDE_DRAWVERT_STRUCT_LAYOUT in imconfig.h
@@ -2315,7 +2353,10 @@ enum ImDrawListFlags_
     ImDrawListFlags_AntiAliasedLines        = 1 << 0,  // Enable anti-aliased lines/borders (*2 the number of triangles for 1.0f wide line or lines thin enough to be drawn using textures, otherwise *3 the number of triangles)
     ImDrawListFlags_AntiAliasedLinesUseTex  = 1 << 1,  // Enable anti-aliased lines/borders using textures when possible. Require backend to render with bilinear filtering.
     ImDrawListFlags_AntiAliasedFill         = 1 << 2,  // Enable anti-aliased edge around filled shapes (rounded rectangles, circles).
-    ImDrawListFlags_AllowVtxOffset          = 1 << 3   // Can emit 'VtxOffset > 0' to allow large meshes. Set when 'ImGuiBackendFlags_RendererHasVtxOffset' is enabled.
+    ImDrawListFlags_AllowVtxOffset          = 1 << 3,  // Can emit 'VtxOffset > 0' to allow large meshes. Set when 'ImGuiBackendFlags_RendererHasVtxOffset' is enabled.
+    ImDrawListFlags_SignedDistanceFonts     = 1 << 4,  // Enable/disabled signed distance operations.
+    ImDrawListFlags_SignedDistanceShapes    = 1 << 5,  // Enable/disabled signed distance operations.
+    ImDrawListFlags_ProvocingVertexFirst    = 1 << 7,  // Needed for DirectX if the signed distance fields operations are enabled.
 };
 
 // Draw command list
@@ -2367,8 +2408,10 @@ struct ImDrawList
     //   In future versions we will use textures to provide cheaper and higher-quality circles.
     //   Use AddNgon() and AddNgonFilled() functions if you need to guaranteed a specific number of sides.
     IMGUI_API void  AddLine(const ImVec2& p1, const ImVec2& p2, ImU32 col, float thickness = 1.0f);
+    IMGUI_API ImDrawIdx PushVtx(const ImVec2& pos, const ImVec2& uv, ImU32 inner_color, ImU32 start_outer_color = IM_COL32_BLACK_TRANS, ImU32 end_outer_color = IM_COL32_BLACK_TRANS, float a = 0.0, float b = 0.0, float w = 0.0);
+    IMGUI_API void  PushQuadIndex(ImDrawIdx a, ImDrawIdx b, ImDrawIdx c, ImDrawIdx d);
     IMGUI_API void  AddRect(const ImVec2& p_min, const ImVec2& p_max, ImU32 col, float rounding = 0.0f, ImDrawFlags flags = 0, float thickness = 1.0f);   // a: upper-left, b: lower-right (== upper-left + size)
-    IMGUI_API void  AddRectFilled(const ImVec2& p_min, const ImVec2& p_max, ImU32 col, float rounding = 0.0f, ImDrawFlags flags = 0);                     // a: upper-left, b: lower-right (== upper-left + size)
+    IMGUI_API void  AddRectFilled(ImVec2 p_min, ImVec2 p_max, ImU32 col, float rounding = 0.0f, ImDrawFlags flags = 0, float outer = 0.0f, ImU32 start_outer_color = IM_COL32_BLACK_TRANS, ImU32 end_outer_color = IM_COL32_BLACK_TRANS);
     IMGUI_API void  AddRectFilledMultiColor(const ImVec2& p_min, const ImVec2& p_max, ImU32 col_upr_left, ImU32 col_upr_right, ImU32 col_bot_right, ImU32 col_bot_left);
     IMGUI_API void  AddQuad(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, ImU32 col, float thickness = 1.0f);
     IMGUI_API void  AddQuadFilled(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, ImU32 col);
@@ -2378,8 +2421,8 @@ struct ImDrawList
     IMGUI_API void  AddCircleFilled(const ImVec2& center, float radius, ImU32 col, int num_segments = 0);
     IMGUI_API void  AddNgon(const ImVec2& center, float radius, ImU32 col, int num_segments, float thickness = 1.0f);
     IMGUI_API void  AddNgonFilled(const ImVec2& center, float radius, ImU32 col, int num_segments);
-    IMGUI_API void  AddText(const ImVec2& pos, ImU32 col, const char* text_begin, const char* text_end = NULL);
-    IMGUI_API void  AddText(const ImFont* font, float font_size, const ImVec2& pos, ImU32 col, const char* text_begin, const char* text_end = NULL, float wrap_width = 0.0f, const ImVec4* cpu_fine_clip_rect = NULL);
+    IMGUI_API void  AddText(const ImVec2& pos, ImU32 col, const char* text_begin, const char* text_end = NULL, float shadow_size = 0.0f, ImU32 shadow_start = IM_COL32_BLACK_TRANS, ImU32 shadow_end = IM_COL32_BLACK_TRANS);
+    IMGUI_API void  AddText(const ImFont* font, float font_size, const ImVec2& pos, ImU32 col, const char* text_begin, const char* text_end = NULL, float wrap_width = 0.0f, const ImVec4* cpu_fine_clip_rect = NULL, float shadow_size = 0.0f, ImU32 shadow_start = IM_COL32_BLACK_TRANS, ImU32 shadow_end = IM_COL32_BLACK_TRANS);
     IMGUI_API void  AddPolyline(const ImVec2* points, int num_points, ImU32 col, ImDrawFlags flags, float thickness);
     IMGUI_API void  AddConvexPolyFilled(const ImVec2* points, int num_points, ImU32 col); // Note: Anti-aliased filling requires points to be in clockwise order.
     IMGUI_API void  AddBezierCubic(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, ImU32 col, float thickness, int num_segments = 0); // Cubic Bezier (4 control points)
@@ -2425,10 +2468,14 @@ struct ImDrawList
     // - All primitives needs to be reserved via PrimReserve() beforehand.
     IMGUI_API void  PrimReserve(int idx_count, int vtx_count);
     IMGUI_API void  PrimUnreserve(int idx_count, int vtx_count);
-    IMGUI_API void  PrimRect(const ImVec2& a, const ImVec2& b, ImU32 col);      // Axis aligned rectangle (composed of two triangles)
-    IMGUI_API void  PrimRectUV(const ImVec2& a, const ImVec2& b, const ImVec2& uv_a, const ImVec2& uv_b, ImU32 col);
-    IMGUI_API void  PrimQuadUV(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& d, const ImVec2& uv_a, const ImVec2& uv_b, const ImVec2& uv_c, const ImVec2& uv_d, ImU32 col);
+    IMGUI_API void  PrimRect(const ImVec2& tl, const ImVec2& br, ImU32 col);      // Axis aligned rectangle (composed of two triangles)
+    IMGUI_API void  PrimRectUV(const ImVec2& tl, const ImVec2& br, const ImVec2& uv_a, const ImVec2& uv_b, ImU32 innerCol, ImU32 startOuterCol = IM_COL32_BLACK_TRANS, ImU32 endOuterCol = IM_COL32_BLACK_TRANS, float a = 0.0, float b = 0.0, float w = 0.0);
+    IMGUI_API void  PrimQuadUV(const ImVec2& tl, const ImVec2& br, const ImVec2& c, const ImVec2& d, const ImVec2& uv_a, const ImVec2& uv_b, const ImVec2& uv_c, const ImVec2& uv_d, ImU32 col, float w = 0.0);
+#ifndef IMGUI_DISABLE_SDF
+    inline    void  PrimWriteVtx(const ImVec2& pos, const ImVec2& uv, ImU32 col)    { _VtxWritePtr->pos = pos; _VtxWritePtr->uv = uv; _VtxWritePtr->col = col; _VtxWritePtr->simple(); _VtxWritePtr++; _VtxCurrentIdx++; }
+#else
     inline    void  PrimWriteVtx(const ImVec2& pos, const ImVec2& uv, ImU32 col)    { _VtxWritePtr->pos = pos; _VtxWritePtr->uv = uv; _VtxWritePtr->col = col; _VtxWritePtr++; _VtxCurrentIdx++; }
+#endif
     inline    void  PrimWriteIdx(ImDrawIdx idx)                                     { *_IdxWritePtr = idx; _IdxWritePtr++; }
     inline    void  PrimVtx(const ImVec2& pos, const ImVec2& uv, ImU32 col)         { PrimWriteIdx((ImDrawIdx)_VtxCurrentIdx); PrimWriteVtx(pos, uv, col); } // Write vertex with unique index
 
@@ -2493,6 +2540,7 @@ struct ImFontConfig
     unsigned int    FontBuilderFlags;       // 0        // Settings for custom font builder. THIS IS BUILDER IMPLEMENTATION DEPENDENT. Leave as zero if unsure.
     float           RasterizerMultiply;     // 1.0f     // Brighten (>1.0f) or darken (<1.0f) font output. Brightening small fonts may be a good workaround to make them more readable.
     ImWchar         EllipsisChar;           // -1       // Explicitly specify unicode codepoint of ellipsis character. When fonts are being merged first specified ellipsis will be used.
+    bool            SignedDistanceFont;     // false    // Load the font as a signed distance font (if the SignedDistanceFonts backend flag is enabled, if so size is ignored)
 
     // [Internal]
     char            Name[40];               // Name (strictly to ease debugging)
@@ -2680,6 +2728,7 @@ struct ImFont
     ImVector<ImWchar>           IndexLookup;        // 12-16 // out //            // Sparse. Index glyphs by Unicode code-point.
     ImVector<ImFontGlyph>       Glyphs;             // 12-16 // out //            // All glyphs.
     const ImFontGlyph*          FallbackGlyph;      // 4-8   // out // = FindGlyph(FontFallbackChar)
+    bool                        SignedDistanceFont; // 1     //                   // Font was loaded as a signed distance font
 
     // Members: Cold ~32/40 bytes
     ImFontAtlas*                ContainerAtlas;     // 4-8   // out //            // What we has been loaded into
@@ -2706,14 +2755,14 @@ struct ImFont
     // 'wrap_width' enable automatic word-wrapping across multiple lines to fit into given width. 0.0f to disable.
     IMGUI_API ImVec2            CalcTextSizeA(float size, float max_width, float wrap_width, const char* text_begin, const char* text_end = NULL, const char** remaining = NULL) const; // utf8
     IMGUI_API const char*       CalcWordWrapPositionA(float scale, const char* text, const char* text_end, float wrap_width) const;
-    IMGUI_API void              RenderChar(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col, ImWchar c) const;
-    IMGUI_API void              RenderText(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col, const ImVec4& clip_rect, const char* text_begin, const char* text_end, float wrap_width = 0.0f, bool cpu_fine_clip = false) const;
+    IMGUI_API void              RenderChar(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col, ImWchar c, bool sdf = false, float shadow_size = 0.0, ImU32 shadow_start = IM_COL32_BLACK_TRANS, ImU32 shadow_end = IM_COL32_BLACK_TRANS) const;
+    IMGUI_API void              RenderText(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col, const ImVec4& clip_rect, const char* text_begin, const char* text_end, float wrap_width = 0.0f, bool cpu_fine_clip = false, bool sdf = false, float shadow_size = 0.0, ImU32 shadow_start = IM_COL32_BLACK_TRANS, ImU32 shadow_end = IM_COL32_BLACK_TRANS) const;
 
     // [Internal] Don't use!
     IMGUI_API void              BuildLookupTable();
     IMGUI_API void              ClearOutputData();
     IMGUI_API void              GrowIndex(int new_size);
-    IMGUI_API void              AddGlyph(const ImFontConfig* src_cfg, ImWchar c, float x0, float y0, float x1, float y1, float u0, float v0, float u1, float v1, float advance_x);
+    IMGUI_API void              AddGlyph(const ImFontConfig* src_cfg, ImWchar c, float x0, float y0, float x1, float y1, float u0, float v0, float u1, float v1, float advance_x, float scale);
     IMGUI_API void              AddRemapChar(ImWchar dst, ImWchar src, bool overwrite_dst = true); // Makes 'dst' character/glyph points to 'src' character/glyph. Currently needs to be called AFTER fonts have been built.
     IMGUI_API void              SetGlyphVisible(ImWchar c, bool visible);
     IMGUI_API void              SetFallbackChar(ImWchar c);

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -463,6 +463,9 @@ void ImGui::ShowDemoWindow(bool* p_open)
             ImGui::CheckboxFlags("io.BackendFlags: HasMouseCursors",      &backend_flags, ImGuiBackendFlags_HasMouseCursors);
             ImGui::CheckboxFlags("io.BackendFlags: HasSetMousePos",       &backend_flags, ImGuiBackendFlags_HasSetMousePos);
             ImGui::CheckboxFlags("io.BackendFlags: RendererHasVtxOffset", &backend_flags, ImGuiBackendFlags_RendererHasVtxOffset);
+            ImGui::CheckboxFlags("io.BackendFlags: SignedDistanceFonts",  &backend_flags, ImGuiBackendFlags_SignedDistanceFonts);
+            ImGui::CheckboxFlags("io.BackendFlags: SignedDistanceShapes", &backend_flags, ImGuiBackendFlags_SignedDistanceShapes);
+            ImGui::CheckboxFlags("io.BackendFlags: ProvocingVertexFirst", &backend_flags, ImGuiBackendFlags_ProvocingVertexFirst);
             ImGui::TreePop();
             ImGui::Separator();
         }
@@ -5798,8 +5801,8 @@ static void NodeFont(ImFont* font)
 {
     ImGuiIO& io = ImGui::GetIO();
     ImGuiStyle& style = ImGui::GetStyle();
-    bool font_details_opened = ImGui::TreeNode(font, "Font: \"%s\"\n%.2f px, %d glyphs, %d file(s)",
-        font->ConfigData ? font->ConfigData[0].Name : "", font->FontSize, font->Glyphs.Size, font->ConfigDataCount);
+    bool font_details_opened = ImGui::TreeNode(font, "Font: \"%s\"\n%.2f px, %d glyphs, %d file(s)%s",
+        font->ConfigData ? font->ConfigData[0].Name : "", font->FontSize, font->Glyphs.Size, font->ConfigDataCount, font->SignedDistanceFont ? ", uses signed distance" : "");
     ImGui::SameLine(); if (ImGui::SmallButton("Set as default")) { io.FontDefault = font; }
     if (!font_details_opened)
         return;
@@ -5944,6 +5947,10 @@ void ImGui::ShowStyleEditor(ImGuiStyle* ref)
             ImGui::SliderFloat("PopupBorderSize", &style.PopupBorderSize, 0.0f, 1.0f, "%.0f");
             ImGui::SliderFloat("FrameBorderSize", &style.FrameBorderSize, 0.0f, 1.0f, "%.0f");
             ImGui::SliderFloat("TabBorderSize", &style.TabBorderSize, 0.0f, 1.0f, "%.0f");
+            ImGui::Text("Shadows (for SDF backends)");
+            ImGui::SliderFloat("WindowShadowSize", &style.WindowShadowSize, 0.0f, 32.0f, "%.0f");
+            ImGui::SliderFloat("FrameShadowSize", &style.FrameShadowSize, 0.0f, 32.0f, "%.0f");
+            ImGui::SliderFloat("FontShadowSize", &style.FontShadowSize, 0.0f, 1.0f, "%.01f");
             ImGui::Text("Rounding");
             ImGui::SliderFloat("WindowRounding", &style.WindowRounding, 0.0f, 12.0f, "%.0f");
             ImGui::SliderFloat("ChildRounding", &style.ChildRounding, 0.0f, 12.0f, "%.0f");
@@ -6065,7 +6072,17 @@ void ImGui::ShowStyleEditor(ImGuiStyle* ref)
             static float window_scale = 1.0f;
             if (ImGui::DragFloat("window scale", &window_scale, 0.005f, MIN_SCALE, MAX_SCALE, "%.2f", ImGuiSliderFlags_AlwaysClamp)) // Scale only this window
                 ImGui::SetWindowFontScale(window_scale);
+            ImGui::SameLine();
+            if (ImGui::Button("Reset")) {
+              window_scale = 1.0;
+              ImGui::SetWindowFontScale(window_scale);
+            }
             ImGui::DragFloat("global scale", &io.FontGlobalScale, 0.005f, MIN_SCALE, MAX_SCALE, "%.2f", ImGuiSliderFlags_AlwaysClamp); // Scale everything
+            ImGui::SameLine();
+            ImGui::PushID("global_scale_reset");
+            if (ImGui::Button("Reset"))
+              io.FontGlobalScale = 1.0f;
+            ImGui::PopID();
             ImGui::PopItemWidth();
 
             ImGui::EndTabItem();

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -1466,7 +1466,7 @@ ImDrawIdx ImDrawList::PushVtx(const ImVec2& pos, const ImVec2& uv, ImU32 innerCo
     _VtxWritePtr[0] = {pos, uv, innerColor};
 #endif
     ++_VtxWritePtr;
-    return _VtxCurrentIdx++;
+    return ImDrawIdx(_VtxCurrentIdx++);
 }
 
 // first vertex is the provocing vertex
@@ -1548,11 +1548,11 @@ void ImDrawList::AddRectFilled(ImVec2 p_min, ImVec2 p_max, ImU32 col, float roun
     }
 
     float total = outer + rounding;
-    float antialiasing = 0.25 / total; // In the shader this value is used both ways, so in effect this is half a pixel. This results in sharp corners for the sides of the rounded rect.
+    float antialiasing = 0.25f / total; // In the shader this value is used both ways, so in effect this is half a pixel. This results in sharp corners for the sides of the rounded rect.
     float threshold = ImMin(1.0f, float(outer + 0.25) / total);
     float outer_threshold = outer == 0 ? threshold : antialiasing; // if the outer calculatings are not needed, set the outer threshold to same value as inner threshold to avoid unneeded calculations
 
-    float antialiasing_irregular = outer ? 0.25 / outer : 0.0f; // In the shader this value is used both ways, so in effect this is half a pixel. This results in sharp corners for the sides of the rounded rect.
+    float antialiasing_irregular = outer ? 0.25f / outer : 0.0f; // In the shader this value is used both ways, so in effect this is half a pixel. This results in sharp corners for the sides of the rounded rect.
     float outer_threshold_irregular = outer == 0 ? threshold : antialiasing_irregular; // if the outer calculatings are not needed, set the outer threshold to same value as inner threshold to avoid unneeded calculations
     // we want circular signed distance calculations
     threshold += 2.0;
@@ -1600,10 +1600,10 @@ void ImDrawList::AddRectFilled(ImVec2 p_min, ImVec2 p_max, ImU32 col, float roun
     PrimReserve(indeces, vertices);
 
     // make the grid of points (see figure above)
-    ImDrawIdx v1 = PushVtx(ImVec2(p_min.x - outer, p_min.y - outer), uv_a, col, startOuterColor, endOuterColor, top_left_irregular ? threshold : 3.0, top_left_irregular ? outer_threshold : outer_threshold_irregular, top_left_irregular ? antialiasing : antialiasing_irregular);
+    ImDrawIdx v1 = PushVtx(ImVec2(p_min.x - outer, p_min.y - outer), uv_a, col, startOuterColor, endOuterColor, top_left_irregular ? threshold : 3.0f, top_left_irregular ? outer_threshold : outer_threshold_irregular, top_left_irregular ? antialiasing : antialiasing_irregular);
     ImDrawIdx v2 = PushVtx(ImVec2(p_min.x + (top_left_irregular ? rounding : 0), p_min.y - outer), uv_b, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
     ImDrawIdx v3 = !middle_column ? v2 : PushVtx(ImVec2(p_max.x - (top_right_irregular ? rounding : 0), p_min.y - outer), uv_b, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
-    ImDrawIdx v4 = PushVtx(ImVec2(p_max.x + outer, p_min.y - outer), uv_a, col, startOuterColor, endOuterColor, top_right_irregular ? threshold : 3.0, top_right_irregular ? outer_threshold : outer_threshold_irregular, top_right_irregular ? antialiasing : antialiasing_irregular);
+    ImDrawIdx v4 = PushVtx(ImVec2(p_max.x + outer, p_min.y - outer), uv_a, col, startOuterColor, endOuterColor, top_right_irregular ? threshold : 3.0f, top_right_irregular ? outer_threshold : outer_threshold_irregular, top_right_irregular ? antialiasing : antialiasing_irregular);
 
     ImDrawIdx w1 = PushVtx(ImVec2(p_min.x - outer, p_min.y + (top_left_irregular ? rounding : 0)), uv_d, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
     ImDrawIdx w2 = PushVtx(ImVec2(p_min.x + (top_left_irregular ? rounding : 0), p_min.y + (top_left_irregular ? rounding : 0)), uv_c, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
@@ -1615,10 +1615,10 @@ void ImDrawList::AddRectFilled(ImVec2 p_min, ImVec2 p_max, ImU32 col, float roun
     ImDrawIdx x3 = !middle_row ? w3 : !middle_column ? x2 : PushVtx(ImVec2(p_max.x - (bottom_right_irregular ? rounding : 0), p_max.y - (bottom_right_irregular ? rounding : 0)), uv_c, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
     ImDrawIdx x4 = !middle_row ? w4 : PushVtx(ImVec2(p_max.x + outer, p_max.y - (bottom_right_irregular ? rounding : 0)), uv_d, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
 
-    ImDrawIdx y1 = PushVtx(ImVec2(p_min.x - outer, p_max.y + outer), uv_a, col, startOuterColor, endOuterColor, bottom_left_irregular ? threshold : 3.0, bottom_left_irregular ? outer_threshold : outer_threshold_irregular, bottom_left_irregular ? antialiasing : antialiasing_irregular);
+    ImDrawIdx y1 = PushVtx(ImVec2(p_min.x - outer, p_max.y + outer), uv_a, col, startOuterColor, endOuterColor, bottom_left_irregular ? threshold : 3.0f, bottom_left_irregular ? outer_threshold : outer_threshold_irregular, bottom_left_irregular ? antialiasing : antialiasing_irregular);
     ImDrawIdx y2 = PushVtx(ImVec2(p_min.x + (bottom_left_irregular ? rounding : 0), p_max.y + outer), uv_b, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
     ImDrawIdx y3 = !middle_column ? y2 : PushVtx(ImVec2(p_max.x - (bottom_right_irregular ? rounding : 0), p_max.y + outer), uv_b, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
-    ImDrawIdx y4 = PushVtx(ImVec2(p_max.x + outer, p_max.y + outer), uv_a, col, startOuterColor, endOuterColor, bottom_right_irregular ? threshold : 3.0, bottom_right_irregular ? outer_threshold : outer_threshold_irregular, bottom_right_irregular ? antialiasing : antialiasing_irregular);
+    ImDrawIdx y4 = PushVtx(ImVec2(p_max.x + outer, p_max.y + outer), uv_a, col, startOuterColor, endOuterColor, bottom_right_irregular ? threshold : 3.0f, bottom_right_irregular ? outer_threshold : outer_threshold_irregular, bottom_right_irregular ? antialiasing : antialiasing_irregular);
 
     // Push out quads based on the vertices above.
     // Sometimes we need to push an additional vertices if an irregular corner is encounterd (with a different/no rounding as the rest).
@@ -3778,11 +3778,11 @@ void ImFont::RenderChar(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col
     pos.x = IM_FLOOR(pos.x);
     pos.y = IM_FLOOR(pos.y);
 
-    // calculate SDF properties, a = cut-off value for signed distance, width = anti-aliasing width
-    float a = sdf ? 0.5 : 0.0;
-    float width = float(IMGUI_SDF_DETAIL) / size * 1. / IMGUI_SDF_PADDING * 1. / IMGUI_SDF_SHARPENING;
-    if (size < IMGUI_SDF_DETAIL) {
-        width *= float(size) / IMGUI_SDF_DETAIL;
+    // calculate SDF properties, a = cut-off value for signed distance (0.0 = disabled), width = anti-aliasing width
+    float a = sdf ? 0.5f : 0.0f;
+    float width = 0.20f / IMGUI_SDF_PADDING * float(IMGUI_SDF_DETAIL) / float(size);
+    if (size < 16.0) {
+        width *= float(size) / 16.0f;
     }
     shadow_size = ImClamp(0.5f - shadow_size/2.0f, width, a);
     if (shadow_size == a) {
@@ -3853,10 +3853,10 @@ void ImFont::RenderText(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col
     const ImU32 col_untinted = col | ~IM_COL32_A_MASK;
 
     // calculate SDF properties, a = cut-off value for signed distance (0.0 = disabled), width = anti-aliasing width
-    float a = sdf ? 0.5 : 0.0;
-    float width = float(IMGUI_SDF_DETAIL) / size * 1. / IMGUI_SDF_PADDING * 1. / IMGUI_SDF_SHARPENING;
-    if (size < IMGUI_SDF_DETAIL) {
-        width *= float(size) / IMGUI_SDF_DETAIL;
+    float a = sdf ? 0.5f : 0.0f;
+    float width = 0.20f / IMGUI_SDF_PADDING * float(IMGUI_SDF_DETAIL) / float(size);
+    if (size < 16.0) {
+        width *= float(size) / 16.0f;
     }
     // shadow should be at least a, otherwise it is discarded
     shadow_size = ImClamp(0.5f - shadow_size/2.0f, width, a);

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -1815,7 +1815,7 @@ void ImDrawList::AddBezierQuadratic(const ImVec2& p1, const ImVec2& p2, const Im
 
 void ImDrawList::AddText(const ImFont* font, float font_size, const ImVec2& pos, ImU32 col, const char* text_begin, const char* text_end, float wrap_width, const ImVec4* cpu_fine_clip_rect, float shadow_size, ImU32 shadow_start, ImU32 shadow_end)
 {
-    if ((col & IM_COL32_A_MASK) == 0)
+    if ((col & IM_COL32_A_MASK) == 0 && (shadow_size <= 0.0f || ((shadow_start & IM_COL32_A_MASK) == 0 && (shadow_end & IM_COL32_A_MASK) == 0)))
         return;
 
     if (text_end == NULL)

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -1600,53 +1600,53 @@ void ImDrawList::AddRectFilled(ImVec2 p_min, ImVec2 p_max, ImU32 col, float roun
     PrimReserve(indeces, vertices);
 
     // make the grid of points (see figure above)
-    auto v1 = PushVtx(ImVec2(p_min.x - outer, p_min.y - outer), uv_a, col, startOuterColor, endOuterColor, top_left_irregular ? threshold : 3.0, top_left_irregular ? outer_threshold : outer_threshold_irregular, top_left_irregular ? antialiasing : antialiasing_irregular);
-    auto v2 = PushVtx(ImVec2(p_min.x + (top_left_irregular ? rounding : 0), p_min.y - outer), uv_b, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
-    auto v3 = !middle_column ? v2 : PushVtx(ImVec2(p_max.x - (top_right_irregular ? rounding : 0), p_min.y - outer), uv_b, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
-    auto v4 = PushVtx(ImVec2(p_max.x + outer, p_min.y - outer), uv_a, col, startOuterColor, endOuterColor, top_right_irregular ? threshold : 3.0, top_right_irregular ? outer_threshold : outer_threshold_irregular, top_right_irregular ? antialiasing : antialiasing_irregular);
+    ImDrawIdx v1 = PushVtx(ImVec2(p_min.x - outer, p_min.y - outer), uv_a, col, startOuterColor, endOuterColor, top_left_irregular ? threshold : 3.0, top_left_irregular ? outer_threshold : outer_threshold_irregular, top_left_irregular ? antialiasing : antialiasing_irregular);
+    ImDrawIdx v2 = PushVtx(ImVec2(p_min.x + (top_left_irregular ? rounding : 0), p_min.y - outer), uv_b, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+    ImDrawIdx v3 = !middle_column ? v2 : PushVtx(ImVec2(p_max.x - (top_right_irregular ? rounding : 0), p_min.y - outer), uv_b, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+    ImDrawIdx v4 = PushVtx(ImVec2(p_max.x + outer, p_min.y - outer), uv_a, col, startOuterColor, endOuterColor, top_right_irregular ? threshold : 3.0, top_right_irregular ? outer_threshold : outer_threshold_irregular, top_right_irregular ? antialiasing : antialiasing_irregular);
 
-    auto w1 = PushVtx(ImVec2(p_min.x - outer, p_min.y + (top_left_irregular ? rounding : 0)), uv_d, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
-    auto w2 = PushVtx(ImVec2(p_min.x + (top_left_irregular ? rounding : 0), p_min.y + (top_left_irregular ? rounding : 0)), uv_c, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
-    auto w3 = !middle_column ? w2 : PushVtx(ImVec2(p_max.x - (top_right_irregular ? rounding : 0), p_min.y + (top_right_irregular ? rounding : 0)), uv_c, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
-    auto w4 = PushVtx(ImVec2(p_max.x + outer, p_min.y + (top_right_irregular ? rounding : 0)), uv_d, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+    ImDrawIdx w1 = PushVtx(ImVec2(p_min.x - outer, p_min.y + (top_left_irregular ? rounding : 0)), uv_d, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+    ImDrawIdx w2 = PushVtx(ImVec2(p_min.x + (top_left_irregular ? rounding : 0), p_min.y + (top_left_irregular ? rounding : 0)), uv_c, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+    ImDrawIdx w3 = !middle_column ? w2 : PushVtx(ImVec2(p_max.x - (top_right_irregular ? rounding : 0), p_min.y + (top_right_irregular ? rounding : 0)), uv_c, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+    ImDrawIdx w4 = PushVtx(ImVec2(p_max.x + outer, p_min.y + (top_right_irregular ? rounding : 0)), uv_d, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
 
-    auto x1 = !middle_row ? w1 : PushVtx(ImVec2(p_min.x - outer, p_max.y - (bottom_left_irregular ? rounding : 0)), uv_d, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
-    auto x2 = !middle_row ? w2 : PushVtx(ImVec2(p_min.x + (bottom_left_irregular ? rounding : 0), p_max.y - (bottom_left_irregular ? rounding : 0)), uv_c, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
-    auto x3 = !middle_row ? w3 : !middle_column ? x2 : PushVtx(ImVec2(p_max.x - (bottom_right_irregular ? rounding : 0), p_max.y - (bottom_right_irregular ? rounding : 0)), uv_c, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
-    auto x4 = !middle_row ? w4 : PushVtx(ImVec2(p_max.x + outer, p_max.y - (bottom_right_irregular ? rounding : 0)), uv_d, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+    ImDrawIdx x1 = !middle_row ? w1 : PushVtx(ImVec2(p_min.x - outer, p_max.y - (bottom_left_irregular ? rounding : 0)), uv_d, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+    ImDrawIdx x2 = !middle_row ? w2 : PushVtx(ImVec2(p_min.x + (bottom_left_irregular ? rounding : 0), p_max.y - (bottom_left_irregular ? rounding : 0)), uv_c, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+    ImDrawIdx x3 = !middle_row ? w3 : !middle_column ? x2 : PushVtx(ImVec2(p_max.x - (bottom_right_irregular ? rounding : 0), p_max.y - (bottom_right_irregular ? rounding : 0)), uv_c, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+    ImDrawIdx x4 = !middle_row ? w4 : PushVtx(ImVec2(p_max.x + outer, p_max.y - (bottom_right_irregular ? rounding : 0)), uv_d, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
 
-    auto y1 = PushVtx(ImVec2(p_min.x - outer, p_max.y + outer), uv_a, col, startOuterColor, endOuterColor, bottom_left_irregular ? threshold : 3.0, bottom_left_irregular ? outer_threshold : outer_threshold_irregular, bottom_left_irregular ? antialiasing : antialiasing_irregular);
-    auto y2 = PushVtx(ImVec2(p_min.x + (bottom_left_irregular ? rounding : 0), p_max.y + outer), uv_b, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
-    auto y3 = !middle_column ? y2 : PushVtx(ImVec2(p_max.x - (bottom_right_irregular ? rounding : 0), p_max.y + outer), uv_b, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
-    auto y4 = PushVtx(ImVec2(p_max.x + outer, p_max.y + outer), uv_a, col, startOuterColor, endOuterColor, bottom_right_irregular ? threshold : 3.0, bottom_right_irregular ? outer_threshold : outer_threshold_irregular, bottom_right_irregular ? antialiasing : antialiasing_irregular);
+    ImDrawIdx y1 = PushVtx(ImVec2(p_min.x - outer, p_max.y + outer), uv_a, col, startOuterColor, endOuterColor, bottom_left_irregular ? threshold : 3.0, bottom_left_irregular ? outer_threshold : outer_threshold_irregular, bottom_left_irregular ? antialiasing : antialiasing_irregular);
+    ImDrawIdx y2 = PushVtx(ImVec2(p_min.x + (bottom_left_irregular ? rounding : 0), p_max.y + outer), uv_b, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+    ImDrawIdx y3 = !middle_column ? y2 : PushVtx(ImVec2(p_max.x - (bottom_right_irregular ? rounding : 0), p_max.y + outer), uv_b, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+    ImDrawIdx y4 = PushVtx(ImVec2(p_max.x + outer, p_max.y + outer), uv_a, col, startOuterColor, endOuterColor, bottom_right_irregular ? threshold : 3.0, bottom_right_irregular ? outer_threshold : outer_threshold_irregular, bottom_right_irregular ? antialiasing : antialiasing_irregular);
 
     // Push out quads based on the vertices above.
     // Sometimes we need to push an additional vertices if an irregular corner is encounterd (with a different/no rounding as the rest).
     // If this is the case, we need to compensate for the different rounding of the shadow that originates from this corner.
     PushQuadIndex(v1, v2, w2, w1);
     if (middle_column) {
-      auto w2_bottom = top_left_irregular ? w2 : PushVtx(ImVec2(p_min.x, p_min.y), uv_c + ImVec2(0, 3 - threshold), col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
-      auto w3_bottom = top_right_irregular ? w3 : PushVtx(ImVec2(p_max.x, p_min.y), uv_c + ImVec2(0, 3 - threshold), col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+      ImDrawIdx w2_bottom = top_left_irregular ? w2 : PushVtx(ImVec2(p_min.x, p_min.y), uv_c + ImVec2(0, 3 - threshold), col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+      ImDrawIdx w3_bottom = top_right_irregular ? w3 : PushVtx(ImVec2(p_max.x, p_min.y), uv_c + ImVec2(0, 3 - threshold), col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
       PushQuadIndex(v2, v3, w3_bottom, w2_bottom);
     }
     PushQuadIndex(v4, w4, w3, v3);
 
     if (middle_row) {
-      auto w2_left = top_left_irregular ? w2 : PushVtx(ImVec2(p_min.x, p_min.y), uv_c + ImVec2(3 - threshold, 0), col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
-      auto x2_left = bottom_left_irregular ? x2 : PushVtx(ImVec2(p_min.x, p_max.y), uv_c + ImVec2(3 - threshold, 0), col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+      ImDrawIdx w2_left = top_left_irregular ? w2 : PushVtx(ImVec2(p_min.x, p_min.y), uv_c + ImVec2(3 - threshold, 0), col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+      ImDrawIdx x2_left = bottom_left_irregular ? x2 : PushVtx(ImVec2(p_min.x, p_max.y), uv_c + ImVec2(3 - threshold, 0), col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
       PushQuadIndex(w1, w2_left, x2_left, x1);
       if (middle_column && innerVisible) {
         PushQuadIndex(w2, w3, x3, x2);
       }
-      auto w3_right = top_right_irregular ? w3 : PushVtx(ImVec2(p_max.x, p_min.y), uv_c + ImVec2(3 - threshold, 0), col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
-      auto x3_right = bottom_right_irregular ? x3 : PushVtx(ImVec2(p_max.x, p_max.y), uv_c + ImVec2(3 - threshold, 0), col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+      ImDrawIdx w3_right = top_right_irregular ? w3 : PushVtx(ImVec2(p_max.x, p_min.y), uv_c + ImVec2(3 - threshold, 0), col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+      ImDrawIdx x3_right = bottom_right_irregular ? x3 : PushVtx(ImVec2(p_max.x, p_max.y), uv_c + ImVec2(3 - threshold, 0), col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
       PushQuadIndex(w3_right, w4, x4, x3_right);
     }
 
     PushQuadIndex(y1, x1, x2, y2);
     if (middle_column) {
-      auto x2_bottom = bottom_left_irregular ? x2 : PushVtx(ImVec2(p_min.x, p_max.y), uv_c + ImVec2(0, 3 - threshold), col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
-      auto x3_bottom = bottom_right_irregular ? x3 : PushVtx(ImVec2(p_max.x, p_max.y), uv_c + ImVec2(0, 3 - threshold), col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+      ImDrawIdx x2_bottom = bottom_left_irregular ? x2 : PushVtx(ImVec2(p_min.x, p_max.y), uv_c + ImVec2(0, 3 - threshold), col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+      ImDrawIdx x3_bottom = bottom_right_irregular ? x3 : PushVtx(ImVec2(p_max.x, p_max.y), uv_c + ImVec2(0, 3 - threshold), col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
       PushQuadIndex(x2_bottom, x3_bottom, y3, y2);
     }
     PushQuadIndex(y4, y3, x3, x4);

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -239,6 +239,10 @@ void ImGui::StyleColorsDark(ImGuiStyle* dst)
     colors[ImGuiCol_NavWindowingHighlight]  = ImVec4(1.00f, 1.00f, 1.00f, 0.70f);
     colors[ImGuiCol_NavWindowingDimBg]      = ImVec4(0.80f, 0.80f, 0.80f, 0.20f);
     colors[ImGuiCol_ModalWindowDimBg]       = ImVec4(0.80f, 0.80f, 0.80f, 0.35f);
+    colors[ImGuiCol_WindowShadowStart]      = ImVec4(1.00f, 1.00f, 1.00f, 0.25f);
+    colors[ImGuiCol_WindowShadowEnd]        = ImVec4(1.00f, 1.00f, 1.00f, 0.0);
+    colors[ImGuiCol_FrameShadowStart]       = ImVec4(1.00f, 1.00f, 1.00f, 0.25f);
+    colors[ImGuiCol_FrameShadowEnd]         = ImVec4(1.00f, 1.00f, 1.00f, 0.0);
 }
 
 void ImGui::StyleColorsClassic(ImGuiStyle* dst)
@@ -299,6 +303,10 @@ void ImGui::StyleColorsClassic(ImGuiStyle* dst)
     colors[ImGuiCol_NavWindowingHighlight]  = ImVec4(1.00f, 1.00f, 1.00f, 0.70f);
     colors[ImGuiCol_NavWindowingDimBg]      = ImVec4(0.80f, 0.80f, 0.80f, 0.20f);
     colors[ImGuiCol_ModalWindowDimBg]       = ImVec4(0.20f, 0.20f, 0.20f, 0.35f);
+    colors[ImGuiCol_WindowShadowStart]      = ImVec4(1.00f, 1.00f, 1.00f, 0.25f);
+    colors[ImGuiCol_WindowShadowEnd]        = ImVec4(1.00f, 1.00f, 1.00f, 0.0);
+    colors[ImGuiCol_FrameShadowStart]       = ImVec4(1.00f, 1.00f, 1.00f, 0.25f);
+    colors[ImGuiCol_FrameShadowEnd]         = ImVec4(1.00f, 1.00f, 1.00f, 0.0);
 }
 
 // Those light colors are better suited with a thicker font than the default one + FrameBorder
@@ -360,6 +368,10 @@ void ImGui::StyleColorsLight(ImGuiStyle* dst)
     colors[ImGuiCol_NavWindowingHighlight]  = ImVec4(0.70f, 0.70f, 0.70f, 0.70f);
     colors[ImGuiCol_NavWindowingDimBg]      = ImVec4(0.20f, 0.20f, 0.20f, 0.20f);
     colors[ImGuiCol_ModalWindowDimBg]       = ImVec4(0.20f, 0.20f, 0.20f, 0.35f);
+    colors[ImGuiCol_WindowShadowStart]      = ImVec4(0.00f, 0.00f, 0.00f, 0.25f);
+    colors[ImGuiCol_WindowShadowEnd]        = ImVec4(0.00f, 0.00f, 0.00f, 0.0);
+    colors[ImGuiCol_FrameShadowStart]       = ImVec4(0.00f, 0.00f, 0.00f, 0.25f);
+    colors[ImGuiCol_FrameShadowEnd]         = ImVec4(0.00f, 0.00f, 0.00f, 0.0);
 }
 
 //-----------------------------------------------------------------------------
@@ -652,14 +664,56 @@ void ImDrawList::PrimRect(const ImVec2& a, const ImVec2& c, ImU32 col)
     _VtxWritePtr[1].pos = b; _VtxWritePtr[1].uv = uv; _VtxWritePtr[1].col = col;
     _VtxWritePtr[2].pos = c; _VtxWritePtr[2].uv = uv; _VtxWritePtr[2].col = col;
     _VtxWritePtr[3].pos = d; _VtxWritePtr[3].uv = uv; _VtxWritePtr[3].col = col;
+#ifndef IMGUI_DISABLE_SDF
+    _VtxWritePtr[0].simple();
+    _VtxWritePtr[1].simple();
+    _VtxWritePtr[2].simple();
+    _VtxWritePtr[3].simple();
+#endif
     _VtxWritePtr += 4;
     _VtxCurrentIdx += 4;
     _IdxWritePtr += 6;
 }
 
-void ImDrawList::PrimRectUV(const ImVec2& a, const ImVec2& c, const ImVec2& uv_a, const ImVec2& uv_c, ImU32 col)
+void ImDrawList::PrimRectUV(const ImVec2& tl, const ImVec2& br, const ImVec2& uv_a, const ImVec2& uv_c, ImU32 innerColor, ImU32 startOuterColor, ImU32 endOuterColor, float a, float b, float w)
 {
-    ImVec2 b(c.x, a.y), d(a.x, c.y), uv_b(uv_c.x, uv_a.y), uv_d(uv_a.x, uv_c.y);
+    ImVec2 tr(br.x, tl.y), bl(tl.x, br.y), uv_b(uv_c.x, uv_a.y), uv_d(uv_a.x, uv_c.y);
+    ImDrawIdx idx = (ImDrawIdx)_VtxCurrentIdx;
+    _IdxWritePtr[0] = idx; _IdxWritePtr[1] = (ImDrawIdx)(idx+1); _IdxWritePtr[2] = (ImDrawIdx)(idx+2);
+    _IdxWritePtr[3] = idx; _IdxWritePtr[4] = (ImDrawIdx)(idx+2); _IdxWritePtr[5] = (ImDrawIdx)(idx+3);
+    _VtxWritePtr[0].pos = tl; _VtxWritePtr[0].uv = uv_a; _VtxWritePtr[0].col = innerColor;
+    _VtxWritePtr[1].pos = tr; _VtxWritePtr[1].uv = uv_b; _VtxWritePtr[1].col = innerColor;
+    _VtxWritePtr[2].pos = br; _VtxWritePtr[2].uv = uv_c; _VtxWritePtr[2].col = innerColor;
+    _VtxWritePtr[3].pos = bl; _VtxWritePtr[3].uv = uv_d; _VtxWritePtr[3].col = innerColor;
+#ifndef IMGUI_DISABLE_SDF
+    _VtxWritePtr[0].startOuterColor =
+        _VtxWritePtr[1].startOuterColor =
+        _VtxWritePtr[2].startOuterColor =
+        _VtxWritePtr[3].startOuterColor = startOuterColor;
+    _VtxWritePtr[0].endOuterColor =
+        _VtxWritePtr[1].endOuterColor =
+        _VtxWritePtr[2].endOuterColor =
+        _VtxWritePtr[3].endOuterColor = endOuterColor;
+    _VtxWritePtr[0].a =
+        _VtxWritePtr[1].a =
+        _VtxWritePtr[2].a =
+        _VtxWritePtr[3].a = a;
+    _VtxWritePtr[0].b =
+        _VtxWritePtr[1].b =
+        _VtxWritePtr[2].b =
+        _VtxWritePtr[3].b = b;
+    _VtxWritePtr[0].w =
+        _VtxWritePtr[1].w =
+        _VtxWritePtr[2].w =
+        _VtxWritePtr[3].w = w;
+#endif
+    _VtxWritePtr += 4;
+    _VtxCurrentIdx += 4;
+    _IdxWritePtr += 6;
+}
+
+void ImDrawList::PrimQuadUV(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& d, const ImVec2& uv_a, const ImVec2& uv_b, const ImVec2& uv_c, const ImVec2& uv_d, ImU32 col, float w)
+{
     ImDrawIdx idx = (ImDrawIdx)_VtxCurrentIdx;
     _IdxWritePtr[0] = idx; _IdxWritePtr[1] = (ImDrawIdx)(idx+1); _IdxWritePtr[2] = (ImDrawIdx)(idx+2);
     _IdxWritePtr[3] = idx; _IdxWritePtr[4] = (ImDrawIdx)(idx+2); _IdxWritePtr[5] = (ImDrawIdx)(idx+3);
@@ -667,20 +721,16 @@ void ImDrawList::PrimRectUV(const ImVec2& a, const ImVec2& c, const ImVec2& uv_a
     _VtxWritePtr[1].pos = b; _VtxWritePtr[1].uv = uv_b; _VtxWritePtr[1].col = col;
     _VtxWritePtr[2].pos = c; _VtxWritePtr[2].uv = uv_c; _VtxWritePtr[2].col = col;
     _VtxWritePtr[3].pos = d; _VtxWritePtr[3].uv = uv_d; _VtxWritePtr[3].col = col;
-    _VtxWritePtr += 4;
-    _VtxCurrentIdx += 4;
-    _IdxWritePtr += 6;
-}
-
-void ImDrawList::PrimQuadUV(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& d, const ImVec2& uv_a, const ImVec2& uv_b, const ImVec2& uv_c, const ImVec2& uv_d, ImU32 col)
-{
-    ImDrawIdx idx = (ImDrawIdx)_VtxCurrentIdx;
-    _IdxWritePtr[0] = idx; _IdxWritePtr[1] = (ImDrawIdx)(idx+1); _IdxWritePtr[2] = (ImDrawIdx)(idx+2);
-    _IdxWritePtr[3] = idx; _IdxWritePtr[4] = (ImDrawIdx)(idx+2); _IdxWritePtr[5] = (ImDrawIdx)(idx+3);
-    _VtxWritePtr[0].pos = a; _VtxWritePtr[0].uv = uv_a; _VtxWritePtr[0].col = col;
-    _VtxWritePtr[1].pos = b; _VtxWritePtr[1].uv = uv_b; _VtxWritePtr[1].col = col;
-    _VtxWritePtr[2].pos = c; _VtxWritePtr[2].uv = uv_c; _VtxWritePtr[2].col = col;
-    _VtxWritePtr[3].pos = d; _VtxWritePtr[3].uv = uv_d; _VtxWritePtr[3].col = col;
+#ifndef IMGUI_DISABLE_SDF
+    _VtxWritePtr[0].simple();
+    _VtxWritePtr[1].simple();
+    _VtxWritePtr[2].simple();
+    _VtxWritePtr[3].simple();
+    _VtxWritePtr[0].w =
+        _VtxWritePtr[1].w =
+        _VtxWritePtr[2].w =
+        _VtxWritePtr[3].w = w;
+#endif
     _VtxWritePtr += 4;
     _VtxCurrentIdx += 4;
     _IdxWritePtr += 6;
@@ -828,6 +878,10 @@ void ImDrawList::AddPolyline(const ImVec2* points, const int points_count, ImU32
                 {
                     _VtxWritePtr[0].pos = temp_points[i * 2 + 0]; _VtxWritePtr[0].uv = tex_uv0; _VtxWritePtr[0].col = col; // Left-side outer edge
                     _VtxWritePtr[1].pos = temp_points[i * 2 + 1]; _VtxWritePtr[1].uv = tex_uv1; _VtxWritePtr[1].col = col; // Right-side outer edge
+#ifndef IMGUI_DISABLE_SDF
+                    _VtxWritePtr[0].simple();
+                    _VtxWritePtr[1].simple();
+#endif
                     _VtxWritePtr += 2;
                 }
             }
@@ -839,6 +893,11 @@ void ImDrawList::AddPolyline(const ImVec2* points, const int points_count, ImU32
                     _VtxWritePtr[0].pos = points[i];              _VtxWritePtr[0].uv = opaque_uv; _VtxWritePtr[0].col = col;       // Center of line
                     _VtxWritePtr[1].pos = temp_points[i * 2 + 0]; _VtxWritePtr[1].uv = opaque_uv; _VtxWritePtr[1].col = col_trans; // Left-side outer edge
                     _VtxWritePtr[2].pos = temp_points[i * 2 + 1]; _VtxWritePtr[2].uv = opaque_uv; _VtxWritePtr[2].col = col_trans; // Right-side outer edge
+#ifndef IMGUI_DISABLE_SDF
+                    _VtxWritePtr[0].simple();
+                    _VtxWritePtr[1].simple();
+                    _VtxWritePtr[2].simple();
+#endif
                     _VtxWritePtr += 3;
                 }
             }
@@ -910,6 +969,12 @@ void ImDrawList::AddPolyline(const ImVec2* points, const int points_count, ImU32
                 _VtxWritePtr[1].pos = temp_points[i * 4 + 1]; _VtxWritePtr[1].uv = opaque_uv; _VtxWritePtr[1].col = col;
                 _VtxWritePtr[2].pos = temp_points[i * 4 + 2]; _VtxWritePtr[2].uv = opaque_uv; _VtxWritePtr[2].col = col;
                 _VtxWritePtr[3].pos = temp_points[i * 4 + 3]; _VtxWritePtr[3].uv = opaque_uv; _VtxWritePtr[3].col = col_trans;
+#ifndef IMGUI_DISABLE_SDF
+                _VtxWritePtr[0].simple();
+                _VtxWritePtr[1].simple();
+                _VtxWritePtr[2].simple();
+                _VtxWritePtr[3].simple();
+#endif
                 _VtxWritePtr += 4;
             }
         }
@@ -938,6 +1003,12 @@ void ImDrawList::AddPolyline(const ImVec2* points, const int points_count, ImU32
             _VtxWritePtr[1].pos.x = p2.x + dy; _VtxWritePtr[1].pos.y = p2.y - dx; _VtxWritePtr[1].uv = opaque_uv; _VtxWritePtr[1].col = col;
             _VtxWritePtr[2].pos.x = p2.x - dy; _VtxWritePtr[2].pos.y = p2.y + dx; _VtxWritePtr[2].uv = opaque_uv; _VtxWritePtr[2].col = col;
             _VtxWritePtr[3].pos.x = p1.x - dy; _VtxWritePtr[3].pos.y = p1.y + dx; _VtxWritePtr[3].uv = opaque_uv; _VtxWritePtr[3].col = col;
+#ifndef IMGUI_DISABLE_SDF
+            _VtxWritePtr[0].simple();
+            _VtxWritePtr[1].simple();
+            _VtxWritePtr[2].simple();
+            _VtxWritePtr[3].simple();
+#endif
             _VtxWritePtr += 4;
 
             _IdxWritePtr[0] = (ImDrawIdx)(_VtxCurrentIdx); _IdxWritePtr[1] = (ImDrawIdx)(_VtxCurrentIdx + 1); _IdxWritePtr[2] = (ImDrawIdx)(_VtxCurrentIdx + 2);
@@ -1001,6 +1072,10 @@ void ImDrawList::AddConvexPolyFilled(const ImVec2* points, const int points_coun
             // Add vertices
             _VtxWritePtr[0].pos.x = (points[i1].x - dm_x); _VtxWritePtr[0].pos.y = (points[i1].y - dm_y); _VtxWritePtr[0].uv = uv; _VtxWritePtr[0].col = col;        // Inner
             _VtxWritePtr[1].pos.x = (points[i1].x + dm_x); _VtxWritePtr[1].pos.y = (points[i1].y + dm_y); _VtxWritePtr[1].uv = uv; _VtxWritePtr[1].col = col_trans;  // Outer
+#ifndef IMGUI_DISABLE_SDF
+            _VtxWritePtr[0].simple();
+            _VtxWritePtr[1].simple();
+#endif
             _VtxWritePtr += 2;
 
             // Add indexes for fringes
@@ -1019,6 +1094,9 @@ void ImDrawList::AddConvexPolyFilled(const ImVec2* points, const int points_coun
         for (int i = 0; i < vtx_count; i++)
         {
             _VtxWritePtr[0].pos = points[i]; _VtxWritePtr[0].uv = uv; _VtxWritePtr[0].col = col;
+#ifndef IMGUI_DISABLE_SDF
+            _VtxWritePtr[0].simple();
+#endif
             _VtxWritePtr++;
         }
         for (int i = 2; i < points_count; i++)
@@ -1365,8 +1443,13 @@ void ImDrawList::AddLine(const ImVec2& p1, const ImVec2& p2, ImU32 col, float th
 
 // p_min = upper-left, p_max = lower-right
 // Note we don't render 1 pixels sized rectangles properly.
-void ImDrawList::AddRect(const ImVec2& p_min, const ImVec2& p_max, ImU32 col, float rounding, ImDrawFlags flags, float thickness)
-{
+void ImDrawList::AddRect(const ImVec2& p_min, const ImVec2& p_max, ImU32 col, float rounding, ImDrawFlags flags, float thickness) {
+#ifndef IMGUI_DISABLE_SDF
+    if ((Flags & ImDrawListFlags_SignedDistanceShapes)) {
+      AddRectFilled(p_min + ImVec2(thickness/2, thickness/2), p_max - ImVec2(thickness/2, thickness/2), IM_COL32_BLACK_TRANS, rounding, flags, thickness, col, col);
+      return;
+    }
+#endif
     if ((col & IM_COL32_A_MASK) == 0)
         return;
     if (Flags & ImDrawListFlags_AntiAliasedLines)
@@ -1376,20 +1459,198 @@ void ImDrawList::AddRect(const ImVec2& p_min, const ImVec2& p_max, ImU32 col, fl
     PathStroke(col, ImDrawFlags_Closed, thickness);
 }
 
-void ImDrawList::AddRectFilled(const ImVec2& p_min, const ImVec2& p_max, ImU32 col, float rounding, ImDrawFlags flags)
-{
-    if ((col & IM_COL32_A_MASK) == 0)
-        return;
-    if (rounding <= 0.0f || (flags & ImDrawFlags_RoundCornersMask_) == ImDrawFlags_RoundCornersNone)
-    {
+ImDrawIdx ImDrawList::PushVtx(const ImVec2& pos, const ImVec2& uv, ImU32 innerColor, ImU32 startOuterColor, ImU32 endOuterColor, float a, float b, float w) {
+#ifndef IMGUI_DISABLE_SDF
+    _VtxWritePtr[0] = {pos, uv, innerColor, startOuterColor, endOuterColor, a, b, w};
+#else
+    _VtxWritePtr[0] = {pos, uv, innerColor};
+#endif
+    ++_VtxWritePtr;
+    return _VtxCurrentIdx++;
+}
+
+// first vertex is the provocing vertex
+void ImDrawList::PushQuadIndex(ImDrawIdx a, ImDrawIdx b, ImDrawIdx c, ImDrawIdx d) {
+    if ((Flags & ImDrawListFlags_ProvocingVertexFirst)) {
+      *_IdxWritePtr++ = a;
+    }
+
+    *_IdxWritePtr++ = b;
+    *_IdxWritePtr++ = c;
+
+    *_IdxWritePtr++ = a;
+
+    *_IdxWritePtr++ = c;
+    *_IdxWritePtr++ = d;
+
+    if (!(Flags & ImDrawListFlags_ProvocingVertexFirst)) {
+      *_IdxWritePtr++ = a;
+    }
+}
+
+void ImDrawList::AddRectFilled(ImVec2 p_min, ImVec2 p_max, ImU32 col, float rounding, ImDrawFlags flags, float outer, ImU32 startOuterColor, ImU32 endOuterColor) {
+#ifndef IMGUI_DISABLE_SDF
+    if (!(Flags & ImDrawListFlags_SignedDistanceShapes)) {
+#endif
+      if ((col & IM_COL32_A_MASK) == 0)
+          return;
+      if (rounding <= 0.0f || (flags & ImDrawFlags_RoundCornersMask_) == ImDrawFlags_RoundCornersNone)
+      {
+          PrimReserve(6, 4);
+          PrimRect(p_min, p_max, col);
+      }
+      else
+      {
+          PathRect(p_min, p_max, rounding, flags);
+          PathFillConvex(col);
+      }
+#ifndef IMGUI_DISABLE_SDF
+      return;
+    }
+
+    if (!flags)
+      flags = ImDrawFlags_RoundCornersAll;
+
+    if (flags == ImDrawFlags_RoundCornersNone)
+      rounding = 0;
+
+    if (p_max.x < p_min.x)
+      ImSwap(p_min.x, p_max.x);
+    if (p_max.y < p_min.y)
+      ImSwap(p_min.y, p_max.y);
+
+    // max rounding is the shortest side
+    if ((flags & ImDrawFlags_RoundCornersTop) && (flags & ImDrawFlags_RoundCornersBottom)) {
+      rounding = ImMin((p_max.y - p_min.y - 1) / 2, rounding);
+    }
+    if ((flags & ImDrawFlags_RoundCornersLeft) && (flags & ImDrawFlags_RoundCornersRight)) {
+      rounding = ImMin((p_max.x - p_min.x - 1) / 2, rounding);
+    }
+    rounding = ImMin(ImMin(p_max.x - p_min.x - 1, p_max.y - p_min.y - 1), rounding);
+
+    // reduce artifacts in shader, especially in a corner the outer color can be seen a bit
+    
+    if (outer == 0) {
+        startOuterColor &= ~IM_COL32_A_MASK;
+        endOuterColor &= ~IM_COL32_A_MASK;
+    }
+
+    if ((startOuterColor & IM_COL32_A_MASK) == 0 && (endOuterColor & IM_COL32_A_MASK) == 0) {
+        startOuterColor = endOuterColor = col;
+        outer = 0;
+    }
+
+    // fast path
+    if (outer + rounding == 0) {
         PrimReserve(6, 4);
         PrimRect(p_min, p_max, col);
+        return;
     }
-    else
-    {
-        PathRect(p_min, p_max, rounding, flags);
-        PathFillConvex(col);
+
+    float total = outer + rounding;
+    float antialiasing = 0.25 / total; // In the shader this value is used both ways, so in effect this is half a pixel. This results in sharp corners for the sides of the rounded rect.
+    float threshold = ImMin(1.0f, float(outer + 0.25) / total);
+    float outer_threshold = outer == 0 ? threshold : antialiasing; // if the outer calculatings are not needed, set the outer threshold to same value as inner threshold to avoid unneeded calculations
+
+    float antialiasing_irregular = outer ? 0.25 / outer : 0.0f; // In the shader this value is used both ways, so in effect this is half a pixel. This results in sharp corners for the sides of the rounded rect.
+    float outer_threshold_irregular = outer == 0 ? threshold : antialiasing_irregular; // if the outer calculatings are not needed, set the outer threshold to same value as inner threshold to avoid unneeded calculations
+    // we want circular signed distance calculations
+    threshold += 2.0;
+
+    /* BASE LAYOUT:
+     * XY coordinates:
+     *   v1, v2, v3, v4
+     *   w1, w2, w3, w4
+     *   x1, x2, x3, x4
+     *   y1, y2, y3, y4
+     * Texture coordinates:
+     *   uv_a, uv_b, uv_c, uv_d
+     *
+     * There are mapped like this (for the normal case with all corners have the same rounding):
+     *
+     *        1 2    3 4
+     *      v a-b----b-a
+     *      w d-c----c-d
+     *        | |    | |
+     *      x d-c----c-d
+     *      y a-b----b-a
+     */
+
+    ImVec2 uv_a{ 1, 1 };
+    ImVec2 uv_b{ 0, 1 };
+    ImVec2 uv_c{ 0, 0 };
+    ImVec2 uv_d{ 1, 0 };
+
+    // mark as rounding if rounding is zero to save vertices (which are generated for non-rounded corners if rounded corners are also present
+    int top_left_irregular = (flags & ImDrawFlags_RoundCornersTopLeft) > 0 || rounding == 0;
+    int top_right_irregular = (flags & ImDrawFlags_RoundCornersTopRight) > 0 || rounding == 0;
+    int bottom_left_irregular = (flags & ImDrawFlags_RoundCornersBottomLeft) > 0 || rounding == 0;
+    int bottom_right_irregular = (flags & ImDrawFlags_RoundCornersBottomRight) > 0 || rounding == 0;
+
+    // check which rows and columns needs to be generated
+    bool middle_row = p_min.y + ((flags & ImDrawFlags_RoundCornersTop) ? rounding : 0) < p_max.y - ((flags & ImDrawFlags_RoundCornersBottom) ? rounding : 0);
+    bool middle_column = p_min.x + ((flags & ImDrawFlags_RoundCornersLeft) ? rounding : 0) < p_max.x - ((flags & ImDrawFlags_RoundCornersRight) ? rounding : 0);
+    bool innerVisible = (col & IM_COL32_A_MASK) > 0;
+
+    // calculate number of indeces/vertices to reserve
+    int noCorners = !top_left_irregular + !top_right_irregular + !bottom_left_irregular + !bottom_right_irregular;
+    int vertices = (3+middle_column)*(3+middle_row) + (middle_column ? noCorners : 0) + (middle_row ? noCorners : 0);
+    int indeces = 6 * (4 + (middle_row ? 2 : 0) + (middle_column ? 2 : 0) + (middle_row && middle_column && innerVisible ? 1 : 0));
+
+    PrimReserve(indeces, vertices);
+
+    // make the grid of points (see figure above)
+    auto v1 = PushVtx(ImVec2(p_min.x - outer, p_min.y - outer), uv_a, col, startOuterColor, endOuterColor, top_left_irregular ? threshold : 3.0, top_left_irregular ? outer_threshold : outer_threshold_irregular, top_left_irregular ? antialiasing : antialiasing_irregular);
+    auto v2 = PushVtx(ImVec2(p_min.x + (top_left_irregular ? rounding : 0), p_min.y - outer), uv_b, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+    auto v3 = !middle_column ? v2 : PushVtx(ImVec2(p_max.x - (top_right_irregular ? rounding : 0), p_min.y - outer), uv_b, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+    auto v4 = PushVtx(ImVec2(p_max.x + outer, p_min.y - outer), uv_a, col, startOuterColor, endOuterColor, top_right_irregular ? threshold : 3.0, top_right_irregular ? outer_threshold : outer_threshold_irregular, top_right_irregular ? antialiasing : antialiasing_irregular);
+
+    auto w1 = PushVtx(ImVec2(p_min.x - outer, p_min.y + (top_left_irregular ? rounding : 0)), uv_d, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+    auto w2 = PushVtx(ImVec2(p_min.x + (top_left_irregular ? rounding : 0), p_min.y + (top_left_irregular ? rounding : 0)), uv_c, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+    auto w3 = !middle_column ? w2 : PushVtx(ImVec2(p_max.x - (top_right_irregular ? rounding : 0), p_min.y + (top_right_irregular ? rounding : 0)), uv_c, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+    auto w4 = PushVtx(ImVec2(p_max.x + outer, p_min.y + (top_right_irregular ? rounding : 0)), uv_d, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+
+    auto x1 = !middle_row ? w1 : PushVtx(ImVec2(p_min.x - outer, p_max.y - (bottom_left_irregular ? rounding : 0)), uv_d, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+    auto x2 = !middle_row ? w2 : PushVtx(ImVec2(p_min.x + (bottom_left_irregular ? rounding : 0), p_max.y - (bottom_left_irregular ? rounding : 0)), uv_c, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+    auto x3 = !middle_row ? w3 : !middle_column ? x2 : PushVtx(ImVec2(p_max.x - (bottom_right_irregular ? rounding : 0), p_max.y - (bottom_right_irregular ? rounding : 0)), uv_c, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+    auto x4 = !middle_row ? w4 : PushVtx(ImVec2(p_max.x + outer, p_max.y - (bottom_right_irregular ? rounding : 0)), uv_d, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+
+    auto y1 = PushVtx(ImVec2(p_min.x - outer, p_max.y + outer), uv_a, col, startOuterColor, endOuterColor, bottom_left_irregular ? threshold : 3.0, bottom_left_irregular ? outer_threshold : outer_threshold_irregular, bottom_left_irregular ? antialiasing : antialiasing_irregular);
+    auto y2 = PushVtx(ImVec2(p_min.x + (bottom_left_irregular ? rounding : 0), p_max.y + outer), uv_b, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+    auto y3 = !middle_column ? y2 : PushVtx(ImVec2(p_max.x - (bottom_right_irregular ? rounding : 0), p_max.y + outer), uv_b, col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+    auto y4 = PushVtx(ImVec2(p_max.x + outer, p_max.y + outer), uv_a, col, startOuterColor, endOuterColor, bottom_right_irregular ? threshold : 3.0, bottom_right_irregular ? outer_threshold : outer_threshold_irregular, bottom_right_irregular ? antialiasing : antialiasing_irregular);
+
+    // Push out quads based on the vertices above.
+    // Sometimes we need to push an additional vertices if an irregular corner is encounterd (with a different/no rounding as the rest).
+    // If this is the case, we need to compensate for the different rounding of the shadow that originates from this corner.
+    PushQuadIndex(v1, v2, w2, w1);
+    if (middle_column) {
+      auto w2_bottom = top_left_irregular ? w2 : PushVtx(ImVec2(p_min.x, p_min.y), uv_c + ImVec2(0, 3 - threshold), col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+      auto w3_bottom = top_right_irregular ? w3 : PushVtx(ImVec2(p_max.x, p_min.y), uv_c + ImVec2(0, 3 - threshold), col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+      PushQuadIndex(v2, v3, w3_bottom, w2_bottom);
     }
+    PushQuadIndex(v4, w4, w3, v3);
+
+    if (middle_row) {
+      auto w2_left = top_left_irregular ? w2 : PushVtx(ImVec2(p_min.x, p_min.y), uv_c + ImVec2(3 - threshold, 0), col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+      auto x2_left = bottom_left_irregular ? x2 : PushVtx(ImVec2(p_min.x, p_max.y), uv_c + ImVec2(3 - threshold, 0), col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+      PushQuadIndex(w1, w2_left, x2_left, x1);
+      if (middle_column && innerVisible) {
+        PushQuadIndex(w2, w3, x3, x2);
+      }
+      auto w3_right = top_right_irregular ? w3 : PushVtx(ImVec2(p_max.x, p_min.y), uv_c + ImVec2(3 - threshold, 0), col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+      auto x3_right = bottom_right_irregular ? x3 : PushVtx(ImVec2(p_max.x, p_max.y), uv_c + ImVec2(3 - threshold, 0), col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+      PushQuadIndex(w3_right, w4, x4, x3_right);
+    }
+
+    PushQuadIndex(y1, x1, x2, y2);
+    if (middle_column) {
+      auto x2_bottom = bottom_left_irregular ? x2 : PushVtx(ImVec2(p_min.x, p_max.y), uv_c + ImVec2(0, 3 - threshold), col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+      auto x3_bottom = bottom_right_irregular ? x3 : PushVtx(ImVec2(p_max.x, p_max.y), uv_c + ImVec2(0, 3 - threshold), col, startOuterColor, endOuterColor, threshold, outer_threshold, antialiasing);
+      PushQuadIndex(x2_bottom, x3_bottom, y3, y2);
+    }
+    PushQuadIndex(y4, y3, x3, x4);
+#endif
 }
 
 // p_min = upper-left, p_max = lower-right
@@ -1552,7 +1813,7 @@ void ImDrawList::AddBezierQuadratic(const ImVec2& p1, const ImVec2& p2, const Im
     PathStroke(col, 0, thickness);
 }
 
-void ImDrawList::AddText(const ImFont* font, float font_size, const ImVec2& pos, ImU32 col, const char* text_begin, const char* text_end, float wrap_width, const ImVec4* cpu_fine_clip_rect)
+void ImDrawList::AddText(const ImFont* font, float font_size, const ImVec2& pos, ImU32 col, const char* text_begin, const char* text_end, float wrap_width, const ImVec4* cpu_fine_clip_rect, float shadow_size, ImU32 shadow_start, ImU32 shadow_end)
 {
     if ((col & IM_COL32_A_MASK) == 0)
         return;
@@ -1578,12 +1839,13 @@ void ImDrawList::AddText(const ImFont* font, float font_size, const ImVec2& pos,
         clip_rect.z = ImMin(clip_rect.z, cpu_fine_clip_rect->z);
         clip_rect.w = ImMin(clip_rect.w, cpu_fine_clip_rect->w);
     }
-    font->RenderText(this, font_size, pos, col, clip_rect, text_begin, text_end, wrap_width, cpu_fine_clip_rect != NULL);
+    bool globalSDF = ImGui::GetIO().BackendFlags & ImGuiBackendFlags_SignedDistanceFonts;
+    font->RenderText(this, font_size, pos, col, clip_rect, text_begin, text_end, wrap_width, cpu_fine_clip_rect != NULL, globalSDF && font->SignedDistanceFont, shadow_size, shadow_start, shadow_end);
 }
 
-void ImDrawList::AddText(const ImVec2& pos, ImU32 col, const char* text_begin, const char* text_end)
+void ImDrawList::AddText(const ImVec2& pos, ImU32 col, const char* text_begin, const char* text_end, float shadow_size, ImU32 shadow_start, ImU32 shadow_end)
 {
-    AddText(NULL, 0.0f, pos, col, text_begin, text_end);
+    AddText(NULL, 0.0f, pos, col, text_begin, text_end, 0.0f, NULL, shadow_size, shadow_start, shadow_end);
 }
 
 void ImDrawList::AddImage(ImTextureID user_texture_id, const ImVec2& p_min, const ImVec2& p_max, const ImVec2& uv_min, const ImVec2& uv_max, ImU32 col)
@@ -2320,6 +2582,8 @@ static bool ImFontAtlasBuildWithStbTruetype(ImFontAtlas* atlas)
 {
     IM_ASSERT(atlas->ConfigData.Size > 0);
 
+    bool globalSDF = ImGui::GetIO().BackendFlags & ImGuiBackendFlags_SignedDistanceFonts;
+
     ImFontAtlasBuildInit(atlas);
 
     // Clear atlas
@@ -2435,25 +2699,26 @@ static bool ImFontAtlasBuildWithStbTruetype(ImFontAtlas* atlas)
 
         // Convert our ranges in the format stb_truetype wants
         ImFontConfig& cfg = atlas->ConfigData[src_i];
-        src_tmp.PackRange.font_size = cfg.SizePixels;
+        bool sdf = globalSDF && cfg.SignedDistanceFont;
+        src_tmp.PackRange.font_size = sdf ? IMGUI_SDF_DETAIL : cfg.SizePixels;
         src_tmp.PackRange.first_unicode_codepoint_in_range = 0;
         src_tmp.PackRange.array_of_unicode_codepoints = src_tmp.GlyphsList.Data;
         src_tmp.PackRange.num_chars = src_tmp.GlyphsList.Size;
         src_tmp.PackRange.chardata_for_range = src_tmp.PackedChars;
-        src_tmp.PackRange.h_oversample = (unsigned char)cfg.OversampleH;
-        src_tmp.PackRange.v_oversample = (unsigned char)cfg.OversampleV;
+        src_tmp.PackRange.h_oversample = sdf ? 1 : (unsigned char)cfg.OversampleH;
+        src_tmp.PackRange.v_oversample = sdf ? 1 : (unsigned char)cfg.OversampleV;
 
         // Gather the sizes of all rectangles we will need to pack (this loop is based on stbtt_PackFontRangesGatherRects)
-        const float scale = (cfg.SizePixels > 0) ? stbtt_ScaleForPixelHeight(&src_tmp.FontInfo, cfg.SizePixels) : stbtt_ScaleForMappingEmToPixels(&src_tmp.FontInfo, -cfg.SizePixels);
-        const int padding = atlas->TexGlyphPadding;
+        const float scale = (sdf || cfg.SizePixels > 0) ? stbtt_ScaleForPixelHeight(&src_tmp.FontInfo, sdf ? IMGUI_SDF_DETAIL : cfg.SizePixels) : stbtt_ScaleForMappingEmToPixels(&src_tmp.FontInfo, -cfg.SizePixels);
+        const int padding = atlas->TexGlyphPadding + (globalSDF ? 2*IMGUI_SDF_PADDING+1 : 0); // *2: because it is actually a margin (TexGlyphPadding is shared between two glyphs), +1 to make sure interpolation is done with a clean pixel;
         for (int glyph_i = 0; glyph_i < src_tmp.GlyphsList.Size; glyph_i++)
         {
             int x0, y0, x1, y1;
             const int glyph_index_in_font = stbtt_FindGlyphIndex(&src_tmp.FontInfo, src_tmp.GlyphsList[glyph_i]);
             IM_ASSERT(glyph_index_in_font != 0);
-            stbtt_GetGlyphBitmapBoxSubpixel(&src_tmp.FontInfo, glyph_index_in_font, scale * cfg.OversampleH, scale * cfg.OversampleV, 0, 0, &x0, &y0, &x1, &y1);
-            src_tmp.Rects[glyph_i].w = (stbrp_coord)(x1 - x0 + padding + cfg.OversampleH - 1);
-            src_tmp.Rects[glyph_i].h = (stbrp_coord)(y1 - y0 + padding + cfg.OversampleV - 1);
+            stbtt_GetGlyphBitmapBoxSubpixel(&src_tmp.FontInfo, glyph_index_in_font, scale * (sdf ? 1 : cfg.OversampleH), scale * (sdf ? 1 : cfg.OversampleV), 0, 0, &x0, &y0, &x1, &y1);
+            src_tmp.Rects[glyph_i].w = (stbrp_coord)(x1 - x0 + padding + (sdf ? 0 : cfg.OversampleH - 1));
+            src_tmp.Rects[glyph_i].h = (stbrp_coord)(y1 - y0 + padding + (sdf ? 0 : cfg.OversampleV - 1));
             total_surface += src_tmp.Rects[glyph_i].w * src_tmp.Rects[glyph_i].h;
         }
     }
@@ -2472,7 +2737,7 @@ static bool ImFontAtlasBuildWithStbTruetype(ImFontAtlas* atlas)
     // Pack our extra data rectangles first, so it will be on the upper-left corner of our texture (UV will have small values).
     const int TEX_HEIGHT_MAX = 1024 * 32;
     stbtt_pack_context spc = {};
-    stbtt_PackBegin(&spc, NULL, atlas->TexWidth, TEX_HEIGHT_MAX, 0, atlas->TexGlyphPadding, NULL);
+    stbtt_PackBegin(&spc, NULL, atlas->TexWidth, TEX_HEIGHT_MAX, 0, atlas->TexGlyphPadding + (globalSDF ? 2*IMGUI_SDF_PADDING+1 : 0), NULL);
     ImFontAtlasBuildPackCustomRects(atlas, spc.pack_info);
 
     // 6. Pack each source font. No rendering yet, we are working with rectangles in an infinitely tall texture at this point.
@@ -2507,7 +2772,8 @@ static bool ImFontAtlasBuildWithStbTruetype(ImFontAtlas* atlas)
         if (src_tmp.GlyphsCount == 0)
             continue;
 
-        stbtt_PackFontRangesRenderIntoRects(&spc, &src_tmp.FontInfo, &src_tmp.PackRange, 1, src_tmp.Rects);
+        bool sdf = globalSDF && cfg.SignedDistanceFont;
+        stbtt_PackFontRangesRenderIntoRects(&spc, &src_tmp.FontInfo, &src_tmp.PackRange, 1, src_tmp.Rects, sdf);
 
         // Apply multiply operator
         if (cfg.RasterizerMultiply != 1.0f)
@@ -2539,7 +2805,9 @@ static bool ImFontAtlasBuildWithStbTruetype(ImFontAtlas* atlas)
         ImFontConfig& cfg = atlas->ConfigData[src_i];
         ImFont* dst_font = cfg.DstFont;
 
-        const float font_scale = stbtt_ScaleForPixelHeight(&src_tmp.FontInfo, cfg.SizePixels);
+        bool sdf = globalSDF && cfg.SignedDistanceFont;
+
+        const float font_scale = stbtt_ScaleForPixelHeight(&src_tmp.FontInfo, sdf ? IMGUI_SDF_DETAIL : cfg.SizePixels);
         int unscaled_ascent, unscaled_descent, unscaled_line_gap;
         stbtt_GetFontVMetrics(&src_tmp.FontInfo, &unscaled_ascent, &unscaled_descent, &unscaled_line_gap);
 
@@ -2549,6 +2817,10 @@ static bool ImFontAtlasBuildWithStbTruetype(ImFontAtlas* atlas)
         const float font_off_x = cfg.GlyphOffset.x;
         const float font_off_y = cfg.GlyphOffset.y + IM_ROUND(dst_font->Ascent);
 
+        float u_padding = sdf ? float(IMGUI_SDF_PADDING)/atlas->TexWidth : 0.0f;
+        float v_padding = sdf ? float(IMGUI_SDF_PADDING)/atlas->TexHeight : 0.0f;
+        float xy_padding = sdf ? float(IMGUI_SDF_PADDING) : 0.0f;
+        float sdf_scale = sdf ? float(cfg.SizePixels) / IMGUI_SDF_DETAIL : 1.0f;
         for (int glyph_i = 0; glyph_i < src_tmp.GlyphsCount; glyph_i++)
         {
             // Register glyph
@@ -2557,7 +2829,7 @@ static bool ImFontAtlasBuildWithStbTruetype(ImFontAtlas* atlas)
             stbtt_aligned_quad q;
             float unused_x = 0.0f, unused_y = 0.0f;
             stbtt_GetPackedQuad(src_tmp.PackedChars, atlas->TexWidth, atlas->TexHeight, glyph_i, &unused_x, &unused_y, &q, 0);
-            dst_font->AddGlyph(&cfg, (ImWchar)codepoint, q.x0 + font_off_x, q.y0 + font_off_y, q.x1 + font_off_x, q.y1 + font_off_y, q.s0, q.t0, q.s1, q.t1, pc.xadvance);
+            dst_font->AddGlyph(&cfg, (ImWchar)codepoint, q.x0 + font_off_x - xy_padding, q.y0 + font_off_y - xy_padding, q.x1 + font_off_x + xy_padding, q.y1 + font_off_y + xy_padding, q.s0 - u_padding, q.t0 - v_padding, q.s1 + u_padding, q.t1 + v_padding, pc.xadvance, sdf_scale);
         }
     }
 
@@ -2583,7 +2855,10 @@ void ImFontAtlasBuildSetupFont(ImFontAtlas* atlas, ImFont* font, ImFontConfig* f
     if (!font_config->MergeMode)
     {
         font->ClearOutputData();
+        bool globalSDF = ImGui::GetIO().BackendFlags & ImGuiBackendFlags_SignedDistanceFonts;
+        bool sdf = globalSDF && font_config->SignedDistanceFont;
         font->FontSize = font_config->SizePixels;
+        font->SignedDistanceFont = sdf;
         font->ConfigData = font_config;
         font->ConfigDataCount = 0;
         font->ContainerAtlas = atlas;
@@ -2771,7 +3046,7 @@ void ImFontAtlasBuildFinish(ImFontAtlas* atlas)
         IM_ASSERT(r->Font->ContainerAtlas == atlas);
         ImVec2 uv0, uv1;
         atlas->CalcCustomRectUV(r, &uv0, &uv1);
-        r->Font->AddGlyph(NULL, (ImWchar)r->GlyphID, r->GlyphOffset.x, r->GlyphOffset.y, r->GlyphOffset.x + r->Width, r->GlyphOffset.y + r->Height, uv0.x, uv0.y, uv1.x, uv1.y, r->GlyphAdvanceX);
+        r->Font->AddGlyph(NULL, (ImWchar)r->GlyphID, r->GlyphOffset.x, r->GlyphOffset.y, r->GlyphOffset.x + r->Width, r->GlyphOffset.y + r->Height, uv0.x, uv0.y, uv1.x, uv1.y, r->GlyphAdvanceX, 1);
     }
 
     // Build all fonts lookup tables
@@ -3212,8 +3487,14 @@ void ImFont::GrowIndex(int new_size)
 // x0/y0/x1/y1 are offset from the character upper-left layout position, in pixels. Therefore x0/y0 are often fairly close to zero.
 // Not to be mistaken with texture coordinates, which are held by u0/v0/u1/v1 in normalized format (0.0..1.0 on each texture axis).
 // 'cfg' is not necessarily == 'this->ConfigData' because multiple source fonts+configs can be used to build one target font.
-void ImFont::AddGlyph(const ImFontConfig* cfg, ImWchar codepoint, float x0, float y0, float x1, float y1, float u0, float v0, float u1, float v1, float advance_x)
+void ImFont::AddGlyph(const ImFontConfig* cfg, ImWchar codepoint, float x0, float y0, float x1, float y1, float u0, float v0, float u1, float v1, float advance_x, float scale)
 {
+    x0 *= scale;
+    x1 *= scale;
+    y0 *= scale;
+    y1 *= scale;
+    advance_x *= scale;
+
     if (cfg != NULL)
     {
         // Clamp & recenter if needed
@@ -3251,7 +3532,8 @@ void ImFont::AddGlyph(const ImFontConfig* cfg, ImWchar codepoint, float x0, floa
 
     // Compute rough surface usage metrics (+1 to account for average padding, +0.99 to round)
     // We use (U1-U0)*TexWidth instead of X1-X0 to account for oversampling.
-    float pad = ContainerAtlas->TexGlyphPadding + 0.99f;
+    bool sdf = ImGui::GetIO().BackendFlags & ImGuiBackendFlags_SignedDistanceFonts;
+    float pad = ContainerAtlas->TexGlyphPadding + 0.99f + (sdf ? 2*IMGUI_SDF_PADDING+1 : 0);
     DirtyLookupTables = true;
     MetricsTotalSurface += (int)((glyph.U1 - glyph.U0) * ContainerAtlas->TexWidth + pad) * (int)((glyph.V1 - glyph.V0) * ContainerAtlas->TexHeight + pad);
 }
@@ -3485,7 +3767,7 @@ ImVec2 ImFont::CalcTextSizeA(float size, float max_width, float wrap_width, cons
 }
 
 // Note: as with every ImDrawList drawing function, this expects that the font atlas texture is bound.
-void ImFont::RenderChar(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col, ImWchar c) const
+void ImFont::RenderChar(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col, ImWchar c, bool sdf, float shadow_size, ImU32 shadow_start, ImU32 shadow_end) const
 {
     const ImFontGlyph* glyph = FindGlyph(c);
     if (!glyph || !glyph->Visible)
@@ -3495,12 +3777,25 @@ void ImFont::RenderChar(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col
     float scale = (size >= 0.0f) ? (size / FontSize) : 1.0f;
     pos.x = IM_FLOOR(pos.x);
     pos.y = IM_FLOOR(pos.y);
+
+    // calculate SDF properties, a = cut-off value for signed distance, width = anti-aliasing width
+    float a = sdf ? 0.5 : 0.0;
+    float width = float(IMGUI_SDF_DETAIL) / size * 1. / IMGUI_SDF_PADDING * 1. / IMGUI_SDF_SHARPENING;
+    if (size < IMGUI_SDF_DETAIL) {
+        width *= float(size) / IMGUI_SDF_DETAIL;
+    }
+    shadow_size = ImClamp(0.5f - shadow_size/2.0f, width, a);
+    if (shadow_size == a) {
+      shadow_start = IM_COL32_BLACK_TRANS;
+      shadow_end = IM_COL32_BLACK_TRANS;
+    }
+
     draw_list->PrimReserve(6, 4);
-    draw_list->PrimRectUV(ImVec2(pos.x + glyph->X0 * scale, pos.y + glyph->Y0 * scale), ImVec2(pos.x + glyph->X1 * scale, pos.y + glyph->Y1 * scale), ImVec2(glyph->U0, glyph->V0), ImVec2(glyph->U1, glyph->V1), col);
+    draw_list->PrimRectUV(ImVec2(pos.x + glyph->X0 * scale, pos.y + glyph->Y0 * scale), ImVec2(pos.x + glyph->X1 * scale, pos.y + glyph->Y1 * scale), ImVec2(glyph->U0, glyph->V0), ImVec2(glyph->U1, glyph->V1), col, shadow_start, shadow_end, a, shadow_size, width);
 }
 
 // Note: as with every ImDrawList drawing function, this expects that the font atlas texture is bound.
-void ImFont::RenderText(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col, const ImVec4& clip_rect, const char* text_begin, const char* text_end, float wrap_width, bool cpu_fine_clip) const
+void ImFont::RenderText(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col, const ImVec4& clip_rect, const char* text_begin, const char* text_end, float wrap_width, bool cpu_fine_clip, bool sdf, float shadow_size, ImU32 shadow_start, ImU32 shadow_end) const
 {
     if (!text_end)
         text_end = text_begin + strlen(text_begin); // ImGui:: functions generally already provides a valid text_end, so this is merely to handle direct calls.
@@ -3556,6 +3851,19 @@ void ImFont::RenderText(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col
     unsigned int vtx_current_idx = draw_list->_VtxCurrentIdx;
 
     const ImU32 col_untinted = col | ~IM_COL32_A_MASK;
+
+    // calculate SDF properties, a = cut-off value for signed distance (0.0 = disabled), width = anti-aliasing width
+    float a = sdf ? 0.5 : 0.0;
+    float width = float(IMGUI_SDF_DETAIL) / size * 1. / IMGUI_SDF_PADDING * 1. / IMGUI_SDF_SHARPENING;
+    if (size < IMGUI_SDF_DETAIL) {
+        width *= float(size) / IMGUI_SDF_DETAIL;
+    }
+    // shadow should be at least a, otherwise it is discarded
+    shadow_size = ImClamp(0.5f - shadow_size/2.0f, width, a);
+    if (shadow_size == a) {
+      shadow_start = IM_COL32_BLACK_TRANS;
+      shadow_end = IM_COL32_BLACK_TRANS;
+    }
 
     while (s < text_end)
     {
@@ -3673,6 +3981,35 @@ void ImFont::RenderText(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col
                     vtx_write[1].pos.x = x2; vtx_write[1].pos.y = y1; vtx_write[1].col = glyph_col; vtx_write[1].uv.x = u2; vtx_write[1].uv.y = v1;
                     vtx_write[2].pos.x = x2; vtx_write[2].pos.y = y2; vtx_write[2].col = glyph_col; vtx_write[2].uv.x = u2; vtx_write[2].uv.y = v2;
                     vtx_write[3].pos.x = x1; vtx_write[3].pos.y = y2; vtx_write[3].col = glyph_col; vtx_write[3].uv.x = u1; vtx_write[3].uv.y = v2;
+#ifndef IMGUI_DISABLE_SDF
+                    if (sdf) {
+                      vtx_write[0].a =
+                        vtx_write[1].a =
+                        vtx_write[2].a =
+                        vtx_write[3].a = a;
+                      vtx_write[0].b =
+                        vtx_write[1].b =
+                        vtx_write[2].b =
+                        vtx_write[3].b = shadow_size;
+                      vtx_write[0].w =
+                        vtx_write[1].w =
+                        vtx_write[2].w =
+                        vtx_write[3].w = width;
+                      vtx_write[0].startOuterColor =
+                        vtx_write[1].startOuterColor =
+                        vtx_write[2].startOuterColor =
+                        vtx_write[3].startOuterColor = shadow_start;
+                      vtx_write[0].endOuterColor =
+                        vtx_write[1].endOuterColor =
+                        vtx_write[2].endOuterColor =
+                        vtx_write[3].endOuterColor = shadow_end;
+                    } else {
+                      vtx_write[0].simple();
+                      vtx_write[1].simple();
+                      vtx_write[2].simple();
+                      vtx_write[3].simple();
+                    }
+#endif
                     vtx_write += 4;
                     vtx_current_idx += 4;
                     idx_write += 6;

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -3780,9 +3780,10 @@ void ImFont::RenderChar(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col
 
     // calculate SDF properties, a = cut-off value for signed distance (0.0 = disabled), width = anti-aliasing width
     float a = sdf ? 0.5f : 0.0f;
-    float width = 0.20f / IMGUI_SDF_PADDING * float(IMGUI_SDF_DETAIL) / float(size);
+    float width = 0.25f / IMGUI_SDF_PADDING * float(IMGUI_SDF_DETAIL) / float(size);
     if (size < 16.0) {
-        width *= float(size) / 16.0f;
+        float extra = float(size) / 16.0f;
+        width *= extra * extra;
     }
     shadow_size = ImClamp(0.5f - shadow_size/2.0f, width, a);
     if (shadow_size == a) {
@@ -3854,9 +3855,10 @@ void ImFont::RenderText(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col
 
     // calculate SDF properties, a = cut-off value for signed distance (0.0 = disabled), width = anti-aliasing width
     float a = sdf ? 0.5f : 0.0f;
-    float width = 0.20f / IMGUI_SDF_PADDING * float(IMGUI_SDF_DETAIL) / float(size);
+    float width = 0.25f / IMGUI_SDF_PADDING * float(IMGUI_SDF_DETAIL) / float(size);
     if (size < 16.0) {
-        width *= float(size) / 16.0f;
+        float extra = float(size) / 16.0f;
+        width *= extra * extra;
     }
     // shadow should be at least a, otherwise it is discarded
     shadow_size = ImClamp(0.5f - shadow_size/2.0f, width, a);

--- a/imstb_truetype.h
+++ b/imstb_truetype.h
@@ -929,7 +929,7 @@ STBTT_DEF void stbtt_FreeSDF(unsigned char *bitmap, void *userdata);
 // frees the SDF bitmap allocated below
 
 STBTT_DEF unsigned char * stbtt_GetGlyphSDF(const stbtt_fontinfo *info, float scale, int glyph, int padding, unsigned char onedge_value, float pixel_dist_scale, int *width, int *height, int *xoff, int *yoff);
-STBTT_DEF void stbtt_GetGlyphSDF2(const stbtt_fontinfo *info, float scale_x, float scale_y, int glyph, int padding, unsigned char onedge_value, float pixel_dist_scale, int ix0, int iy0, int ix1, int iy1, unsigned char* data, int stride);
+STBTT_DEF void stbtt_GetGlyphSDF2(const stbtt_fontinfo *info, float scale_x, float scale_y, int glyph, unsigned char onedge_value, float pixel_dist_scale, int ix0, int iy0, int ix1, int iy1, unsigned char* data, int stride);
 STBTT_DEF unsigned char * stbtt_GetCodepointSDF(const stbtt_fontinfo *info, float scale, int codepoint, int padding, unsigned char onedge_value, float pixel_dist_scale, int *width, int *height, int *xoff, int *yoff);
 // These functions compute a discretized SDF field for a single character, suitable for storing
 // in a single-channel texture, sampling with bilinear filtering, and testing against
@@ -4077,10 +4077,9 @@ STBTT_DEF int stbtt_PackFontRangesRenderIntoRects(stbtt_pack_context *spc, const
             r->w -= pad;
             r->h -= pad;
             stbtt_GetGlyphHMetrics(info, glyph, &advance, &lsb);
-            stbtt_GetGlyphBitmapBoxSubpixel(info, glyph,
+            stbtt_GetGlyphBitmapBox(info, glyph,
                                     scale * spc->h_oversample,
                                     scale * spc->v_oversample,
-                                    0, 0,
                                     &x0,&y0,&x1,&y1);
 
             if (!sdf) {
@@ -4095,7 +4094,7 @@ STBTT_DEF int stbtt_PackFontRangesRenderIntoRects(stbtt_pack_context *spc, const
                                             glyph);
             } else {
               const static int p = IMGUI_SDF_PADDING; // do not use pad here (it is the distance to the other glyph)
-              stbtt_GetGlyphSDF2(info, scale, -scale, glyph, p, 128, (128/p)+1, x0-p, y0-p, x1+p, y1+p, spc->pixels + r->x + (r->y - p)*spc->stride_in_bytes - p, spc->stride_in_bytes);
+              stbtt_GetGlyphSDF2(info, scale, -scale, glyph, 128, (128/p)+1, x0-p, y0-p, x1+p, y1+p, spc->pixels + r->x + (r->y - p)*spc->stride_in_bytes - p, spc->stride_in_bytes);
             }
 
             if (spc->h_oversample > 1)
@@ -4448,11 +4447,11 @@ STBTT_DEF unsigned char * stbtt_GetGlyphSDF(const stbtt_fontinfo *info, float sc
    scale_y = -scale_y;
 
 	 data = (unsigned char *) STBTT_malloc(w * h, info->userdata);
-	 stbtt_GetGlyphSDF2(info, scale_x, scale_y, glyph, padding, onedge_value, pixel_dist_scale, ix0, iy0, ix1, iy1, data, w);
+	 stbtt_GetGlyphSDF2(info, scale_x, scale_y, glyph, onedge_value, pixel_dist_scale, ix0, iy0, ix1, iy1, data, w);
 	 return data;
 }
       
-STBTT_DEF void stbtt_GetGlyphSDF2(const stbtt_fontinfo *info, float scale_x, float scale_y, int glyph, int padding, unsigned char onedge_value, float pixel_dist_scale, int ix0, int iy0, int ix1, int iy1, unsigned char* data, int stride) {
+STBTT_DEF void stbtt_GetGlyphSDF2(const stbtt_fontinfo *info, float scale_x, float scale_y, int glyph, unsigned char onedge_value, float pixel_dist_scale, int ix0, int iy0, int ix1, int iy1, unsigned char* data, int stride) {
       int x,y,i,j;
       float *precompute;
       stbtt_vertex *verts;


### PR DESCRIPTION
This pull requests adds scalable fonts to Dear ImGui. A technique to implement scalable fonts is using signed distance fields: make a bitmap where every pixel value represents the distance to the edge of a shape/font. Values [0, 0.5] represent distances outside the shape, values [0.5, 1] inside the shape. A value of 0.5 is on the edge of the shape. If this bitmap is scaled up these values are automatically interpolated. By using a shader, these interpolated values can be turned into sharp edges, avoiding the normal blurriness if scaling fonts up.

When adding a font, an additional flag can be set in `ImFontConfig`, called `SignedDistanceFont`. If set this flag causes `imstb_truetype` to load the font as a signed distance field sized (currently) 40 pixels (`IMGUI_SDF_DETAILS` define) with padding 4 (`IMGUI_SDF_PADDING` define). This increases the font atlas a bit, but yields very good results when rendering, with almost no artifacts. When rendering fonts, the extended shader is automatically used if available. If the shader is not available (for example with OpenGL 2), the signed distance rendering (and font loading) is disabled.

To indicate support, backends can now set an additional flag `ImGuiBackendFlags_SignedDistanceFonts`. The backend `Init()` methods are extended with an additional field, in which the programmer can indicate which features it wants to be enabled. The default value is `ImGuiBackendFlags_DefaultFast`, which currently disables signed distance fonts, so current users are not confronted with surprises (with increased font atlas size, and a bit longer loading time). `ImGuiBackendFlags_DefaultDesktop` enables the signed distance features.

Signed distance fields also allow certain text effects such as shadows and outlines. To support this, `ImGuiStyleVar_FontShadowSize` indicates the size of the shadow/outline, and the colors `ImGuiCol_FontShadowStart` and `ImGuiCol_FontShadowEnd` specifies the start and end colors of the outline. If these colors are the same, it is an outline. If the alpha value of the end value is set to transparent, it is a shadow.

To support these new font loading, the vertices generated are extended with additional fields: (1) a start color, (2) an end color, (3) a threshold called `a` signifying where the inner color stops, and the start outer color starts (a float), (4) a threshold called `b` signifying where the outer color ends (a float), (5) for anti-aliasing a width called `w` (a float). This makes the vertices list twice as large, increasing an individual vertex from 20 bytes to 40 bytes. This is clearly a drawback of the current approach. An alternative approach could be to encode the end color with only an alpha value (and using the same values for the color channels as the start color), and using unsigned shorts for the `a`, `b`, and `w` values. This will result in a vertex size of 32 bytes, but with somewhat less flexibility (and maybe encoding problems in some shader languages?).

To compensate the increased vertices size, another route was taken. If the `a` value is set between 2 and 3, it is interpreted as a distance request for a quarter of a circle. UV values (0,0) are interpreted as the center of the circle, (1, 0) and (0, 1) are on the edge of the circle. This cost no additional size in the vertices, but allows for perfect shadows of shapes. A rounded rectangle with shadow can be drawn with 18 triangles (size of shadow or rounding does not have an impact). See the `DrawCmd` in Metrics/Debugger window how these rectangles are drawn (especially look for shapes ones with some round corners, and some straight corners). In the demonstrator, the same screen using regular Dear ImGui was drawn using 15734 vertices, 37899 indices, and 12633 triangles. Using the change in this pull request, the same scene was drawn using 11052 vertices, 19953 indices, and 6651 triangles. See the attached screenshot. In these screenshot, the windows and frames have a border (in the regular version), or a shadow (if using this patch).

In the draw list, `AddRect` and `AddRectFilled` are changed to use the new signed distance shape rendering if available in the backend (which indicates support using the `ImGuiBackendFlags_SignedDistanceShapes`). If not available, these methods use the existing drawing primitives. Some additional arguments are added to these methods, but use sensible defaults, so existing code keeps working with no change required. The frame and window rendering code was changed, so frame and window shadows are added. To allow easy styling, the following variables are introduced: `ImGuiStyleVar_WindowShadowSize`, `ImGuiCol_WindowShadowStart`, `ImGuiCol_WindowShadowEnd`, `ImGuiStyleVar_FrameShadowSize`, `ImGuiCol_FrameShadowStart`, `ImGuiCol_FrameShadowEnd`. The new extra argument to the backend `Init()` method can be used to enable or the fonts feature, or the shape feature, both, or none. 

If there is a need to completely disable these signed distance features, a new flag `IMGUI_DISABLE_SDF` can be set in `imconfig.h` complete disabling all the signed distance fonts. To aid testing these features, a demonstration is made in the GLFW OpenGL 3 and the DirectX 11 examples, in which all fonts are loaded twice: as signed distance and regular. Attached are screenshots of two scenes of this demonstration. Each scene is rendered twice: with the signed distance features enabled and disabled (using exactly the same code except for the `IMGUI_DISABLE_SDF` define).

Special attention has been paid to smaller fonts. Both ProggyClean and ProggyTiny are rendered exactly the same with or without signed distance. Due to the way `imstb_truetype` calculates signed distance fields, some fonts will be rendered one pixel higher (as is the case with ProggyClean). Roboto, Cousine, Droid Sans are rendered similarly on 16/15 pixels when rendered with or without signed distance fields.

The shaders are currently implemented for:
- OpenGL3 shaders (except for GL SL version 120);
- Metal;
- DirectX 11.

A logical question is probably why multichannel signed distance fields were not used. This makes loading of the fonts complex. If a live encoding is used, this makes the loading of the fonts slow. A prefab multichannel font atlas was found to be large, and loading cumbersome. Another strategy is to cache the generated multichannel font atlas. I have experimented with that, but was not satisfied with the result (version specific custom storage format, problems with invalidating the cache, etc).

I'm currently looking for feedback on how to improve this pull request. Before investing more work, I would appreciate a feasibility check if this pull request has chances to be merged at all. If that is the case, I can pick up the remaining issues, such as:
- implement the new shaders on DirectX 9, DirectX 10, DirectX 12, and Vulkan;
- try more fonts, and fix any alignment issues (such as the 1 pixel different with the ProggyClean font described above);
- writing documentation;
- look into supporting the freetype font backend.

The screenshot of the first scene [with SDF](https://raw.githubusercontent.com/bvgastel/imgui/sdf_screenshots/imgui_sdf.png) and [without SDF](https://raw.githubusercontent.com/bvgastel/imgui/sdf_screenshots/imgui_regular.png).

The screenshot of the second scene [with SDF](https://raw.githubusercontent.com/bvgastel/imgui/sdf_screenshots/imgui_sdf_shapes.png) and [without SDF](https://raw.githubusercontent.com/bvgastel/imgui/sdf_screenshots/imgui_regular_shapes.png).