### PR TITLE
Change the case of the include, so it cross-compile nicely on unices.

### DIFF
--- a/backends/imgui_impl_win32.cpp
+++ b/backends/imgui_impl_win32.cpp
@@ -25,7 +25,7 @@
 
 // Using XInput for gamepad (will load DLL dynamically)
 #ifndef IMGUI_IMPL_WIN32_DISABLE_GAMEPAD
-#include <XInput.h>
+#include <xinput.h>
 typedef DWORD (WINAPI *PFN_XInputGetCapabilities)(DWORD, DWORD, XINPUT_CAPABILITIES*);
 typedef DWORD (WINAPI *PFN_XInputGetState)(DWORD, XINPUT_STATE*);
 #endif


### PR DESCRIPTION
This is an incredibly long PR to review, sorry in advance.

One notorious OS is case-insensitive in its file paths, and the others are typically not. By using this long and complex patch, one gains the power to use other OSes to cross-compile to the notorious OS without resorting to symlinks and other wizard tricks, and yet, by the miracle of case-insentiveness, the notorious OS is not affected by this change.