### PR TITLE
Fix compiler warning for Release build with -Werror and -Wall on gcc 7.5

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -9508,9 +9508,8 @@ static void ImGui::NavEndFrame()
 
 static int ImGui::FindWindowFocusIndex(ImGuiWindow* window)
 {
-    ImGuiContext& g = *GImGui;
     int order = window->FocusOrder;
-    IM_ASSERT(g.WindowsFocusOrder[order] == window);
+    IM_ASSERT(GImGui->WindowsFocusOrder[order] == window);
     return order;
 }
 


### PR DESCRIPTION

There is an unused-variable warning when compiling in ```Release``` mode which I experienced when compiling with gcc version 7.5.0 on Ubuntu 18.04. When I compile with ```-Werror``` and ```-Wall``` flags, this results in a compilation error. The reason is as far as I can understand that the ```IM_ASSERT``` macro is removed in ```Release``` builds which renders the local ```g``` variable unused. The changes made in this PR resolved the problem for me.

Here is the the compiler output:
```
int ImGui::FindWindowFocusIndex(ImGuiWindow*)’:
imgui/imgui.cpp:9509:19: error: unused variable ‘g’ [-Werror=unused-variable]
     ImGuiContext& g = *GImGui;
cc1plus: all warnings being treated as errors
```





