### PR TITLE
Fix for uninitialized member variable warning

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -2066,7 +2066,7 @@ struct ImGuiStorage
     struct ImGuiStoragePair
     {
         ImGuiID key;
-        union { int val_i; float val_f; void* val_p; };
+        union { int val_i; float val_f; void* val_p = nullptr; };
         ImGuiStoragePair(ImGuiID _key, int _val_i)      { key = _key; val_i = _val_i; }
         ImGuiStoragePair(ImGuiID _key, float _val_f)    { key = _key; val_f = _val_f; }
         ImGuiStoragePair(ImGuiID _key, void* _val_p)    { key = _key; val_p = _val_p; }

--- a/imgui.h
+++ b/imgui.h
@@ -2067,8 +2067,8 @@ struct ImGuiStorage
     {
         ImGuiID key;
         union { int val_i; float val_f; void* val_p; };
-        ImGuiStoragePair(ImGuiID _key, int _val_i)   { memset(val_p, 0, 4); key = _key; val_i = _val_i; }
-        ImGuiStoragePair(ImGuiID _key, float _val_f) { memset(val_p, 0, 4); key = _key; val_f = _val_f; }
+        ImGuiStoragePair(ImGuiID _key, int _val_i)   { memset(val_p, 0, sizeof(val_p)); key = _key; val_i = _val_i; }
+        ImGuiStoragePair(ImGuiID _key, float _val_f) { memset(val_p, 0, sizeof(val_p)); key = _key; val_f = _val_f; }
         ImGuiStoragePair(ImGuiID _key, void* _val_p) { key = _key; val_p = _val_p; }
     };
 

--- a/imgui.h
+++ b/imgui.h
@@ -2067,9 +2067,9 @@ struct ImGuiStorage
     {
         ImGuiID key;
         union { int val_i; float val_f; void* val_p; };
-        ImGuiStoragePair(ImGuiID _key, int _val_i)   { memset(val_p, 0, sizeof(val_p)); key = _key; val_i = _val_i; }
-        ImGuiStoragePair(ImGuiID _key, float _val_f) { memset(val_p, 0, sizeof(val_p)); key = _key; val_f = _val_f; }
-        ImGuiStoragePair(ImGuiID _key, void* _val_p) { key = _key; val_p = _val_p; }
+        ImGuiStoragePair(ImGuiID _key, int _val_i)   { memset(this, 0, sizeof(*this)); key = _key; val_i = _val_i; }
+        ImGuiStoragePair(ImGuiID _key, float _val_f) { memset(this, 0, sizeof(*this)); key = _key; val_f = _val_f; }
+        ImGuiStoragePair(ImGuiID _key, void* _val_p) { memset(this, 0, sizeof(*this)); key = _key; val_p = _val_p; }
     };
 
     ImVector<ImGuiStoragePair>      Data;

--- a/imgui.h
+++ b/imgui.h
@@ -2066,10 +2066,10 @@ struct ImGuiStorage
     struct ImGuiStoragePair
     {
         ImGuiID key;
-        union { int val_i; float val_f; void* val_p = nullptr; };
-        ImGuiStoragePair(ImGuiID _key, int _val_i)      { key = _key; val_i = _val_i; }
-        ImGuiStoragePair(ImGuiID _key, float _val_f)    { key = _key; val_f = _val_f; }
-        ImGuiStoragePair(ImGuiID _key, void* _val_p)    { key = _key; val_p = _val_p; }
+        union { int val_i; float val_f; void* val_p; };
+        ImGuiStoragePair(ImGuiID _key, int _val_i)   { memset(val_p, 0, 4); key = _key; val_i = _val_i; }
+        ImGuiStoragePair(ImGuiID _key, float _val_f) { memset(val_p, 0, 4); key = _key; val_f = _val_f; }
+        ImGuiStoragePair(ImGuiID _key, void* _val_p) { key = _key; val_p = _val_p; }
     };
 
     ImVector<ImGuiStoragePair>      Data;


### PR DESCRIPTION
This PR fixes a warning caused by an uninitialized pointer in the `ImGuiStoragePair` struct.

### Warning Info
The warning log from the compiler is as follows:
![IMGUI warning image](https://i.imgur.com/C4XuFis.png)

The warning is thrown in `imgui.h` on line 1888 and 1889. It is shown below.
```cpp
// [Internal]
struct ImGuiStoragePair
{
    ImGuiID key;
    union { int val_i; float val_f; void* val_p; }; //val_p is not initialized
    ImGuiStoragePair(ImGuiID _key, int _val_i)      { key = _key; val_i = _val_i; } //warning on 1888 
    ImGuiStoragePair(ImGuiID _key, float _val_f)    { key = _key; val_f = _val_f; } //warning on 1889
    ImGuiStoragePair(ImGuiID _key, void* _val_p)    { key = _key; val_p = _val_p; }
};
```

### Compiler info
Compiler: MSVC / Visual studio 2019
Warning Level: /W3

### Fix Info
This PR fixes it by setting a default value to the `val_p` pointer to nullptr.

### Testing
I tested this change with the Dear Imgui demo window, and a few windows of my own. It was fully functional without any issue.