### PR TITLE
Optimize IM_NORMALIZE2F_OVER_ZERO

### DIFF
--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -694,7 +694,7 @@ void ImDrawList::PrimQuadUV(const ImVec2& a, const ImVec2& b, const ImVec2& c, c
 
 // On AddPolyline() and AddConvexPolyFilled() we intentionally avoid using ImVec2 and superfluous function calls to optimize debug/non-inlined builds.
 // Those macros expects l-values.
-#define IM_NORMALIZE2F_OVER_ZERO(VX,VY)     do { float d2 = VX*VX + VY*VY; if (d2 > 0.0f) { float inv_len = 1.0f / ImSqrt(d2); VX *= inv_len; VY *= inv_len; } } while (0)
+#define IM_NORMALIZE2F_OVER_ZERO(VX,VY)     do { float d2 = VX*VX + VY*VY; if (d2 > 0.0f) { float inv_len = ImRsqrt(d2); VX *= inv_len; VY *= inv_len; } } while (0)
 #define IM_FIXNORMAL2F_MAX_INVLEN2          100.0f // 500.0f (see #4053, #3366)
 #define IM_FIXNORMAL2F(VX,VY)               do { float d2 = VX*VX + VY*VY; if (d2 > 0.000001f) { float inv_len2 = 1.0f / d2; if (inv_len2 > IM_FIXNORMAL2F_MAX_INVLEN2) inv_len2 = IM_FIXNORMAL2F_MAX_INVLEN2; VX *= inv_len2; VY *= inv_len2; } } while (0)
 

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -696,7 +696,7 @@ void ImDrawList::PrimQuadUV(const ImVec2& a, const ImVec2& b, const ImVec2& c, c
 // Those macros expects l-values.
 #define IM_NORMALIZE2F_OVER_ZERO(VX,VY)     do { float d2 = VX*VX + VY*VY; if (d2 > 0.0f) { float inv_len = ImRsqrt(d2); VX *= inv_len; VY *= inv_len; } } while (0)
 #define IM_FIXNORMAL2F_MAX_INVLEN2          100.0f // 500.0f (see #4053, #3366)
-#define IM_FIXNORMAL2F(VX,VY)               do { float d2 = VX*VX + VY*VY; if (d2 > 0.000001f) { float inv_len2 = 1.0f / d2; if (inv_len2 > IM_FIXNORMAL2F_MAX_INVLEN2) inv_len2 = IM_FIXNORMAL2F_MAX_INVLEN2; VX *= inv_len2; VY *= inv_len2; } } while (0)
+#define IM_FIXNORMAL2F(VX,VY)               do { float d2 = VX*VX + VY*VY; if (d2 > 0.000001f) { float inv_len2 = ImRecip(d2); if (inv_len2 > IM_FIXNORMAL2F_MAX_INVLEN2) inv_len2 = IM_FIXNORMAL2F_MAX_INVLEN2; VX *= inv_len2; VY *= inv_len2; } } while (0)
 
 // TODO: Thickness anti-aliased lines cap are missing their AA fringe.
 // We avoid using the ImVec2 math operators here to reduce cost to a minimum for debug/non-inlined builds.

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -400,6 +400,12 @@ static inline float  ImRsqrt(float x)           { return _mm_cvtss_f32(_mm_rsqrt
 static inline float  ImRsqrt(float x)           { return 1.0f / sqrtf(x); }
 #endif
 static inline double ImRsqrt(double x)          { return 1.0 / sqrt(x); }
+#if defined __SSE__ || defined __x86_64__ || defined _M_X64
+static inline float  ImRecip(float x)           { return _mm_cvtss_f32(_mm_rcp_ps(_mm_set_ss(x))); }
+#else
+static inline float  ImRecip(float x)           { return 1.0f / x; }
+#endif
+static inline double ImRecip(double x)          { return 1.0 / x; }
 #endif
 // - ImMin/ImMax/ImClamp/ImLerp/ImSwap are used by widgets which support variety of types: signed/unsigned int/long long float/double
 // (Exceptionally using templates here but we could also redefine them for those types)

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -412,7 +412,7 @@ static inline ImVec4 ImLerp(const ImVec4& a, const ImVec4& b, float t)          
 static inline float  ImSaturate(float f)                                        { return (f < 0.0f) ? 0.0f : (f > 1.0f) ? 1.0f : f; }
 static inline float  ImLengthSqr(const ImVec2& lhs)                             { return (lhs.x * lhs.x) + (lhs.y * lhs.y); }
 static inline float  ImLengthSqr(const ImVec4& lhs)                             { return (lhs.x * lhs.x) + (lhs.y * lhs.y) + (lhs.z * lhs.z) + (lhs.w * lhs.w); }
-static inline float  ImInvLength(const ImVec2& lhs, float fail_value)           { float d = (lhs.x * lhs.x) + (lhs.y * lhs.y); if (d > 0.0f) return 1.0f / ImSqrt(d); return fail_value; }
+static inline float  ImInvLength(const ImVec2& lhs, float fail_value)           { float d = (lhs.x * lhs.x) + (lhs.y * lhs.y); if (d > 0.0f) return ImRsqrt(d); return fail_value; }
 static inline float  ImFloor(float f)                                           { return (float)(int)(f); }
 static inline float  ImFloorSigned(float f)                                     { return (float)((f >= 0 || (int)f == f) ? (int)f : (int)f - 1); } // Decent replacement for floorf()
 static inline ImVec2 ImFloor(const ImVec2& v)                                   { return ImVec2((float)(int)(v.x), (float)(int)(v.y)); }

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -51,6 +51,10 @@ Index of this file:
 #include <math.h>       // sqrtf, fabsf, fmodf, powf, floorf, ceilf, cosf, sinf
 #include <limits.h>     // INT_MIN, INT_MAX
 
+#if defined __SSE__ || defined __x86_64__ || defined _M_X64
+#include <immintrin.h>
+#endif
+
 // Visual Studio warnings
 #ifdef _MSC_VER
 #pragma warning (push)
@@ -390,7 +394,11 @@ static inline float  ImAbs(float x)             { return fabsf(x); }
 static inline double ImAbs(double x)            { return fabs(x); }
 static inline float  ImSign(float x)            { return (x < 0.0f) ? -1.0f : ((x > 0.0f) ? 1.0f : 0.0f); } // Sign operator - returns -1, 0 or 1 based on sign of argument
 static inline double ImSign(double x)           { return (x < 0.0) ? -1.0 : ((x > 0.0) ? 1.0 : 0.0); }
+#if defined __SSE__ || defined __x86_64__ || defined _M_X64
+static inline float  ImRsqrt(float x)           { return _mm_cvtss_f32(_mm_rsqrt_ss(_mm_set_ss(x))); }
+#else
 static inline float  ImRsqrt(float x)           { return 1.0f / sqrtf(x); }
+#endif
 static inline double ImRsqrt(double x)          { return 1.0 / sqrt(x); }
 #endif
 // - ImMin/ImMax/ImClamp/ImLerp/ImSwap are used by widgets which support variety of types: signed/unsigned int/long long float/double

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -390,6 +390,8 @@ static inline float  ImAbs(float x)             { return fabsf(x); }
 static inline double ImAbs(double x)            { return fabs(x); }
 static inline float  ImSign(float x)            { return (x < 0.0f) ? -1.0f : ((x > 0.0f) ? 1.0f : 0.0f); } // Sign operator - returns -1, 0 or 1 based on sign of argument
 static inline double ImSign(double x)           { return (x < 0.0) ? -1.0 : ((x > 0.0) ? 1.0 : 0.0); }
+static inline float  ImRsqrt(float x)           { return 1.0f / sqrtf(x); }
+static inline double ImRsqrt(double x)          { return 1.0 / sqrt(x); }
 #endif
 // - ImMin/ImMax/ImClamp/ImLerp/ImSwap are used by widgets which support variety of types: signed/unsigned int/long long float/double
 // (Exceptionally using templates here but we could also redefine them for those types)


### PR DESCRIPTION
Currently Dear ImGui uses `1/sqrt()` in `IM_NORMALIZE2F_OVER_ZERO()`.  This produces the following instruction sequence in `ImDrawList::AddPolyline()`:

![11](https://user-images.githubusercontent.com/600573/116751932-07f53180-aa05-11eb-9470-d56c236043d0.png)

Notice that both `vsqrtss` and `vdivss` both have high sample hit count (visible in dependent instructions). This is caused by high latency of both instructions:

![sqrt](https://user-images.githubusercontent.com/600573/116751966-14798a00-aa05-11eb-8107-6d805942b1ef.png)

This PR introduces a new function, `ImRsqrt()`, which also has an alternate implementation if SSE1 is available. Note that SSE2 support is mandated in x64 architecture. With these changes the following assembly is generated:

![22](https://user-images.githubusercontent.com/600573/116752148-61f5f700-aa05-11eb-82c7-930ead5cbcfe.png)

With the new code only one instruction is emitted, `vrqsrtss`, which produces an approximate result, but the reduced precision shouldn't matter in this case. Notice that the relative cost of calling `IM_NORMALIZE2F_OVER_ZERO()` has dropped significantly. This is caused by much lower latency of `vrqsrtss` across all uarchs:

![rsqrt](https://user-images.githubusercontent.com/600573/116752465-e6e11080-aa05-11eb-8097-5f58852d0daa.png)

ARM NEON has similar instruction, `FRSQRTE`, which may or may not be beneficial to use.

For context, `ImDrawList::AddPolyline()` in certain conditions can be the hottest function in Tracy.

I'm not sure if including `immintrin.h` is the right solution. It works for me, but it may be problematic on older compilers, in which case a more targetted header inclusion should be used.