### PR TITLE
Fix possible dx9 memory leaks

### DIFF
--- a/backends/imgui_impl_dx9.cpp
+++ b/backends/imgui_impl_dx9.cpp
@@ -162,11 +162,19 @@ void ImGui_ImplDX9_RenderDrawData(ImDrawData* draw_data)
     //  1) to avoid repacking colors:   #define IMGUI_USE_BGRA_PACKED_COLOR
     //  2) to avoid repacking vertices: #define IMGUI_OVERRIDE_DRAWVERT_STRUCT_LAYOUT struct ImDrawVert { ImVec2 pos; float z; ImU32 col; ImVec2 uv; }
     CUSTOMVERTEX* vtx_dst;
-    ImDrawIdx* idx_dst;
     if (g_pVB->Lock(0, (UINT)(draw_data->TotalVtxCount * sizeof(CUSTOMVERTEX)), (void**)&vtx_dst, D3DLOCK_DISCARD) < 0)
+    {
+        d3d9_state_block->Release();
         return;
+    }
+
+    ImDrawIdx* idx_dst;
     if (g_pIB->Lock(0, (UINT)(draw_data->TotalIdxCount * sizeof(ImDrawIdx)), (void**)&idx_dst, D3DLOCK_DISCARD) < 0)
+    {
+        d3d9_state_block->Release();
         return;
+    }
+
     for (int n = 0; n < draw_data->CmdListsCount; n++)
     {
         const ImDrawList* cmd_list = draw_data->CmdLists[n];


### PR DESCRIPTION
After `Capture()`, `Release()` must be called. See [Remarks](https://docs.microsoft.com/en-us/windows/win32/api/d3d9helper/nf-d3d9helper-idirect3dstateblock9-capture#remarks).

[Once again, since the stateblock object is an interface, you will need to release it when you are done with it.](https://docs.microsoft.com/en-us/windows/win32/direct3d9/state-blocks-save-and-restore-state#capture-individual-states)