### PR TITLE
Allow support for 'noexcept' specifier

### DIFF
--- a/imconfig.h
+++ b/imconfig.h
@@ -35,10 +35,10 @@
 //#define IMGUI_DISABLE_DEMO_WINDOWS                        // Disable demo windows: ShowDemoWindow()/ShowStyleEditor() will be empty. Not recommended.
 //#define IMGUI_DISABLE_METRICS_WINDOW                      // Disable metrics/debugger window: ShowMetricsWindow() will be empty.
 
-//---- If you are using modern C++ and need to mark functions as not throwing exceptions, for performance.
-//#if __cplusplus >= 201103L
-//#define IMGUI_NOEXCEPT noexcept
-//#endif
+//---- Tell >= C++11 compilers functions do not throw exceptions.
+#if __cplusplus >= 201103L
+#define IM_NOEXCEPT noexcept
+#endif
 
 //---- Don't implement some functions to reduce linkage requirements.
 //#define IMGUI_DISABLE_WIN32_DEFAULT_CLIPBOARD_FUNCTIONS   // [Win32] Don't implement default clipboard handler. Won't use and link with OpenClipboard/GetClipboardData/CloseClipboard etc. (user32.lib/.a, kernel32.lib/.a)

--- a/imconfig.h
+++ b/imconfig.h
@@ -35,6 +35,11 @@
 //#define IMGUI_DISABLE_DEMO_WINDOWS                        // Disable demo windows: ShowDemoWindow()/ShowStyleEditor() will be empty. Not recommended.
 //#define IMGUI_DISABLE_METRICS_WINDOW                      // Disable metrics/debugger window: ShowMetricsWindow() will be empty.
 
+//---- If you are using modern C++ and need to mark functions as not throwing exceptions, for performance.
+//#if __cplusplus >= 201103L
+//#define IMGUI_NOEXCEPT noexcept
+//#endif
+
 //---- Don't implement some functions to reduce linkage requirements.
 //#define IMGUI_DISABLE_WIN32_DEFAULT_CLIPBOARD_FUNCTIONS   // [Win32] Don't implement default clipboard handler. Won't use and link with OpenClipboard/GetClipboardData/CloseClipboard etc. (user32.lib/.a, kernel32.lib/.a)
 //#define IMGUI_DISABLE_WIN32_DEFAULT_IME_FUNCTIONS         // [Win32] Don't implement default IME handler. Won't use and link with ImmGetContext/ImmSetCompositionWindow. (imm32.lib/.a)

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -872,63 +872,63 @@ static const float WINDOWS_MOUSE_WHEEL_SCROLL_LOCK_TIMER    = 2.00f;    // Lock 
 // [SECTION] FORWARD DECLARATIONS
 //-------------------------------------------------------------------------
 
-static void             SetCurrentWindow(ImGuiWindow* window);
-static void             FindHoveredWindow();
-static ImGuiWindow*     CreateNewWindow(const char* name, ImGuiWindowFlags flags);
-static ImVec2           CalcNextScrollFromScrollTargetAndClamp(ImGuiWindow* window);
+static void             SetCurrentWindow(ImGuiWindow* window) IMGUI_NOEXCEPT;
+static void             FindHoveredWindow() IMGUI_NOEXCEPT;
+static ImGuiWindow*     CreateNewWindow(const char* name, ImGuiWindowFlags flags) IMGUI_NOEXCEPT;
+static ImVec2           CalcNextScrollFromScrollTargetAndClamp(ImGuiWindow* window) IMGUI_NOEXCEPT;
 
-static void             AddDrawListToDrawData(ImVector<ImDrawList*>* out_list, ImDrawList* draw_list);
-static void             AddWindowToSortBuffer(ImVector<ImGuiWindow*>* out_sorted_windows, ImGuiWindow* window);
+static void             AddDrawListToDrawData(ImVector<ImDrawList*>* out_list, ImDrawList* draw_list) IMGUI_NOEXCEPT;
+static void             AddWindowToSortBuffer(ImVector<ImGuiWindow*>* out_sorted_windows, ImGuiWindow* window) IMGUI_NOEXCEPT;
 
 // Settings
-static void             WindowSettingsHandler_ClearAll(ImGuiContext*, ImGuiSettingsHandler*);
-static void*            WindowSettingsHandler_ReadOpen(ImGuiContext*, ImGuiSettingsHandler*, const char* name);
-static void             WindowSettingsHandler_ReadLine(ImGuiContext*, ImGuiSettingsHandler*, void* entry, const char* line);
-static void             WindowSettingsHandler_ApplyAll(ImGuiContext*, ImGuiSettingsHandler*);
-static void             WindowSettingsHandler_WriteAll(ImGuiContext*, ImGuiSettingsHandler*, ImGuiTextBuffer* buf);
+static void             WindowSettingsHandler_ClearAll(ImGuiContext*, ImGuiSettingsHandler*) IMGUI_NOEXCEPT;
+static void*            WindowSettingsHandler_ReadOpen(ImGuiContext*, ImGuiSettingsHandler*, const char* name) IMGUI_NOEXCEPT;
+static void             WindowSettingsHandler_ReadLine(ImGuiContext*, ImGuiSettingsHandler*, void* entry, const char* line) IMGUI_NOEXCEPT;
+static void             WindowSettingsHandler_ApplyAll(ImGuiContext*, ImGuiSettingsHandler*) IMGUI_NOEXCEPT;
+static void             WindowSettingsHandler_WriteAll(ImGuiContext*, ImGuiSettingsHandler*, ImGuiTextBuffer* buf) IMGUI_NOEXCEPT;
 
 // Platform Dependents default implementation for IO functions
-static const char*      GetClipboardTextFn_DefaultImpl(void* user_data);
-static void             SetClipboardTextFn_DefaultImpl(void* user_data, const char* text);
-static void             ImeSetInputScreenPosFn_DefaultImpl(int x, int y);
+static const char*      GetClipboardTextFn_DefaultImpl(void* user_data) IMGUI_NOEXCEPT;
+static void             SetClipboardTextFn_DefaultImpl(void* user_data, const char* text) IMGUI_NOEXCEPT;
+static void             ImeSetInputScreenPosFn_DefaultImpl(int x, int y) IMGUI_NOEXCEPT;
 
 namespace ImGui
 {
 // Navigation
-static void             NavUpdate();
-static void             NavUpdateWindowing();
-static void             NavUpdateWindowingOverlay();
-static void             NavUpdateMoveResult();
-static void             NavUpdateInitResult();
-static float            NavUpdatePageUpPageDown();
-static inline void      NavUpdateAnyRequestFlag();
-static void             NavEndFrame();
-static bool             NavScoreItem(ImGuiNavItemData* result, ImRect cand);
-static void             NavApplyItemToResult(ImGuiNavItemData* result, ImGuiWindow* window, ImGuiID id, const ImRect& nav_bb_rel);
-static void             NavProcessItem(ImGuiWindow* window, const ImRect& nav_bb, ImGuiID id);
-static ImVec2           NavCalcPreferredRefPos();
-static void             NavSaveLastChildNavWindowIntoParent(ImGuiWindow* nav_window);
-static ImGuiWindow*     NavRestoreLastChildNavWindow(ImGuiWindow* window);
-static void             NavRestoreLayer(ImGuiNavLayer layer);
-static int              FindWindowFocusIndex(ImGuiWindow* window);
+static void             NavUpdate() IMGUI_NOEXCEPT;
+static void             NavUpdateWindowing() IMGUI_NOEXCEPT;
+static void             NavUpdateWindowingOverlay() IMGUI_NOEXCEPT;
+static void             NavUpdateMoveResult() IMGUI_NOEXCEPT;
+static void             NavUpdateInitResult() IMGUI_NOEXCEPT;
+static float            NavUpdatePageUpPageDown() IMGUI_NOEXCEPT;
+static inline void      NavUpdateAnyRequestFlag() IMGUI_NOEXCEPT;
+static void             NavEndFrame() IMGUI_NOEXCEPT;
+static bool             NavScoreItem(ImGuiNavItemData* result, ImRect cand) IMGUI_NOEXCEPT;
+static void             NavApplyItemToResult(ImGuiNavItemData* result, ImGuiWindow* window, ImGuiID id, const ImRect& nav_bb_rel) IMGUI_NOEXCEPT;
+static void             NavProcessItem(ImGuiWindow* window, const ImRect& nav_bb, ImGuiID id) IMGUI_NOEXCEPT;
+static ImVec2           NavCalcPreferredRefPos() IMGUI_NOEXCEPT;
+static void             NavSaveLastChildNavWindowIntoParent(ImGuiWindow* nav_window) IMGUI_NOEXCEPT;
+static ImGuiWindow*     NavRestoreLastChildNavWindow(ImGuiWindow* window) IMGUI_NOEXCEPT;
+static void             NavRestoreLayer(ImGuiNavLayer layer) IMGUI_NOEXCEPT;
+static int              FindWindowFocusIndex(ImGuiWindow* window) IMGUI_NOEXCEPT;
 
 // Error Checking
-static void             ErrorCheckNewFrameSanityChecks();
-static void             ErrorCheckEndFrameSanityChecks();
+static void             ErrorCheckNewFrameSanityChecks() IMGUI_NOEXCEPT;
+static void             ErrorCheckEndFrameSanityChecks() IMGUI_NOEXCEPT;
 
 // Misc
-static void             UpdateSettings();
-static void             UpdateMouseInputs();
-static void             UpdateMouseWheel();
-static void             UpdateTabFocus();
-static void             UpdateDebugToolItemPicker();
-static bool             UpdateWindowManualResize(ImGuiWindow* window, const ImVec2& size_auto_fit, int* border_held, int resize_grip_count, ImU32 resize_grip_col[4], const ImRect& visibility_rect);
-static void             RenderWindowOuterBorders(ImGuiWindow* window);
-static void             RenderWindowDecorations(ImGuiWindow* window, const ImRect& title_bar_rect, bool title_bar_is_highlight, int resize_grip_count, const ImU32 resize_grip_col[4], float resize_grip_draw_size);
-static void             RenderWindowTitleBarContents(ImGuiWindow* window, const ImRect& title_bar_rect, const char* name, bool* p_open);
+static void             UpdateSettings() IMGUI_NOEXCEPT;
+static void             UpdateMouseInputs() IMGUI_NOEXCEPT;
+static void             UpdateMouseWheel() IMGUI_NOEXCEPT;
+static void             UpdateTabFocus() IMGUI_NOEXCEPT;
+static void             UpdateDebugToolItemPicker() IMGUI_NOEXCEPT;
+static bool             UpdateWindowManualResize(ImGuiWindow* window, const ImVec2& size_auto_fit, int* border_held, int resize_grip_count, ImU32 resize_grip_col[4], const ImRect& visibility_rect) IMGUI_NOEXCEPT;
+static void             RenderWindowOuterBorders(ImGuiWindow* window) IMGUI_NOEXCEPT;
+static void             RenderWindowDecorations(ImGuiWindow* window, const ImRect& title_bar_rect, bool title_bar_is_highlight, int resize_grip_count, const ImU32 resize_grip_col[4], float resize_grip_draw_size) IMGUI_NOEXCEPT;
+static void             RenderWindowTitleBarContents(ImGuiWindow* window, const ImRect& title_bar_rect, const char* name, bool* p_open) IMGUI_NOEXCEPT;
 
 // Viewports
-static void             UpdateViewportsNewFrame();
+static void             UpdateViewportsNewFrame() IMGUI_NOEXCEPT;
 
 }
 
@@ -964,11 +964,11 @@ ImGuiContext*   GImGui = NULL;
 // - You probably don't want to modify that mid-program, and if you use global/static e.g. ImVector<> instances you may need to keep them accessible during program destruction.
 // - DLL users: read comments above.
 #ifndef IMGUI_DISABLE_DEFAULT_ALLOCATORS
-static void*   MallocWrapper(size_t size, void* user_data)    { IM_UNUSED(user_data); return malloc(size); }
-static void    FreeWrapper(void* ptr, void* user_data)        { IM_UNUSED(user_data); free(ptr); }
+static void*   MallocWrapper(size_t size, void* user_data) IMGUI_NOEXCEPT  { IM_UNUSED(user_data); return malloc(size); }
+static void    FreeWrapper(void* ptr, void* user_data)     IMGUI_NOEXCEPT  { IM_UNUSED(user_data); free(ptr); }
 #else
-static void*   MallocWrapper(size_t size, void* user_data)    { IM_UNUSED(user_data); IM_UNUSED(size); IM_ASSERT(0); return NULL; }
-static void    FreeWrapper(void* ptr, void* user_data)        { IM_UNUSED(user_data); IM_UNUSED(ptr); IM_ASSERT(0); }
+static void*   MallocWrapper(size_t size, void* user_data) IMGUI_NOEXCEPT  { IM_UNUSED(user_data); IM_UNUSED(size); IM_ASSERT(0); return NULL; }
+static void    FreeWrapper(void* ptr, void* user_data)     IMGUI_NOEXCEPT  { IM_UNUSED(user_data); IM_UNUSED(ptr); IM_ASSERT(0); }
 #endif
 static ImGuiMemAllocFunc    GImAllocatorAllocFunc = MallocWrapper;
 static ImGuiMemFreeFunc     GImAllocatorFreeFunc = FreeWrapper;
@@ -978,7 +978,7 @@ static void*                GImAllocatorUserData = NULL;
 // [SECTION] USER FACING STRUCTURES (ImGuiStyle, ImGuiIO)
 //-----------------------------------------------------------------------------
 
-ImGuiStyle::ImGuiStyle()
+ImGuiStyle::ImGuiStyle() IMGUI_NOEXCEPT
 {
     Alpha                   = 1.0f;             // Global alpha applies to everything in ImGui
     WindowPadding           = ImVec2(8,8);      // Padding within a window
@@ -1026,7 +1026,7 @@ ImGuiStyle::ImGuiStyle()
 
 // To scale your entire UI (e.g. if you want your app to use High DPI or generally be DPI aware) you may use this helper function. Scaling the fonts is done separately and is up to you.
 // Important: This operation is lossy because we round all sizes to integer. If you need to change your scale multiples, call this over a freshly initialized ImGuiStyle structure rather than scaling multiple times.
-void ImGuiStyle::ScaleAllSizes(float scale_factor)
+void ImGuiStyle::ScaleAllSizes(float scale_factor) IMGUI_NOEXCEPT
 {
     WindowPadding = ImFloor(WindowPadding * scale_factor);
     WindowRounding = ImFloor(WindowRounding * scale_factor);
@@ -1053,7 +1053,7 @@ void ImGuiStyle::ScaleAllSizes(float scale_factor)
     MouseCursorScale = ImFloor(MouseCursorScale * scale_factor);
 }
 
-ImGuiIO::ImGuiIO()
+ImGuiIO::ImGuiIO() IMGUI_NOEXCEPT
 {
     // Most fields are initialized with zero
     memset(this, 0, sizeof(*this));
@@ -1114,7 +1114,7 @@ ImGuiIO::ImGuiIO()
 // Pass in translated ASCII characters for text input.
 // - with glfw you can get those from the callback set in glfwSetCharCallback()
 // - on Windows you can get those using ToAscii+keyboard state, or via the WM_CHAR message
-void ImGuiIO::AddInputCharacter(unsigned int c)
+void ImGuiIO::AddInputCharacter(unsigned int c) IMGUI_NOEXCEPT
 {
     if (c != 0)
         InputQueueCharacters.push_back(c <= IM_UNICODE_CODEPOINT_MAX ? (ImWchar)c : IM_UNICODE_CODEPOINT_INVALID);
@@ -1122,7 +1122,7 @@ void ImGuiIO::AddInputCharacter(unsigned int c)
 
 // UTF16 strings use surrogate pairs to encode codepoints >= 0x10000, so
 // we should save the high surrogate.
-void ImGuiIO::AddInputCharacterUTF16(ImWchar16 c)
+void ImGuiIO::AddInputCharacterUTF16(ImWchar16 c) IMGUI_NOEXCEPT
 {
     if (c == 0 && InputQueueSurrogate == 0)
         return;
@@ -1156,7 +1156,7 @@ void ImGuiIO::AddInputCharacterUTF16(ImWchar16 c)
     InputQueueCharacters.push_back(cp);
 }
 
-void ImGuiIO::AddInputCharactersUTF8(const char* utf8_chars)
+void ImGuiIO::AddInputCharactersUTF8(const char* utf8_chars) IMGUI_NOEXCEPT
 {
     while (*utf8_chars != 0)
     {
@@ -1167,7 +1167,7 @@ void ImGuiIO::AddInputCharactersUTF8(const char* utf8_chars)
     }
 }
 
-void ImGuiIO::ClearInputCharacters()
+void ImGuiIO::ClearInputCharacters() IMGUI_NOEXCEPT
 {
     InputQueueCharacters.resize(0);
 }
@@ -1176,7 +1176,7 @@ void ImGuiIO::ClearInputCharacters()
 // [SECTION] MISC HELPERS/UTILITIES (Geometry functions)
 //-----------------------------------------------------------------------------
 
-ImVec2 ImBezierCubicClosestPoint(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, const ImVec2& p, int num_segments)
+ImVec2 ImBezierCubicClosestPoint(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, const ImVec2& p, int num_segments) IMGUI_NOEXCEPT
 {
     IM_ASSERT(num_segments > 0); // Use ImBezierCubicClosestPointCasteljau()
     ImVec2 p_last = p1;
@@ -1199,7 +1199,7 @@ ImVec2 ImBezierCubicClosestPoint(const ImVec2& p1, const ImVec2& p2, const ImVec
 }
 
 // Closely mimics PathBezierToCasteljau() in imgui_draw.cpp
-static void ImBezierCubicClosestPointCasteljauStep(const ImVec2& p, ImVec2& p_closest, ImVec2& p_last, float& p_closest_dist2, float x1, float y1, float x2, float y2, float x3, float y3, float x4, float y4, float tess_tol, int level)
+static void ImBezierCubicClosestPointCasteljauStep(const ImVec2& p, ImVec2& p_closest, ImVec2& p_last, float& p_closest_dist2, float x1, float y1, float x2, float y2, float x3, float y3, float x4, float y4, float tess_tol, int level) IMGUI_NOEXCEPT
 {
     float dx = x4 - x1;
     float dy = y4 - y1;
@@ -1234,7 +1234,7 @@ static void ImBezierCubicClosestPointCasteljauStep(const ImVec2& p, ImVec2& p_cl
 
 // tess_tol is generally the same value you would find in ImGui::GetStyle().CurveTessellationTol
 // Because those ImXXX functions are lower-level than ImGui:: we cannot access this value automatically.
-ImVec2 ImBezierCubicClosestPointCasteljau(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, const ImVec2& p, float tess_tol)
+ImVec2 ImBezierCubicClosestPointCasteljau(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, const ImVec2& p, float tess_tol) IMGUI_NOEXCEPT
 {
     IM_ASSERT(tess_tol > 0.0f);
     ImVec2 p_last = p1;
@@ -1244,7 +1244,7 @@ ImVec2 ImBezierCubicClosestPointCasteljau(const ImVec2& p1, const ImVec2& p2, co
     return p_closest;
 }
 
-ImVec2 ImLineClosestPoint(const ImVec2& a, const ImVec2& b, const ImVec2& p)
+ImVec2 ImLineClosestPoint(const ImVec2& a, const ImVec2& b, const ImVec2& p) IMGUI_NOEXCEPT
 {
     ImVec2 ap = p - a;
     ImVec2 ab_dir = b - a;
@@ -1257,7 +1257,7 @@ ImVec2 ImLineClosestPoint(const ImVec2& a, const ImVec2& b, const ImVec2& p)
     return a + ab_dir * dot / ab_len_sqr;
 }
 
-bool ImTriangleContainsPoint(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& p)
+bool ImTriangleContainsPoint(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& p) IMGUI_NOEXCEPT
 {
     bool b1 = ((p.x - b.x) * (a.y - b.y) - (p.y - b.y) * (a.x - b.x)) < 0.0f;
     bool b2 = ((p.x - c.x) * (b.y - c.y) - (p.y - c.y) * (b.x - c.x)) < 0.0f;
@@ -1265,7 +1265,7 @@ bool ImTriangleContainsPoint(const ImVec2& a, const ImVec2& b, const ImVec2& c, 
     return ((b1 == b2) && (b2 == b3));
 }
 
-void ImTriangleBarycentricCoords(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& p, float& out_u, float& out_v, float& out_w)
+void ImTriangleBarycentricCoords(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& p, float& out_u, float& out_v, float& out_w) IMGUI_NOEXCEPT
 {
     ImVec2 v0 = b - a;
     ImVec2 v1 = c - a;
@@ -1276,7 +1276,7 @@ void ImTriangleBarycentricCoords(const ImVec2& a, const ImVec2& b, const ImVec2&
     out_u = 1.0f - out_v - out_w;
 }
 
-ImVec2 ImTriangleClosestPoint(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& p)
+ImVec2 ImTriangleClosestPoint(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& p) IMGUI_NOEXCEPT
 {
     ImVec2 proj_ab = ImLineClosestPoint(a, b, p);
     ImVec2 proj_bc = ImLineClosestPoint(b, c, p);
@@ -1297,21 +1297,21 @@ ImVec2 ImTriangleClosestPoint(const ImVec2& a, const ImVec2& b, const ImVec2& c,
 //-----------------------------------------------------------------------------
 
 // Consider using _stricmp/_strnicmp under Windows or strcasecmp/strncasecmp. We don't actually use either ImStricmp/ImStrnicmp in the codebase any more.
-int ImStricmp(const char* str1, const char* str2)
+int ImStricmp(const char* str1, const char* str2) IMGUI_NOEXCEPT
 {
     int d;
     while ((d = toupper(*str2) - toupper(*str1)) == 0 && *str1) { str1++; str2++; }
     return d;
 }
 
-int ImStrnicmp(const char* str1, const char* str2, size_t count)
+int ImStrnicmp(const char* str1, const char* str2, size_t count) IMGUI_NOEXCEPT
 {
     int d = 0;
     while (count > 0 && (d = toupper(*str2) - toupper(*str1)) == 0 && *str1) { str1++; str2++; count--; }
     return d;
 }
 
-void ImStrncpy(char* dst, const char* src, size_t count)
+void ImStrncpy(char* dst, const char* src, size_t count) IMGUI_NOEXCEPT
 {
     if (count < 1)
         return;
@@ -1320,14 +1320,14 @@ void ImStrncpy(char* dst, const char* src, size_t count)
     dst[count - 1] = 0;
 }
 
-char* ImStrdup(const char* str)
+char* ImStrdup(const char* str) IMGUI_NOEXCEPT
 {
     size_t len = strlen(str);
     void* buf = IM_ALLOC(len + 1);
     return (char*)memcpy(buf, (const void*)str, len + 1);
 }
 
-char* ImStrdupcpy(char* dst, size_t* p_dst_size, const char* src)
+char* ImStrdupcpy(char* dst, size_t* p_dst_size, const char* src) IMGUI_NOEXCEPT
 {
     size_t dst_buf_size = p_dst_size ? *p_dst_size : strlen(dst) + 1;
     size_t src_size = strlen(src) + 1;
@@ -1341,13 +1341,13 @@ char* ImStrdupcpy(char* dst, size_t* p_dst_size, const char* src)
     return (char*)memcpy(dst, (const void*)src, src_size);
 }
 
-const char* ImStrchrRange(const char* str, const char* str_end, char c)
+const char* ImStrchrRange(const char* str, const char* str_end, char c) IMGUI_NOEXCEPT
 {
     const char* p = (const char*)memchr(str, (int)c, str_end - str);
     return p;
 }
 
-int ImStrlenW(const ImWchar* str)
+int ImStrlenW(const ImWchar* str) IMGUI_NOEXCEPT
 {
     //return (int)wcslen((const wchar_t*)str);  // FIXME-OPT: Could use this when wchar_t are 16-bit
     int n = 0;
@@ -1356,20 +1356,20 @@ int ImStrlenW(const ImWchar* str)
 }
 
 // Find end-of-line. Return pointer will point to either first \n, either str_end.
-const char* ImStreolRange(const char* str, const char* str_end)
+const char* ImStreolRange(const char* str, const char* str_end) IMGUI_NOEXCEPT
 {
     const char* p = (const char*)memchr(str, '\n', str_end - str);
     return p ? p : str_end;
 }
 
-const ImWchar* ImStrbolW(const ImWchar* buf_mid_line, const ImWchar* buf_begin) // find beginning-of-line
+const ImWchar* ImStrbolW(const ImWchar* buf_mid_line, const ImWchar* buf_begin) IMGUI_NOEXCEPT // find beginning-of-line
 {
     while (buf_mid_line > buf_begin && buf_mid_line[-1] != '\n')
         buf_mid_line--;
     return buf_mid_line;
 }
 
-const char* ImStristr(const char* haystack, const char* haystack_end, const char* needle, const char* needle_end)
+const char* ImStristr(const char* haystack, const char* haystack_end, const char* needle, const char* needle_end) IMGUI_NOEXCEPT
 {
     if (!needle_end)
         needle_end = needle + strlen(needle);
@@ -1392,7 +1392,7 @@ const char* ImStristr(const char* haystack, const char* haystack_end, const char
 }
 
 // Trim str by offsetting contents when there's leading data + writing a \0 at the trailing position. We use this in situation where the cost is negligible.
-void ImStrTrimBlanks(char* buf)
+void ImStrTrimBlanks(char* buf) IMGUI_NOEXCEPT
 {
     char* p = buf;
     while (p[0] == ' ' || p[0] == '\t')     // Leading blanks
@@ -1407,7 +1407,7 @@ void ImStrTrimBlanks(char* buf)
     buf[p - p_start] = 0;                   // Zero terminate
 }
 
-const char* ImStrSkipBlank(const char* str)
+const char* ImStrSkipBlank(const char* str) IMGUI_NOEXCEPT
 {
     while (str[0] == ' ' || str[0] == '\t')
         str++;
@@ -1432,7 +1432,7 @@ const char* ImStrSkipBlank(const char* str)
 #define vsnprintf _vsnprintf
 #endif
 
-int ImFormatString(char* buf, size_t buf_size, const char* fmt, ...)
+int ImFormatString(char* buf, size_t buf_size, const char* fmt, ...) IMGUI_NOEXCEPT
 {
     va_list args;
     va_start(args, fmt);
@@ -1450,7 +1450,7 @@ int ImFormatString(char* buf, size_t buf_size, const char* fmt, ...)
     return w;
 }
 
-int ImFormatStringV(char* buf, size_t buf_size, const char* fmt, va_list args)
+int ImFormatStringV(char* buf, size_t buf_size, const char* fmt, va_list args) IMGUI_NOEXCEPT
 {
 #ifdef IMGUI_USE_STB_SPRINTF
     int w = stbsp_vsnprintf(buf, (int)buf_size, fmt, args);
@@ -1492,7 +1492,7 @@ static const ImU32 GCrc32LookupTable[256] =
 // Known size hash
 // It is ok to call ImHashData on a string with known length but the ### operator won't be supported.
 // FIXME-OPT: Replace with e.g. FNV1a hash? CRC32 pretty much randomly access 1KB. Need to do proper measurements.
-ImGuiID ImHashData(const void* data_p, size_t data_size, ImU32 seed)
+ImGuiID ImHashData(const void* data_p, size_t data_size, ImU32 seed) IMGUI_NOEXCEPT
 {
     ImU32 crc = ~seed;
     const unsigned char* data = (const unsigned char*)data_p;
@@ -1508,7 +1508,7 @@ ImGuiID ImHashData(const void* data_p, size_t data_size, ImU32 seed)
 // - If we reach ### in the string we discard the hash so far and reset to the seed.
 // - We don't do 'current += 2; continue;' after handling ### to keep the code smaller/faster (measured ~10% diff in Debug build)
 // FIXME-OPT: Replace with e.g. FNV1a hash? CRC32 pretty much randomly access 1KB. Need to do proper measurements.
-ImGuiID ImHashStr(const char* data_p, size_t data_size, ImU32 seed)
+ImGuiID ImHashStr(const char* data_p, size_t data_size, ImU32 seed) IMGUI_NOEXCEPT
 {
     seed = ~seed;
     ImU32 crc = seed;
@@ -1543,7 +1543,7 @@ ImGuiID ImHashStr(const char* data_p, size_t data_size, ImU32 seed)
 // Default file functions
 #ifndef IMGUI_DISABLE_DEFAULT_FILE_FUNCTIONS
 
-ImFileHandle ImFileOpen(const char* filename, const char* mode)
+ImFileHandle ImFileOpen(const char* filename, const char* mode) IMGUI_NOEXCEPT
 {
 #if defined(_WIN32) && !defined(IMGUI_DISABLE_WIN32_FUNCTIONS) && !defined(__CYGWIN__) && !defined(__GNUC__)
     // We need a fopen() wrapper because MSVC/Windows fopen doesn't handle UTF-8 filenames.
@@ -1561,16 +1561,16 @@ ImFileHandle ImFileOpen(const char* filename, const char* mode)
 }
 
 // We should in theory be using fseeko()/ftello() with off_t and _fseeki64()/_ftelli64() with __int64, waiting for the PR that does that in a very portable pre-C++11 zero-warnings way.
-bool    ImFileClose(ImFileHandle f)     { return fclose(f) == 0; }
-ImU64   ImFileGetSize(ImFileHandle f)   { long off = 0, sz = 0; return ((off = ftell(f)) != -1 && !fseek(f, 0, SEEK_END) && (sz = ftell(f)) != -1 && !fseek(f, off, SEEK_SET)) ? (ImU64)sz : (ImU64)-1; }
-ImU64   ImFileRead(void* data, ImU64 sz, ImU64 count, ImFileHandle f)           { return fread(data, (size_t)sz, (size_t)count, f); }
-ImU64   ImFileWrite(const void* data, ImU64 sz, ImU64 count, ImFileHandle f)    { return fwrite(data, (size_t)sz, (size_t)count, f); }
+bool    ImFileClose(ImFileHandle f)   IMGUI_NOEXCEPT   { return fclose(f) == 0; }
+ImU64   ImFileGetSize(ImFileHandle f) IMGUI_NOEXCEPT   { long off = 0, sz = 0; return ((off = ftell(f)) != -1 && !fseek(f, 0, SEEK_END) && (sz = ftell(f)) != -1 && !fseek(f, off, SEEK_SET)) ? (ImU64)sz : (ImU64)-1; }
+ImU64   ImFileRead(void* data, ImU64 sz, ImU64 count, ImFileHandle f) IMGUI_NOEXCEPT           { return fread(data, (size_t)sz, (size_t)count, f); }
+ImU64   ImFileWrite(const void* data, ImU64 sz, ImU64 count, ImFileHandle f) IMGUI_NOEXCEPT    { return fwrite(data, (size_t)sz, (size_t)count, f); }
 #endif // #ifndef IMGUI_DISABLE_DEFAULT_FILE_FUNCTIONS
 
 // Helper: Load file content into memory
 // Memory allocated with IM_ALLOC(), must be freed by user using IM_FREE() == ImGui::MemFree()
 // This can't really be used with "rt" because fseek size won't match read size.
-void*   ImFileLoadToMemory(const char* filename, const char* mode, size_t* out_file_size, int padding_bytes)
+void*   ImFileLoadToMemory(const char* filename, const char* mode, size_t* out_file_size, int padding_bytes) IMGUI_NOEXCEPT
 {
     IM_ASSERT(filename && mode);
     if (out_file_size)
@@ -1616,7 +1616,7 @@ void*   ImFileLoadToMemory(const char* filename, const char* mode, size_t* out_f
 // Convert UTF-8 to 32-bit character, process single character input.
 // A nearly-branchless UTF-8 decoder, based on work of Christopher Wellons (https://github.com/skeeto/branchless-utf8).
 // We handle UTF-8 decoding error by skipping forward.
-int ImTextCharFromUtf8(unsigned int* out_char, const char* in_text, const char* in_text_end)
+int ImTextCharFromUtf8(unsigned int* out_char, const char* in_text, const char* in_text_end) IMGUI_NOEXCEPT
 {
     static const char lengths[32] = { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 2, 3, 3, 4, 0 };
     static const int masks[]  = { 0x00, 0x7f, 0x1f, 0x0f, 0x07 };
@@ -1668,7 +1668,7 @@ int ImTextCharFromUtf8(unsigned int* out_char, const char* in_text, const char* 
     return wanted;
 }
 
-int ImTextStrFromUtf8(ImWchar* buf, int buf_size, const char* in_text, const char* in_text_end, const char** in_text_remaining)
+int ImTextStrFromUtf8(ImWchar* buf, int buf_size, const char* in_text, const char* in_text_end, const char** in_text_remaining) IMGUI_NOEXCEPT
 {
     ImWchar* buf_out = buf;
     ImWchar* buf_end = buf + buf_size;
@@ -1686,7 +1686,7 @@ int ImTextStrFromUtf8(ImWchar* buf, int buf_size, const char* in_text, const cha
     return (int)(buf_out - buf);
 }
 
-int ImTextCountCharsFromUtf8(const char* in_text, const char* in_text_end)
+int ImTextCountCharsFromUtf8(const char* in_text, const char* in_text_end) IMGUI_NOEXCEPT
 {
     int char_count = 0;
     while ((!in_text_end || in_text < in_text_end) && *in_text)
@@ -1701,7 +1701,7 @@ int ImTextCountCharsFromUtf8(const char* in_text, const char* in_text_end)
 }
 
 // Based on stb_to_utf8() from github.com/nothings/stb/
-static inline int ImTextCharToUtf8(char* buf, int buf_size, unsigned int c)
+static inline int ImTextCharToUtf8(char* buf, int buf_size, unsigned int c) IMGUI_NOEXCEPT
 {
     if (c < 0x80)
     {
@@ -1737,13 +1737,13 @@ static inline int ImTextCharToUtf8(char* buf, int buf_size, unsigned int c)
 }
 
 // Not optimal but we very rarely use this function.
-int ImTextCountUtf8BytesFromChar(const char* in_text, const char* in_text_end)
+int ImTextCountUtf8BytesFromChar(const char* in_text, const char* in_text_end) IMGUI_NOEXCEPT
 {
     unsigned int unused = 0;
     return ImTextCharFromUtf8(&unused, in_text, in_text_end);
 }
 
-static inline int ImTextCountUtf8BytesFromChar(unsigned int c)
+static inline int ImTextCountUtf8BytesFromChar(unsigned int c) IMGUI_NOEXCEPT
 {
     if (c < 0x80) return 1;
     if (c < 0x800) return 2;
@@ -1752,7 +1752,7 @@ static inline int ImTextCountUtf8BytesFromChar(unsigned int c)
     return 3;
 }
 
-int ImTextStrToUtf8(char* buf, int buf_size, const ImWchar* in_text, const ImWchar* in_text_end)
+int ImTextStrToUtf8(char* buf, int buf_size, const ImWchar* in_text, const ImWchar* in_text_end) IMGUI_NOEXCEPT
 {
     char* buf_out = buf;
     const char* buf_end = buf + buf_size;
@@ -1768,7 +1768,7 @@ int ImTextStrToUtf8(char* buf, int buf_size, const ImWchar* in_text, const ImWch
     return (int)(buf_out - buf);
 }
 
-int ImTextCountUtf8BytesFromStr(const ImWchar* in_text, const ImWchar* in_text_end)
+int ImTextCountUtf8BytesFromStr(const ImWchar* in_text, const ImWchar* in_text_end) IMGUI_NOEXCEPT
 {
     int bytes_count = 0;
     while ((!in_text_end || in_text < in_text_end) && *in_text)
@@ -1787,7 +1787,7 @@ int ImTextCountUtf8BytesFromStr(const ImWchar* in_text, const ImWchar* in_text_e
 // Note: The Convert functions are early design which are not consistent with other API.
 //-----------------------------------------------------------------------------
 
-IMGUI_API ImU32 ImAlphaBlendColors(ImU32 col_a, ImU32 col_b)
+IMGUI_API ImU32 ImAlphaBlendColors(ImU32 col_a, ImU32 col_b) IMGUI_NOEXCEPT
 {
     float t = ((col_b >> IM_COL32_A_SHIFT) & 0xFF) / 255.f;
     int r = ImLerp((int)(col_a >> IM_COL32_R_SHIFT) & 0xFF, (int)(col_b >> IM_COL32_R_SHIFT) & 0xFF, t);
@@ -1796,7 +1796,7 @@ IMGUI_API ImU32 ImAlphaBlendColors(ImU32 col_a, ImU32 col_b)
     return IM_COL32(r, g, b, 0xFF);
 }
 
-ImVec4 ImGui::ColorConvertU32ToFloat4(ImU32 in)
+ImVec4 ImGui::ColorConvertU32ToFloat4(ImU32 in) IMGUI_NOEXCEPT
 {
     float s = 1.0f / 255.0f;
     return ImVec4(
@@ -1806,7 +1806,7 @@ ImVec4 ImGui::ColorConvertU32ToFloat4(ImU32 in)
         ((in >> IM_COL32_A_SHIFT) & 0xFF) * s);
 }
 
-ImU32 ImGui::ColorConvertFloat4ToU32(const ImVec4& in)
+ImU32 ImGui::ColorConvertFloat4ToU32(const ImVec4& in) IMGUI_NOEXCEPT
 {
     ImU32 out;
     out  = ((ImU32)IM_F32_TO_INT8_SAT(in.x)) << IM_COL32_R_SHIFT;
@@ -1818,7 +1818,7 @@ ImU32 ImGui::ColorConvertFloat4ToU32(const ImVec4& in)
 
 // Convert rgb floats ([0-1],[0-1],[0-1]) to hsv floats ([0-1],[0-1],[0-1]), from Foley & van Dam p592
 // Optimized http://lolengine.net/blog/2013/01/13/fast-rgb-to-hsv
-void ImGui::ColorConvertRGBtoHSV(float r, float g, float b, float& out_h, float& out_s, float& out_v)
+void ImGui::ColorConvertRGBtoHSV(float r, float g, float b, float& out_h, float& out_s, float& out_v) IMGUI_NOEXCEPT
 {
     float K = 0.f;
     if (g < b)
@@ -1840,7 +1840,7 @@ void ImGui::ColorConvertRGBtoHSV(float r, float g, float b, float& out_h, float&
 
 // Convert hsv floats ([0-1],[0-1],[0-1]) to rgb floats ([0-1],[0-1],[0-1]), from Foley & van Dam p593
 // also http://en.wikipedia.org/wiki/HSL_and_HSV
-void ImGui::ColorConvertHSVtoRGB(float h, float s, float v, float& out_r, float& out_g, float& out_b)
+void ImGui::ColorConvertHSVtoRGB(float h, float s, float v, float& out_r, float& out_g, float& out_b) IMGUI_NOEXCEPT
 {
     if (s == 0.0f)
     {
@@ -1873,7 +1873,7 @@ void ImGui::ColorConvertHSVtoRGB(float h, float s, float v, float& out_r, float&
 //-----------------------------------------------------------------------------
 
 // std::lower_bound but without the bullshit
-static ImGuiStorage::ImGuiStoragePair* LowerBound(ImVector<ImGuiStorage::ImGuiStoragePair>& data, ImGuiID key)
+static ImGuiStorage::ImGuiStoragePair* LowerBound(ImVector<ImGuiStorage::ImGuiStoragePair>& data, ImGuiID key) IMGUI_NOEXCEPT
 {
     ImGuiStorage::ImGuiStoragePair* first = data.Data;
     ImGuiStorage::ImGuiStoragePair* last = data.Data + data.Size;
@@ -1896,7 +1896,7 @@ static ImGuiStorage::ImGuiStoragePair* LowerBound(ImVector<ImGuiStorage::ImGuiSt
 }
 
 // For quicker full rebuild of a storage (instead of an incremental one), you may add all your contents and then sort once.
-void ImGuiStorage::BuildSortByKey()
+void ImGuiStorage::BuildSortByKey() IMGUI_NOEXCEPT
 {
     struct StaticFunc
     {
@@ -1912,7 +1912,7 @@ void ImGuiStorage::BuildSortByKey()
         ImQsort(Data.Data, (size_t)Data.Size, sizeof(ImGuiStoragePair), StaticFunc::PairCompareByID);
 }
 
-int ImGuiStorage::GetInt(ImGuiID key, int default_val) const
+int ImGuiStorage::GetInt(ImGuiID key, int default_val) const IMGUI_NOEXCEPT
 {
     ImGuiStoragePair* it = LowerBound(const_cast<ImVector<ImGuiStoragePair>&>(Data), key);
     if (it == Data.end() || it->key != key)
@@ -1920,12 +1920,12 @@ int ImGuiStorage::GetInt(ImGuiID key, int default_val) const
     return it->val_i;
 }
 
-bool ImGuiStorage::GetBool(ImGuiID key, bool default_val) const
+bool ImGuiStorage::GetBool(ImGuiID key, bool default_val) const IMGUI_NOEXCEPT
 {
     return GetInt(key, default_val ? 1 : 0) != 0;
 }
 
-float ImGuiStorage::GetFloat(ImGuiID key, float default_val) const
+float ImGuiStorage::GetFloat(ImGuiID key, float default_val) const IMGUI_NOEXCEPT
 {
     ImGuiStoragePair* it = LowerBound(const_cast<ImVector<ImGuiStoragePair>&>(Data), key);
     if (it == Data.end() || it->key != key)
@@ -1933,7 +1933,7 @@ float ImGuiStorage::GetFloat(ImGuiID key, float default_val) const
     return it->val_f;
 }
 
-void* ImGuiStorage::GetVoidPtr(ImGuiID key) const
+void* ImGuiStorage::GetVoidPtr(ImGuiID key) const IMGUI_NOEXCEPT
 {
     ImGuiStoragePair* it = LowerBound(const_cast<ImVector<ImGuiStoragePair>&>(Data), key);
     if (it == Data.end() || it->key != key)
@@ -1942,7 +1942,7 @@ void* ImGuiStorage::GetVoidPtr(ImGuiID key) const
 }
 
 // References are only valid until a new value is added to the storage. Calling a Set***() function or a Get***Ref() function invalidates the pointer.
-int* ImGuiStorage::GetIntRef(ImGuiID key, int default_val)
+int* ImGuiStorage::GetIntRef(ImGuiID key, int default_val) IMGUI_NOEXCEPT
 {
     ImGuiStoragePair* it = LowerBound(Data, key);
     if (it == Data.end() || it->key != key)
@@ -1950,12 +1950,12 @@ int* ImGuiStorage::GetIntRef(ImGuiID key, int default_val)
     return &it->val_i;
 }
 
-bool* ImGuiStorage::GetBoolRef(ImGuiID key, bool default_val)
+bool* ImGuiStorage::GetBoolRef(ImGuiID key, bool default_val) IMGUI_NOEXCEPT
 {
     return (bool*)GetIntRef(key, default_val ? 1 : 0);
 }
 
-float* ImGuiStorage::GetFloatRef(ImGuiID key, float default_val)
+float* ImGuiStorage::GetFloatRef(ImGuiID key, float default_val) IMGUI_NOEXCEPT
 {
     ImGuiStoragePair* it = LowerBound(Data, key);
     if (it == Data.end() || it->key != key)
@@ -1963,7 +1963,7 @@ float* ImGuiStorage::GetFloatRef(ImGuiID key, float default_val)
     return &it->val_f;
 }
 
-void** ImGuiStorage::GetVoidPtrRef(ImGuiID key, void* default_val)
+void** ImGuiStorage::GetVoidPtrRef(ImGuiID key, void* default_val) IMGUI_NOEXCEPT
 {
     ImGuiStoragePair* it = LowerBound(Data, key);
     if (it == Data.end() || it->key != key)
@@ -1972,7 +1972,7 @@ void** ImGuiStorage::GetVoidPtrRef(ImGuiID key, void* default_val)
 }
 
 // FIXME-OPT: Need a way to reuse the result of lower_bound when doing GetInt()/SetInt() - not too bad because it only happens on explicit interaction (maximum one a frame)
-void ImGuiStorage::SetInt(ImGuiID key, int val)
+void ImGuiStorage::SetInt(ImGuiID key, int val) IMGUI_NOEXCEPT
 {
     ImGuiStoragePair* it = LowerBound(Data, key);
     if (it == Data.end() || it->key != key)
@@ -1983,12 +1983,12 @@ void ImGuiStorage::SetInt(ImGuiID key, int val)
     it->val_i = val;
 }
 
-void ImGuiStorage::SetBool(ImGuiID key, bool val)
+void ImGuiStorage::SetBool(ImGuiID key, bool val) IMGUI_NOEXCEPT
 {
     SetInt(key, val ? 1 : 0);
 }
 
-void ImGuiStorage::SetFloat(ImGuiID key, float val)
+void ImGuiStorage::SetFloat(ImGuiID key, float val) IMGUI_NOEXCEPT
 {
     ImGuiStoragePair* it = LowerBound(Data, key);
     if (it == Data.end() || it->key != key)
@@ -1999,7 +1999,7 @@ void ImGuiStorage::SetFloat(ImGuiID key, float val)
     it->val_f = val;
 }
 
-void ImGuiStorage::SetVoidPtr(ImGuiID key, void* val)
+void ImGuiStorage::SetVoidPtr(ImGuiID key, void* val) IMGUI_NOEXCEPT
 {
     ImGuiStoragePair* it = LowerBound(Data, key);
     if (it == Data.end() || it->key != key)
@@ -2010,7 +2010,7 @@ void ImGuiStorage::SetVoidPtr(ImGuiID key, void* val)
     it->val_p = val;
 }
 
-void ImGuiStorage::SetAllInt(int v)
+void ImGuiStorage::SetAllInt(int v) IMGUI_NOEXCEPT
 {
     for (int i = 0; i < Data.Size; i++)
         Data[i].val_i = v;
@@ -2021,7 +2021,7 @@ void ImGuiStorage::SetAllInt(int v)
 //-----------------------------------------------------------------------------
 
 // Helper: Parse and apply text filters. In format "aaaaa[,bbbb][,ccccc]"
-ImGuiTextFilter::ImGuiTextFilter(const char* default_filter)
+ImGuiTextFilter::ImGuiTextFilter(const char* default_filter) IMGUI_NOEXCEPT
 {
     if (default_filter)
     {
@@ -2035,7 +2035,7 @@ ImGuiTextFilter::ImGuiTextFilter(const char* default_filter)
     }
 }
 
-bool ImGuiTextFilter::Draw(const char* label, float width)
+bool ImGuiTextFilter::Draw(const char* label, float width) IMGUI_NOEXCEPT
 {
     if (width != 0.0f)
         ImGui::SetNextItemWidth(width);
@@ -2045,7 +2045,7 @@ bool ImGuiTextFilter::Draw(const char* label, float width)
     return value_changed;
 }
 
-void ImGuiTextFilter::ImGuiTextRange::split(char separator, ImVector<ImGuiTextRange>* out) const
+void ImGuiTextFilter::ImGuiTextRange::split(char separator, ImVector<ImGuiTextRange>* out) const IMGUI_NOEXCEPT
 {
     out->resize(0);
     const char* wb = b;
@@ -2063,7 +2063,7 @@ void ImGuiTextFilter::ImGuiTextRange::split(char separator, ImVector<ImGuiTextRa
         out->push_back(ImGuiTextRange(wb, we));
 }
 
-void ImGuiTextFilter::Build()
+void ImGuiTextFilter::Build() IMGUI_NOEXCEPT
 {
     Filters.resize(0);
     ImGuiTextRange input_range(InputBuf, InputBuf + strlen(InputBuf));
@@ -2084,7 +2084,7 @@ void ImGuiTextFilter::Build()
     }
 }
 
-bool ImGuiTextFilter::PassFilter(const char* text, const char* text_end) const
+bool ImGuiTextFilter::PassFilter(const char* text, const char* text_end) const IMGUI_NOEXCEPT
 {
     if (Filters.empty())
         return true;
@@ -2134,7 +2134,7 @@ bool ImGuiTextFilter::PassFilter(const char* text, const char* text_end) const
 
 char ImGuiTextBuffer::EmptyString[1] = { 0 };
 
-void ImGuiTextBuffer::append(const char* str, const char* str_end)
+void ImGuiTextBuffer::append(const char* str, const char* str_end) IMGUI_NOEXCEPT
 {
     int len = str_end ? (int)(str_end - str) : (int)strlen(str);
 
@@ -2152,7 +2152,7 @@ void ImGuiTextBuffer::append(const char* str, const char* str_end)
     Buf[write_off - 1 + len] = 0;
 }
 
-void ImGuiTextBuffer::appendf(const char* fmt, ...)
+void ImGuiTextBuffer::appendf(const char* fmt, ...) IMGUI_NOEXCEPT
 {
     va_list args;
     va_start(args, fmt);
@@ -2161,7 +2161,7 @@ void ImGuiTextBuffer::appendf(const char* fmt, ...)
 }
 
 // Helper: Text buffer for logging/accumulating text
-void ImGuiTextBuffer::appendfv(const char* fmt, va_list args)
+void ImGuiTextBuffer::appendfv(const char* fmt, va_list args) IMGUI_NOEXCEPT
 {
     va_list args_copy;
     va_copy(args_copy, args);
@@ -2195,7 +2195,7 @@ void ImGuiTextBuffer::appendfv(const char* fmt, va_list args)
 
 // FIXME-TABLE: This prevents us from using ImGuiListClipper _inside_ a table cell.
 // The problem we have is that without a Begin/End scheme for rows using the clipper is ambiguous.
-static bool GetSkipItemForListClipping()
+static bool GetSkipItemForListClipping() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return (g.CurrentTable ? g.CurrentTable->HostSkipItems : g.CurrentWindow->SkipItems);
@@ -2204,7 +2204,7 @@ static bool GetSkipItemForListClipping()
 // Helper to calculate coarse clipping of large list of evenly sized items.
 // NB: Prefer using the ImGuiListClipper higher-level helper if you can! Read comments and instructions there on how those use this sort of pattern.
 // NB: 'items_count' is only used to clamp the result, if you don't know your count you can use INT_MAX
-void ImGui::CalcListClipping(int items_count, float items_height, int* out_items_display_start, int* out_items_display_end)
+void ImGui::CalcListClipping(int items_count, float items_height, int* out_items_display_start, int* out_items_display_end) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -2244,7 +2244,7 @@ void ImGui::CalcListClipping(int items_count, float items_height, int* out_items
     *out_items_display_end = end;
 }
 
-static void SetCursorPosYAndSetupForPrevLine(float pos_y, float line_height)
+static void SetCursorPosYAndSetupForPrevLine(float pos_y, float line_height) IMGUI_NOEXCEPT
 {
     // Set cursor position and a few other things so that SetScrollHereY() and Columns() can work when seeking cursor.
     // FIXME: It is problematic that we have to do that here, because custom/equivalent end-user code would stumble on the same issue.
@@ -2269,13 +2269,13 @@ static void SetCursorPosYAndSetupForPrevLine(float pos_y, float line_height)
     }
 }
 
-ImGuiListClipper::ImGuiListClipper()
+ImGuiListClipper::ImGuiListClipper() IMGUI_NOEXCEPT
 {
     memset(this, 0, sizeof(*this));
     ItemsCount = -1;
 }
 
-ImGuiListClipper::~ImGuiListClipper()
+ImGuiListClipper::~ImGuiListClipper() IMGUI_NOEXCEPT
 {
     IM_ASSERT(ItemsCount == -1 && "Forgot to call End(), or to Step() until false?");
 }
@@ -2313,7 +2313,7 @@ void ImGuiListClipper::End() IMGUI_NOEXCEPT
     StepNo = 3;
 }
 
-bool ImGuiListClipper::Step()
+bool ImGuiListClipper::Step() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -2420,13 +2420,13 @@ bool ImGuiListClipper::Step()
 // [SECTION] STYLING
 //-----------------------------------------------------------------------------
 
-ImGuiStyle& ImGui::GetStyle()
+ImGuiStyle& ImGui::GetStyle() IMGUI_NOEXCEPT
 {
     IM_ASSERT(GImGui != NULL && "No current context. Did you call ImGui::CreateContext() and ImGui::SetCurrentContext() ?");
     return GImGui->Style;
 }
 
-ImU32 ImGui::GetColorU32(ImGuiCol idx, float alpha_mul)
+ImU32 ImGui::GetColorU32(ImGuiCol idx, float alpha_mul) IMGUI_NOEXCEPT
 {
     ImGuiStyle& style = GImGui->Style;
     ImVec4 c = style.Colors[idx];
@@ -2434,7 +2434,7 @@ ImU32 ImGui::GetColorU32(ImGuiCol idx, float alpha_mul)
     return ColorConvertFloat4ToU32(c);
 }
 
-ImU32 ImGui::GetColorU32(const ImVec4& col)
+ImU32 ImGui::GetColorU32(const ImVec4& col) IMGUI_NOEXCEPT
 {
     ImGuiStyle& style = GImGui->Style;
     ImVec4 c = col;
@@ -2442,13 +2442,13 @@ ImU32 ImGui::GetColorU32(const ImVec4& col)
     return ColorConvertFloat4ToU32(c);
 }
 
-const ImVec4& ImGui::GetStyleColorVec4(ImGuiCol idx)
+const ImVec4& ImGui::GetStyleColorVec4(ImGuiCol idx) IMGUI_NOEXCEPT
 {
     ImGuiStyle& style = GImGui->Style;
     return style.Colors[idx];
 }
 
-ImU32 ImGui::GetColorU32(ImU32 col)
+ImU32 ImGui::GetColorU32(ImU32 col) IMGUI_NOEXCEPT
 {
     ImGuiStyle& style = GImGui->Style;
     if (style.Alpha >= 1.0f)
@@ -2459,7 +2459,7 @@ ImU32 ImGui::GetColorU32(ImU32 col)
 }
 
 // FIXME: This may incur a round-trip (if the end user got their data from a float4) but eventually we aim to store the in-flight colors as ImU32
-void ImGui::PushStyleColor(ImGuiCol idx, ImU32 col)
+void ImGui::PushStyleColor(ImGuiCol idx, ImU32 col) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiColorMod backup;
@@ -2469,7 +2469,7 @@ void ImGui::PushStyleColor(ImGuiCol idx, ImU32 col)
     g.Style.Colors[idx] = ColorConvertU32ToFloat4(col);
 }
 
-void ImGui::PushStyleColor(ImGuiCol idx, const ImVec4& col)
+void ImGui::PushStyleColor(ImGuiCol idx, const ImVec4& col) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiColorMod backup;
@@ -2479,7 +2479,7 @@ void ImGui::PushStyleColor(ImGuiCol idx, const ImVec4& col)
     g.Style.Colors[idx] = col;
 }
 
-void ImGui::PopStyleColor(int count)
+void ImGui::PopStyleColor(int count) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     while (count > 0)
@@ -2527,14 +2527,14 @@ static const ImGuiStyleVarInfo GStyleVarInfo[] =
     { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImGuiStyle, SelectableTextAlign) }, // ImGuiStyleVar_SelectableTextAlign
 };
 
-static const ImGuiStyleVarInfo* GetStyleVarInfo(ImGuiStyleVar idx)
+static const ImGuiStyleVarInfo* GetStyleVarInfo(ImGuiStyleVar idx) IMGUI_NOEXCEPT
 {
     IM_ASSERT(idx >= 0 && idx < ImGuiStyleVar_COUNT);
     IM_ASSERT(IM_ARRAYSIZE(GStyleVarInfo) == ImGuiStyleVar_COUNT);
     return &GStyleVarInfo[idx];
 }
 
-void ImGui::PushStyleVar(ImGuiStyleVar idx, float val)
+void ImGui::PushStyleVar(ImGuiStyleVar idx, float val) IMGUI_NOEXCEPT
 {
     const ImGuiStyleVarInfo* var_info = GetStyleVarInfo(idx);
     if (var_info->Type == ImGuiDataType_Float && var_info->Count == 1)
@@ -2548,7 +2548,7 @@ void ImGui::PushStyleVar(ImGuiStyleVar idx, float val)
     IM_ASSERT(0 && "Called PushStyleVar() float variant but variable is not a float!");
 }
 
-void ImGui::PushStyleVar(ImGuiStyleVar idx, const ImVec2& val)
+void ImGui::PushStyleVar(ImGuiStyleVar idx, const ImVec2& val) IMGUI_NOEXCEPT
 {
     const ImGuiStyleVarInfo* var_info = GetStyleVarInfo(idx);
     if (var_info->Type == ImGuiDataType_Float && var_info->Count == 2)
@@ -2562,7 +2562,7 @@ void ImGui::PushStyleVar(ImGuiStyleVar idx, const ImVec2& val)
     IM_ASSERT(0 && "Called PushStyleVar() ImVec2 variant but variable is not a ImVec2!");
 }
 
-void ImGui::PopStyleVar(int count)
+void ImGui::PopStyleVar(int count) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     while (count > 0)
@@ -2578,7 +2578,7 @@ void ImGui::PopStyleVar(int count)
     }
 }
 
-const char* ImGui::GetStyleColorName(ImGuiCol idx)
+const char* ImGui::GetStyleColorName(ImGuiCol idx) IMGUI_NOEXCEPT
 {
     // Create switch-case from enum with regexp: ImGuiCol_{.*}, --> case ImGuiCol_\1: return "\1";
     switch (idx)
@@ -2649,7 +2649,7 @@ const char* ImGui::GetStyleColorName(ImGuiCol idx)
 // Also see imgui_draw.cpp for some more which have been reworked to not rely on ImGui:: context.
 //-----------------------------------------------------------------------------
 
-const char* ImGui::FindRenderedTextEnd(const char* text, const char* text_end)
+const char* ImGui::FindRenderedTextEnd(const char* text, const char* text_end) IMGUI_NOEXCEPT
 {
     const char* text_display_end = text;
     if (!text_end)
@@ -2662,7 +2662,7 @@ const char* ImGui::FindRenderedTextEnd(const char* text, const char* text_end)
 
 // Internal ImGui functions to render text
 // RenderText***() functions calls ImDrawList::AddText() calls ImBitmapFont::RenderText()
-void ImGui::RenderText(ImVec2 pos, const char* text, const char* text_end, bool hide_text_after_hash)
+void ImGui::RenderText(ImVec2 pos, const char* text, const char* text_end, bool hide_text_after_hash) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -2688,7 +2688,7 @@ void ImGui::RenderText(ImVec2 pos, const char* text, const char* text_end, bool 
     }
 }
 
-void ImGui::RenderTextWrapped(ImVec2 pos, const char* text, const char* text_end, float wrap_width)
+void ImGui::RenderTextWrapped(ImVec2 pos, const char* text, const char* text_end, float wrap_width) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -2706,7 +2706,7 @@ void ImGui::RenderTextWrapped(ImVec2 pos, const char* text, const char* text_end
 
 // Default clip_rect uses (pos_min,pos_max)
 // Handle clipping on CPU immediately (vs typically let the GPU clip the triangles that are overlapping the clipping rectangle edges)
-void ImGui::RenderTextClippedEx(ImDrawList* draw_list, const ImVec2& pos_min, const ImVec2& pos_max, const char* text, const char* text_display_end, const ImVec2* text_size_if_known, const ImVec2& align, const ImRect* clip_rect)
+void ImGui::RenderTextClippedEx(ImDrawList* draw_list, const ImVec2& pos_min, const ImVec2& pos_max, const char* text, const char* text_display_end, const ImVec2* text_size_if_known, const ImVec2& align, const ImRect* clip_rect) IMGUI_NOEXCEPT
 {
     // Perform CPU side clipping for single clipped element to avoid using scissor state
     ImVec2 pos = pos_min;
@@ -2734,7 +2734,7 @@ void ImGui::RenderTextClippedEx(ImDrawList* draw_list, const ImVec2& pos_min, co
     }
 }
 
-void ImGui::RenderTextClipped(const ImVec2& pos_min, const ImVec2& pos_max, const char* text, const char* text_end, const ImVec2* text_size_if_known, const ImVec2& align, const ImRect* clip_rect)
+void ImGui::RenderTextClipped(const ImVec2& pos_min, const ImVec2& pos_max, const char* text, const char* text_end, const ImVec2* text_size_if_known, const ImVec2& align, const ImRect* clip_rect) IMGUI_NOEXCEPT
 {
     // Hide anything after a '##' string
     const char* text_display_end = FindRenderedTextEnd(text, text_end);
@@ -2753,7 +2753,7 @@ void ImGui::RenderTextClipped(const ImVec2& pos_min, const ImVec2& pos_max, cons
 // Another overly complex function until we reorganize everything into a nice all-in-one helper.
 // This is made more complex because we have dissociated the layout rectangle (pos_min..pos_max) which define _where_ the ellipsis is, from actual clipping of text and limit of the ellipsis display.
 // This is because in the context of tabs we selectively hide part of the text when the Close Button appears, but we don't want the ellipsis to move.
-void ImGui::RenderTextEllipsis(ImDrawList* draw_list, const ImVec2& pos_min, const ImVec2& pos_max, float clip_max_x, float ellipsis_max_x, const char* text, const char* text_end_full, const ImVec2* text_size_if_known)
+void ImGui::RenderTextEllipsis(ImDrawList* draw_list, const ImVec2& pos_min, const ImVec2& pos_max, float clip_max_x, float ellipsis_max_x, const char* text, const char* text_end_full, const ImVec2* text_size_if_known) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (text_end_full == NULL)
@@ -2831,7 +2831,7 @@ void ImGui::RenderTextEllipsis(ImDrawList* draw_list, const ImVec2& pos_min, con
 }
 
 // Render a rectangle shaped with optional rounding and borders
-void ImGui::RenderFrame(ImVec2 p_min, ImVec2 p_max, ImU32 fill_col, bool border, float rounding)
+void ImGui::RenderFrame(ImVec2 p_min, ImVec2 p_max, ImU32 fill_col, bool border, float rounding) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -2844,7 +2844,7 @@ void ImGui::RenderFrame(ImVec2 p_min, ImVec2 p_max, ImU32 fill_col, bool border,
     }
 }
 
-void ImGui::RenderFrameBorder(ImVec2 p_min, ImVec2 p_max, float rounding)
+void ImGui::RenderFrameBorder(ImVec2 p_min, ImVec2 p_max, float rounding) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -2856,7 +2856,7 @@ void ImGui::RenderFrameBorder(ImVec2 p_min, ImVec2 p_max, float rounding)
     }
 }
 
-void ImGui::RenderNavHighlight(const ImRect& bb, ImGuiID id, ImGuiNavHighlightFlags flags)
+void ImGui::RenderNavHighlight(const ImRect& bb, ImGuiID id, ImGuiNavHighlightFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (id != g.NavId)
@@ -2893,7 +2893,7 @@ void ImGui::RenderNavHighlight(const ImRect& bb, ImGuiID id, ImGuiNavHighlightFl
 //-----------------------------------------------------------------------------
 
 // ImGuiWindow is mostly a dumb struct. It merely has a constructor and a few helper methods
-ImGuiWindow::ImGuiWindow(ImGuiContext* context, const char* name) : DrawListInst(NULL)
+ImGuiWindow::ImGuiWindow(ImGuiContext* context, const char* name) IMGUI_NOEXCEPT : DrawListInst(NULL)
 {
     memset(this, 0, sizeof(*this));
     Name = ImStrdup(name);
@@ -2916,7 +2916,7 @@ ImGuiWindow::ImGuiWindow(ImGuiContext* context, const char* name) : DrawListInst
     DrawList->_OwnerName = Name;
 }
 
-ImGuiWindow::~ImGuiWindow()
+ImGuiWindow::~ImGuiWindow() IMGUI_NOEXCEPT
 {
     IM_ASSERT(DrawList == &DrawListInst);
     IM_DELETE(Name);
@@ -2924,7 +2924,7 @@ ImGuiWindow::~ImGuiWindow()
         ColumnsStorage[i].~ImGuiOldColumns();
 }
 
-ImGuiID ImGuiWindow::GetID(const char* str, const char* str_end)
+ImGuiID ImGuiWindow::GetID(const char* str, const char* str_end) IMGUI_NOEXCEPT
 {
     ImGuiID seed = IDStack.back();
     ImGuiID id = ImHashStr(str, str_end ? (str_end - str) : 0, seed);
@@ -2936,7 +2936,7 @@ ImGuiID ImGuiWindow::GetID(const char* str, const char* str_end)
     return id;
 }
 
-ImGuiID ImGuiWindow::GetID(const void* ptr)
+ImGuiID ImGuiWindow::GetID(const void* ptr) IMGUI_NOEXCEPT
 {
     ImGuiID seed = IDStack.back();
     ImGuiID id = ImHashData(&ptr, sizeof(void*), seed);
@@ -2948,7 +2948,7 @@ ImGuiID ImGuiWindow::GetID(const void* ptr)
     return id;
 }
 
-ImGuiID ImGuiWindow::GetID(int n)
+ImGuiID ImGuiWindow::GetID(int n) IMGUI_NOEXCEPT
 {
     ImGuiID seed = IDStack.back();
     ImGuiID id = ImHashData(&n, sizeof(n), seed);
@@ -2960,7 +2960,7 @@ ImGuiID ImGuiWindow::GetID(int n)
     return id;
 }
 
-ImGuiID ImGuiWindow::GetIDNoKeepAlive(const char* str, const char* str_end)
+ImGuiID ImGuiWindow::GetIDNoKeepAlive(const char* str, const char* str_end) IMGUI_NOEXCEPT
 {
     ImGuiID seed = IDStack.back();
     ImGuiID id = ImHashStr(str, str_end ? (str_end - str) : 0, seed);
@@ -2971,7 +2971,7 @@ ImGuiID ImGuiWindow::GetIDNoKeepAlive(const char* str, const char* str_end)
     return id;
 }
 
-ImGuiID ImGuiWindow::GetIDNoKeepAlive(const void* ptr)
+ImGuiID ImGuiWindow::GetIDNoKeepAlive(const void* ptr) IMGUI_NOEXCEPT
 {
     ImGuiID seed = IDStack.back();
     ImGuiID id = ImHashData(&ptr, sizeof(void*), seed);
@@ -2982,7 +2982,7 @@ ImGuiID ImGuiWindow::GetIDNoKeepAlive(const void* ptr)
     return id;
 }
 
-ImGuiID ImGuiWindow::GetIDNoKeepAlive(int n)
+ImGuiID ImGuiWindow::GetIDNoKeepAlive(int n) IMGUI_NOEXCEPT
 {
     ImGuiID seed = IDStack.back();
     ImGuiID id = ImHashData(&n, sizeof(n), seed);
@@ -2994,7 +2994,7 @@ ImGuiID ImGuiWindow::GetIDNoKeepAlive(int n)
 }
 
 // This is only used in rare/specific situations to manufacture an ID out of nowhere.
-ImGuiID ImGuiWindow::GetIDFromRectangle(const ImRect& r_abs)
+ImGuiID ImGuiWindow::GetIDFromRectangle(const ImRect& r_abs) IMGUI_NOEXCEPT
 {
     ImGuiID seed = IDStack.back();
     const int r_rel[4] = { (int)(r_abs.Min.x - Pos.x), (int)(r_abs.Min.y - Pos.y), (int)(r_abs.Max.x - Pos.x), (int)(r_abs.Max.y - Pos.y) };
@@ -3003,7 +3003,7 @@ ImGuiID ImGuiWindow::GetIDFromRectangle(const ImRect& r_abs)
     return id;
 }
 
-static void SetCurrentWindow(ImGuiWindow* window)
+static void SetCurrentWindow(ImGuiWindow* window) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.CurrentWindow = window;
@@ -3012,7 +3012,7 @@ static void SetCurrentWindow(ImGuiWindow* window)
         g.FontSize = g.DrawListSharedData.FontSize = window->CalcFontSize();
 }
 
-void ImGui::GcCompactTransientMiscBuffers()
+void ImGui::GcCompactTransientMiscBuffers() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.ItemFlagsStack.clear();
@@ -3024,7 +3024,7 @@ void ImGui::GcCompactTransientMiscBuffers()
 // Not freed:
 // - ImGuiWindow, ImGuiWindowSettings, Name, StateStorage, ColumnsStorage (may hold useful data)
 // This should have no noticeable visual effect. When the window reappear however, expect new allocation/buffer growth/copy cost.
-void ImGui::GcCompactTransientWindowBuffers(ImGuiWindow* window)
+void ImGui::GcCompactTransientWindowBuffers(ImGuiWindow* window) IMGUI_NOEXCEPT
 {
     window->MemoryCompacted = true;
     window->MemoryDrawListIdxCapacity = window->DrawList->IdxBuffer.Capacity;
@@ -3036,7 +3036,7 @@ void ImGui::GcCompactTransientWindowBuffers(ImGuiWindow* window)
     window->DC.TextWrapPosStack.clear();
 }
 
-void ImGui::GcAwakeTransientWindowBuffers(ImGuiWindow* window)
+void ImGui::GcAwakeTransientWindowBuffers(ImGuiWindow* window) IMGUI_NOEXCEPT
 {
     // We stored capacity of the ImDrawList buffer to reduce growth-caused allocation/copy when awakening.
     // The other buffers tends to amortize much faster.
@@ -3046,7 +3046,7 @@ void ImGui::GcAwakeTransientWindowBuffers(ImGuiWindow* window)
     window->MemoryDrawListIdxCapacity = window->MemoryDrawListVtxCapacity = 0;
 }
 
-void ImGui::SetActiveID(ImGuiID id, ImGuiWindow* window)
+void ImGui::SetActiveID(ImGuiID id, ImGuiWindow* window) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.ActiveIdIsJustActivated = (g.ActiveId != id);
@@ -3081,12 +3081,12 @@ void ImGui::SetActiveID(ImGuiID id, ImGuiWindow* window)
     g.ActiveIdUsingKeyInputMask = 0x00;
 }
 
-void ImGui::ClearActiveID()
+void ImGui::ClearActiveID() IMGUI_NOEXCEPT
 {
     SetActiveID(0, NULL); // g.ActiveId = 0;
 }
 
-void ImGui::SetHoveredID(ImGuiID id)
+void ImGui::SetHoveredID(ImGuiID id) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.HoveredId = id;
@@ -3096,13 +3096,13 @@ void ImGui::SetHoveredID(ImGuiID id)
         g.HoveredIdTimer = g.HoveredIdNotActiveTimer = 0.0f;
 }
 
-ImGuiID ImGui::GetHoveredID()
+ImGuiID ImGui::GetHoveredID() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return g.HoveredId ? g.HoveredId : g.HoveredIdPreviousFrame;
 }
 
-void ImGui::KeepAliveID(ImGuiID id)
+void ImGui::KeepAliveID(ImGuiID id) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.ActiveId == id)
@@ -3111,7 +3111,7 @@ void ImGui::KeepAliveID(ImGuiID id)
         g.ActiveIdPreviousFrameIsAlive = true;
 }
 
-void ImGui::MarkItemEdited(ImGuiID id)
+void ImGui::MarkItemEdited(ImGuiID id) IMGUI_NOEXCEPT
 {
     // This marking is solely to be able to provide info for IsItemDeactivatedAfterEdit().
     // ActiveId might have been released by the time we call this (as in the typical press/release button behavior) but still need need to fill the data.
@@ -3124,7 +3124,7 @@ void ImGui::MarkItemEdited(ImGuiID id)
     g.CurrentWindow->DC.LastItemStatusFlags |= ImGuiItemStatusFlags_Edited;
 }
 
-static inline bool IsWindowContentHoverable(ImGuiWindow* window, ImGuiHoveredFlags flags)
+static inline bool IsWindowContentHoverable(ImGuiWindow* window, ImGuiHoveredFlags flags) IMGUI_NOEXCEPT
 {
     // An active popup disable hovering on other windows (apart from its own children)
     // FIXME-OPT: This could be cached/stored within the window.
@@ -3146,7 +3146,7 @@ static inline bool IsWindowContentHoverable(ImGuiWindow* window, ImGuiHoveredFla
 // This is roughly matching the behavior of internal-facing ItemHoverable()
 // - we allow hovering to be true when ActiveId==window->MoveID, so that clicking on non-interactive items such as a Text() item still returns true with IsItemHovered()
 // - this should work even for non-interactive items that have no ID, so we cannot use LastItemId
-bool ImGui::IsItemHovered(ImGuiHoveredFlags flags)
+bool ImGui::IsItemHovered(ImGuiHoveredFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -3190,7 +3190,7 @@ bool ImGui::IsItemHovered(ImGuiHoveredFlags flags)
 }
 
 // Internal facing ItemHoverable() used when submitting widgets. Differs slightly from IsItemHovered().
-bool ImGui::ItemHoverable(const ImRect& bb, ImGuiID id)
+bool ImGui::ItemHoverable(const ImRect& bb, ImGuiID id) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.HoveredId != 0 && g.HoveredId != id && !g.HoveredIdAllowOverlap)
@@ -3231,7 +3231,7 @@ bool ImGui::ItemHoverable(const ImRect& bb, ImGuiID id)
     return true;
 }
 
-bool ImGui::IsClippedEx(const ImRect& bb, ImGuiID id, bool clip_even_when_logged)
+bool ImGui::IsClippedEx(const ImRect& bb, ImGuiID id, bool clip_even_when_logged) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -3244,7 +3244,7 @@ bool ImGui::IsClippedEx(const ImRect& bb, ImGuiID id, bool clip_even_when_logged
 
 // This is also inlined in ItemAdd()
 // Note: if ImGuiItemStatusFlags_HasDisplayRect is set, user needs to set window->DC.LastItemDisplayRect!
-void ImGui::SetLastItemData(ImGuiWindow* window, ImGuiID item_id, ImGuiItemStatusFlags item_flags, const ImRect& item_rect)
+void ImGui::SetLastItemData(ImGuiWindow* window, ImGuiID item_id, ImGuiItemStatusFlags item_flags, const ImRect& item_rect) IMGUI_NOEXCEPT
 {
     window->DC.LastItemId = item_id;
     window->DC.LastItemStatusFlags = item_flags;
@@ -3252,7 +3252,7 @@ void ImGui::SetLastItemData(ImGuiWindow* window, ImGuiID item_id, ImGuiItemStatu
 }
 
 // Process TAB/Shift+TAB. Be mindful that this function may _clear_ the ActiveID when tabbing out.
-void ImGui::ItemFocusable(ImGuiWindow* window, ImGuiID id)
+void ImGui::ItemFocusable(ImGuiWindow* window, ImGuiID id) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(id != 0 && id == window->DC.LastItemId);
@@ -3297,7 +3297,7 @@ void ImGui::ItemFocusable(ImGuiWindow* window, ImGuiID id)
     }
 }
 
-float ImGui::CalcWrapWidthForPos(const ImVec2& pos, float wrap_pos_x)
+float ImGui::CalcWrapWidthForPos(const ImVec2& pos, float wrap_pos_x) IMGUI_NOEXCEPT
 {
     if (wrap_pos_x < 0.0f)
         return 0.0f;
@@ -3338,32 +3338,32 @@ void ImGui::MemFree(void* ptr) IMGUI_NOEXCEPT
     return (*GImAllocatorFreeFunc)(ptr, GImAllocatorUserData);
 }
 
-const char* ImGui::GetClipboardText()
+const char* ImGui::GetClipboardText() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return g.IO.GetClipboardTextFn ? g.IO.GetClipboardTextFn(g.IO.ClipboardUserData) : "";
 }
 
-void ImGui::SetClipboardText(const char* text)
+void ImGui::SetClipboardText(const char* text) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.IO.SetClipboardTextFn)
         g.IO.SetClipboardTextFn(g.IO.ClipboardUserData, text);
 }
 
-const char* ImGui::GetVersion()
+const char* ImGui::GetVersion() IMGUI_NOEXCEPT
 {
     return IMGUI_VERSION;
 }
 
 // Internal state access - if you want to share Dear ImGui state between modules (e.g. DLL) or allocate it yourself
 // Note that we still point to some static data and members (such as GFontAtlas), so the state instance you end up using will point to the static data within its module
-ImGuiContext* ImGui::GetCurrentContext()
+ImGuiContext* ImGui::GetCurrentContext() IMGUI_NOEXCEPT
 {
     return GImGui;
 }
 
-void ImGui::SetCurrentContext(ImGuiContext* ctx)
+void ImGui::SetCurrentContext(ImGuiContext* ctx) IMGUI_NOEXCEPT
 {
 #ifdef IMGUI_SET_CURRENT_CONTEXT_FUNC
     IMGUI_SET_CURRENT_CONTEXT_FUNC(ctx); // For custom thread-based hackery you may want to have control over this.
@@ -3372,7 +3372,7 @@ void ImGui::SetCurrentContext(ImGuiContext* ctx)
 #endif
 }
 
-void ImGui::SetAllocatorFunctions(ImGuiMemAllocFunc alloc_func, ImGuiMemFreeFunc free_func, void* user_data)
+void ImGui::SetAllocatorFunctions(ImGuiMemAllocFunc alloc_func, ImGuiMemFreeFunc free_func, void* user_data) IMGUI_NOEXCEPT
 {
     GImAllocatorAllocFunc = alloc_func;
     GImAllocatorFreeFunc = free_func;
@@ -3380,14 +3380,14 @@ void ImGui::SetAllocatorFunctions(ImGuiMemAllocFunc alloc_func, ImGuiMemFreeFunc
 }
 
 // This is provided to facilitate copying allocators from one static/DLL boundary to another (e.g. retrieve default allocator of your executable address space)
-void ImGui::GetAllocatorFunctions(ImGuiMemAllocFunc* p_alloc_func, ImGuiMemFreeFunc* p_free_func, void** p_user_data)
+void ImGui::GetAllocatorFunctions(ImGuiMemAllocFunc* p_alloc_func, ImGuiMemFreeFunc* p_free_func, void** p_user_data) IMGUI_NOEXCEPT
 {
     *p_alloc_func = GImAllocatorAllocFunc;
     *p_free_func = GImAllocatorFreeFunc;
     *p_user_data = GImAllocatorUserData;
 }
 
-ImGuiContext* ImGui::CreateContext(ImFontAtlas* shared_font_atlas)
+ImGuiContext* ImGui::CreateContext(ImFontAtlas* shared_font_atlas) IMGUI_NOEXCEPT
 {
     ImGuiContext* ctx = IM_NEW(ImGuiContext)(shared_font_atlas);
     if (GImGui == NULL)
@@ -3396,7 +3396,7 @@ ImGuiContext* ImGui::CreateContext(ImFontAtlas* shared_font_atlas)
     return ctx;
 }
 
-void ImGui::DestroyContext(ImGuiContext* ctx)
+void ImGui::DestroyContext(ImGuiContext* ctx) IMGUI_NOEXCEPT
 {
     if (ctx == NULL)
         ctx = GImGui;
@@ -3407,7 +3407,7 @@ void ImGui::DestroyContext(ImGuiContext* ctx)
 }
 
 // No specific ordering/dependency support, will see as needed
-ImGuiID ImGui::AddContextHook(ImGuiContext* ctx, const ImGuiContextHook* hook)
+ImGuiID ImGui::AddContextHook(ImGuiContext* ctx, const ImGuiContextHook* hook) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *ctx;
     IM_ASSERT(hook->Callback != NULL && hook->HookId == 0 && hook->Type != ImGuiContextHookType_PendingRemoval_);
@@ -3417,7 +3417,7 @@ ImGuiID ImGui::AddContextHook(ImGuiContext* ctx, const ImGuiContextHook* hook)
 }
 
 // Deferred removal, avoiding issue with changing vector while iterating it
-void ImGui::RemoveContextHook(ImGuiContext* ctx, ImGuiID hook_id)
+void ImGui::RemoveContextHook(ImGuiContext* ctx, ImGuiID hook_id) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *ctx;
     IM_ASSERT(hook_id != 0);
@@ -3428,7 +3428,7 @@ void ImGui::RemoveContextHook(ImGuiContext* ctx, ImGuiID hook_id)
 
 // Call context hooks (used by e.g. test engine)
 // We assume a small number of hooks so all stored in same array
-void ImGui::CallContextHooks(ImGuiContext* ctx, ImGuiContextHookType hook_type)
+void ImGui::CallContextHooks(ImGuiContext* ctx, ImGuiContextHookType hook_type) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *ctx;
     for (int n = 0; n < g.Hooks.Size; n++)
@@ -3436,31 +3436,31 @@ void ImGui::CallContextHooks(ImGuiContext* ctx, ImGuiContextHookType hook_type)
             g.Hooks[n].Callback(&g, &g.Hooks[n]);
 }
 
-ImGuiIO& ImGui::GetIO()
+ImGuiIO& ImGui::GetIO() IMGUI_NOEXCEPT
 {
     IM_ASSERT(GImGui != NULL && "No current context. Did you call ImGui::CreateContext() and ImGui::SetCurrentContext() ?");
     return GImGui->IO;
 }
 
 // Pass this to your backend rendering function! Valid after Render() and until the next call to NewFrame()
-ImDrawData* ImGui::GetDrawData()
+ImDrawData* ImGui::GetDrawData() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiViewportP* viewport = g.Viewports[0];
     return viewport->DrawDataP.Valid ? &viewport->DrawDataP : NULL;
 }
 
-double ImGui::GetTime()
+double ImGui::GetTime() IMGUI_NOEXCEPT
 {
     return GImGui->Time;
 }
 
-int ImGui::GetFrameCount()
+int ImGui::GetFrameCount() IMGUI_NOEXCEPT
 {
     return GImGui->FrameCount;
 }
 
-static ImDrawList* GetViewportDrawList(ImGuiViewportP* viewport, size_t drawlist_no, const char* drawlist_name)
+static ImDrawList* GetViewportDrawList(ImGuiViewportP* viewport, size_t drawlist_no, const char* drawlist_name) IMGUI_NOEXCEPT
 {
     // Create the draw list on demand, because they are not frequently used for all viewports
     ImGuiContext& g = *GImGui;
@@ -3484,34 +3484,34 @@ static ImDrawList* GetViewportDrawList(ImGuiViewportP* viewport, size_t drawlist
     return draw_list;
 }
 
-ImDrawList* ImGui::GetBackgroundDrawList(ImGuiViewport* viewport)
+ImDrawList* ImGui::GetBackgroundDrawList(ImGuiViewport* viewport) IMGUI_NOEXCEPT
 {
     return GetViewportDrawList((ImGuiViewportP*)viewport, 0, "##Background");
 }
 
-ImDrawList* ImGui::GetBackgroundDrawList()
+ImDrawList* ImGui::GetBackgroundDrawList() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return GetBackgroundDrawList(g.Viewports[0]);
 }
 
-ImDrawList* ImGui::GetForegroundDrawList(ImGuiViewport* viewport)
+ImDrawList* ImGui::GetForegroundDrawList(ImGuiViewport* viewport) IMGUI_NOEXCEPT
 {
     return GetViewportDrawList((ImGuiViewportP*)viewport, 1, "##Foreground");
 }
 
-ImDrawList* ImGui::GetForegroundDrawList()
+ImDrawList* ImGui::GetForegroundDrawList() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return GetForegroundDrawList(g.Viewports[0]);
 }
 
-ImDrawListSharedData* ImGui::GetDrawListSharedData()
+ImDrawListSharedData* ImGui::GetDrawListSharedData() IMGUI_NOEXCEPT
 {
     return &GImGui->DrawListSharedData;
 }
 
-void ImGui::StartMouseMovingWindow(ImGuiWindow* window)
+void ImGui::StartMouseMovingWindow(ImGuiWindow* window) IMGUI_NOEXCEPT
 {
     // Set ActiveId even if the _NoMove flag is set. Without it, dragging away from a window with _NoMove would activate hover on other windows.
     // We _also_ call this when clicking in a window empty space when io.ConfigWindowsMoveFromTitleBarOnly is set, but clear g.MovingWindow afterward.
@@ -3535,7 +3535,7 @@ void ImGui::StartMouseMovingWindow(ImGuiWindow* window)
 // FIXME: We don't have strong guarantee that g.MovingWindow stay synched with g.ActiveId == g.MovingWindow->MoveId.
 // This is currently enforced by the fact that BeginDragDropSource() is setting all g.ActiveIdUsingXXXX flags to inhibit navigation inputs,
 // but if we should more thoroughly test cases where g.ActiveId or g.MovingWindow gets changed and not the other.
-void ImGui::UpdateMouseMovingWindowNewFrame()
+void ImGui::UpdateMouseMovingWindowNewFrame() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.MovingWindow != NULL)
@@ -3575,7 +3575,7 @@ void ImGui::UpdateMouseMovingWindowNewFrame()
 
 // Initiate moving window when clicking on empty space or title bar.
 // Handle left-click and right-click focus.
-void ImGui::UpdateMouseMovingWindowEndFrame()
+void ImGui::UpdateMouseMovingWindowEndFrame() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.ActiveId != 0 || g.HoveredId != 0)
@@ -3627,12 +3627,12 @@ void ImGui::UpdateMouseMovingWindowEndFrame()
     }
 }
 
-static bool IsWindowActiveAndVisible(ImGuiWindow* window)
+static bool IsWindowActiveAndVisible(ImGuiWindow* window) IMGUI_NOEXCEPT
 {
     return (window->Active) && (!window->Hidden);
 }
 
-static void ImGui::UpdateMouseInputs()
+static void ImGui::UpdateMouseInputs() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -3689,7 +3689,7 @@ static void ImGui::UpdateMouseInputs()
     }
 }
 
-static void StartLockWheelingWindow(ImGuiWindow* window)
+static void StartLockWheelingWindow(ImGuiWindow* window) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.WheelingWindow == window)
@@ -3699,7 +3699,7 @@ static void StartLockWheelingWindow(ImGuiWindow* window)
     g.WheelingWindowTimer = WINDOWS_MOUSE_WHEEL_SCROLL_LOCK_TIMER;
 }
 
-void ImGui::UpdateMouseWheel()
+void ImGui::UpdateMouseWheel() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -3784,7 +3784,7 @@ void ImGui::UpdateMouseWheel()
     }
 }
 
-void ImGui::UpdateTabFocus()
+void ImGui::UpdateTabFocus() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -3823,7 +3823,7 @@ void ImGui::UpdateTabFocus()
 }
 
 // The reason this is exposed in imgui_internal.h is: on touch-based system that don't have hovering, we want to dispatch inputs to the right target (imgui vs imgui+app)
-void ImGui::UpdateHoveredWindowAndCaptureFlags()
+void ImGui::UpdateHoveredWindowAndCaptureFlags() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.WindowsHoverPadding = ImMax(g.Style.TouchExtraPadding, ImVec2(WINDOWS_HOVER_PADDING, WINDOWS_HOVER_PADDING));
@@ -3885,7 +3885,7 @@ void ImGui::UpdateHoveredWindowAndCaptureFlags()
     g.IO.WantTextInput = (g.WantTextInputNextFrame != -1) ? (g.WantTextInputNextFrame != 0) : false;
 }
 
-ImGuiKeyModFlags ImGui::GetMergedKeyModFlags()
+ImGuiKeyModFlags ImGui::GetMergedKeyModFlags() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiKeyModFlags key_mod_flags = ImGuiKeyModFlags_None;
@@ -3896,7 +3896,7 @@ ImGuiKeyModFlags ImGui::GetMergedKeyModFlags()
     return key_mod_flags;
 }
 
-void ImGui::NewFrame()
+void ImGui::NewFrame() IMGUI_NOEXCEPT
 {
     IM_ASSERT(GImGui != NULL && "No current context. Did you call ImGui::CreateContext() and ImGui::SetCurrentContext() ?");
     ImGuiContext& g = *GImGui;
@@ -4099,7 +4099,7 @@ void ImGui::NewFrame()
 }
 
 // [DEBUG] Item picker tool - start with DebugStartItemPicker() - useful to visually select an item and break into its call-stack.
-void ImGui::UpdateDebugToolItemPicker()
+void ImGui::UpdateDebugToolItemPicker() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.DebugItemPickerBreakId = 0;
@@ -4123,7 +4123,7 @@ void ImGui::UpdateDebugToolItemPicker()
     }
 }
 
-void ImGui::Initialize(ImGuiContext* context)
+void ImGui::Initialize(ImGuiContext* context) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *context;
     IM_ASSERT(!g.Initialized && !g.SettingsLoaded);
@@ -4157,7 +4157,7 @@ void ImGui::Initialize(ImGuiContext* context)
 }
 
 // This function is merely here to free heap allocations.
-void ImGui::Shutdown(ImGuiContext* context)
+void ImGui::Shutdown(ImGuiContext* context) IMGUI_NOEXCEPT
 {
     // The fonts atlas can be used prior to calling NewFrame(), so we clear it even if g.Initialized is FALSE (which would happen if we never called NewFrame)
     ImGuiContext& g = *context;
@@ -4237,7 +4237,7 @@ void ImGui::Shutdown(ImGuiContext* context)
 }
 
 // FIXME: Add a more explicit sort order in the window structure.
-static int IMGUI_CDECL ChildWindowComparer(const void* lhs, const void* rhs)
+static int IMGUI_CDECL ChildWindowComparer(const void* lhs, const void* rhs) IMGUI_NOEXCEPT
 {
     const ImGuiWindow* const a = *(const ImGuiWindow* const *)lhs;
     const ImGuiWindow* const b = *(const ImGuiWindow* const *)rhs;
@@ -4248,7 +4248,7 @@ static int IMGUI_CDECL ChildWindowComparer(const void* lhs, const void* rhs)
     return (a->BeginOrderWithinParent - b->BeginOrderWithinParent);
 }
 
-static void AddWindowToSortBuffer(ImVector<ImGuiWindow*>* out_sorted_windows, ImGuiWindow* window)
+static void AddWindowToSortBuffer(ImVector<ImGuiWindow*>* out_sorted_windows, ImGuiWindow* window) IMGUI_NOEXCEPT
 {
     out_sorted_windows->push_back(window);
     if (window->Active)
@@ -4265,7 +4265,7 @@ static void AddWindowToSortBuffer(ImVector<ImGuiWindow*>* out_sorted_windows, Im
     }
 }
 
-static void AddDrawListToDrawData(ImVector<ImDrawList*>* out_list, ImDrawList* draw_list)
+static void AddDrawListToDrawData(ImVector<ImDrawList*>* out_list, ImDrawList* draw_list) IMGUI_NOEXCEPT
 {
     // Remove trailing command if unused.
     // Technically we could return directly instead of popping, but this make things looks neat in Metrics/Debugger window as well.
@@ -4301,7 +4301,7 @@ static void AddDrawListToDrawData(ImVector<ImDrawList*>* out_list, ImDrawList* d
     out_list->push_back(draw_list);
 }
 
-static void AddWindowToDrawData(ImGuiWindow* window, int layer)
+static void AddWindowToDrawData(ImGuiWindow* window, int layer) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiViewportP* viewport = g.Viewports[0];
@@ -4316,13 +4316,13 @@ static void AddWindowToDrawData(ImGuiWindow* window, int layer)
 }
 
 // Layer is locked for the root window, however child windows may use a different viewport (e.g. extruding menu)
-static void AddRootWindowToDrawData(ImGuiWindow* window)
+static void AddRootWindowToDrawData(ImGuiWindow* window) IMGUI_NOEXCEPT
 {
     int layer = (window->Flags & ImGuiWindowFlags_Tooltip) ? 1 : 0;
     AddWindowToDrawData(window, layer);
 }
 
-void ImDrawDataBuilder::FlattenIntoSingleLayer()
+void ImDrawDataBuilder::FlattenIntoSingleLayer() IMGUI_NOEXCEPT
 {
     int n = Layers[0].Size;
     int size = n;
@@ -4340,7 +4340,7 @@ void ImDrawDataBuilder::FlattenIntoSingleLayer()
     }
 }
 
-static void SetupViewportDrawData(ImGuiViewportP* viewport, ImVector<ImDrawList*>* draw_lists)
+static void SetupViewportDrawData(ImGuiViewportP* viewport, ImVector<ImDrawList*>* draw_lists) IMGUI_NOEXCEPT
 {
     ImGuiIO& io = ImGui::GetIO();
     ImDrawData* draw_data = &viewport->DrawDataP;
@@ -4364,14 +4364,14 @@ static void SetupViewportDrawData(ImGuiViewportP* viewport, ImVector<ImDrawList*
 // - If the code here changes, may need to update code of functions like NextColumn() and PushColumnClipRect():
 //   some frequently called functions which to modify both channels and clipping simultaneously tend to use the
 //   more specialized SetWindowClipRectBeforeSetChannel() to avoid extraneous updates of underlying ImDrawCmds.
-void ImGui::PushClipRect(const ImVec2& clip_rect_min, const ImVec2& clip_rect_max, bool intersect_with_current_clip_rect)
+void ImGui::PushClipRect(const ImVec2& clip_rect_min, const ImVec2& clip_rect_max, bool intersect_with_current_clip_rect) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     window->DrawList->PushClipRect(clip_rect_min, clip_rect_max, intersect_with_current_clip_rect);
     window->ClipRect = window->DrawList->_ClipRectStack.back();
 }
 
-void ImGui::PopClipRect()
+void ImGui::PopClipRect() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     window->DrawList->PopClipRect();
@@ -4379,7 +4379,7 @@ void ImGui::PopClipRect()
 }
 
 // This is normally called by Render(). You may want to call it directly if you want to avoid calling Render() but the gain will be very minimal.
-void ImGui::EndFrame()
+void ImGui::EndFrame() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(g.Initialized);
@@ -4461,7 +4461,7 @@ void ImGui::EndFrame()
     CallContextHooks(&g, ImGuiContextHookType_EndFramePost);
 }
 
-void ImGui::Render()
+void ImGui::Render() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(g.Initialized);
@@ -4523,7 +4523,7 @@ void ImGui::Render()
 
 // Calculate text size. Text can be multi-line. Optionally ignore text after a ## marker.
 // CalcTextSize("") should return ImVec2(0.0f, g.FontSize)
-ImVec2 ImGui::CalcTextSize(const char* text, const char* text_end, bool hide_text_after_double_hash, float wrap_width)
+ImVec2 ImGui::CalcTextSize(const char* text, const char* text_end, bool hide_text_after_double_hash, float wrap_width) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -4553,7 +4553,7 @@ ImVec2 ImGui::CalcTextSize(const char* text, const char* text_end, bool hide_tex
 // FIXME: Note that we have an inconsequential lag here: OuterRectClipped is updated in Begin(), so windows moved programmatically
 // with SetWindowPos() and not SetNextWindowPos() will have that rectangle lagging by a frame at the time FindHoveredWindow() is
 // called, aka before the next Begin(). Moving window isn't affected.
-static void FindHoveredWindow()
+static void FindHoveredWindow() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -4608,7 +4608,7 @@ static void FindHoveredWindow()
 // Test if mouse cursor is hovering given rectangle
 // NB- Rectangle is clipped by our current clip setting
 // NB- Expand the rectangle to be generous on imprecise inputs systems (g.Style.TouchExtraPadding)
-bool ImGui::IsMouseHoveringRect(const ImVec2& r_min, const ImVec2& r_max, bool clip)
+bool ImGui::IsMouseHoveringRect(const ImVec2& r_min, const ImVec2& r_max, bool clip) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -4624,7 +4624,7 @@ bool ImGui::IsMouseHoveringRect(const ImVec2& r_min, const ImVec2& r_max, bool c
     return true;
 }
 
-int ImGui::GetKeyIndex(ImGuiKey imgui_key)
+int ImGui::GetKeyIndex(ImGuiKey imgui_key) IMGUI_NOEXCEPT
 {
     IM_ASSERT(imgui_key >= 0 && imgui_key < ImGuiKey_COUNT);
     ImGuiContext& g = *GImGui;
@@ -4633,7 +4633,7 @@ int ImGui::GetKeyIndex(ImGuiKey imgui_key)
 
 // Note that dear imgui doesn't know the semantic of each entry of io.KeysDown[]!
 // Use your own indices/enums according to how your backend/engine stored them into io.KeysDown[]!
-bool ImGui::IsKeyDown(int user_key_index)
+bool ImGui::IsKeyDown(int user_key_index) IMGUI_NOEXCEPT
 {
     if (user_key_index < 0)
         return false;
@@ -4646,7 +4646,7 @@ bool ImGui::IsKeyDown(int user_key_index)
 // t1 = current time (e.g.: g.Time)
 // An event is triggered at:
 //  t = 0.0f     t = repeat_delay,    t = repeat_delay + repeat_rate*N
-int ImGui::CalcTypematicRepeatAmount(float t0, float t1, float repeat_delay, float repeat_rate)
+int ImGui::CalcTypematicRepeatAmount(float t0, float t1, float repeat_delay, float repeat_rate) IMGUI_NOEXCEPT
 {
     if (t1 == 0.0f)
         return 1;
@@ -4660,7 +4660,7 @@ int ImGui::CalcTypematicRepeatAmount(float t0, float t1, float repeat_delay, flo
     return count;
 }
 
-int ImGui::GetKeyPressedAmount(int key_index, float repeat_delay, float repeat_rate)
+int ImGui::GetKeyPressedAmount(int key_index, float repeat_delay, float repeat_rate) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (key_index < 0)
@@ -4670,7 +4670,7 @@ int ImGui::GetKeyPressedAmount(int key_index, float repeat_delay, float repeat_r
     return CalcTypematicRepeatAmount(t - g.IO.DeltaTime, t, repeat_delay, repeat_rate);
 }
 
-bool ImGui::IsKeyPressed(int user_key_index, bool repeat)
+bool ImGui::IsKeyPressed(int user_key_index, bool repeat) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (user_key_index < 0)
@@ -4684,7 +4684,7 @@ bool ImGui::IsKeyPressed(int user_key_index, bool repeat)
     return false;
 }
 
-bool ImGui::IsKeyReleased(int user_key_index)
+bool ImGui::IsKeyReleased(int user_key_index) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (user_key_index < 0) return false;
@@ -4692,14 +4692,14 @@ bool ImGui::IsKeyReleased(int user_key_index)
     return g.IO.KeysDownDurationPrev[user_key_index] >= 0.0f && !g.IO.KeysDown[user_key_index];
 }
 
-bool ImGui::IsMouseDown(ImGuiMouseButton button)
+bool ImGui::IsMouseDown(ImGuiMouseButton button) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(button >= 0 && button < IM_ARRAYSIZE(g.IO.MouseDown));
     return g.IO.MouseDown[button];
 }
 
-bool ImGui::IsMouseClicked(ImGuiMouseButton button, bool repeat)
+bool ImGui::IsMouseClicked(ImGuiMouseButton button, bool repeat) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(button >= 0 && button < IM_ARRAYSIZE(g.IO.MouseDown));
@@ -4717,14 +4717,14 @@ bool ImGui::IsMouseClicked(ImGuiMouseButton button, bool repeat)
     return false;
 }
 
-bool ImGui::IsMouseReleased(ImGuiMouseButton button)
+bool ImGui::IsMouseReleased(ImGuiMouseButton button) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(button >= 0 && button < IM_ARRAYSIZE(g.IO.MouseDown));
     return g.IO.MouseReleased[button];
 }
 
-bool ImGui::IsMouseDoubleClicked(ImGuiMouseButton button)
+bool ImGui::IsMouseDoubleClicked(ImGuiMouseButton button) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(button >= 0 && button < IM_ARRAYSIZE(g.IO.MouseDown));
@@ -4733,7 +4733,7 @@ bool ImGui::IsMouseDoubleClicked(ImGuiMouseButton button)
 
 // Return if a mouse click/drag went past the given threshold. Valid to call during the MouseReleased frame.
 // [Internal] This doesn't test if the button is pressed
-bool ImGui::IsMouseDragPastThreshold(ImGuiMouseButton button, float lock_threshold)
+bool ImGui::IsMouseDragPastThreshold(ImGuiMouseButton button, float lock_threshold) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(button >= 0 && button < IM_ARRAYSIZE(g.IO.MouseDown));
@@ -4742,7 +4742,7 @@ bool ImGui::IsMouseDragPastThreshold(ImGuiMouseButton button, float lock_thresho
     return g.IO.MouseDragMaxDistanceSqr[button] >= lock_threshold * lock_threshold;
 }
 
-bool ImGui::IsMouseDragging(ImGuiMouseButton button, float lock_threshold)
+bool ImGui::IsMouseDragging(ImGuiMouseButton button, float lock_threshold) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(button >= 0 && button < IM_ARRAYSIZE(g.IO.MouseDown));
@@ -4751,14 +4751,14 @@ bool ImGui::IsMouseDragging(ImGuiMouseButton button, float lock_threshold)
     return IsMouseDragPastThreshold(button, lock_threshold);
 }
 
-ImVec2 ImGui::GetMousePos()
+ImVec2 ImGui::GetMousePos() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return g.IO.MousePos;
 }
 
 // NB: prefer to call right after BeginPopup(). At the time Selectable/MenuItem is activated, the popup is already closed!
-ImVec2 ImGui::GetMousePosOnOpeningCurrentPopup()
+ImVec2 ImGui::GetMousePosOnOpeningCurrentPopup() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.BeginPopupStack.Size > 0)
@@ -4767,7 +4767,7 @@ ImVec2 ImGui::GetMousePosOnOpeningCurrentPopup()
 }
 
 // We typically use ImVec2(-FLT_MAX,-FLT_MAX) to denote an invalid mouse position.
-bool ImGui::IsMousePosValid(const ImVec2* mouse_pos)
+bool ImGui::IsMousePosValid(const ImVec2* mouse_pos) IMGUI_NOEXCEPT
 {
     // The assert is only to silence a false-positive in XCode Static Analysis.
     // Because GImGui is not dereferenced in every code path, the static analyzer assume that it may be NULL (which it doesn't for other functions).
@@ -4777,7 +4777,7 @@ bool ImGui::IsMousePosValid(const ImVec2* mouse_pos)
     return p.x >= MOUSE_INVALID && p.y >= MOUSE_INVALID;
 }
 
-bool ImGui::IsAnyMouseDown()
+bool ImGui::IsAnyMouseDown() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     for (int n = 0; n < IM_ARRAYSIZE(g.IO.MouseDown); n++)
@@ -4789,7 +4789,7 @@ bool ImGui::IsAnyMouseDown()
 // Return the delta from the initial clicking position while the mouse button is clicked or was just released.
 // This is locked and return 0.0f until the mouse moves past a distance threshold at least once.
 // NB: This is only valid if IsMousePosValid(). backends in theory should always keep mouse position valid when dragging even outside the client window.
-ImVec2 ImGui::GetMouseDragDelta(ImGuiMouseButton button, float lock_threshold)
+ImVec2 ImGui::GetMouseDragDelta(ImGuiMouseButton button, float lock_threshold) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(button >= 0 && button < IM_ARRAYSIZE(g.IO.MouseDown));
@@ -4802,7 +4802,7 @@ ImVec2 ImGui::GetMouseDragDelta(ImGuiMouseButton button, float lock_threshold)
     return ImVec2(0.0f, 0.0f);
 }
 
-void ImGui::ResetMouseDragDelta(ImGuiMouseButton button)
+void ImGui::ResetMouseDragDelta(ImGuiMouseButton button) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(button >= 0 && button < IM_ARRAYSIZE(g.IO.MouseDown));
@@ -4810,27 +4810,27 @@ void ImGui::ResetMouseDragDelta(ImGuiMouseButton button)
     g.IO.MouseClickedPos[button] = g.IO.MousePos;
 }
 
-ImGuiMouseCursor ImGui::GetMouseCursor()
+ImGuiMouseCursor ImGui::GetMouseCursor() IMGUI_NOEXCEPT
 {
     return GImGui->MouseCursor;
 }
 
-void ImGui::SetMouseCursor(ImGuiMouseCursor cursor_type)
+void ImGui::SetMouseCursor(ImGuiMouseCursor cursor_type) IMGUI_NOEXCEPT
 {
     GImGui->MouseCursor = cursor_type;
 }
 
-void ImGui::CaptureKeyboardFromApp(bool capture)
+void ImGui::CaptureKeyboardFromApp(bool capture) IMGUI_NOEXCEPT
 {
     GImGui->WantCaptureKeyboardNextFrame = capture ? 1 : 0;
 }
 
-void ImGui::CaptureMouseFromApp(bool capture)
+void ImGui::CaptureMouseFromApp(bool capture) IMGUI_NOEXCEPT
 {
     GImGui->WantCaptureMouseNextFrame = capture ? 1 : 0;
 }
 
-bool ImGui::IsItemActive()
+bool ImGui::IsItemActive() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.ActiveId)
@@ -4841,7 +4841,7 @@ bool ImGui::IsItemActive()
     return false;
 }
 
-bool ImGui::IsItemActivated()
+bool ImGui::IsItemActivated() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.ActiveId)
@@ -4853,7 +4853,7 @@ bool ImGui::IsItemActivated()
     return false;
 }
 
-bool ImGui::IsItemDeactivated()
+bool ImGui::IsItemDeactivated() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -4862,14 +4862,14 @@ bool ImGui::IsItemDeactivated()
     return (g.ActiveIdPreviousFrame == window->DC.LastItemId && g.ActiveIdPreviousFrame != 0 && g.ActiveId != window->DC.LastItemId);
 }
 
-bool ImGui::IsItemDeactivatedAfterEdit()
+bool ImGui::IsItemDeactivatedAfterEdit() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return IsItemDeactivated() && (g.ActiveIdPreviousFrameHasBeenEditedBefore || (g.ActiveId == 0 && g.ActiveIdHasBeenEditedBefore));
 }
 
 // == GetItemID() == GetFocusID()
-bool ImGui::IsItemFocused()
+bool ImGui::IsItemFocused() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -4881,48 +4881,48 @@ bool ImGui::IsItemFocused()
 
 // Important: this can be useful but it is NOT equivalent to the behavior of e.g.Button()!
 // Most widgets have specific reactions based on mouse-up/down state, mouse position etc.
-bool ImGui::IsItemClicked(ImGuiMouseButton mouse_button)
+bool ImGui::IsItemClicked(ImGuiMouseButton mouse_button) IMGUI_NOEXCEPT
 {
     return IsMouseClicked(mouse_button) && IsItemHovered(ImGuiHoveredFlags_None);
 }
 
-bool ImGui::IsItemToggledOpen()
+bool ImGui::IsItemToggledOpen() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return (g.CurrentWindow->DC.LastItemStatusFlags & ImGuiItemStatusFlags_ToggledOpen) ? true : false;
 }
 
-bool ImGui::IsItemToggledSelection()
+bool ImGui::IsItemToggledSelection() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return (g.CurrentWindow->DC.LastItemStatusFlags & ImGuiItemStatusFlags_ToggledSelection) ? true : false;
 }
 
-bool ImGui::IsAnyItemHovered()
+bool ImGui::IsAnyItemHovered() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return g.HoveredId != 0 || g.HoveredIdPreviousFrame != 0;
 }
 
-bool ImGui::IsAnyItemActive()
+bool ImGui::IsAnyItemActive() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return g.ActiveId != 0;
 }
 
-bool ImGui::IsAnyItemFocused()
+bool ImGui::IsAnyItemFocused() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return g.NavId != 0 && !g.NavDisableHighlight;
 }
 
-bool ImGui::IsItemVisible()
+bool ImGui::IsItemVisible() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     return window->ClipRect.Overlaps(window->DC.LastItemRect);
 }
 
-bool ImGui::IsItemEdited()
+bool ImGui::IsItemEdited() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     return (window->DC.LastItemStatusFlags & ImGuiItemStatusFlags_Edited) != 0;
@@ -4930,7 +4930,7 @@ bool ImGui::IsItemEdited()
 
 // Allow last item to be overlapped by a subsequent item. Both may be activated during the same frame before the later one takes priority.
 // FIXME: Although this is exposed, its interaction and ideal idiom with using ImGuiButtonFlags_AllowItemOverlap flag are extremely confusing, need rework.
-void ImGui::SetItemAllowOverlap()
+void ImGui::SetItemAllowOverlap() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiID id = g.CurrentWindow->DC.LastItemId;
@@ -4940,7 +4940,7 @@ void ImGui::SetItemAllowOverlap()
         g.ActiveIdAllowOverlap = true;
 }
 
-void ImGui::SetItemUsingMouseWheel()
+void ImGui::SetItemUsingMouseWheel() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiID id = g.CurrentWindow->DC.LastItemId;
@@ -4950,25 +4950,25 @@ void ImGui::SetItemUsingMouseWheel()
         g.ActiveIdUsingMouseWheel = true;
 }
 
-ImVec2 ImGui::GetItemRectMin()
+ImVec2 ImGui::GetItemRectMin() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     return window->DC.LastItemRect.Min;
 }
 
-ImVec2 ImGui::GetItemRectMax()
+ImVec2 ImGui::GetItemRectMax() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     return window->DC.LastItemRect.Max;
 }
 
-ImVec2 ImGui::GetItemRectSize()
+ImVec2 ImGui::GetItemRectSize() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     return window->DC.LastItemRect.GetSize();
 }
 
-bool ImGui::BeginChildEx(const char* name, ImGuiID id, const ImVec2& size_arg, bool border, ImGuiWindowFlags flags)
+bool ImGui::BeginChildEx(const char* name, ImGuiID id, const ImVec2& size_arg, bool border, ImGuiWindowFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* parent_window = g.CurrentWindow;
@@ -5096,26 +5096,26 @@ void ImGui::EndChildFrame() IMGUI_NOEXCEPT
     EndChild();
 }
 
-static void SetWindowConditionAllowFlags(ImGuiWindow* window, ImGuiCond flags, bool enabled)
+static void SetWindowConditionAllowFlags(ImGuiWindow* window, ImGuiCond flags, bool enabled) IMGUI_NOEXCEPT
 {
     window->SetWindowPosAllowFlags       = enabled ? (window->SetWindowPosAllowFlags       | flags) : (window->SetWindowPosAllowFlags       & ~flags);
     window->SetWindowSizeAllowFlags      = enabled ? (window->SetWindowSizeAllowFlags      | flags) : (window->SetWindowSizeAllowFlags      & ~flags);
     window->SetWindowCollapsedAllowFlags = enabled ? (window->SetWindowCollapsedAllowFlags | flags) : (window->SetWindowCollapsedAllowFlags & ~flags);
 }
 
-ImGuiWindow* ImGui::FindWindowByID(ImGuiID id)
+ImGuiWindow* ImGui::FindWindowByID(ImGuiID id) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return (ImGuiWindow*)g.WindowsById.GetVoidPtr(id);
 }
 
-ImGuiWindow* ImGui::FindWindowByName(const char* name)
+ImGuiWindow* ImGui::FindWindowByName(const char* name) IMGUI_NOEXCEPT
 {
     ImGuiID id = ImHashStr(name);
     return FindWindowByID(id);
 }
 
-static void ApplyWindowSettings(ImGuiWindow* window, ImGuiWindowSettings* settings)
+static void ApplyWindowSettings(ImGuiWindow* window, ImGuiWindowSettings* settings) IMGUI_NOEXCEPT
 {
     window->Pos = ImFloor(ImVec2(settings->Pos.x, settings->Pos.y));
     if (settings->Size.x > 0 && settings->Size.y > 0)
@@ -5123,7 +5123,7 @@ static void ApplyWindowSettings(ImGuiWindow* window, ImGuiWindowSettings* settin
     window->Collapsed = settings->Collapsed;
 }
 
-static ImGuiWindow* CreateNewWindow(const char* name, ImGuiWindowFlags flags)
+static ImGuiWindow* CreateNewWindow(const char* name, ImGuiWindowFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     //IMGUI_DEBUG_LOG("CreateNewWindow '%s', flags = 0x%08X\n", name, flags);
@@ -5175,7 +5175,7 @@ static ImGuiWindow* CreateNewWindow(const char* name, ImGuiWindowFlags flags)
     return window;
 }
 
-static ImVec2 CalcWindowSizeAfterConstraint(ImGuiWindow* window, const ImVec2& size_desired)
+static ImVec2 CalcWindowSizeAfterConstraint(ImGuiWindow* window, const ImVec2& size_desired) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImVec2 new_size = size_desired;
@@ -5210,7 +5210,7 @@ static ImVec2 CalcWindowSizeAfterConstraint(ImGuiWindow* window, const ImVec2& s
     return new_size;
 }
 
-static void CalcWindowContentSizes(ImGuiWindow* window, ImVec2* content_size_current, ImVec2* content_size_ideal)
+static void CalcWindowContentSizes(ImGuiWindow* window, ImVec2* content_size_current, ImVec2* content_size_ideal) IMGUI_NOEXCEPT
 {
     bool preserve_old_content_sizes = false;
     if (window->Collapsed && window->AutoFitFramesX <= 0 && window->AutoFitFramesY <= 0)
@@ -5230,7 +5230,7 @@ static void CalcWindowContentSizes(ImGuiWindow* window, ImVec2* content_size_cur
     content_size_ideal->y = (window->ContentSizeExplicit.y != 0.0f) ? window->ContentSizeExplicit.y : IM_FLOOR(ImMax(window->DC.CursorMaxPos.y, window->DC.IdealMaxPos.y) - window->DC.CursorStartPos.y);
 }
 
-static ImVec2 CalcWindowAutoFitSize(ImGuiWindow* window, const ImVec2& size_contents)
+static ImVec2 CalcWindowAutoFitSize(ImGuiWindow* window, const ImVec2& size_contents) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiStyle& style = g.Style;
@@ -5268,7 +5268,7 @@ static ImVec2 CalcWindowAutoFitSize(ImGuiWindow* window, const ImVec2& size_cont
     }
 }
 
-ImVec2 ImGui::CalcWindowNextAutoFitSize(ImGuiWindow* window)
+ImVec2 ImGui::CalcWindowNextAutoFitSize(ImGuiWindow* window) IMGUI_NOEXCEPT
 {
     ImVec2 size_contents_current;
     ImVec2 size_contents_ideal;
@@ -5278,7 +5278,7 @@ ImVec2 ImGui::CalcWindowNextAutoFitSize(ImGuiWindow* window)
     return size_final;
 }
 
-static ImGuiCol GetWindowBgColorIdxFromFlags(ImGuiWindowFlags flags)
+static ImGuiCol GetWindowBgColorIdxFromFlags(ImGuiWindowFlags flags) IMGUI_NOEXCEPT
 {
     if (flags & (ImGuiWindowFlags_Tooltip | ImGuiWindowFlags_Popup))
         return ImGuiCol_PopupBg;
@@ -5287,7 +5287,7 @@ static ImGuiCol GetWindowBgColorIdxFromFlags(ImGuiWindowFlags flags)
     return ImGuiCol_WindowBg;
 }
 
-static void CalcResizePosSizeFromAnyCorner(ImGuiWindow* window, const ImVec2& corner_target, const ImVec2& corner_norm, ImVec2* out_pos, ImVec2* out_size)
+static void CalcResizePosSizeFromAnyCorner(ImGuiWindow* window, const ImVec2& corner_target, const ImVec2& corner_norm, ImVec2* out_pos, ImVec2* out_size) IMGUI_NOEXCEPT
 {
     ImVec2 pos_min = ImLerp(corner_target, window->Pos, corner_norm);                // Expected window upper-left
     ImVec2 pos_max = ImLerp(window->Pos + window->Size, corner_target, corner_norm); // Expected window lower-right
@@ -5331,7 +5331,7 @@ static const ImGuiResizeBorderDef resize_border_def[4] =
     { ImVec2(0, -1), ImVec2(1, 1), ImVec2(0, 1), IM_PI * 0.50f }  // Down
 };
 
-static ImRect GetResizeBorderRect(ImGuiWindow* window, int border_n, float perp_padding, float thickness)
+static ImRect GetResizeBorderRect(ImGuiWindow* window, int border_n, float perp_padding, float thickness) IMGUI_NOEXCEPT
 {
     ImRect rect = window->Rect();
     if (thickness == 0.0f)
@@ -5345,7 +5345,7 @@ static ImRect GetResizeBorderRect(ImGuiWindow* window, int border_n, float perp_
 }
 
 // 0..3: corners (Lower-right, Lower-left, Unused, Unused)
-ImGuiID ImGui::GetWindowResizeCornerID(ImGuiWindow* window, int n)
+ImGuiID ImGui::GetWindowResizeCornerID(ImGuiWindow* window, int n) IMGUI_NOEXCEPT
 {
     IM_ASSERT(n >= 0 && n < 4);
     ImGuiID id = window->ID;
@@ -5355,7 +5355,7 @@ ImGuiID ImGui::GetWindowResizeCornerID(ImGuiWindow* window, int n)
 }
 
 // Borders (Left, Right, Up, Down)
-ImGuiID ImGui::GetWindowResizeBorderID(ImGuiWindow* window, ImGuiDir dir)
+ImGuiID ImGui::GetWindowResizeBorderID(ImGuiWindow* window, ImGuiDir dir) IMGUI_NOEXCEPT
 {
     IM_ASSERT(dir >= 0 && dir < 4);
     int n = (int)dir + 4;
@@ -5367,7 +5367,7 @@ ImGuiID ImGui::GetWindowResizeBorderID(ImGuiWindow* window, ImGuiDir dir)
 
 // Handle resize for: Resize Grips, Borders, Gamepad
 // Return true when using auto-fit (double click on resize grip)
-static bool ImGui::UpdateWindowManualResize(ImGuiWindow* window, const ImVec2& size_auto_fit, int* border_held, int resize_grip_count, ImU32 resize_grip_col[4], const ImRect& visibility_rect)
+static bool ImGui::UpdateWindowManualResize(ImGuiWindow* window, const ImVec2& size_auto_fit, int* border_held, int resize_grip_count, ImU32 resize_grip_col[4], const ImRect& visibility_rect) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindowFlags flags = window->Flags;
@@ -5497,7 +5497,7 @@ static bool ImGui::UpdateWindowManualResize(ImGuiWindow* window, const ImVec2& s
     return ret_auto_fit;
 }
 
-static inline void ClampWindowRect(ImGuiWindow* window, const ImRect& visibility_rect)
+static inline void ClampWindowRect(ImGuiWindow* window, const ImRect& visibility_rect) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImVec2 size_for_clamping = window->Size;
@@ -5506,7 +5506,7 @@ static inline void ClampWindowRect(ImGuiWindow* window, const ImRect& visibility
     window->Pos = ImClamp(window->Pos, visibility_rect.Min - size_for_clamping, visibility_rect.Max);
 }
 
-static void ImGui::RenderWindowOuterBorders(ImGuiWindow* window)
+static void ImGui::RenderWindowOuterBorders(ImGuiWindow* window) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     float rounding = window->WindowRounding;
@@ -5532,7 +5532,7 @@ static void ImGui::RenderWindowOuterBorders(ImGuiWindow* window)
 
 // Draw background and borders
 // Draw and handle scrollbars
-void ImGui::RenderWindowDecorations(ImGuiWindow* window, const ImRect& title_bar_rect, bool title_bar_is_highlight, int resize_grip_count, const ImU32 resize_grip_col[4], float resize_grip_draw_size)
+void ImGui::RenderWindowDecorations(ImGuiWindow* window, const ImRect& title_bar_rect, bool title_bar_is_highlight, int resize_grip_count, const ImU32 resize_grip_col[4], float resize_grip_draw_size) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiStyle& style = g.Style;
@@ -5616,7 +5616,7 @@ void ImGui::RenderWindowDecorations(ImGuiWindow* window, const ImRect& title_bar
 }
 
 // Render title text, collapse button, close button
-void ImGui::RenderWindowTitleBarContents(ImGuiWindow* window, const ImRect& title_bar_rect, const char* name, bool* p_open)
+void ImGui::RenderWindowTitleBarContents(ImGuiWindow* window, const ImRect& title_bar_rect, const char* name, bool* p_open) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiStyle& style = g.Style;
@@ -5699,7 +5699,7 @@ void ImGui::RenderWindowTitleBarContents(ImGuiWindow* window, const ImRect& titl
     }
 }
 
-void ImGui::UpdateWindowParentAndRootLinks(ImGuiWindow* window, ImGuiWindowFlags flags, ImGuiWindow* parent_window)
+void ImGui::UpdateWindowParentAndRootLinks(ImGuiWindow* window, ImGuiWindowFlags flags, ImGuiWindow* parent_window) IMGUI_NOEXCEPT
 {
     window->ParentWindow = parent_window;
     window->RootWindow = window->RootWindowForTitleBarHighlight = window->RootWindowForNav = window;
@@ -6399,7 +6399,7 @@ void ImGui::End() IMGUI_NOEXCEPT
     SetCurrentWindow(g.CurrentWindowStack.empty() ? NULL : g.CurrentWindowStack.back());
 }
 
-void ImGui::BringWindowToFocusFront(ImGuiWindow* window)
+void ImGui::BringWindowToFocusFront(ImGuiWindow* window) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(window == window->RootWindow);
@@ -6420,7 +6420,7 @@ void ImGui::BringWindowToFocusFront(ImGuiWindow* window)
     window->FocusOrder = (short)new_order;
 }
 
-void ImGui::BringWindowToDisplayFront(ImGuiWindow* window)
+void ImGui::BringWindowToDisplayFront(ImGuiWindow* window) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* current_front_window = g.Windows.back();
@@ -6435,7 +6435,7 @@ void ImGui::BringWindowToDisplayFront(ImGuiWindow* window)
         }
 }
 
-void ImGui::BringWindowToDisplayBack(ImGuiWindow* window)
+void ImGui::BringWindowToDisplayBack(ImGuiWindow* window) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.Windows[0] == window)
@@ -6450,7 +6450,7 @@ void ImGui::BringWindowToDisplayBack(ImGuiWindow* window)
 }
 
 // Moving window to front of display and set focus (which happens to be back of our sorted list)
-void ImGui::FocusWindow(ImGuiWindow* window)
+void ImGui::FocusWindow(ImGuiWindow* window) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -6493,7 +6493,7 @@ void ImGui::FocusWindow(ImGuiWindow* window)
         BringWindowToDisplayFront(display_front_window);
 }
 
-void ImGui::FocusTopMostWindowUnderOne(ImGuiWindow* under_this_window, ImGuiWindow* ignore_window)
+void ImGui::FocusTopMostWindowUnderOne(ImGuiWindow* under_this_window, ImGuiWindow* ignore_window) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -6515,7 +6515,7 @@ void ImGui::FocusTopMostWindowUnderOne(ImGuiWindow* under_this_window, ImGuiWind
 }
 
 // Important: this alone doesn't alter current ImDrawList state. This is called by PushFont/PopFont only.
-void ImGui::SetCurrentFont(ImFont* font)
+void ImGui::SetCurrentFont(ImFont* font) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(font && font->IsLoaded());    // Font Atlas not created. Did you call io.Fonts->GetTexDataAsRGBA32 / GetTexDataAsAlpha8 ?
@@ -6531,7 +6531,7 @@ void ImGui::SetCurrentFont(ImFont* font)
     g.DrawListSharedData.FontSize = g.FontSize;
 }
 
-void ImGui::PushFont(ImFont* font)
+void ImGui::PushFont(ImFont* font) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (!font)
@@ -6541,7 +6541,7 @@ void ImGui::PushFont(ImFont* font)
     g.CurrentWindow->DrawList->PushTextureID(font->ContainerAtlas->TexID);
 }
 
-void  ImGui::PopFont()
+void  ImGui::PopFont() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.CurrentWindow->DrawList->PopTextureID();
@@ -6549,7 +6549,7 @@ void  ImGui::PopFont()
     SetCurrentFont(g.FontStack.empty() ? GetDefaultFont() : g.FontStack.back());
 }
 
-void ImGui::PushItemFlag(ImGuiItemFlags option, bool enabled)
+void ImGui::PushItemFlag(ImGuiItemFlags option, bool enabled) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiItemFlags item_flags = g.CurrentItemFlags;
@@ -6562,7 +6562,7 @@ void ImGui::PushItemFlag(ImGuiItemFlags option, bool enabled)
     g.ItemFlagsStack.push_back(item_flags);
 }
 
-void ImGui::PopItemFlag()
+void ImGui::PopItemFlag() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(g.ItemFlagsStack.Size > 1); // Too many calls to PopItemFlag() - we always leave a 0 at the bottom of the stack.
@@ -6571,41 +6571,41 @@ void ImGui::PopItemFlag()
 }
 
 // FIXME: Look into renaming this once we have settled the new Focus/Activation/TabStop system.
-void ImGui::PushAllowKeyboardFocus(bool allow_keyboard_focus)
+void ImGui::PushAllowKeyboardFocus(bool allow_keyboard_focus) IMGUI_NOEXCEPT
 {
     PushItemFlag(ImGuiItemFlags_NoTabStop, !allow_keyboard_focus);
 }
 
-void ImGui::PopAllowKeyboardFocus()
+void ImGui::PopAllowKeyboardFocus() IMGUI_NOEXCEPT
 {
     PopItemFlag();
 }
 
-void ImGui::PushButtonRepeat(bool repeat)
+void ImGui::PushButtonRepeat(bool repeat) IMGUI_NOEXCEPT
 {
     PushItemFlag(ImGuiItemFlags_ButtonRepeat, repeat);
 }
 
-void ImGui::PopButtonRepeat()
+void ImGui::PopButtonRepeat() IMGUI_NOEXCEPT
 {
     PopItemFlag();
 }
 
-void ImGui::PushTextWrapPos(float wrap_pos_x)
+void ImGui::PushTextWrapPos(float wrap_pos_x) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     window->DC.TextWrapPosStack.push_back(window->DC.TextWrapPos);
     window->DC.TextWrapPos = wrap_pos_x;
 }
 
-void ImGui::PopTextWrapPos()
+void ImGui::PopTextWrapPos() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     window->DC.TextWrapPos = window->DC.TextWrapPosStack.back();
     window->DC.TextWrapPosStack.pop_back();
 }
 
-bool ImGui::IsWindowChildOf(ImGuiWindow* window, ImGuiWindow* potential_parent)
+bool ImGui::IsWindowChildOf(ImGuiWindow* window, ImGuiWindow* potential_parent) IMGUI_NOEXCEPT
 {
     if (window->RootWindow == potential_parent)
         return true;
@@ -6618,7 +6618,7 @@ bool ImGui::IsWindowChildOf(ImGuiWindow* window, ImGuiWindow* potential_parent)
     return false;
 }
 
-bool ImGui::IsWindowAbove(ImGuiWindow* potential_above, ImGuiWindow* potential_below)
+bool ImGui::IsWindowAbove(ImGuiWindow* potential_above, ImGuiWindow* potential_below) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     for (int i = g.Windows.Size - 1; i >= 0; i--)
@@ -6632,7 +6632,7 @@ bool ImGui::IsWindowAbove(ImGuiWindow* potential_above, ImGuiWindow* potential_b
     return false;
 }
 
-bool ImGui::IsWindowHovered(ImGuiHoveredFlags flags)
+bool ImGui::IsWindowHovered(ImGuiHoveredFlags flags) IMGUI_NOEXCEPT
 {
     IM_ASSERT((flags & ImGuiHoveredFlags_AllowWhenOverlapped) == 0);   // Flags not supported by this function
     ImGuiContext& g = *GImGui;
@@ -6671,7 +6671,7 @@ bool ImGui::IsWindowHovered(ImGuiHoveredFlags flags)
     return true;
 }
 
-bool ImGui::IsWindowFocused(ImGuiFocusedFlags flags)
+bool ImGui::IsWindowFocused(ImGuiFocusedFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -6695,31 +6695,31 @@ bool ImGui::IsWindowFocused(ImGuiFocusedFlags flags)
 // Can we focus this window with CTRL+TAB (or PadMenu + PadFocusPrev/PadFocusNext)
 // Note that NoNavFocus makes the window not reachable with CTRL+TAB but it can still be focused with mouse or programmatically.
 // If you want a window to never be focused, you may use the e.g. NoInputs flag.
-bool ImGui::IsWindowNavFocusable(ImGuiWindow* window)
+bool ImGui::IsWindowNavFocusable(ImGuiWindow* window) IMGUI_NOEXCEPT
 {
     return window->WasActive && window == window->RootWindow && !(window->Flags & ImGuiWindowFlags_NoNavFocus);
 }
 
-float ImGui::GetWindowWidth()
+float ImGui::GetWindowWidth() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     return window->Size.x;
 }
 
-float ImGui::GetWindowHeight()
+float ImGui::GetWindowHeight() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     return window->Size.y;
 }
 
-ImVec2 ImGui::GetWindowPos()
+ImVec2 ImGui::GetWindowPos() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
     return window->Pos;
 }
 
-void ImGui::SetWindowPos(ImGuiWindow* window, const ImVec2& pos, ImGuiCond cond)
+void ImGui::SetWindowPos(ImGuiWindow* window, const ImVec2& pos, ImGuiCond cond) IMGUI_NOEXCEPT
 {
     // Test condition (NB: bit 0 is always true) and clear flags for next time
     if (cond && (window->SetWindowPosAllowFlags & cond) == 0)
@@ -6739,25 +6739,25 @@ void ImGui::SetWindowPos(ImGuiWindow* window, const ImVec2& pos, ImGuiCond cond)
     window->DC.CursorStartPos += offset;
 }
 
-void ImGui::SetWindowPos(const ImVec2& pos, ImGuiCond cond)
+void ImGui::SetWindowPos(const ImVec2& pos, ImGuiCond cond) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     SetWindowPos(window, pos, cond);
 }
 
-void ImGui::SetWindowPos(const char* name, const ImVec2& pos, ImGuiCond cond)
+void ImGui::SetWindowPos(const char* name, const ImVec2& pos, ImGuiCond cond) IMGUI_NOEXCEPT
 {
     if (ImGuiWindow* window = FindWindowByName(name))
         SetWindowPos(window, pos, cond);
 }
 
-ImVec2 ImGui::GetWindowSize()
+ImVec2 ImGui::GetWindowSize() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     return window->Size;
 }
 
-void ImGui::SetWindowSize(ImGuiWindow* window, const ImVec2& size, ImGuiCond cond)
+void ImGui::SetWindowSize(ImGuiWindow* window, const ImVec2& size, ImGuiCond cond) IMGUI_NOEXCEPT
 {
     // Test condition (NB: bit 0 is always true) and clear flags for next time
     if (cond && (window->SetWindowSizeAllowFlags & cond) == 0)
@@ -6789,18 +6789,18 @@ void ImGui::SetWindowSize(ImGuiWindow* window, const ImVec2& size, ImGuiCond con
     }
 }
 
-void ImGui::SetWindowSize(const ImVec2& size, ImGuiCond cond)
+void ImGui::SetWindowSize(const ImVec2& size, ImGuiCond cond) IMGUI_NOEXCEPT
 {
     SetWindowSize(GImGui->CurrentWindow, size, cond);
 }
 
-void ImGui::SetWindowSize(const char* name, const ImVec2& size, ImGuiCond cond)
+void ImGui::SetWindowSize(const char* name, const ImVec2& size, ImGuiCond cond) IMGUI_NOEXCEPT
 {
     if (ImGuiWindow* window = FindWindowByName(name))
         SetWindowSize(window, size, cond);
 }
 
-void ImGui::SetWindowCollapsed(ImGuiWindow* window, bool collapsed, ImGuiCond cond)
+void ImGui::SetWindowCollapsed(ImGuiWindow* window, bool collapsed, ImGuiCond cond) IMGUI_NOEXCEPT
 {
     // Test condition (NB: bit 0 is always true) and clear flags for next time
     if (cond && (window->SetWindowCollapsedAllowFlags & cond) == 0)
@@ -6811,42 +6811,42 @@ void ImGui::SetWindowCollapsed(ImGuiWindow* window, bool collapsed, ImGuiCond co
     window->Collapsed = collapsed;
 }
 
-void ImGui::SetWindowHitTestHole(ImGuiWindow* window, const ImVec2& pos, const ImVec2& size)
+void ImGui::SetWindowHitTestHole(ImGuiWindow* window, const ImVec2& pos, const ImVec2& size) IMGUI_NOEXCEPT
 {
     IM_ASSERT(window->HitTestHoleSize.x == 0);     // We don't support multiple holes/hit test filters
     window->HitTestHoleSize = ImVec2ih(size);
     window->HitTestHoleOffset = ImVec2ih(pos - window->Pos);
 }
 
-void ImGui::SetWindowCollapsed(bool collapsed, ImGuiCond cond)
+void ImGui::SetWindowCollapsed(bool collapsed, ImGuiCond cond) IMGUI_NOEXCEPT
 {
     SetWindowCollapsed(GImGui->CurrentWindow, collapsed, cond);
 }
 
-bool ImGui::IsWindowCollapsed()
+bool ImGui::IsWindowCollapsed() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     return window->Collapsed;
 }
 
-bool ImGui::IsWindowAppearing()
+bool ImGui::IsWindowAppearing() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     return window->Appearing;
 }
 
-void ImGui::SetWindowCollapsed(const char* name, bool collapsed, ImGuiCond cond)
+void ImGui::SetWindowCollapsed(const char* name, bool collapsed, ImGuiCond cond) IMGUI_NOEXCEPT
 {
     if (ImGuiWindow* window = FindWindowByName(name))
         SetWindowCollapsed(window, collapsed, cond);
 }
 
-void ImGui::SetWindowFocus()
+void ImGui::SetWindowFocus() IMGUI_NOEXCEPT
 {
     FocusWindow(GImGui->CurrentWindow);
 }
 
-void ImGui::SetWindowFocus(const char* name)
+void ImGui::SetWindowFocus(const char* name) IMGUI_NOEXCEPT
 {
     if (name)
     {
@@ -6859,7 +6859,7 @@ void ImGui::SetWindowFocus(const char* name)
     }
 }
 
-void ImGui::SetNextWindowPos(const ImVec2& pos, ImGuiCond cond, const ImVec2& pivot)
+void ImGui::SetNextWindowPos(const ImVec2& pos, ImGuiCond cond, const ImVec2& pivot) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(cond == 0 || ImIsPowerOfTwo(cond)); // Make sure the user doesn't attempt to combine multiple condition flags.
@@ -6869,7 +6869,7 @@ void ImGui::SetNextWindowPos(const ImVec2& pos, ImGuiCond cond, const ImVec2& pi
     g.NextWindowData.PosCond = cond ? cond : ImGuiCond_Always;
 }
 
-void ImGui::SetNextWindowSize(const ImVec2& size, ImGuiCond cond)
+void ImGui::SetNextWindowSize(const ImVec2& size, ImGuiCond cond) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(cond == 0 || ImIsPowerOfTwo(cond)); // Make sure the user doesn't attempt to combine multiple condition flags.
@@ -6878,7 +6878,7 @@ void ImGui::SetNextWindowSize(const ImVec2& size, ImGuiCond cond)
     g.NextWindowData.SizeCond = cond ? cond : ImGuiCond_Always;
 }
 
-void ImGui::SetNextWindowSizeConstraints(const ImVec2& size_min, const ImVec2& size_max, ImGuiSizeCallback custom_callback, void* custom_callback_user_data)
+void ImGui::SetNextWindowSizeConstraints(const ImVec2& size_min, const ImVec2& size_max, ImGuiSizeCallback custom_callback, void* custom_callback_user_data) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.NextWindowData.Flags |= ImGuiNextWindowDataFlags_HasSizeConstraint;
@@ -6889,21 +6889,21 @@ void ImGui::SetNextWindowSizeConstraints(const ImVec2& size_min, const ImVec2& s
 
 // Content size = inner scrollable rectangle, padded with WindowPadding.
 // SetNextWindowContentSize(ImVec2(100,100) + ImGuiWindowFlags_AlwaysAutoResize will always allow submitting a 100x100 item.
-void ImGui::SetNextWindowContentSize(const ImVec2& size)
+void ImGui::SetNextWindowContentSize(const ImVec2& size) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.NextWindowData.Flags |= ImGuiNextWindowDataFlags_HasContentSize;
     g.NextWindowData.ContentSizeVal = ImFloor(size);
 }
 
-void ImGui::SetNextWindowScroll(const ImVec2& scroll)
+void ImGui::SetNextWindowScroll(const ImVec2& scroll) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.NextWindowData.Flags |= ImGuiNextWindowDataFlags_HasScroll;
     g.NextWindowData.ScrollVal = scroll;
 }
 
-void ImGui::SetNextWindowCollapsed(bool collapsed, ImGuiCond cond)
+void ImGui::SetNextWindowCollapsed(bool collapsed, ImGuiCond cond) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(cond == 0 || ImIsPowerOfTwo(cond)); // Make sure the user doesn't attempt to combine multiple condition flags.
@@ -6912,41 +6912,41 @@ void ImGui::SetNextWindowCollapsed(bool collapsed, ImGuiCond cond)
     g.NextWindowData.CollapsedCond = cond ? cond : ImGuiCond_Always;
 }
 
-void ImGui::SetNextWindowFocus()
+void ImGui::SetNextWindowFocus() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.NextWindowData.Flags |= ImGuiNextWindowDataFlags_HasFocus;
 }
 
-void ImGui::SetNextWindowBgAlpha(float alpha)
+void ImGui::SetNextWindowBgAlpha(float alpha) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.NextWindowData.Flags |= ImGuiNextWindowDataFlags_HasBgAlpha;
     g.NextWindowData.BgAlphaVal = alpha;
 }
 
-ImDrawList* ImGui::GetWindowDrawList()
+ImDrawList* ImGui::GetWindowDrawList() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     return window->DrawList;
 }
 
-ImFont* ImGui::GetFont()
+ImFont* ImGui::GetFont() IMGUI_NOEXCEPT
 {
     return GImGui->Font;
 }
 
-float ImGui::GetFontSize()
+float ImGui::GetFontSize() IMGUI_NOEXCEPT
 {
     return GImGui->FontSize;
 }
 
-ImVec2 ImGui::GetFontTexUvWhitePixel()
+ImVec2 ImGui::GetFontTexUvWhitePixel() IMGUI_NOEXCEPT
 {
     return GImGui->DrawListSharedData.TexUvWhitePixel;
 }
 
-void ImGui::SetWindowFontScale(float scale)
+void ImGui::SetWindowFontScale(float scale) IMGUI_NOEXCEPT
 {
     IM_ASSERT(scale > 0.0f);
     ImGuiContext& g = *GImGui;
@@ -6955,13 +6955,13 @@ void ImGui::SetWindowFontScale(float scale)
     g.FontSize = g.DrawListSharedData.FontSize = window->CalcFontSize();
 }
 
-void ImGui::ActivateItem(ImGuiID id)
+void ImGui::ActivateItem(ImGuiID id) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.NavNextActivateId = id;
 }
 
-void ImGui::PushFocusScope(ImGuiID id)
+void ImGui::PushFocusScope(ImGuiID id) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -6969,7 +6969,7 @@ void ImGui::PushFocusScope(ImGuiID id)
     window->DC.NavFocusScopeIdCurrent = id;
 }
 
-void ImGui::PopFocusScope()
+void ImGui::PopFocusScope() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -6978,7 +6978,7 @@ void ImGui::PopFocusScope()
     g.FocusScopeStack.pop_back();
 }
 
-void ImGui::SetKeyboardFocusHere(int offset)
+void ImGui::SetKeyboardFocusHere(int offset) IMGUI_NOEXCEPT
 {
     IM_ASSERT(offset >= -1);    // -1 is allowed but not below
     ImGuiContext& g = *GImGui;
@@ -6988,7 +6988,7 @@ void ImGui::SetKeyboardFocusHere(int offset)
     g.TabFocusRequestNextCounterTabStop = INT_MAX;
 }
 
-void ImGui::SetItemDefaultFocus()
+void ImGui::SetItemDefaultFocus() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7005,19 +7005,19 @@ void ImGui::SetItemDefaultFocus()
     }
 }
 
-void ImGui::SetStateStorage(ImGuiStorage* tree)
+void ImGui::SetStateStorage(ImGuiStorage* tree) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     window->DC.StateStorage = tree ? tree : &window->StateStorage;
 }
 
-ImGuiStorage* ImGui::GetStateStorage()
+ImGuiStorage* ImGui::GetStateStorage() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     return window->DC.StateStorage;
 }
 
-void ImGui::PushID(const char* str_id)
+void ImGui::PushID(const char* str_id) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7025,7 +7025,7 @@ void ImGui::PushID(const char* str_id)
     window->IDStack.push_back(id);
 }
 
-void ImGui::PushID(const char* str_id_begin, const char* str_id_end)
+void ImGui::PushID(const char* str_id_begin, const char* str_id_end) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7033,7 +7033,7 @@ void ImGui::PushID(const char* str_id_begin, const char* str_id_end)
     window->IDStack.push_back(id);
 }
 
-void ImGui::PushID(const void* ptr_id)
+void ImGui::PushID(const void* ptr_id) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7041,7 +7041,7 @@ void ImGui::PushID(const void* ptr_id)
     window->IDStack.push_back(id);
 }
 
-void ImGui::PushID(int int_id)
+void ImGui::PushID(int int_id) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7050,7 +7050,7 @@ void ImGui::PushID(int int_id)
 }
 
 // Push a given id value ignoring the ID stack as a seed.
-void ImGui::PushOverrideID(ImGuiID id)
+void ImGui::PushOverrideID(ImGuiID id) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7060,7 +7060,7 @@ void ImGui::PushOverrideID(ImGuiID id)
 // Helper to avoid a common series of PushOverrideID -> GetID() -> PopID() call
 // (note that when using this pattern, TestEngine's "Stack Tool" will tend to not display the intermediate stack level.
 //  for that to work we would need to do PushOverrideID() -> ItemAdd() -> PopID() which would alter widget code a little more)
-ImGuiID ImGui::GetIDWithSeed(const char* str, const char* str_end, ImGuiID seed)
+ImGuiID ImGui::GetIDWithSeed(const char* str, const char* str_end, ImGuiID seed) IMGUI_NOEXCEPT
 {
     ImGuiID id = ImHashStr(str, str_end ? (str_end - str) : 0, seed);
     ImGui::KeepAliveID(id);
@@ -7071,38 +7071,38 @@ ImGuiID ImGui::GetIDWithSeed(const char* str, const char* str_end, ImGuiID seed)
     return id;
 }
 
-void ImGui::PopID()
+void ImGui::PopID() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     IM_ASSERT(window->IDStack.Size > 1); // Too many PopID(), or could be popping in a wrong/different window?
     window->IDStack.pop_back();
 }
 
-ImGuiID ImGui::GetID(const char* str_id)
+ImGuiID ImGui::GetID(const char* str_id) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     return window->GetID(str_id);
 }
 
-ImGuiID ImGui::GetID(const char* str_id_begin, const char* str_id_end)
+ImGuiID ImGui::GetID(const char* str_id_begin, const char* str_id_end) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     return window->GetID(str_id_begin, str_id_end);
 }
 
-ImGuiID ImGui::GetID(const void* ptr_id)
+ImGuiID ImGui::GetID(const void* ptr_id) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     return window->GetID(ptr_id);
 }
 
-bool ImGui::IsRectVisible(const ImVec2& size)
+bool ImGui::IsRectVisible(const ImVec2& size) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     return window->ClipRect.Overlaps(ImRect(window->DC.CursorPos, window->DC.CursorPos + size));
 }
 
-bool ImGui::IsRectVisible(const ImVec2& rect_min, const ImVec2& rect_max)
+bool ImGui::IsRectVisible(const ImVec2& rect_min, const ImVec2& rect_max) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     return window->ClipRect.Overlaps(ImRect(rect_min, rect_max));
@@ -7118,7 +7118,7 @@ bool ImGui::IsRectVisible(const ImVec2& rect_min, const ImVec2& rect_max)
 // If the user has inconsistent compilation settings, imgui configuration #define, packing pragma, etc. your user code
 // may see different structures than what imgui.cpp sees, which is problematic.
 // We usually require settings to be in imconfig.h to make sure that they are accessible to all compilation units involved with Dear ImGui.
-bool ImGui::DebugCheckVersionAndDataLayout(const char* version, size_t sz_io, size_t sz_style, size_t sz_vec2, size_t sz_vec4, size_t sz_vert, size_t sz_idx)
+bool ImGui::DebugCheckVersionAndDataLayout(const char* version, size_t sz_io, size_t sz_style, size_t sz_vec2, size_t sz_vec4, size_t sz_vert, size_t sz_idx) IMGUI_NOEXCEPT
 {
     bool error = false;
     if (strcmp(version, IMGUI_VERSION) != 0) { error = true; IM_ASSERT(strcmp(version, IMGUI_VERSION) == 0 && "Mismatched version string!"); }
@@ -7131,7 +7131,7 @@ bool ImGui::DebugCheckVersionAndDataLayout(const char* version, size_t sz_io, si
     return !error;
 }
 
-static void ImGui::ErrorCheckNewFrameSanityChecks()
+static void ImGui::ErrorCheckNewFrameSanityChecks() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -7168,7 +7168,7 @@ static void ImGui::ErrorCheckNewFrameSanityChecks()
         g.IO.ConfigWindowsResizeFromEdges = false;
 }
 
-static void ImGui::ErrorCheckEndFrameSanityChecks()
+static void ImGui::ErrorCheckEndFrameSanityChecks() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -7209,7 +7209,7 @@ static void ImGui::ErrorCheckEndFrameSanityChecks()
 // This is generally flawed as we are not necessarily End/Popping things in the right order.
 // FIXME: Can't recover from inside BeginTabItem/EndTabItem yet.
 // FIXME: Can't recover from interleaved BeginTabBar/Begin
-void    ImGui::ErrorCheckEndFrameRecover(ImGuiErrorLogCallback log_callback, void* user_data)
+void    ImGui::ErrorCheckEndFrameRecover(ImGuiErrorLogCallback log_callback, void* user_data) IMGUI_NOEXCEPT
 {
     // PVS-Studio V1044 is "Loop break conditions do not depend on the number of iterations"
     ImGuiContext& g = *GImGui;
@@ -7279,7 +7279,7 @@ void    ImGui::ErrorCheckEndFrameRecover(ImGuiErrorLogCallback log_callback, voi
 }
 
 // Save current stack sizes for later compare
-void ImGuiStackSizes::SetToCurrentState()
+void ImGuiStackSizes::SetToCurrentState() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7293,7 +7293,7 @@ void ImGuiStackSizes::SetToCurrentState()
 }
 
 // Compare to detect usage errors
-void ImGuiStackSizes::CompareWithCurrentState()
+void ImGuiStackSizes::CompareWithCurrentState() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7350,7 +7350,7 @@ void ImGuiStackSizes::CompareWithCurrentState()
 // Advance cursor given item size for layout.
 // Register minimum needed size so it can extend the bounding box used for auto-fit calculation.
 // See comments in ItemAdd() about how/why the size provided to ItemSize() vs ItemAdd() may often different.
-void ImGui::ItemSize(const ImVec2& size, float text_baseline_y)
+void ImGui::ItemSize(const ImVec2& size, float text_baseline_y) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7383,7 +7383,7 @@ void ImGui::ItemSize(const ImVec2& size, float text_baseline_y)
         SameLine();
 }
 
-void ImGui::ItemSize(const ImRect& bb, float text_baseline_y)
+void ImGui::ItemSize(const ImRect& bb, float text_baseline_y) IMGUI_NOEXCEPT
 {
     ItemSize(bb.GetSize(), text_baseline_y);
 }
@@ -7391,7 +7391,7 @@ void ImGui::ItemSize(const ImRect& bb, float text_baseline_y)
 // Declare item bounding box for clipping and interaction.
 // Note that the size can be different than the one provided to ItemSize(). Typically, widgets that spread over available surface
 // declare their minimum size requirement to ItemSize() and provide a larger region to ItemAdd() which is used drawing/interaction.
-bool ImGui::ItemAdd(const ImRect& bb, ImGuiID id, const ImRect* nav_bb_arg, ImGuiItemAddFlags flags)
+bool ImGui::ItemAdd(const ImRect& bb, ImGuiID id, const ImRect* nav_bb_arg, ImGuiItemAddFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7456,7 +7456,7 @@ bool ImGui::ItemAdd(const ImRect& bb, ImGuiID id, const ImRect* nav_bb_arg, ImGu
 //      offset_from_start_x != 0 : align to specified x position (relative to window/group left)
 //      spacing_w < 0            : use default spacing if pos_x == 0, no spacing if pos_x != 0
 //      spacing_w >= 0           : enforce spacing amount
-void ImGui::SameLine(float offset_from_start_x, float spacing_w)
+void ImGui::SameLine(float offset_from_start_x, float spacing_w) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -7479,13 +7479,13 @@ void ImGui::SameLine(float offset_from_start_x, float spacing_w)
     window->DC.CurrLineTextBaseOffset = window->DC.PrevLineTextBaseOffset;
 }
 
-ImVec2 ImGui::GetCursorScreenPos()
+ImVec2 ImGui::GetCursorScreenPos() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     return window->DC.CursorPos;
 }
 
-void ImGui::SetCursorScreenPos(const ImVec2& pos)
+void ImGui::SetCursorScreenPos(const ImVec2& pos) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     window->DC.CursorPos = pos;
@@ -7494,52 +7494,52 @@ void ImGui::SetCursorScreenPos(const ImVec2& pos)
 
 // User generally sees positions in window coordinates. Internally we store CursorPos in absolute screen coordinates because it is more convenient.
 // Conversion happens as we pass the value to user, but it makes our naming convention confusing because GetCursorPos() == (DC.CursorPos - window.Pos). May want to rename 'DC.CursorPos'.
-ImVec2 ImGui::GetCursorPos()
+ImVec2 ImGui::GetCursorPos() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     return window->DC.CursorPos - window->Pos + window->Scroll;
 }
 
-float ImGui::GetCursorPosX()
+float ImGui::GetCursorPosX() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     return window->DC.CursorPos.x - window->Pos.x + window->Scroll.x;
 }
 
-float ImGui::GetCursorPosY()
+float ImGui::GetCursorPosY() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     return window->DC.CursorPos.y - window->Pos.y + window->Scroll.y;
 }
 
-void ImGui::SetCursorPos(const ImVec2& local_pos)
+void ImGui::SetCursorPos(const ImVec2& local_pos) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     window->DC.CursorPos = window->Pos - window->Scroll + local_pos;
     window->DC.CursorMaxPos = ImMax(window->DC.CursorMaxPos, window->DC.CursorPos);
 }
 
-void ImGui::SetCursorPosX(float x)
+void ImGui::SetCursorPosX(float x) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     window->DC.CursorPos.x = window->Pos.x - window->Scroll.x + x;
     window->DC.CursorMaxPos.x = ImMax(window->DC.CursorMaxPos.x, window->DC.CursorPos.x);
 }
 
-void ImGui::SetCursorPosY(float y)
+void ImGui::SetCursorPosY(float y) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     window->DC.CursorPos.y = window->Pos.y - window->Scroll.y + y;
     window->DC.CursorMaxPos.y = ImMax(window->DC.CursorMaxPos.y, window->DC.CursorPos.y);
 }
 
-ImVec2 ImGui::GetCursorStartPos()
+ImVec2 ImGui::GetCursorStartPos() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     return window->DC.CursorStartPos - window->Pos;
 }
 
-void ImGui::Indent(float indent_w)
+void ImGui::Indent(float indent_w) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = GetCurrentWindow();
@@ -7547,7 +7547,7 @@ void ImGui::Indent(float indent_w)
     window->DC.CursorPos.x = window->Pos.x + window->DC.Indent.x + window->DC.ColumnsOffset.x;
 }
 
-void ImGui::Unindent(float indent_w)
+void ImGui::Unindent(float indent_w) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = GetCurrentWindow();
@@ -7556,7 +7556,7 @@ void ImGui::Unindent(float indent_w)
 }
 
 // Affect large frame+labels widgets only.
-void ImGui::SetNextItemWidth(float item_width)
+void ImGui::SetNextItemWidth(float item_width) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.NextItemData.Flags |= ImGuiNextItemDataFlags_HasWidth;
@@ -7564,7 +7564,7 @@ void ImGui::SetNextItemWidth(float item_width)
 }
 
 // FIXME: Remove the == 0.0f behavior?
-void ImGui::PushItemWidth(float item_width)
+void ImGui::PushItemWidth(float item_width) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7573,7 +7573,7 @@ void ImGui::PushItemWidth(float item_width)
     g.NextItemData.Flags &= ~ImGuiNextItemDataFlags_HasWidth;
 }
 
-void ImGui::PushMultiItemsWidths(int components, float w_full)
+void ImGui::PushMultiItemsWidths(int components, float w_full) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7588,7 +7588,7 @@ void ImGui::PushMultiItemsWidths(int components, float w_full)
     g.NextItemData.Flags &= ~ImGuiNextItemDataFlags_HasWidth;
 }
 
-void ImGui::PopItemWidth()
+void ImGui::PopItemWidth() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     window->DC.ItemWidth = window->DC.ItemWidthStack.back();
@@ -7597,7 +7597,7 @@ void ImGui::PopItemWidth()
 
 // Calculate default item width given value passed to PushItemWidth() or SetNextItemWidth().
 // The SetNextItemWidth() data is generally cleared/consumed by ItemAdd() or NextItemData.ClearFlags()
-float ImGui::CalcItemWidth()
+float ImGui::CalcItemWidth() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7619,7 +7619,7 @@ float ImGui::CalcItemWidth()
 // Those two functions CalcItemWidth vs CalcItemSize are awkwardly named because they are not fully symmetrical.
 // Note that only CalcItemWidth() is publicly exposed.
 // The 4.0f here may be changed to match CalcItemWidth() and/or BeginChild() (right now we have a mismatch which is harmless but undesirable)
-ImVec2 ImGui::CalcItemSize(ImVec2 size, float default_w, float default_h)
+ImVec2 ImGui::CalcItemSize(ImVec2 size, float default_w, float default_h) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
 
@@ -7640,25 +7640,25 @@ ImVec2 ImGui::CalcItemSize(ImVec2 size, float default_w, float default_h)
     return size;
 }
 
-float ImGui::GetTextLineHeight()
+float ImGui::GetTextLineHeight() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return g.FontSize;
 }
 
-float ImGui::GetTextLineHeightWithSpacing()
+float ImGui::GetTextLineHeightWithSpacing() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return g.FontSize + g.Style.ItemSpacing.y;
 }
 
-float ImGui::GetFrameHeight()
+float ImGui::GetFrameHeight() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return g.FontSize + g.Style.FramePadding.y * 2.0f;
 }
 
-float ImGui::GetFrameHeightWithSpacing()
+float ImGui::GetFrameHeightWithSpacing() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return g.FontSize + g.Style.FramePadding.y * 2.0f + g.Style.ItemSpacing.y;
@@ -7667,7 +7667,7 @@ float ImGui::GetFrameHeightWithSpacing()
 // FIXME: All the Contents Region function are messy or misleading. WE WILL AIM TO OBSOLETE ALL OF THEM WITH A NEW "WORK RECT" API. Thanks for your patience!
 
 // FIXME: This is in window space (not screen space!).
-ImVec2 ImGui::GetContentRegionMax()
+ImVec2 ImGui::GetContentRegionMax() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7678,7 +7678,7 @@ ImVec2 ImGui::GetContentRegionMax()
 }
 
 // [Internal] Absolute coordinate. Saner. This is not exposed until we finishing refactoring work rect features.
-ImVec2 ImGui::GetContentRegionMaxAbs()
+ImVec2 ImGui::GetContentRegionMaxAbs() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7688,26 +7688,26 @@ ImVec2 ImGui::GetContentRegionMaxAbs()
     return mx;
 }
 
-ImVec2 ImGui::GetContentRegionAvail()
+ImVec2 ImGui::GetContentRegionAvail() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     return GetContentRegionMaxAbs() - window->DC.CursorPos;
 }
 
 // In window space (not screen space!)
-ImVec2 ImGui::GetWindowContentRegionMin()
+ImVec2 ImGui::GetWindowContentRegionMin() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     return window->ContentRegionRect.Min - window->Pos;
 }
 
-ImVec2 ImGui::GetWindowContentRegionMax()
+ImVec2 ImGui::GetWindowContentRegionMax() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     return window->ContentRegionRect.Max - window->Pos;
 }
 
-float ImGui::GetWindowContentRegionWidth()
+float ImGui::GetWindowContentRegionWidth() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     return window->ContentRegionRect.GetWidth();
@@ -7811,7 +7811,7 @@ void ImGui::EndGroup() IMGUI_NOEXCEPT
 // So the difference between WindowPadding and ItemSpacing will be in the visible area after scrolling.
 // When we refactor the scrolling API this may be configurable with a flag?
 // Note that the effect for this won't be visible on X axis with default Style settings as WindowPadding.x == ItemSpacing.x by default.
-static float CalcScrollEdgeSnap(float target, float snap_min, float snap_max, float snap_threshold, float center_ratio)
+static float CalcScrollEdgeSnap(float target, float snap_min, float snap_max, float snap_threshold, float center_ratio) IMGUI_NOEXCEPT
 {
     if (target <= snap_min + snap_threshold)
         return ImLerp(snap_min, target, center_ratio);
@@ -7820,7 +7820,7 @@ static float CalcScrollEdgeSnap(float target, float snap_min, float snap_max, fl
     return target;
 }
 
-static ImVec2 CalcNextScrollFromScrollTargetAndClamp(ImGuiWindow* window)
+static ImVec2 CalcNextScrollFromScrollTargetAndClamp(ImGuiWindow* window) IMGUI_NOEXCEPT
 {
     ImVec2 scroll = window->Scroll;
     if (window->ScrollTarget.x < FLT_MAX)
@@ -7860,7 +7860,7 @@ static ImVec2 CalcNextScrollFromScrollTargetAndClamp(ImGuiWindow* window)
 }
 
 // Scroll to keep newly navigated item fully into view
-ImVec2 ImGui::ScrollToBringRectIntoView(ImGuiWindow* window, const ImRect& item_rect)
+ImVec2 ImGui::ScrollToBringRectIntoView(ImGuiWindow* window, const ImRect& item_rect) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImRect window_rect(window->InnerRect.Min - ImVec2(1, 1), window->InnerRect.Max + ImVec2(1, 1));
@@ -7889,51 +7889,51 @@ ImVec2 ImGui::ScrollToBringRectIntoView(ImGuiWindow* window, const ImRect& item_
     return delta_scroll;
 }
 
-float ImGui::GetScrollX()
+float ImGui::GetScrollX() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     return window->Scroll.x;
 }
 
-float ImGui::GetScrollY()
+float ImGui::GetScrollY() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     return window->Scroll.y;
 }
 
-float ImGui::GetScrollMaxX()
+float ImGui::GetScrollMaxX() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     return window->ScrollMax.x;
 }
 
-float ImGui::GetScrollMaxY()
+float ImGui::GetScrollMaxY() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     return window->ScrollMax.y;
 }
 
-void ImGui::SetScrollX(ImGuiWindow* window, float scroll_x)
+void ImGui::SetScrollX(ImGuiWindow* window, float scroll_x) IMGUI_NOEXCEPT
 {
     window->ScrollTarget.x = scroll_x;
     window->ScrollTargetCenterRatio.x = 0.0f;
     window->ScrollTargetEdgeSnapDist.x = 0.0f;
 }
 
-void ImGui::SetScrollY(ImGuiWindow* window, float scroll_y)
+void ImGui::SetScrollY(ImGuiWindow* window, float scroll_y) IMGUI_NOEXCEPT
 {
     window->ScrollTarget.y = scroll_y;
     window->ScrollTargetCenterRatio.y = 0.0f;
     window->ScrollTargetEdgeSnapDist.y = 0.0f;
 }
 
-void ImGui::SetScrollX(float scroll_x)
+void ImGui::SetScrollX(float scroll_x) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     SetScrollX(g.CurrentWindow, scroll_x);
 }
 
-void ImGui::SetScrollY(float scroll_y)
+void ImGui::SetScrollY(float scroll_y) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     SetScrollY(g.CurrentWindow, scroll_y);
@@ -7949,7 +7949,7 @@ void ImGui::SetScrollY(float scroll_y)
 //  - SetScrollFromPosY(0.0f) == SetScrollY(0.0f + scroll.y) == has no effect!
 //  - SetScrollFromPosY(-scroll.y) == SetScrollY(-scroll.y + scroll.y) == SetScrollY(0.0f) == reset scroll. Of course writing SetScrollY(0.0f) directly then makes more sense
 // We store a target position so centering and clamping can occur on the next frame when we are guaranteed to have a known window size
-void ImGui::SetScrollFromPosX(ImGuiWindow* window, float local_x, float center_x_ratio)
+void ImGui::SetScrollFromPosX(ImGuiWindow* window, float local_x, float center_x_ratio) IMGUI_NOEXCEPT
 {
     IM_ASSERT(center_x_ratio >= 0.0f && center_x_ratio <= 1.0f);
     window->ScrollTarget.x = IM_FLOOR(local_x + window->Scroll.x); // Convert local position to scroll offset
@@ -7957,7 +7957,7 @@ void ImGui::SetScrollFromPosX(ImGuiWindow* window, float local_x, float center_x
     window->ScrollTargetEdgeSnapDist.x = 0.0f;
 }
 
-void ImGui::SetScrollFromPosY(ImGuiWindow* window, float local_y, float center_y_ratio)
+void ImGui::SetScrollFromPosY(ImGuiWindow* window, float local_y, float center_y_ratio) IMGUI_NOEXCEPT
 {
     IM_ASSERT(center_y_ratio >= 0.0f && center_y_ratio <= 1.0f);
     const float decoration_up_height = window->TitleBarHeight() + window->MenuBarHeight(); // FIXME: Would be nice to have a more standardized access to our scrollable/client rect;
@@ -7967,20 +7967,20 @@ void ImGui::SetScrollFromPosY(ImGuiWindow* window, float local_y, float center_y
     window->ScrollTargetEdgeSnapDist.y = 0.0f;
 }
 
-void ImGui::SetScrollFromPosX(float local_x, float center_x_ratio)
+void ImGui::SetScrollFromPosX(float local_x, float center_x_ratio) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     SetScrollFromPosX(g.CurrentWindow, local_x, center_x_ratio);
 }
 
-void ImGui::SetScrollFromPosY(float local_y, float center_y_ratio)
+void ImGui::SetScrollFromPosY(float local_y, float center_y_ratio) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     SetScrollFromPosY(g.CurrentWindow, local_y, center_y_ratio);
 }
 
 // center_x_ratio: 0.0f left of last item, 0.5f horizontal center of last item, 1.0f right of last item.
-void ImGui::SetScrollHereX(float center_x_ratio)
+void ImGui::SetScrollHereX(float center_x_ratio) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7993,7 +7993,7 @@ void ImGui::SetScrollHereX(float center_x_ratio)
 }
 
 // center_y_ratio: 0.0f top of last item, 0.5f vertical center of last item, 1.0f bottom of last item.
-void ImGui::SetScrollHereY(float center_y_ratio)
+void ImGui::SetScrollHereY(float center_y_ratio) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -8014,7 +8014,7 @@ void ImGui::BeginTooltip() IMGUI_NOEXCEPT
     BeginTooltipEx(ImGuiWindowFlags_None, ImGuiTooltipFlags_None);
 }
 
-void ImGui::BeginTooltipEx(ImGuiWindowFlags extra_flags, ImGuiTooltipFlags tooltip_flags)
+void ImGui::BeginTooltipEx(ImGuiWindowFlags extra_flags, ImGuiTooltipFlags tooltip_flags) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -8052,14 +8052,14 @@ void ImGui::EndTooltip() IMGUI_NOEXCEPT
     End();
 }
 
-void ImGui::SetTooltipV(const char* fmt, va_list args)
+void ImGui::SetTooltipV(const char* fmt, va_list args) IMGUI_NOEXCEPT
 {
     BeginTooltipEx(0, ImGuiTooltipFlags_OverridePreviousTooltip);
     TextV(fmt, args);
     EndTooltip();
 }
 
-void ImGui::SetTooltip(const char* fmt, ...)
+void ImGui::SetTooltip(const char* fmt, ...) IMGUI_NOEXCEPT
 {
     va_list args;
     va_start(args, fmt);
@@ -8072,7 +8072,7 @@ void ImGui::SetTooltip(const char* fmt, ...)
 //-----------------------------------------------------------------------------
 
 // Supported flags: ImGuiPopupFlags_AnyPopupId, ImGuiPopupFlags_AnyPopupLevel
-bool ImGui::IsPopupOpen(ImGuiID id, ImGuiPopupFlags popup_flags)
+bool ImGui::IsPopupOpen(ImGuiID id, ImGuiPopupFlags popup_flags) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (popup_flags & ImGuiPopupFlags_AnyPopupId)
@@ -8103,7 +8103,7 @@ bool ImGui::IsPopupOpen(ImGuiID id, ImGuiPopupFlags popup_flags)
     }
 }
 
-bool ImGui::IsPopupOpen(const char* str_id, ImGuiPopupFlags popup_flags)
+bool ImGui::IsPopupOpen(const char* str_id, ImGuiPopupFlags popup_flags) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiID id = (popup_flags & ImGuiPopupFlags_AnyPopupId) ? 0 : g.CurrentWindow->GetID(str_id);
@@ -8112,7 +8112,7 @@ bool ImGui::IsPopupOpen(const char* str_id, ImGuiPopupFlags popup_flags)
     return IsPopupOpen(id, popup_flags);
 }
 
-ImGuiWindow* ImGui::GetTopMostPopupModal()
+ImGuiWindow* ImGui::GetTopMostPopupModal() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     for (int n = g.OpenPopupStack.Size - 1; n >= 0; n--)
@@ -8122,13 +8122,13 @@ ImGuiWindow* ImGui::GetTopMostPopupModal()
     return NULL;
 }
 
-void ImGui::OpenPopup(const char* str_id, ImGuiPopupFlags popup_flags)
+void ImGui::OpenPopup(const char* str_id, ImGuiPopupFlags popup_flags) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     OpenPopupEx(g.CurrentWindow->GetID(str_id), popup_flags);
 }
 
-void ImGui::OpenPopup(ImGuiID id, ImGuiPopupFlags popup_flags)
+void ImGui::OpenPopup(ImGuiID id, ImGuiPopupFlags popup_flags) IMGUI_NOEXCEPT
 {
     OpenPopupEx(id, popup_flags);
 }
@@ -8137,7 +8137,7 @@ void ImGui::OpenPopup(ImGuiID id, ImGuiPopupFlags popup_flags)
 // Popups are closed when user click outside, or activate a pressable item, or CloseCurrentPopup() is called within a BeginPopup()/EndPopup() block.
 // Popup identifiers are relative to the current ID-stack (so OpenPopup and BeginPopup needs to be at the same level).
 // One open popup per level of the popup hierarchy (NB: when assigning we reset the Window member of ImGuiPopupRef to NULL)
-void ImGui::OpenPopupEx(ImGuiID id, ImGuiPopupFlags popup_flags)
+void ImGui::OpenPopupEx(ImGuiID id, ImGuiPopupFlags popup_flags) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* parent_window = g.CurrentWindow;
@@ -8186,7 +8186,7 @@ void ImGui::OpenPopupEx(ImGuiID id, ImGuiPopupFlags popup_flags)
 
 // When popups are stacked, clicking on a lower level popups puts focus back to it and close popups above it.
 // This function closes any popups that are over 'ref_window'.
-void ImGui::ClosePopupsOverWindow(ImGuiWindow* ref_window, bool restore_focus_to_window_under_popup)
+void ImGui::ClosePopupsOverWindow(ImGuiWindow* ref_window, bool restore_focus_to_window_under_popup) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.OpenPopupStack.Size == 0)
@@ -8230,7 +8230,7 @@ void ImGui::ClosePopupsOverWindow(ImGuiWindow* ref_window, bool restore_focus_to
     }
 }
 
-void ImGui::ClosePopupToLevel(int remaining, bool restore_focus_to_window_under_popup)
+void ImGui::ClosePopupToLevel(int remaining, bool restore_focus_to_window_under_popup) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IMGUI_DEBUG_LOG_POPUP("ClosePopupToLevel(%d), restore_focus_to_window_under_popup=%d\n", remaining, restore_focus_to_window_under_popup);
@@ -8258,7 +8258,7 @@ void ImGui::ClosePopupToLevel(int remaining, bool restore_focus_to_window_under_
 }
 
 // Close the popup we have begin-ed into.
-void ImGui::CloseCurrentPopup()
+void ImGui::CloseCurrentPopup() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     int popup_idx = g.BeginPopupStack.Size - 1;
@@ -8289,7 +8289,7 @@ void ImGui::CloseCurrentPopup()
 }
 
 // Attention! BeginPopup() adds default flags which BeginPopupEx()!
-bool ImGui::BeginPopupEx(ImGuiID id, ImGuiWindowFlags flags)
+bool ImGui::BeginPopupEx(ImGuiID id, ImGuiWindowFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (!IsPopupOpen(id, ImGuiPopupFlags_None))
@@ -8379,7 +8379,7 @@ void ImGui::EndPopup() IMGUI_NOEXCEPT
 
 // Helper to open a popup if mouse button is released over the item
 // - This is essentially the same as BeginPopupContextItem() but without the trailing BeginPopup()
-void ImGui::OpenPopupOnItemClick(const char* str_id, ImGuiPopupFlags popup_flags)
+void ImGui::OpenPopupOnItemClick(const char* str_id, ImGuiPopupFlags popup_flags) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     int mouse_button = (popup_flags & ImGuiPopupFlags_MouseButtonMask_);
@@ -8451,7 +8451,7 @@ bool ImGui::BeginPopupContextVoid(const char* str_id, ImGuiPopupFlags popup_flag
 // (r_outer is usually equivalent to the viewport rectangle minus padding, but when multi-viewports are enabled and monitor
 //  information are available, it may represent the entire platform monitor from the frame of reference of the current viewport.
 //  this allows us to have tooltips/popups displayed out of the parent viewport.)
-ImVec2 ImGui::FindBestWindowPosForPopupEx(const ImVec2& ref_pos, const ImVec2& size, ImGuiDir* last_dir, const ImRect& r_outer, const ImRect& r_avoid, ImGuiPopupPositionPolicy policy)
+ImVec2 ImGui::FindBestWindowPosForPopupEx(const ImVec2& ref_pos, const ImVec2& size, ImGuiDir* last_dir, const ImRect& r_outer, const ImRect& r_avoid, ImGuiPopupPositionPolicy policy) IMGUI_NOEXCEPT
 {
     ImVec2 base_pos_clamped = ImClamp(ref_pos, r_outer.Min, r_outer.Max - size);
     //GetForegroundDrawList()->AddRect(r_avoid.Min, r_avoid.Max, IM_COL32(255,0,0,255));
@@ -8526,7 +8526,7 @@ ImVec2 ImGui::FindBestWindowPosForPopupEx(const ImVec2& ref_pos, const ImVec2& s
 }
 
 // Note that this is used for popups, which can overlap the non work-area of individual viewports.
-ImRect ImGui::GetWindowAllowedExtentRect(ImGuiWindow* window)
+ImRect ImGui::GetWindowAllowedExtentRect(ImGuiWindow* window) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_UNUSED(window);
@@ -8536,7 +8536,7 @@ ImRect ImGui::GetWindowAllowedExtentRect(ImGuiWindow* window)
     return r_screen;
 }
 
-ImVec2 ImGui::FindBestWindowPosForPopup(ImGuiWindow* window)
+ImVec2 ImGui::FindBestWindowPosForPopup(ImGuiWindow* window) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -8581,7 +8581,7 @@ ImVec2 ImGui::FindBestWindowPosForPopup(ImGuiWindow* window)
 //-----------------------------------------------------------------------------
 
 // FIXME-NAV: The existence of SetNavID vs SetFocusID properly needs to be clarified/reworked.
-void ImGui::SetNavID(ImGuiID id, ImGuiNavLayer nav_layer, ImGuiID focus_scope_id, const ImRect& rect_rel)
+void ImGui::SetNavID(ImGuiID id, ImGuiNavLayer nav_layer, ImGuiID focus_scope_id, const ImRect& rect_rel) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(g.NavWindow != NULL);
@@ -8595,7 +8595,7 @@ void ImGui::SetNavID(ImGuiID id, ImGuiNavLayer nav_layer, ImGuiID focus_scope_id
     //g.NavDisableMouseHover = g.NavMousePosDirty = true;
 }
 
-void ImGui::SetFocusID(ImGuiID id, ImGuiWindow* window)
+void ImGui::SetFocusID(ImGuiID id, ImGuiWindow* window) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(id != 0);
@@ -8619,14 +8619,14 @@ void ImGui::SetFocusID(ImGuiID id, ImGuiWindow* window)
         g.NavDisableHighlight = true;
 }
 
-ImGuiDir ImGetDirQuadrantFromDelta(float dx, float dy)
+ImGuiDir ImGetDirQuadrantFromDelta(float dx, float dy) IMGUI_NOEXCEPT
 {
     if (ImFabs(dx) > ImFabs(dy))
         return (dx > 0.0f) ? ImGuiDir_Right : ImGuiDir_Left;
     return (dy > 0.0f) ? ImGuiDir_Down : ImGuiDir_Up;
 }
 
-static float inline NavScoreItemDistInterval(float a0, float a1, float b0, float b1)
+static float inline NavScoreItemDistInterval(float a0, float a1, float b0, float b1) IMGUI_NOEXCEPT
 {
     if (a1 < b0)
         return a1 - b0;
@@ -8635,7 +8635,7 @@ static float inline NavScoreItemDistInterval(float a0, float a1, float b0, float
     return 0.0f;
 }
 
-static void inline NavClampRectToVisibleAreaForMoveDir(ImGuiDir move_dir, ImRect& r, const ImRect& clip_rect)
+static void inline NavClampRectToVisibleAreaForMoveDir(ImGuiDir move_dir, ImRect& r, const ImRect& clip_rect) IMGUI_NOEXCEPT
 {
     if (move_dir == ImGuiDir_Left || move_dir == ImGuiDir_Right)
     {
@@ -8650,7 +8650,7 @@ static void inline NavClampRectToVisibleAreaForMoveDir(ImGuiDir move_dir, ImRect
 }
 
 // Scoring function for gamepad/keyboard directional navigation. Based on https://gist.github.com/rygorous/6981057
-static bool ImGui::NavScoreItem(ImGuiNavItemData* result, ImRect cand)
+static bool ImGui::NavScoreItem(ImGuiNavItemData* result, ImRect cand) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -8781,7 +8781,7 @@ static bool ImGui::NavScoreItem(ImGuiNavItemData* result, ImRect cand)
     return new_best;
 }
 
-static void ImGui::NavApplyItemToResult(ImGuiNavItemData* result, ImGuiWindow* window, ImGuiID id, const ImRect& nav_bb_rel)
+static void ImGui::NavApplyItemToResult(ImGuiNavItemData* result, ImGuiWindow* window, ImGuiID id, const ImRect& nav_bb_rel) IMGUI_NOEXCEPT
 {
     result->Window = window;
     result->ID = id;
@@ -8790,7 +8790,7 @@ static void ImGui::NavApplyItemToResult(ImGuiNavItemData* result, ImGuiWindow* w
 }
 
 // We get there when either NavId == id, or when g.NavAnyRequest is set (which is updated by NavUpdateAnyRequestFlag above)
-static void ImGui::NavProcessItem(ImGuiWindow* window, const ImRect& nav_bb, const ImGuiID id)
+static void ImGui::NavProcessItem(ImGuiWindow* window, const ImRect& nav_bb, const ImGuiID id) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     //if (!g.IO.NavActive)  // [2017/10/06] Removed this possibly redundant test but I am not sure of all the side-effects yet. Some of the feature here will need to work regardless of using a _NoNavInputs flag.
@@ -8850,20 +8850,20 @@ static void ImGui::NavProcessItem(ImGuiWindow* window, const ImRect& nav_bb, con
     }
 }
 
-bool ImGui::NavMoveRequestButNoResultYet()
+bool ImGui::NavMoveRequestButNoResultYet() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return g.NavMoveRequest && g.NavMoveResultLocal.ID == 0 && g.NavMoveResultOther.ID == 0;
 }
 
-void ImGui::NavMoveRequestCancel()
+void ImGui::NavMoveRequestCancel() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.NavMoveRequest = false;
     NavUpdateAnyRequestFlag();
 }
 
-void ImGui::NavMoveRequestForward(ImGuiDir move_dir, ImGuiDir clip_dir, const ImRect& bb_rel, ImGuiNavMoveFlags move_flags)
+void ImGui::NavMoveRequestForward(ImGuiDir move_dir, ImGuiDir clip_dir, const ImRect& bb_rel, ImGuiNavMoveFlags move_flags) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(g.NavMoveRequestForward == ImGuiNavForward_None);
@@ -8875,7 +8875,7 @@ void ImGui::NavMoveRequestForward(ImGuiDir move_dir, ImGuiDir clip_dir, const Im
     g.NavWindow->NavRectRel[g.NavLayer] = bb_rel;
 }
 
-void ImGui::NavMoveRequestTryWrapping(ImGuiWindow* window, ImGuiNavMoveFlags move_flags)
+void ImGui::NavMoveRequestTryWrapping(ImGuiWindow* window, ImGuiNavMoveFlags move_flags) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -8887,7 +8887,7 @@ void ImGui::NavMoveRequestTryWrapping(ImGuiWindow* window, ImGuiNavMoveFlags mov
 
 // FIXME: This could be replaced by updating a frame number in each window when (window == NavWindow) and (NavLayer == 0).
 // This way we could find the last focused window among our children. It would be much less confusing this way?
-static void ImGui::NavSaveLastChildNavWindowIntoParent(ImGuiWindow* nav_window)
+static void ImGui::NavSaveLastChildNavWindowIntoParent(ImGuiWindow* nav_window) IMGUI_NOEXCEPT
 {
     ImGuiWindow* parent = nav_window;
     while (parent && parent->RootWindow != parent && (parent->Flags & (ImGuiWindowFlags_Popup | ImGuiWindowFlags_ChildMenu)) == 0)
@@ -8898,14 +8898,14 @@ static void ImGui::NavSaveLastChildNavWindowIntoParent(ImGuiWindow* nav_window)
 
 // Restore the last focused child.
 // Call when we are expected to land on the Main Layer (0) after FocusWindow()
-static ImGuiWindow* ImGui::NavRestoreLastChildNavWindow(ImGuiWindow* window)
+static ImGuiWindow* ImGui::NavRestoreLastChildNavWindow(ImGuiWindow* window) IMGUI_NOEXCEPT
 {
     if (window->NavLastChildNavWindow && window->NavLastChildNavWindow->WasActive)
         return window->NavLastChildNavWindow;
     return window;
 }
 
-void ImGui::NavRestoreLayer(ImGuiNavLayer layer)
+void ImGui::NavRestoreLayer(ImGuiNavLayer layer) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (layer == ImGuiNavLayer_Main)
@@ -8924,7 +8924,7 @@ void ImGui::NavRestoreLayer(ImGuiNavLayer layer)
     }
 }
 
-static inline void ImGui::NavUpdateAnyRequestFlag()
+static inline void ImGui::NavUpdateAnyRequestFlag() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.NavAnyRequest = g.NavMoveRequest || g.NavInitRequest || (IMGUI_DEBUG_NAV_SCORING && g.NavWindow != NULL);
@@ -8933,7 +8933,7 @@ static inline void ImGui::NavUpdateAnyRequestFlag()
 }
 
 // This needs to be called before we submit any widget (aka in or before Begin)
-void ImGui::NavInitWindow(ImGuiWindow* window, bool force_reinit)
+void ImGui::NavInitWindow(ImGuiWindow* window, bool force_reinit) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(window == g.NavWindow);
@@ -8964,7 +8964,7 @@ void ImGui::NavInitWindow(ImGuiWindow* window, bool force_reinit)
     }
 }
 
-static ImVec2 ImGui::NavCalcPreferredRefPos()
+static ImVec2 ImGui::NavCalcPreferredRefPos() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.NavDisableHighlight || !g.NavDisableMouseHover || !g.NavWindow)
@@ -8984,7 +8984,7 @@ static ImVec2 ImGui::NavCalcPreferredRefPos()
     }
 }
 
-float ImGui::GetNavInputAmount(ImGuiNavInput n, ImGuiInputReadMode mode)
+float ImGui::GetNavInputAmount(ImGuiNavInput n, ImGuiInputReadMode mode) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (mode == ImGuiInputReadMode_Down)
@@ -9006,7 +9006,7 @@ float ImGui::GetNavInputAmount(ImGuiNavInput n, ImGuiInputReadMode mode)
     return 0.0f;
 }
 
-ImVec2 ImGui::GetNavInputAmount2d(ImGuiNavDirSourceFlags dir_sources, ImGuiInputReadMode mode, float slow_factor, float fast_factor)
+ImVec2 ImGui::GetNavInputAmount2d(ImGuiNavDirSourceFlags dir_sources, ImGuiInputReadMode mode, float slow_factor, float fast_factor) IMGUI_NOEXCEPT
 {
     ImVec2 delta(0.0f, 0.0f);
     if (dir_sources & ImGuiNavDirSourceFlags_Keyboard)
@@ -9022,7 +9022,7 @@ ImVec2 ImGui::GetNavInputAmount2d(ImGuiNavDirSourceFlags dir_sources, ImGuiInput
     return delta;
 }
 
-static void ImGui::NavUpdate()
+static void ImGui::NavUpdate() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiIO& io = g.IO;
@@ -9303,7 +9303,7 @@ static void ImGui::NavUpdate()
 #endif
 }
 
-static void ImGui::NavUpdateInitResult()
+static void ImGui::NavUpdateInitResult() IMGUI_NOEXCEPT
 {
     // In very rare cases g.NavWindow may be null (e.g. clearing focus after requesting an init request, which does happen when releasing Alt while clicking on void)
     ImGuiContext& g = *GImGui;
@@ -9322,7 +9322,7 @@ static void ImGui::NavUpdateInitResult()
 }
 
 // Apply result from previous frame navigation directional move request
-static void ImGui::NavUpdateMoveResult()
+static void ImGui::NavUpdateMoveResult() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.NavMoveResultLocal.ID == 0 && g.NavMoveResultOther.ID == 0)
@@ -9387,7 +9387,7 @@ static void ImGui::NavUpdateMoveResult()
 }
 
 // Handle PageUp/PageDown/Home/End keys
-static float ImGui::NavUpdatePageUpPageDown()
+static float ImGui::NavUpdatePageUpPageDown() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiIO& io = g.IO;
@@ -9460,7 +9460,7 @@ static float ImGui::NavUpdatePageUpPageDown()
     return 0.0f;
 }
 
-static void ImGui::NavEndFrame()
+static void ImGui::NavEndFrame() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -9522,7 +9522,7 @@ static void ImGui::NavEndFrame()
     }
 }
 
-static int ImGui::FindWindowFocusIndex(ImGuiWindow* window)
+static int ImGui::FindWindowFocusIndex(ImGuiWindow* window) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_UNUSED(g);
@@ -9531,7 +9531,7 @@ static int ImGui::FindWindowFocusIndex(ImGuiWindow* window)
     return order;
 }
 
-static ImGuiWindow* FindWindowNavFocusable(int i_start, int i_stop, int dir) // FIXME-OPT O(N)
+static ImGuiWindow* FindWindowNavFocusable(int i_start, int i_stop, int dir)  IMGUI_NOEXCEPT  // FIXME-OPT O(N)
 {
     ImGuiContext& g = *GImGui;
     for (int i = i_start; i >= 0 && i < g.WindowsFocusOrder.Size && i != i_stop; i += dir)
@@ -9540,7 +9540,7 @@ static ImGuiWindow* FindWindowNavFocusable(int i_start, int i_stop, int dir) // 
     return NULL;
 }
 
-static void NavUpdateWindowingHighlightWindow(int focus_change_dir)
+static void NavUpdateWindowingHighlightWindow(int focus_change_dir) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(g.NavWindowingTarget);
@@ -9559,7 +9559,7 @@ static void NavUpdateWindowingHighlightWindow(int focus_change_dir)
 // Windowing management mode
 // Keyboard: CTRL+Tab (change focus/move/resize), Alt (toggle menu layer)
 // Gamepad:  Hold Menu/Square (change focus/move/resize), Tap Menu/Square (toggle menu layer)
-static void ImGui::NavUpdateWindowing()
+static void ImGui::NavUpdateWindowing() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* apply_focus_window = NULL;
@@ -9705,7 +9705,7 @@ static void ImGui::NavUpdateWindowing()
 }
 
 // Window has already passed the IsWindowNavFocusable()
-static const char* GetFallbackWindowNameForWindowingList(ImGuiWindow* window)
+static const char* GetFallbackWindowNameForWindowingList(ImGuiWindow* window) IMGUI_NOEXCEPT
 {
     if (window->Flags & ImGuiWindowFlags_Popup)
         return "(Popup)";
@@ -9715,7 +9715,7 @@ static const char* GetFallbackWindowNameForWindowingList(ImGuiWindow* window)
 }
 
 // Overlay displayed when using CTRL+TAB. Called by EndFrame().
-void ImGui::NavUpdateWindowingOverlay()
+void ImGui::NavUpdateWindowingOverlay() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(g.NavWindowingTarget != NULL);
@@ -9750,7 +9750,7 @@ void ImGui::NavUpdateWindowingOverlay()
 // [SECTION] DRAG AND DROP
 //-----------------------------------------------------------------------------
 
-void ImGui::ClearDragDrop()
+void ImGui::ClearDragDrop() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.DragDropActive = false;
@@ -9901,7 +9901,7 @@ void ImGui::EndDragDropSource() IMGUI_NOEXCEPT
 }
 
 // Use 'cond' to choose to submit payload on drag start or every frame
-bool ImGui::SetDragDropPayload(const char* type, const void* data, size_t data_size, ImGuiCond cond)
+bool ImGui::SetDragDropPayload(const char* type, const void* data, size_t data_size, ImGuiCond cond) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiPayload& payload = g.DragDropPayload;
@@ -9944,7 +9944,7 @@ bool ImGui::SetDragDropPayload(const char* type, const void* data, size_t data_s
     return (g.DragDropAcceptFrameCount == g.FrameCount) || (g.DragDropAcceptFrameCount == g.FrameCount - 1);
 }
 
-bool ImGui::BeginDragDropTargetCustom(const ImRect& bb, ImGuiID id)
+bool ImGui::BeginDragDropTargetCustom(const ImRect& bb, ImGuiID id) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (!g.DragDropActive)
@@ -9998,13 +9998,13 @@ bool ImGui::BeginDragDropTarget() IMGUI_NOEXCEPT
     return true;
 }
 
-bool ImGui::IsDragDropPayloadBeingAccepted()
+bool ImGui::IsDragDropPayloadBeingAccepted() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return g.DragDropActive && g.DragDropAcceptIdPrev != 0;
 }
 
-const ImGuiPayload* ImGui::AcceptDragDropPayload(const char* type, ImGuiDragDropFlags flags)
+const ImGuiPayload* ImGui::AcceptDragDropPayload(const char* type, ImGuiDragDropFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -10047,7 +10047,7 @@ const ImGuiPayload* ImGui::AcceptDragDropPayload(const char* type, ImGuiDragDrop
     return &payload;
 }
 
-const ImGuiPayload* ImGui::GetDragDropPayload()
+const ImGuiPayload* ImGui::GetDragDropPayload() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return g.DragDropActive ? &g.DragDropPayload : NULL;
@@ -10070,7 +10070,7 @@ void ImGui::EndDragDropTarget() IMGUI_NOEXCEPT
 //-----------------------------------------------------------------------------
 
 // Pass text data straight to log (without being displayed)
-static inline void LogTextV(ImGuiContext& g, const char* fmt, va_list args)
+static inline void LogTextV(ImGuiContext& g, const char* fmt, va_list args) IMGUI_NOEXCEPT
 {
     if (g.LogFile)
     {
@@ -10084,7 +10084,7 @@ static inline void LogTextV(ImGuiContext& g, const char* fmt, va_list args)
     }
 }
 
-void ImGui::LogText(const char* fmt, ...)
+void ImGui::LogText(const char* fmt, ...) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (!g.LogEnabled)
@@ -10096,7 +10096,7 @@ void ImGui::LogText(const char* fmt, ...)
     va_end(args);
 }
 
-void ImGui::LogTextV(const char* fmt, va_list args)
+void ImGui::LogTextV(const char* fmt, va_list args) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (!g.LogEnabled)
@@ -10108,7 +10108,7 @@ void ImGui::LogTextV(const char* fmt, va_list args)
 // Internal version that takes a position to decide on newline placement and pad items according to their depth.
 // We split text into individual lines to add current tree level padding
 // FIXME: This code is a little complicated perhaps, considering simplifying the whole system.
-void ImGui::LogRenderedText(const ImVec2* ref_pos, const char* text, const char* text_end)
+void ImGui::LogRenderedText(const ImVec2* ref_pos, const char* text, const char* text_end) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -10167,7 +10167,7 @@ void ImGui::LogRenderedText(const ImVec2* ref_pos, const char* text, const char*
 }
 
 // Start logging/capturing text output
-void ImGui::LogBegin(ImGuiLogType type, int auto_open_depth)
+void ImGui::LogBegin(ImGuiLogType type, int auto_open_depth) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -10184,14 +10184,14 @@ void ImGui::LogBegin(ImGuiLogType type, int auto_open_depth)
 }
 
 // Important: doesn't copy underlying data, use carefully (prefix/suffix must be in scope at the time of the next LogRenderedText)
-void ImGui::LogSetNextTextDecoration(const char* prefix, const char* suffix)
+void ImGui::LogSetNextTextDecoration(const char* prefix, const char* suffix) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.LogNextPrefix = prefix;
     g.LogNextSuffix = suffix;
 }
 
-void ImGui::LogToTTY(int auto_open_depth)
+void ImGui::LogToTTY(int auto_open_depth) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.LogEnabled)
@@ -10204,7 +10204,7 @@ void ImGui::LogToTTY(int auto_open_depth)
 }
 
 // Start logging/capturing text output to given file
-void ImGui::LogToFile(int auto_open_depth, const char* filename)
+void ImGui::LogToFile(int auto_open_depth, const char* filename) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.LogEnabled)
@@ -10229,7 +10229,7 @@ void ImGui::LogToFile(int auto_open_depth, const char* filename)
 }
 
 // Start logging/capturing text output to clipboard
-void ImGui::LogToClipboard(int auto_open_depth)
+void ImGui::LogToClipboard(int auto_open_depth) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.LogEnabled)
@@ -10237,7 +10237,7 @@ void ImGui::LogToClipboard(int auto_open_depth)
     LogBegin(ImGuiLogType_Clipboard, auto_open_depth);
 }
 
-void ImGui::LogToBuffer(int auto_open_depth)
+void ImGui::LogToBuffer(int auto_open_depth) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.LogEnabled)
@@ -10245,7 +10245,7 @@ void ImGui::LogToBuffer(int auto_open_depth)
     LogBegin(ImGuiLogType_Buffer, auto_open_depth);
 }
 
-void ImGui::LogFinish()
+void ImGui::LogFinish() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (!g.LogEnabled)
@@ -10281,7 +10281,7 @@ void ImGui::LogFinish()
 
 // Helper to display logging buttons
 // FIXME-OBSOLETE: We should probably obsolete this and let the user have their own helper (this is one of the oldest function alive!)
-void ImGui::LogButtons()
+void ImGui::LogButtons() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -10327,7 +10327,7 @@ void ImGui::LogButtons()
 //-----------------------------------------------------------------------------
 
 // Called by NewFrame()
-void ImGui::UpdateSettings()
+void ImGui::UpdateSettings() IMGUI_NOEXCEPT
 {
     // Load settings on first frame (if not explicitly loaded manually before)
     ImGuiContext& g = *GImGui;
@@ -10354,14 +10354,14 @@ void ImGui::UpdateSettings()
     }
 }
 
-void ImGui::MarkIniSettingsDirty()
+void ImGui::MarkIniSettingsDirty() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.SettingsDirtyTimer <= 0.0f)
         g.SettingsDirtyTimer = g.IO.IniSavingRate;
 }
 
-void ImGui::MarkIniSettingsDirty(ImGuiWindow* window)
+void ImGui::MarkIniSettingsDirty(ImGuiWindow* window) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (!(window->Flags & ImGuiWindowFlags_NoSavedSettings))
@@ -10369,7 +10369,7 @@ void ImGui::MarkIniSettingsDirty(ImGuiWindow* window)
             g.SettingsDirtyTimer = g.IO.IniSavingRate;
 }
 
-ImGuiWindowSettings* ImGui::CreateNewWindowSettings(const char* name)
+ImGuiWindowSettings* ImGui::CreateNewWindowSettings(const char* name) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -10391,7 +10391,7 @@ ImGuiWindowSettings* ImGui::CreateNewWindowSettings(const char* name)
     return settings;
 }
 
-ImGuiWindowSettings* ImGui::FindWindowSettings(ImGuiID id)
+ImGuiWindowSettings* ImGui::FindWindowSettings(ImGuiID id) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     for (ImGuiWindowSettings* settings = g.SettingsWindows.begin(); settings != NULL; settings = g.SettingsWindows.next_chunk(settings))
@@ -10400,14 +10400,14 @@ ImGuiWindowSettings* ImGui::FindWindowSettings(ImGuiID id)
     return NULL;
 }
 
-ImGuiWindowSettings* ImGui::FindOrCreateWindowSettings(const char* name)
+ImGuiWindowSettings* ImGui::FindOrCreateWindowSettings(const char* name) IMGUI_NOEXCEPT
 {
     if (ImGuiWindowSettings* settings = FindWindowSettings(ImHashStr(name)))
         return settings;
     return CreateNewWindowSettings(name);
 }
 
-ImGuiSettingsHandler* ImGui::FindSettingsHandler(const char* type_name)
+ImGuiSettingsHandler* ImGui::FindSettingsHandler(const char* type_name) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     const ImGuiID type_hash = ImHashStr(type_name);
@@ -10417,7 +10417,7 @@ ImGuiSettingsHandler* ImGui::FindSettingsHandler(const char* type_name)
     return NULL;
 }
 
-void ImGui::ClearIniSettings()
+void ImGui::ClearIniSettings() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.SettingsIniData.clear();
@@ -10426,7 +10426,7 @@ void ImGui::ClearIniSettings()
             g.SettingsHandlers[handler_n].ClearAllFn(&g, &g.SettingsHandlers[handler_n]);
 }
 
-void ImGui::LoadIniSettingsFromDisk(const char* ini_filename)
+void ImGui::LoadIniSettingsFromDisk(const char* ini_filename) IMGUI_NOEXCEPT
 {
     size_t file_data_size = 0;
     char* file_data = (char*)ImFileLoadToMemory(ini_filename, "rb", &file_data_size);
@@ -10437,7 +10437,7 @@ void ImGui::LoadIniSettingsFromDisk(const char* ini_filename)
 }
 
 // Zero-tolerance, no error reporting, cheap .ini parsing
-void ImGui::LoadIniSettingsFromMemory(const char* ini_data, size_t ini_size)
+void ImGui::LoadIniSettingsFromMemory(const char* ini_data, size_t ini_size) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(g.Initialized);
@@ -10507,7 +10507,7 @@ void ImGui::LoadIniSettingsFromMemory(const char* ini_data, size_t ini_size)
             g.SettingsHandlers[handler_n].ApplyAllFn(&g, &g.SettingsHandlers[handler_n]);
 }
 
-void ImGui::SaveIniSettingsToDisk(const char* ini_filename)
+void ImGui::SaveIniSettingsToDisk(const char* ini_filename) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.SettingsDirtyTimer = 0.0f;
@@ -10524,7 +10524,7 @@ void ImGui::SaveIniSettingsToDisk(const char* ini_filename)
 }
 
 // Call registered handlers (e.g. SettingsHandlerWindow_WriteAll() + custom handlers) to write their stuff into a text buffer
-const char* ImGui::SaveIniSettingsToMemory(size_t* out_size)
+const char* ImGui::SaveIniSettingsToMemory(size_t* out_size) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.SettingsDirtyTimer = 0.0f;
@@ -10540,7 +10540,7 @@ const char* ImGui::SaveIniSettingsToMemory(size_t* out_size)
     return g.SettingsIniData.c_str();
 }
 
-static void WindowSettingsHandler_ClearAll(ImGuiContext* ctx, ImGuiSettingsHandler*)
+static void WindowSettingsHandler_ClearAll(ImGuiContext* ctx, ImGuiSettingsHandler*) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *ctx;
     for (int i = 0; i != g.Windows.Size; i++)
@@ -10548,7 +10548,7 @@ static void WindowSettingsHandler_ClearAll(ImGuiContext* ctx, ImGuiSettingsHandl
     g.SettingsWindows.clear();
 }
 
-static void* WindowSettingsHandler_ReadOpen(ImGuiContext*, ImGuiSettingsHandler*, const char* name)
+static void* WindowSettingsHandler_ReadOpen(ImGuiContext*, ImGuiSettingsHandler*, const char* name) IMGUI_NOEXCEPT
 {
     ImGuiWindowSettings* settings = ImGui::FindOrCreateWindowSettings(name);
     ImGuiID id = settings->ID;
@@ -10558,7 +10558,7 @@ static void* WindowSettingsHandler_ReadOpen(ImGuiContext*, ImGuiSettingsHandler*
     return (void*)settings;
 }
 
-static void WindowSettingsHandler_ReadLine(ImGuiContext*, ImGuiSettingsHandler*, void* entry, const char* line)
+static void WindowSettingsHandler_ReadLine(ImGuiContext*, ImGuiSettingsHandler*, void* entry, const char* line) IMGUI_NOEXCEPT
 {
     ImGuiWindowSettings* settings = (ImGuiWindowSettings*)entry;
     int x, y;
@@ -10569,7 +10569,7 @@ static void WindowSettingsHandler_ReadLine(ImGuiContext*, ImGuiSettingsHandler*,
 }
 
 // Apply to existing windows (if any)
-static void WindowSettingsHandler_ApplyAll(ImGuiContext* ctx, ImGuiSettingsHandler*)
+static void WindowSettingsHandler_ApplyAll(ImGuiContext* ctx, ImGuiSettingsHandler*) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *ctx;
     for (ImGuiWindowSettings* settings = g.SettingsWindows.begin(); settings != NULL; settings = g.SettingsWindows.next_chunk(settings))
@@ -10581,7 +10581,7 @@ static void WindowSettingsHandler_ApplyAll(ImGuiContext* ctx, ImGuiSettingsHandl
         }
 }
 
-static void WindowSettingsHandler_WriteAll(ImGuiContext* ctx, ImGuiSettingsHandler* handler, ImGuiTextBuffer* buf)
+static void WindowSettingsHandler_WriteAll(ImGuiContext* ctx, ImGuiSettingsHandler* handler, ImGuiTextBuffer* buf) IMGUI_NOEXCEPT
 {
     // Gather data from windows that were active during this session
     // (if a window wasn't opened in this session we preserve its settings)
@@ -10626,14 +10626,14 @@ static void WindowSettingsHandler_WriteAll(ImGuiContext* ctx, ImGuiSettingsHandl
 // (this section is more complete in the 'docking' branch)
 //-----------------------------------------------------------------------------
 
-ImGuiViewport* ImGui::GetMainViewport()
+ImGuiViewport* ImGui::GetMainViewport() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return g.Viewports[0];
 }
 
 // Update viewports and monitor infos
-static void ImGui::UpdateViewportsNewFrame()
+static void ImGui::UpdateViewportsNewFrame() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(g.Viewports.Size == 1);
@@ -10677,7 +10677,7 @@ static void ImGui::UpdateViewportsNewFrame()
 
 // Win32 clipboard implementation
 // We use g.ClipboardHandlerData for temporary storage to ensure it is freed on Shutdown()
-static const char* GetClipboardTextFn_DefaultImpl(void*)
+static const char* GetClipboardTextFn_DefaultImpl(void*) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.ClipboardHandlerData.clear();
@@ -10700,7 +10700,7 @@ static const char* GetClipboardTextFn_DefaultImpl(void*)
     return g.ClipboardHandlerData.Data;
 }
 
-static void SetClipboardTextFn_DefaultImpl(void*, const char* text)
+static void SetClipboardTextFn_DefaultImpl(void*, const char* text) IMGUI_NOEXCEPT
 {
     if (!::OpenClipboard(NULL))
         return;
@@ -10727,7 +10727,7 @@ static PasteboardRef main_clipboard = 0;
 
 // OSX clipboard implementation
 // If you enable this you will need to add '-framework ApplicationServices' to your linker command-line!
-static void SetClipboardTextFn_DefaultImpl(void*, const char* text)
+static void SetClipboardTextFn_DefaultImpl(void*, const char* text) IMGUI_NOEXCEPT
 {
     if (!main_clipboard)
         PasteboardCreate(kPasteboardClipboard, &main_clipboard);
@@ -10740,7 +10740,7 @@ static void SetClipboardTextFn_DefaultImpl(void*, const char* text)
     }
 }
 
-static const char* GetClipboardTextFn_DefaultImpl(void*)
+static const char* GetClipboardTextFn_DefaultImpl(void*) IMGUI_NOEXCEPT
 {
     if (!main_clipboard)
         PasteboardCreate(kPasteboardClipboard, &main_clipboard);
@@ -10776,13 +10776,13 @@ static const char* GetClipboardTextFn_DefaultImpl(void*)
 #else
 
 // Local Dear ImGui-only clipboard implementation, if user hasn't defined better clipboard handlers.
-static const char* GetClipboardTextFn_DefaultImpl(void*)
+static const char* GetClipboardTextFn_DefaultImpl(void*) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return g.ClipboardHandlerData.empty() ? NULL : g.ClipboardHandlerData.begin();
 }
 
-static void SetClipboardTextFn_DefaultImpl(void*, const char* text)
+static void SetClipboardTextFn_DefaultImpl(void*, const char* text) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.ClipboardHandlerData.clear();
@@ -10802,7 +10802,7 @@ static void SetClipboardTextFn_DefaultImpl(void*, const char* text)
 #pragma comment(lib, "imm32")
 #endif
 
-static void ImeSetInputScreenPosFn_DefaultImpl(int x, int y)
+static void ImeSetInputScreenPosFn_DefaultImpl(int x, int y) IMGUI_NOEXCEPT
 {
     // Notify OS Input Method Editor of text input position
     ImGuiIO& io = ImGui::GetIO();
@@ -10820,7 +10820,7 @@ static void ImeSetInputScreenPosFn_DefaultImpl(int x, int y)
 
 #else
 
-static void ImeSetInputScreenPosFn_DefaultImpl(int, int) {}
+static void ImeSetInputScreenPosFn_DefaultImpl(int, int) IMGUI_NOEXCEPT {}
 
 #endif
 
@@ -10844,7 +10844,7 @@ static void ImeSetInputScreenPosFn_DefaultImpl(int, int) {}
 
 #ifndef IMGUI_DISABLE_METRICS_WINDOW
 
-void ImGui::DebugRenderViewportThumbnail(ImDrawList* draw_list, ImGuiViewportP* viewport, const ImRect& bb)
+void ImGui::DebugRenderViewportThumbnail(ImDrawList* draw_list, ImGuiViewportP* viewport, const ImRect& bb) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -10874,7 +10874,7 @@ void ImGui::DebugRenderViewportThumbnail(ImDrawList* draw_list, ImGuiViewportP* 
     draw_list->AddRect(bb.Min, bb.Max, GetColorU32(ImGuiCol_Border, alpha_mul));
 }
 
-static void RenderViewportsThumbnails()
+static void RenderViewportsThumbnails() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -10896,7 +10896,7 @@ static void RenderViewportsThumbnails()
 }
 
 // Avoid naming collision with imgui_demo.cpp's HelpMarker() for unity builds.
-static void MetricsHelpMarker(const char* desc)
+static void MetricsHelpMarker(const char* desc) IMGUI_NOEXCEPT
 {
     ImGui::TextDisabled("(?)");
     if (ImGui::IsItemHovered())
@@ -10909,7 +10909,7 @@ static void MetricsHelpMarker(const char* desc)
     }
 }
 
-void ImGui::ShowMetricsWindow(bool* p_open)
+void ImGui::ShowMetricsWindow(bool* p_open) IMGUI_NOEXCEPT
 {
     if (!Begin("Dear ImGui Metrics/Debugger", p_open))
     {
@@ -11272,7 +11272,7 @@ void ImGui::ShowMetricsWindow(bool* p_open)
 }
 
 // [DEBUG] Display contents of Columns
-void ImGui::DebugNodeColumns(ImGuiOldColumns* columns)
+void ImGui::DebugNodeColumns(ImGuiOldColumns* columns) IMGUI_NOEXCEPT
 {
     if (!TreeNode((void*)(uintptr_t)columns->ID, "Columns Id: 0x%08X, Count: %d, Flags: 0x%04X", columns->ID, columns->Count, columns->Flags))
         return;
@@ -11283,7 +11283,7 @@ void ImGui::DebugNodeColumns(ImGuiOldColumns* columns)
 }
 
 // [DEBUG] Display contents of ImDrawList
-void ImGui::DebugNodeDrawList(ImGuiWindow* window, const ImDrawList* draw_list, const char* label)
+void ImGui::DebugNodeDrawList(ImGuiWindow* window, const ImDrawList* draw_list, const char* label) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiMetricsConfig* cfg = &g.DebugMetricsConfig;
@@ -11377,7 +11377,7 @@ void ImGui::DebugNodeDrawList(ImGuiWindow* window, const ImDrawList* draw_list, 
 }
 
 // [DEBUG] Display mesh/aabb of a ImDrawCmd
-void ImGui::DebugNodeDrawCmdShowMeshAndBoundingBox(ImDrawList* out_draw_list, const ImDrawList* draw_list, const ImDrawCmd* draw_cmd, bool show_mesh, bool show_aabb)
+void ImGui::DebugNodeDrawCmdShowMeshAndBoundingBox(ImDrawList* out_draw_list, const ImDrawList* draw_list, const ImDrawCmd* draw_cmd, bool show_mesh, bool show_aabb) IMGUI_NOEXCEPT
 {
     IM_ASSERT(show_mesh || show_aabb);
     ImDrawIdx* idx_buffer = (draw_list->IdxBuffer.Size > 0) ? draw_list->IdxBuffer.Data : NULL;
@@ -11406,7 +11406,7 @@ void ImGui::DebugNodeDrawCmdShowMeshAndBoundingBox(ImDrawList* out_draw_list, co
 }
 
 // [DEBUG] Display contents of ImGuiStorage
-void ImGui::DebugNodeStorage(ImGuiStorage* storage, const char* label)
+void ImGui::DebugNodeStorage(ImGuiStorage* storage, const char* label) IMGUI_NOEXCEPT
 {
     if (!TreeNode(label, "%s: %d entries, %d bytes", label, storage->Data.Size, storage->Data.size_in_bytes()))
         return;
@@ -11419,7 +11419,7 @@ void ImGui::DebugNodeStorage(ImGuiStorage* storage, const char* label)
 }
 
 // [DEBUG] Display contents of ImGuiTabBar
-void ImGui::DebugNodeTabBar(ImGuiTabBar* tab_bar, const char* label)
+void ImGui::DebugNodeTabBar(ImGuiTabBar* tab_bar, const char* label) IMGUI_NOEXCEPT
 {
     // Standalone tab bars (not associated to docking/windows functionality) currently hold no discernible strings.
     char buf[256];
@@ -11454,7 +11454,7 @@ void ImGui::DebugNodeTabBar(ImGuiTabBar* tab_bar, const char* label)
     }
 }
 
-void ImGui::DebugNodeViewport(ImGuiViewportP* viewport)
+void ImGui::DebugNodeViewport(ImGuiViewportP* viewport) IMGUI_NOEXCEPT
 {
     SetNextItemOpen(true, ImGuiCond_Once);
     if (TreeNode("viewport0", "Viewport #%d", 0))
@@ -11474,7 +11474,7 @@ void ImGui::DebugNodeViewport(ImGuiViewportP* viewport)
     }
 }
 
-void ImGui::DebugNodeWindow(ImGuiWindow* window, const char* label)
+void ImGui::DebugNodeWindow(ImGuiWindow* window, const char* label) IMGUI_NOEXCEPT
 {
     if (window == NULL)
     {
@@ -11532,13 +11532,13 @@ void ImGui::DebugNodeWindow(ImGuiWindow* window, const char* label)
     TreePop();
 }
 
-void ImGui::DebugNodeWindowSettings(ImGuiWindowSettings* settings)
+void ImGui::DebugNodeWindowSettings(ImGuiWindowSettings* settings) IMGUI_NOEXCEPT
 {
     Text("0x%08X \"%s\" Pos (%d,%d) Size (%d,%d) Collapsed=%d",
         settings->ID, settings->GetName(), settings->Pos.x, settings->Pos.y, settings->Size.x, settings->Size.y, settings->Collapsed);
 }
 
-void ImGui::DebugNodeWindowsList(ImVector<ImGuiWindow*>* windows, const char* label)
+void ImGui::DebugNodeWindowsList(ImVector<ImGuiWindow*>* windows, const char* label) IMGUI_NOEXCEPT
 {
     if (!TreeNode(label, "%s (%d)", label, windows->Size))
         return;
@@ -11554,16 +11554,16 @@ void ImGui::DebugNodeWindowsList(ImVector<ImGuiWindow*>* windows, const char* la
 
 #else
 
-void ImGui::ShowMetricsWindow(bool*) {}
-void ImGui::DebugNodeColumns(ImGuiOldColumns*) {}
-void ImGui::DebugNodeDrawList(ImGuiWindow*, const ImDrawList*, const char*) {}
-void ImGui::DebugNodeDrawCmdShowMeshAndBoundingBox(ImDrawList*, const ImDrawList*, const ImDrawCmd*, bool, bool) {}
-void ImGui::DebugNodeStorage(ImGuiStorage*, const char*) {}
-void ImGui::DebugNodeTabBar(ImGuiTabBar*, const char*) {}
-void ImGui::DebugNodeWindow(ImGuiWindow*, const char*) {}
-void ImGui::DebugNodeWindowSettings(ImGuiWindowSettings*) {}
-void ImGui::DebugNodeWindowsList(ImVector<ImGuiWindow*>*, const char*) {}
-void ImGui::DebugNodeViewport(ImGuiViewportP*) {}
+void ImGui::ShowMetricsWindow(bool*)                      IMGUI_NOEXCEPT {}
+void ImGui::DebugNodeColumns(ImGuiOldColumns*)            IMGUI_NOEXCEPT {}
+void ImGui::DebugNodeDrawList(ImGuiWindow*, const ImDrawList*, const char*) IMGUI_NOEXCEPT {}
+void ImGui::DebugNodeDrawCmdShowMeshAndBoundingBox(ImDrawList*, const ImDrawList*, const ImDrawCmd*, bool, bool) IMGUI_NOEXCEPT {}
+void ImGui::DebugNodeStorage(ImGuiStorage*, const char*)  IMGUI_NOEXCEPT {}
+void ImGui::DebugNodeTabBar(ImGuiTabBar*, const char*)    IMGUI_NOEXCEPT {}
+void ImGui::DebugNodeWindow(ImGuiWindow*, const char*)    IMGUI_NOEXCEPT {}
+void ImGui::DebugNodeWindowSettings(ImGuiWindowSettings*) IMGUI_NOEXCEPT {}
+void ImGui::DebugNodeWindowsList(ImVector<ImGuiWindow*>*, const char*) IMGUI_NOEXCEPT {}
+void ImGui::DebugNodeViewport(ImGuiViewportP*)            IMGUI_NOEXCEPT {}
 
 #endif
 

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -872,63 +872,63 @@ static const float WINDOWS_MOUSE_WHEEL_SCROLL_LOCK_TIMER    = 2.00f;    // Lock 
 // [SECTION] FORWARD DECLARATIONS
 //-------------------------------------------------------------------------
 
-static void             SetCurrentWindow(ImGuiWindow* window) IMGUI_NOEXCEPT;
-static void             FindHoveredWindow() IMGUI_NOEXCEPT;
-static ImGuiWindow*     CreateNewWindow(const char* name, ImGuiWindowFlags flags) IMGUI_NOEXCEPT;
-static ImVec2           CalcNextScrollFromScrollTargetAndClamp(ImGuiWindow* window) IMGUI_NOEXCEPT;
+static void             SetCurrentWindow(ImGuiWindow* window) IM_NOEXCEPT;
+static void             FindHoveredWindow() IM_NOEXCEPT;
+static ImGuiWindow*     CreateNewWindow(const char* name, ImGuiWindowFlags flags) IM_NOEXCEPT;
+static ImVec2           CalcNextScrollFromScrollTargetAndClamp(ImGuiWindow* window) IM_NOEXCEPT;
 
-static void             AddDrawListToDrawData(ImVector<ImDrawList*>* out_list, ImDrawList* draw_list) IMGUI_NOEXCEPT;
-static void             AddWindowToSortBuffer(ImVector<ImGuiWindow*>* out_sorted_windows, ImGuiWindow* window) IMGUI_NOEXCEPT;
+static void             AddDrawListToDrawData(ImVector<ImDrawList*>* out_list, ImDrawList* draw_list) IM_NOEXCEPT;
+static void             AddWindowToSortBuffer(ImVector<ImGuiWindow*>* out_sorted_windows, ImGuiWindow* window) IM_NOEXCEPT;
 
 // Settings
-static void             WindowSettingsHandler_ClearAll(ImGuiContext*, ImGuiSettingsHandler*) IMGUI_NOEXCEPT;
-static void*            WindowSettingsHandler_ReadOpen(ImGuiContext*, ImGuiSettingsHandler*, const char* name) IMGUI_NOEXCEPT;
-static void             WindowSettingsHandler_ReadLine(ImGuiContext*, ImGuiSettingsHandler*, void* entry, const char* line) IMGUI_NOEXCEPT;
-static void             WindowSettingsHandler_ApplyAll(ImGuiContext*, ImGuiSettingsHandler*) IMGUI_NOEXCEPT;
-static void             WindowSettingsHandler_WriteAll(ImGuiContext*, ImGuiSettingsHandler*, ImGuiTextBuffer* buf) IMGUI_NOEXCEPT;
+static void             WindowSettingsHandler_ClearAll(ImGuiContext*, ImGuiSettingsHandler*) IM_NOEXCEPT;
+static void*            WindowSettingsHandler_ReadOpen(ImGuiContext*, ImGuiSettingsHandler*, const char* name) IM_NOEXCEPT;
+static void             WindowSettingsHandler_ReadLine(ImGuiContext*, ImGuiSettingsHandler*, void* entry, const char* line) IM_NOEXCEPT;
+static void             WindowSettingsHandler_ApplyAll(ImGuiContext*, ImGuiSettingsHandler*) IM_NOEXCEPT;
+static void             WindowSettingsHandler_WriteAll(ImGuiContext*, ImGuiSettingsHandler*, ImGuiTextBuffer* buf) IM_NOEXCEPT;
 
 // Platform Dependents default implementation for IO functions
-static const char*      GetClipboardTextFn_DefaultImpl(void* user_data) IMGUI_NOEXCEPT;
-static void             SetClipboardTextFn_DefaultImpl(void* user_data, const char* text) IMGUI_NOEXCEPT;
-static void             ImeSetInputScreenPosFn_DefaultImpl(int x, int y) IMGUI_NOEXCEPT;
+static const char*      GetClipboardTextFn_DefaultImpl(void* user_data) IM_NOEXCEPT;
+static void             SetClipboardTextFn_DefaultImpl(void* user_data, const char* text) IM_NOEXCEPT;
+static void             ImeSetInputScreenPosFn_DefaultImpl(int x, int y) IM_NOEXCEPT;
 
 namespace ImGui
 {
 // Navigation
-static void             NavUpdate() IMGUI_NOEXCEPT;
-static void             NavUpdateWindowing() IMGUI_NOEXCEPT;
-static void             NavUpdateWindowingOverlay() IMGUI_NOEXCEPT;
-static void             NavUpdateMoveResult() IMGUI_NOEXCEPT;
-static void             NavUpdateInitResult() IMGUI_NOEXCEPT;
-static float            NavUpdatePageUpPageDown() IMGUI_NOEXCEPT;
-static inline void      NavUpdateAnyRequestFlag() IMGUI_NOEXCEPT;
-static void             NavEndFrame() IMGUI_NOEXCEPT;
-static bool             NavScoreItem(ImGuiNavItemData* result, ImRect cand) IMGUI_NOEXCEPT;
-static void             NavApplyItemToResult(ImGuiNavItemData* result, ImGuiWindow* window, ImGuiID id, const ImRect& nav_bb_rel) IMGUI_NOEXCEPT;
-static void             NavProcessItem(ImGuiWindow* window, const ImRect& nav_bb, ImGuiID id) IMGUI_NOEXCEPT;
-static ImVec2           NavCalcPreferredRefPos() IMGUI_NOEXCEPT;
-static void             NavSaveLastChildNavWindowIntoParent(ImGuiWindow* nav_window) IMGUI_NOEXCEPT;
-static ImGuiWindow*     NavRestoreLastChildNavWindow(ImGuiWindow* window) IMGUI_NOEXCEPT;
-static void             NavRestoreLayer(ImGuiNavLayer layer) IMGUI_NOEXCEPT;
-static int              FindWindowFocusIndex(ImGuiWindow* window) IMGUI_NOEXCEPT;
+static void             NavUpdate() IM_NOEXCEPT;
+static void             NavUpdateWindowing() IM_NOEXCEPT;
+static void             NavUpdateWindowingOverlay() IM_NOEXCEPT;
+static void             NavUpdateMoveResult() IM_NOEXCEPT;
+static void             NavUpdateInitResult() IM_NOEXCEPT;
+static float            NavUpdatePageUpPageDown() IM_NOEXCEPT;
+static inline void      NavUpdateAnyRequestFlag() IM_NOEXCEPT;
+static void             NavEndFrame() IM_NOEXCEPT;
+static bool             NavScoreItem(ImGuiNavItemData* result, ImRect cand) IM_NOEXCEPT;
+static void             NavApplyItemToResult(ImGuiNavItemData* result, ImGuiWindow* window, ImGuiID id, const ImRect& nav_bb_rel) IM_NOEXCEPT;
+static void             NavProcessItem(ImGuiWindow* window, const ImRect& nav_bb, ImGuiID id) IM_NOEXCEPT;
+static ImVec2           NavCalcPreferredRefPos() IM_NOEXCEPT;
+static void             NavSaveLastChildNavWindowIntoParent(ImGuiWindow* nav_window) IM_NOEXCEPT;
+static ImGuiWindow*     NavRestoreLastChildNavWindow(ImGuiWindow* window) IM_NOEXCEPT;
+static void             NavRestoreLayer(ImGuiNavLayer layer) IM_NOEXCEPT;
+static int              FindWindowFocusIndex(ImGuiWindow* window) IM_NOEXCEPT;
 
 // Error Checking
-static void             ErrorCheckNewFrameSanityChecks() IMGUI_NOEXCEPT;
-static void             ErrorCheckEndFrameSanityChecks() IMGUI_NOEXCEPT;
+static void             ErrorCheckNewFrameSanityChecks() IM_NOEXCEPT;
+static void             ErrorCheckEndFrameSanityChecks() IM_NOEXCEPT;
 
 // Misc
-static void             UpdateSettings() IMGUI_NOEXCEPT;
-static void             UpdateMouseInputs() IMGUI_NOEXCEPT;
-static void             UpdateMouseWheel() IMGUI_NOEXCEPT;
-static void             UpdateTabFocus() IMGUI_NOEXCEPT;
-static void             UpdateDebugToolItemPicker() IMGUI_NOEXCEPT;
-static bool             UpdateWindowManualResize(ImGuiWindow* window, const ImVec2& size_auto_fit, int* border_held, int resize_grip_count, ImU32 resize_grip_col[4], const ImRect& visibility_rect) IMGUI_NOEXCEPT;
-static void             RenderWindowOuterBorders(ImGuiWindow* window) IMGUI_NOEXCEPT;
-static void             RenderWindowDecorations(ImGuiWindow* window, const ImRect& title_bar_rect, bool title_bar_is_highlight, int resize_grip_count, const ImU32 resize_grip_col[4], float resize_grip_draw_size) IMGUI_NOEXCEPT;
-static void             RenderWindowTitleBarContents(ImGuiWindow* window, const ImRect& title_bar_rect, const char* name, bool* p_open) IMGUI_NOEXCEPT;
+static void             UpdateSettings() IM_NOEXCEPT;
+static void             UpdateMouseInputs() IM_NOEXCEPT;
+static void             UpdateMouseWheel() IM_NOEXCEPT;
+static void             UpdateTabFocus() IM_NOEXCEPT;
+static void             UpdateDebugToolItemPicker() IM_NOEXCEPT;
+static bool             UpdateWindowManualResize(ImGuiWindow* window, const ImVec2& size_auto_fit, int* border_held, int resize_grip_count, ImU32 resize_grip_col[4], const ImRect& visibility_rect) IM_NOEXCEPT;
+static void             RenderWindowOuterBorders(ImGuiWindow* window) IM_NOEXCEPT;
+static void             RenderWindowDecorations(ImGuiWindow* window, const ImRect& title_bar_rect, bool title_bar_is_highlight, int resize_grip_count, const ImU32 resize_grip_col[4], float resize_grip_draw_size) IM_NOEXCEPT;
+static void             RenderWindowTitleBarContents(ImGuiWindow* window, const ImRect& title_bar_rect, const char* name, bool* p_open) IM_NOEXCEPT;
 
 // Viewports
-static void             UpdateViewportsNewFrame() IMGUI_NOEXCEPT;
+static void             UpdateViewportsNewFrame() IM_NOEXCEPT;
 
 }
 
@@ -964,11 +964,11 @@ ImGuiContext*   GImGui = NULL;
 // - You probably don't want to modify that mid-program, and if you use global/static e.g. ImVector<> instances you may need to keep them accessible during program destruction.
 // - DLL users: read comments above.
 #ifndef IMGUI_DISABLE_DEFAULT_ALLOCATORS
-static void*   MallocWrapper(size_t size, void* user_data) IMGUI_NOEXCEPT  { IM_UNUSED(user_data); return malloc(size); }
-static void    FreeWrapper(void* ptr, void* user_data)     IMGUI_NOEXCEPT  { IM_UNUSED(user_data); free(ptr); }
+static void*   MallocWrapper(size_t size, void* user_data) IM_NOEXCEPT  { IM_UNUSED(user_data); return malloc(size); }
+static void    FreeWrapper(void* ptr, void* user_data)     IM_NOEXCEPT  { IM_UNUSED(user_data); free(ptr); }
 #else
-static void*   MallocWrapper(size_t size, void* user_data) IMGUI_NOEXCEPT  { IM_UNUSED(user_data); IM_UNUSED(size); IM_ASSERT(0); return NULL; }
-static void    FreeWrapper(void* ptr, void* user_data)     IMGUI_NOEXCEPT  { IM_UNUSED(user_data); IM_UNUSED(ptr); IM_ASSERT(0); }
+static void*   MallocWrapper(size_t size, void* user_data) IM_NOEXCEPT  { IM_UNUSED(user_data); IM_UNUSED(size); IM_ASSERT(0); return NULL; }
+static void    FreeWrapper(void* ptr, void* user_data)     IM_NOEXCEPT  { IM_UNUSED(user_data); IM_UNUSED(ptr); IM_ASSERT(0); }
 #endif
 static ImGuiMemAllocFunc    GImAllocatorAllocFunc = MallocWrapper;
 static ImGuiMemFreeFunc     GImAllocatorFreeFunc = FreeWrapper;
@@ -978,7 +978,7 @@ static void*                GImAllocatorUserData = NULL;
 // [SECTION] USER FACING STRUCTURES (ImGuiStyle, ImGuiIO)
 //-----------------------------------------------------------------------------
 
-ImGuiStyle::ImGuiStyle() IMGUI_NOEXCEPT
+ImGuiStyle::ImGuiStyle() IM_NOEXCEPT
 {
     Alpha                   = 1.0f;             // Global alpha applies to everything in ImGui
     WindowPadding           = ImVec2(8,8);      // Padding within a window
@@ -1026,7 +1026,7 @@ ImGuiStyle::ImGuiStyle() IMGUI_NOEXCEPT
 
 // To scale your entire UI (e.g. if you want your app to use High DPI or generally be DPI aware) you may use this helper function. Scaling the fonts is done separately and is up to you.
 // Important: This operation is lossy because we round all sizes to integer. If you need to change your scale multiples, call this over a freshly initialized ImGuiStyle structure rather than scaling multiple times.
-void ImGuiStyle::ScaleAllSizes(float scale_factor) IMGUI_NOEXCEPT
+void ImGuiStyle::ScaleAllSizes(float scale_factor) IM_NOEXCEPT
 {
     WindowPadding = ImFloor(WindowPadding * scale_factor);
     WindowRounding = ImFloor(WindowRounding * scale_factor);
@@ -1053,7 +1053,7 @@ void ImGuiStyle::ScaleAllSizes(float scale_factor) IMGUI_NOEXCEPT
     MouseCursorScale = ImFloor(MouseCursorScale * scale_factor);
 }
 
-ImGuiIO::ImGuiIO() IMGUI_NOEXCEPT
+ImGuiIO::ImGuiIO() IM_NOEXCEPT
 {
     // Most fields are initialized with zero
     memset(this, 0, sizeof(*this));
@@ -1114,7 +1114,7 @@ ImGuiIO::ImGuiIO() IMGUI_NOEXCEPT
 // Pass in translated ASCII characters for text input.
 // - with glfw you can get those from the callback set in glfwSetCharCallback()
 // - on Windows you can get those using ToAscii+keyboard state, or via the WM_CHAR message
-void ImGuiIO::AddInputCharacter(unsigned int c) IMGUI_NOEXCEPT
+void ImGuiIO::AddInputCharacter(unsigned int c) IM_NOEXCEPT
 {
     if (c != 0)
         InputQueueCharacters.push_back(c <= IM_UNICODE_CODEPOINT_MAX ? (ImWchar)c : IM_UNICODE_CODEPOINT_INVALID);
@@ -1122,7 +1122,7 @@ void ImGuiIO::AddInputCharacter(unsigned int c) IMGUI_NOEXCEPT
 
 // UTF16 strings use surrogate pairs to encode codepoints >= 0x10000, so
 // we should save the high surrogate.
-void ImGuiIO::AddInputCharacterUTF16(ImWchar16 c) IMGUI_NOEXCEPT
+void ImGuiIO::AddInputCharacterUTF16(ImWchar16 c) IM_NOEXCEPT
 {
     if (c == 0 && InputQueueSurrogate == 0)
         return;
@@ -1156,7 +1156,7 @@ void ImGuiIO::AddInputCharacterUTF16(ImWchar16 c) IMGUI_NOEXCEPT
     InputQueueCharacters.push_back(cp);
 }
 
-void ImGuiIO::AddInputCharactersUTF8(const char* utf8_chars) IMGUI_NOEXCEPT
+void ImGuiIO::AddInputCharactersUTF8(const char* utf8_chars) IM_NOEXCEPT
 {
     while (*utf8_chars != 0)
     {
@@ -1167,7 +1167,7 @@ void ImGuiIO::AddInputCharactersUTF8(const char* utf8_chars) IMGUI_NOEXCEPT
     }
 }
 
-void ImGuiIO::ClearInputCharacters() IMGUI_NOEXCEPT
+void ImGuiIO::ClearInputCharacters() IM_NOEXCEPT
 {
     InputQueueCharacters.resize(0);
 }
@@ -1176,7 +1176,7 @@ void ImGuiIO::ClearInputCharacters() IMGUI_NOEXCEPT
 // [SECTION] MISC HELPERS/UTILITIES (Geometry functions)
 //-----------------------------------------------------------------------------
 
-ImVec2 ImBezierCubicClosestPoint(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, const ImVec2& p, int num_segments) IMGUI_NOEXCEPT
+ImVec2 ImBezierCubicClosestPoint(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, const ImVec2& p, int num_segments) IM_NOEXCEPT
 {
     IM_ASSERT(num_segments > 0); // Use ImBezierCubicClosestPointCasteljau()
     ImVec2 p_last = p1;
@@ -1199,7 +1199,7 @@ ImVec2 ImBezierCubicClosestPoint(const ImVec2& p1, const ImVec2& p2, const ImVec
 }
 
 // Closely mimics PathBezierToCasteljau() in imgui_draw.cpp
-static void ImBezierCubicClosestPointCasteljauStep(const ImVec2& p, ImVec2& p_closest, ImVec2& p_last, float& p_closest_dist2, float x1, float y1, float x2, float y2, float x3, float y3, float x4, float y4, float tess_tol, int level) IMGUI_NOEXCEPT
+static void ImBezierCubicClosestPointCasteljauStep(const ImVec2& p, ImVec2& p_closest, ImVec2& p_last, float& p_closest_dist2, float x1, float y1, float x2, float y2, float x3, float y3, float x4, float y4, float tess_tol, int level) IM_NOEXCEPT
 {
     float dx = x4 - x1;
     float dy = y4 - y1;
@@ -1234,7 +1234,7 @@ static void ImBezierCubicClosestPointCasteljauStep(const ImVec2& p, ImVec2& p_cl
 
 // tess_tol is generally the same value you would find in ImGui::GetStyle().CurveTessellationTol
 // Because those ImXXX functions are lower-level than ImGui:: we cannot access this value automatically.
-ImVec2 ImBezierCubicClosestPointCasteljau(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, const ImVec2& p, float tess_tol) IMGUI_NOEXCEPT
+ImVec2 ImBezierCubicClosestPointCasteljau(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, const ImVec2& p, float tess_tol) IM_NOEXCEPT
 {
     IM_ASSERT(tess_tol > 0.0f);
     ImVec2 p_last = p1;
@@ -1244,7 +1244,7 @@ ImVec2 ImBezierCubicClosestPointCasteljau(const ImVec2& p1, const ImVec2& p2, co
     return p_closest;
 }
 
-ImVec2 ImLineClosestPoint(const ImVec2& a, const ImVec2& b, const ImVec2& p) IMGUI_NOEXCEPT
+ImVec2 ImLineClosestPoint(const ImVec2& a, const ImVec2& b, const ImVec2& p) IM_NOEXCEPT
 {
     ImVec2 ap = p - a;
     ImVec2 ab_dir = b - a;
@@ -1257,7 +1257,7 @@ ImVec2 ImLineClosestPoint(const ImVec2& a, const ImVec2& b, const ImVec2& p) IMG
     return a + ab_dir * dot / ab_len_sqr;
 }
 
-bool ImTriangleContainsPoint(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& p) IMGUI_NOEXCEPT
+bool ImTriangleContainsPoint(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& p) IM_NOEXCEPT
 {
     bool b1 = ((p.x - b.x) * (a.y - b.y) - (p.y - b.y) * (a.x - b.x)) < 0.0f;
     bool b2 = ((p.x - c.x) * (b.y - c.y) - (p.y - c.y) * (b.x - c.x)) < 0.0f;
@@ -1265,7 +1265,7 @@ bool ImTriangleContainsPoint(const ImVec2& a, const ImVec2& b, const ImVec2& c, 
     return ((b1 == b2) && (b2 == b3));
 }
 
-void ImTriangleBarycentricCoords(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& p, float& out_u, float& out_v, float& out_w) IMGUI_NOEXCEPT
+void ImTriangleBarycentricCoords(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& p, float& out_u, float& out_v, float& out_w) IM_NOEXCEPT
 {
     ImVec2 v0 = b - a;
     ImVec2 v1 = c - a;
@@ -1276,7 +1276,7 @@ void ImTriangleBarycentricCoords(const ImVec2& a, const ImVec2& b, const ImVec2&
     out_u = 1.0f - out_v - out_w;
 }
 
-ImVec2 ImTriangleClosestPoint(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& p) IMGUI_NOEXCEPT
+ImVec2 ImTriangleClosestPoint(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& p) IM_NOEXCEPT
 {
     ImVec2 proj_ab = ImLineClosestPoint(a, b, p);
     ImVec2 proj_bc = ImLineClosestPoint(b, c, p);
@@ -1297,21 +1297,21 @@ ImVec2 ImTriangleClosestPoint(const ImVec2& a, const ImVec2& b, const ImVec2& c,
 //-----------------------------------------------------------------------------
 
 // Consider using _stricmp/_strnicmp under Windows or strcasecmp/strncasecmp. We don't actually use either ImStricmp/ImStrnicmp in the codebase any more.
-int ImStricmp(const char* str1, const char* str2) IMGUI_NOEXCEPT
+int ImStricmp(const char* str1, const char* str2) IM_NOEXCEPT
 {
     int d;
     while ((d = toupper(*str2) - toupper(*str1)) == 0 && *str1) { str1++; str2++; }
     return d;
 }
 
-int ImStrnicmp(const char* str1, const char* str2, size_t count) IMGUI_NOEXCEPT
+int ImStrnicmp(const char* str1, const char* str2, size_t count) IM_NOEXCEPT
 {
     int d = 0;
     while (count > 0 && (d = toupper(*str2) - toupper(*str1)) == 0 && *str1) { str1++; str2++; count--; }
     return d;
 }
 
-void ImStrncpy(char* dst, const char* src, size_t count) IMGUI_NOEXCEPT
+void ImStrncpy(char* dst, const char* src, size_t count) IM_NOEXCEPT
 {
     if (count < 1)
         return;
@@ -1320,14 +1320,14 @@ void ImStrncpy(char* dst, const char* src, size_t count) IMGUI_NOEXCEPT
     dst[count - 1] = 0;
 }
 
-char* ImStrdup(const char* str) IMGUI_NOEXCEPT
+char* ImStrdup(const char* str) IM_NOEXCEPT
 {
     size_t len = strlen(str);
     void* buf = IM_ALLOC(len + 1);
     return (char*)memcpy(buf, (const void*)str, len + 1);
 }
 
-char* ImStrdupcpy(char* dst, size_t* p_dst_size, const char* src) IMGUI_NOEXCEPT
+char* ImStrdupcpy(char* dst, size_t* p_dst_size, const char* src) IM_NOEXCEPT
 {
     size_t dst_buf_size = p_dst_size ? *p_dst_size : strlen(dst) + 1;
     size_t src_size = strlen(src) + 1;
@@ -1341,13 +1341,13 @@ char* ImStrdupcpy(char* dst, size_t* p_dst_size, const char* src) IMGUI_NOEXCEPT
     return (char*)memcpy(dst, (const void*)src, src_size);
 }
 
-const char* ImStrchrRange(const char* str, const char* str_end, char c) IMGUI_NOEXCEPT
+const char* ImStrchrRange(const char* str, const char* str_end, char c) IM_NOEXCEPT
 {
     const char* p = (const char*)memchr(str, (int)c, str_end - str);
     return p;
 }
 
-int ImStrlenW(const ImWchar* str) IMGUI_NOEXCEPT
+int ImStrlenW(const ImWchar* str) IM_NOEXCEPT
 {
     //return (int)wcslen((const wchar_t*)str);  // FIXME-OPT: Could use this when wchar_t are 16-bit
     int n = 0;
@@ -1356,20 +1356,20 @@ int ImStrlenW(const ImWchar* str) IMGUI_NOEXCEPT
 }
 
 // Find end-of-line. Return pointer will point to either first \n, either str_end.
-const char* ImStreolRange(const char* str, const char* str_end) IMGUI_NOEXCEPT
+const char* ImStreolRange(const char* str, const char* str_end) IM_NOEXCEPT
 {
     const char* p = (const char*)memchr(str, '\n', str_end - str);
     return p ? p : str_end;
 }
 
-const ImWchar* ImStrbolW(const ImWchar* buf_mid_line, const ImWchar* buf_begin) IMGUI_NOEXCEPT // find beginning-of-line
+const ImWchar* ImStrbolW(const ImWchar* buf_mid_line, const ImWchar* buf_begin) IM_NOEXCEPT // find beginning-of-line
 {
     while (buf_mid_line > buf_begin && buf_mid_line[-1] != '\n')
         buf_mid_line--;
     return buf_mid_line;
 }
 
-const char* ImStristr(const char* haystack, const char* haystack_end, const char* needle, const char* needle_end) IMGUI_NOEXCEPT
+const char* ImStristr(const char* haystack, const char* haystack_end, const char* needle, const char* needle_end) IM_NOEXCEPT
 {
     if (!needle_end)
         needle_end = needle + strlen(needle);
@@ -1392,7 +1392,7 @@ const char* ImStristr(const char* haystack, const char* haystack_end, const char
 }
 
 // Trim str by offsetting contents when there's leading data + writing a \0 at the trailing position. We use this in situation where the cost is negligible.
-void ImStrTrimBlanks(char* buf) IMGUI_NOEXCEPT
+void ImStrTrimBlanks(char* buf) IM_NOEXCEPT
 {
     char* p = buf;
     while (p[0] == ' ' || p[0] == '\t')     // Leading blanks
@@ -1407,7 +1407,7 @@ void ImStrTrimBlanks(char* buf) IMGUI_NOEXCEPT
     buf[p - p_start] = 0;                   // Zero terminate
 }
 
-const char* ImStrSkipBlank(const char* str) IMGUI_NOEXCEPT
+const char* ImStrSkipBlank(const char* str) IM_NOEXCEPT
 {
     while (str[0] == ' ' || str[0] == '\t')
         str++;
@@ -1432,7 +1432,7 @@ const char* ImStrSkipBlank(const char* str) IMGUI_NOEXCEPT
 #define vsnprintf _vsnprintf
 #endif
 
-int ImFormatString(char* buf, size_t buf_size, const char* fmt, ...) IMGUI_NOEXCEPT
+int ImFormatString(char* buf, size_t buf_size, const char* fmt, ...) IM_NOEXCEPT
 {
     va_list args;
     va_start(args, fmt);
@@ -1450,7 +1450,7 @@ int ImFormatString(char* buf, size_t buf_size, const char* fmt, ...) IMGUI_NOEXC
     return w;
 }
 
-int ImFormatStringV(char* buf, size_t buf_size, const char* fmt, va_list args) IMGUI_NOEXCEPT
+int ImFormatStringV(char* buf, size_t buf_size, const char* fmt, va_list args) IM_NOEXCEPT
 {
 #ifdef IMGUI_USE_STB_SPRINTF
     int w = stbsp_vsnprintf(buf, (int)buf_size, fmt, args);
@@ -1492,7 +1492,7 @@ static const ImU32 GCrc32LookupTable[256] =
 // Known size hash
 // It is ok to call ImHashData on a string with known length but the ### operator won't be supported.
 // FIXME-OPT: Replace with e.g. FNV1a hash? CRC32 pretty much randomly access 1KB. Need to do proper measurements.
-ImGuiID ImHashData(const void* data_p, size_t data_size, ImU32 seed) IMGUI_NOEXCEPT
+ImGuiID ImHashData(const void* data_p, size_t data_size, ImU32 seed) IM_NOEXCEPT
 {
     ImU32 crc = ~seed;
     const unsigned char* data = (const unsigned char*)data_p;
@@ -1508,7 +1508,7 @@ ImGuiID ImHashData(const void* data_p, size_t data_size, ImU32 seed) IMGUI_NOEXC
 // - If we reach ### in the string we discard the hash so far and reset to the seed.
 // - We don't do 'current += 2; continue;' after handling ### to keep the code smaller/faster (measured ~10% diff in Debug build)
 // FIXME-OPT: Replace with e.g. FNV1a hash? CRC32 pretty much randomly access 1KB. Need to do proper measurements.
-ImGuiID ImHashStr(const char* data_p, size_t data_size, ImU32 seed) IMGUI_NOEXCEPT
+ImGuiID ImHashStr(const char* data_p, size_t data_size, ImU32 seed) IM_NOEXCEPT
 {
     seed = ~seed;
     ImU32 crc = seed;
@@ -1543,7 +1543,7 @@ ImGuiID ImHashStr(const char* data_p, size_t data_size, ImU32 seed) IMGUI_NOEXCE
 // Default file functions
 #ifndef IMGUI_DISABLE_DEFAULT_FILE_FUNCTIONS
 
-ImFileHandle ImFileOpen(const char* filename, const char* mode) IMGUI_NOEXCEPT
+ImFileHandle ImFileOpen(const char* filename, const char* mode) IM_NOEXCEPT
 {
 #if defined(_WIN32) && !defined(IMGUI_DISABLE_WIN32_FUNCTIONS) && !defined(__CYGWIN__) && !defined(__GNUC__)
     // We need a fopen() wrapper because MSVC/Windows fopen doesn't handle UTF-8 filenames.
@@ -1561,16 +1561,16 @@ ImFileHandle ImFileOpen(const char* filename, const char* mode) IMGUI_NOEXCEPT
 }
 
 // We should in theory be using fseeko()/ftello() with off_t and _fseeki64()/_ftelli64() with __int64, waiting for the PR that does that in a very portable pre-C++11 zero-warnings way.
-bool    ImFileClose(ImFileHandle f)   IMGUI_NOEXCEPT   { return fclose(f) == 0; }
-ImU64   ImFileGetSize(ImFileHandle f) IMGUI_NOEXCEPT   { long off = 0, sz = 0; return ((off = ftell(f)) != -1 && !fseek(f, 0, SEEK_END) && (sz = ftell(f)) != -1 && !fseek(f, off, SEEK_SET)) ? (ImU64)sz : (ImU64)-1; }
-ImU64   ImFileRead(void* data, ImU64 sz, ImU64 count, ImFileHandle f) IMGUI_NOEXCEPT           { return fread(data, (size_t)sz, (size_t)count, f); }
-ImU64   ImFileWrite(const void* data, ImU64 sz, ImU64 count, ImFileHandle f) IMGUI_NOEXCEPT    { return fwrite(data, (size_t)sz, (size_t)count, f); }
+bool    ImFileClose(ImFileHandle f)   IM_NOEXCEPT   { return fclose(f) == 0; }
+ImU64   ImFileGetSize(ImFileHandle f) IM_NOEXCEPT   { long off = 0, sz = 0; return ((off = ftell(f)) != -1 && !fseek(f, 0, SEEK_END) && (sz = ftell(f)) != -1 && !fseek(f, off, SEEK_SET)) ? (ImU64)sz : (ImU64)-1; }
+ImU64   ImFileRead(void* data, ImU64 sz, ImU64 count, ImFileHandle f) IM_NOEXCEPT           { return fread(data, (size_t)sz, (size_t)count, f); }
+ImU64   ImFileWrite(const void* data, ImU64 sz, ImU64 count, ImFileHandle f) IM_NOEXCEPT    { return fwrite(data, (size_t)sz, (size_t)count, f); }
 #endif // #ifndef IMGUI_DISABLE_DEFAULT_FILE_FUNCTIONS
 
 // Helper: Load file content into memory
 // Memory allocated with IM_ALLOC(), must be freed by user using IM_FREE() == ImGui::MemFree()
 // This can't really be used with "rt" because fseek size won't match read size.
-void*   ImFileLoadToMemory(const char* filename, const char* mode, size_t* out_file_size, int padding_bytes) IMGUI_NOEXCEPT
+void*   ImFileLoadToMemory(const char* filename, const char* mode, size_t* out_file_size, int padding_bytes) IM_NOEXCEPT
 {
     IM_ASSERT(filename && mode);
     if (out_file_size)
@@ -1616,7 +1616,7 @@ void*   ImFileLoadToMemory(const char* filename, const char* mode, size_t* out_f
 // Convert UTF-8 to 32-bit character, process single character input.
 // A nearly-branchless UTF-8 decoder, based on work of Christopher Wellons (https://github.com/skeeto/branchless-utf8).
 // We handle UTF-8 decoding error by skipping forward.
-int ImTextCharFromUtf8(unsigned int* out_char, const char* in_text, const char* in_text_end) IMGUI_NOEXCEPT
+int ImTextCharFromUtf8(unsigned int* out_char, const char* in_text, const char* in_text_end) IM_NOEXCEPT
 {
     static const char lengths[32] = { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 2, 3, 3, 4, 0 };
     static const int masks[]  = { 0x00, 0x7f, 0x1f, 0x0f, 0x07 };
@@ -1668,7 +1668,7 @@ int ImTextCharFromUtf8(unsigned int* out_char, const char* in_text, const char* 
     return wanted;
 }
 
-int ImTextStrFromUtf8(ImWchar* buf, int buf_size, const char* in_text, const char* in_text_end, const char** in_text_remaining) IMGUI_NOEXCEPT
+int ImTextStrFromUtf8(ImWchar* buf, int buf_size, const char* in_text, const char* in_text_end, const char** in_text_remaining) IM_NOEXCEPT
 {
     ImWchar* buf_out = buf;
     ImWchar* buf_end = buf + buf_size;
@@ -1686,7 +1686,7 @@ int ImTextStrFromUtf8(ImWchar* buf, int buf_size, const char* in_text, const cha
     return (int)(buf_out - buf);
 }
 
-int ImTextCountCharsFromUtf8(const char* in_text, const char* in_text_end) IMGUI_NOEXCEPT
+int ImTextCountCharsFromUtf8(const char* in_text, const char* in_text_end) IM_NOEXCEPT
 {
     int char_count = 0;
     while ((!in_text_end || in_text < in_text_end) && *in_text)
@@ -1701,7 +1701,7 @@ int ImTextCountCharsFromUtf8(const char* in_text, const char* in_text_end) IMGUI
 }
 
 // Based on stb_to_utf8() from github.com/nothings/stb/
-static inline int ImTextCharToUtf8(char* buf, int buf_size, unsigned int c) IMGUI_NOEXCEPT
+static inline int ImTextCharToUtf8(char* buf, int buf_size, unsigned int c) IM_NOEXCEPT
 {
     if (c < 0x80)
     {
@@ -1737,13 +1737,13 @@ static inline int ImTextCharToUtf8(char* buf, int buf_size, unsigned int c) IMGU
 }
 
 // Not optimal but we very rarely use this function.
-int ImTextCountUtf8BytesFromChar(const char* in_text, const char* in_text_end) IMGUI_NOEXCEPT
+int ImTextCountUtf8BytesFromChar(const char* in_text, const char* in_text_end) IM_NOEXCEPT
 {
     unsigned int unused = 0;
     return ImTextCharFromUtf8(&unused, in_text, in_text_end);
 }
 
-static inline int ImTextCountUtf8BytesFromChar(unsigned int c) IMGUI_NOEXCEPT
+static inline int ImTextCountUtf8BytesFromChar(unsigned int c) IM_NOEXCEPT
 {
     if (c < 0x80) return 1;
     if (c < 0x800) return 2;
@@ -1752,7 +1752,7 @@ static inline int ImTextCountUtf8BytesFromChar(unsigned int c) IMGUI_NOEXCEPT
     return 3;
 }
 
-int ImTextStrToUtf8(char* buf, int buf_size, const ImWchar* in_text, const ImWchar* in_text_end) IMGUI_NOEXCEPT
+int ImTextStrToUtf8(char* buf, int buf_size, const ImWchar* in_text, const ImWchar* in_text_end) IM_NOEXCEPT
 {
     char* buf_out = buf;
     const char* buf_end = buf + buf_size;
@@ -1768,7 +1768,7 @@ int ImTextStrToUtf8(char* buf, int buf_size, const ImWchar* in_text, const ImWch
     return (int)(buf_out - buf);
 }
 
-int ImTextCountUtf8BytesFromStr(const ImWchar* in_text, const ImWchar* in_text_end) IMGUI_NOEXCEPT
+int ImTextCountUtf8BytesFromStr(const ImWchar* in_text, const ImWchar* in_text_end) IM_NOEXCEPT
 {
     int bytes_count = 0;
     while ((!in_text_end || in_text < in_text_end) && *in_text)
@@ -1787,7 +1787,7 @@ int ImTextCountUtf8BytesFromStr(const ImWchar* in_text, const ImWchar* in_text_e
 // Note: The Convert functions are early design which are not consistent with other API.
 //-----------------------------------------------------------------------------
 
-IMGUI_API ImU32 ImAlphaBlendColors(ImU32 col_a, ImU32 col_b) IMGUI_NOEXCEPT
+IMGUI_API ImU32 ImAlphaBlendColors(ImU32 col_a, ImU32 col_b) IM_NOEXCEPT
 {
     float t = ((col_b >> IM_COL32_A_SHIFT) & 0xFF) / 255.f;
     int r = ImLerp((int)(col_a >> IM_COL32_R_SHIFT) & 0xFF, (int)(col_b >> IM_COL32_R_SHIFT) & 0xFF, t);
@@ -1796,7 +1796,7 @@ IMGUI_API ImU32 ImAlphaBlendColors(ImU32 col_a, ImU32 col_b) IMGUI_NOEXCEPT
     return IM_COL32(r, g, b, 0xFF);
 }
 
-ImVec4 ImGui::ColorConvertU32ToFloat4(ImU32 in) IMGUI_NOEXCEPT
+ImVec4 ImGui::ColorConvertU32ToFloat4(ImU32 in) IM_NOEXCEPT
 {
     float s = 1.0f / 255.0f;
     return ImVec4(
@@ -1806,7 +1806,7 @@ ImVec4 ImGui::ColorConvertU32ToFloat4(ImU32 in) IMGUI_NOEXCEPT
         ((in >> IM_COL32_A_SHIFT) & 0xFF) * s);
 }
 
-ImU32 ImGui::ColorConvertFloat4ToU32(const ImVec4& in) IMGUI_NOEXCEPT
+ImU32 ImGui::ColorConvertFloat4ToU32(const ImVec4& in) IM_NOEXCEPT
 {
     ImU32 out;
     out  = ((ImU32)IM_F32_TO_INT8_SAT(in.x)) << IM_COL32_R_SHIFT;
@@ -1818,7 +1818,7 @@ ImU32 ImGui::ColorConvertFloat4ToU32(const ImVec4& in) IMGUI_NOEXCEPT
 
 // Convert rgb floats ([0-1],[0-1],[0-1]) to hsv floats ([0-1],[0-1],[0-1]), from Foley & van Dam p592
 // Optimized http://lolengine.net/blog/2013/01/13/fast-rgb-to-hsv
-void ImGui::ColorConvertRGBtoHSV(float r, float g, float b, float& out_h, float& out_s, float& out_v) IMGUI_NOEXCEPT
+void ImGui::ColorConvertRGBtoHSV(float r, float g, float b, float& out_h, float& out_s, float& out_v) IM_NOEXCEPT
 {
     float K = 0.f;
     if (g < b)
@@ -1840,7 +1840,7 @@ void ImGui::ColorConvertRGBtoHSV(float r, float g, float b, float& out_h, float&
 
 // Convert hsv floats ([0-1],[0-1],[0-1]) to rgb floats ([0-1],[0-1],[0-1]), from Foley & van Dam p593
 // also http://en.wikipedia.org/wiki/HSL_and_HSV
-void ImGui::ColorConvertHSVtoRGB(float h, float s, float v, float& out_r, float& out_g, float& out_b) IMGUI_NOEXCEPT
+void ImGui::ColorConvertHSVtoRGB(float h, float s, float v, float& out_r, float& out_g, float& out_b) IM_NOEXCEPT
 {
     if (s == 0.0f)
     {
@@ -1873,7 +1873,7 @@ void ImGui::ColorConvertHSVtoRGB(float h, float s, float v, float& out_r, float&
 //-----------------------------------------------------------------------------
 
 // std::lower_bound but without the bullshit
-static ImGuiStorage::ImGuiStoragePair* LowerBound(ImVector<ImGuiStorage::ImGuiStoragePair>& data, ImGuiID key) IMGUI_NOEXCEPT
+static ImGuiStorage::ImGuiStoragePair* LowerBound(ImVector<ImGuiStorage::ImGuiStoragePair>& data, ImGuiID key) IM_NOEXCEPT
 {
     ImGuiStorage::ImGuiStoragePair* first = data.Data;
     ImGuiStorage::ImGuiStoragePair* last = data.Data + data.Size;
@@ -1896,7 +1896,7 @@ static ImGuiStorage::ImGuiStoragePair* LowerBound(ImVector<ImGuiStorage::ImGuiSt
 }
 
 // For quicker full rebuild of a storage (instead of an incremental one), you may add all your contents and then sort once.
-void ImGuiStorage::BuildSortByKey() IMGUI_NOEXCEPT
+void ImGuiStorage::BuildSortByKey() IM_NOEXCEPT
 {
     struct StaticFunc
     {
@@ -1912,7 +1912,7 @@ void ImGuiStorage::BuildSortByKey() IMGUI_NOEXCEPT
         ImQsort(Data.Data, (size_t)Data.Size, sizeof(ImGuiStoragePair), StaticFunc::PairCompareByID);
 }
 
-int ImGuiStorage::GetInt(ImGuiID key, int default_val) const IMGUI_NOEXCEPT
+int ImGuiStorage::GetInt(ImGuiID key, int default_val) const IM_NOEXCEPT
 {
     ImGuiStoragePair* it = LowerBound(const_cast<ImVector<ImGuiStoragePair>&>(Data), key);
     if (it == Data.end() || it->key != key)
@@ -1920,12 +1920,12 @@ int ImGuiStorage::GetInt(ImGuiID key, int default_val) const IMGUI_NOEXCEPT
     return it->val_i;
 }
 
-bool ImGuiStorage::GetBool(ImGuiID key, bool default_val) const IMGUI_NOEXCEPT
+bool ImGuiStorage::GetBool(ImGuiID key, bool default_val) const IM_NOEXCEPT
 {
     return GetInt(key, default_val ? 1 : 0) != 0;
 }
 
-float ImGuiStorage::GetFloat(ImGuiID key, float default_val) const IMGUI_NOEXCEPT
+float ImGuiStorage::GetFloat(ImGuiID key, float default_val) const IM_NOEXCEPT
 {
     ImGuiStoragePair* it = LowerBound(const_cast<ImVector<ImGuiStoragePair>&>(Data), key);
     if (it == Data.end() || it->key != key)
@@ -1933,7 +1933,7 @@ float ImGuiStorage::GetFloat(ImGuiID key, float default_val) const IMGUI_NOEXCEP
     return it->val_f;
 }
 
-void* ImGuiStorage::GetVoidPtr(ImGuiID key) const IMGUI_NOEXCEPT
+void* ImGuiStorage::GetVoidPtr(ImGuiID key) const IM_NOEXCEPT
 {
     ImGuiStoragePair* it = LowerBound(const_cast<ImVector<ImGuiStoragePair>&>(Data), key);
     if (it == Data.end() || it->key != key)
@@ -1942,7 +1942,7 @@ void* ImGuiStorage::GetVoidPtr(ImGuiID key) const IMGUI_NOEXCEPT
 }
 
 // References are only valid until a new value is added to the storage. Calling a Set***() function or a Get***Ref() function invalidates the pointer.
-int* ImGuiStorage::GetIntRef(ImGuiID key, int default_val) IMGUI_NOEXCEPT
+int* ImGuiStorage::GetIntRef(ImGuiID key, int default_val) IM_NOEXCEPT
 {
     ImGuiStoragePair* it = LowerBound(Data, key);
     if (it == Data.end() || it->key != key)
@@ -1950,12 +1950,12 @@ int* ImGuiStorage::GetIntRef(ImGuiID key, int default_val) IMGUI_NOEXCEPT
     return &it->val_i;
 }
 
-bool* ImGuiStorage::GetBoolRef(ImGuiID key, bool default_val) IMGUI_NOEXCEPT
+bool* ImGuiStorage::GetBoolRef(ImGuiID key, bool default_val) IM_NOEXCEPT
 {
     return (bool*)GetIntRef(key, default_val ? 1 : 0);
 }
 
-float* ImGuiStorage::GetFloatRef(ImGuiID key, float default_val) IMGUI_NOEXCEPT
+float* ImGuiStorage::GetFloatRef(ImGuiID key, float default_val) IM_NOEXCEPT
 {
     ImGuiStoragePair* it = LowerBound(Data, key);
     if (it == Data.end() || it->key != key)
@@ -1963,7 +1963,7 @@ float* ImGuiStorage::GetFloatRef(ImGuiID key, float default_val) IMGUI_NOEXCEPT
     return &it->val_f;
 }
 
-void** ImGuiStorage::GetVoidPtrRef(ImGuiID key, void* default_val) IMGUI_NOEXCEPT
+void** ImGuiStorage::GetVoidPtrRef(ImGuiID key, void* default_val) IM_NOEXCEPT
 {
     ImGuiStoragePair* it = LowerBound(Data, key);
     if (it == Data.end() || it->key != key)
@@ -1972,7 +1972,7 @@ void** ImGuiStorage::GetVoidPtrRef(ImGuiID key, void* default_val) IMGUI_NOEXCEP
 }
 
 // FIXME-OPT: Need a way to reuse the result of lower_bound when doing GetInt()/SetInt() - not too bad because it only happens on explicit interaction (maximum one a frame)
-void ImGuiStorage::SetInt(ImGuiID key, int val) IMGUI_NOEXCEPT
+void ImGuiStorage::SetInt(ImGuiID key, int val) IM_NOEXCEPT
 {
     ImGuiStoragePair* it = LowerBound(Data, key);
     if (it == Data.end() || it->key != key)
@@ -1983,12 +1983,12 @@ void ImGuiStorage::SetInt(ImGuiID key, int val) IMGUI_NOEXCEPT
     it->val_i = val;
 }
 
-void ImGuiStorage::SetBool(ImGuiID key, bool val) IMGUI_NOEXCEPT
+void ImGuiStorage::SetBool(ImGuiID key, bool val) IM_NOEXCEPT
 {
     SetInt(key, val ? 1 : 0);
 }
 
-void ImGuiStorage::SetFloat(ImGuiID key, float val) IMGUI_NOEXCEPT
+void ImGuiStorage::SetFloat(ImGuiID key, float val) IM_NOEXCEPT
 {
     ImGuiStoragePair* it = LowerBound(Data, key);
     if (it == Data.end() || it->key != key)
@@ -1999,7 +1999,7 @@ void ImGuiStorage::SetFloat(ImGuiID key, float val) IMGUI_NOEXCEPT
     it->val_f = val;
 }
 
-void ImGuiStorage::SetVoidPtr(ImGuiID key, void* val) IMGUI_NOEXCEPT
+void ImGuiStorage::SetVoidPtr(ImGuiID key, void* val) IM_NOEXCEPT
 {
     ImGuiStoragePair* it = LowerBound(Data, key);
     if (it == Data.end() || it->key != key)
@@ -2010,7 +2010,7 @@ void ImGuiStorage::SetVoidPtr(ImGuiID key, void* val) IMGUI_NOEXCEPT
     it->val_p = val;
 }
 
-void ImGuiStorage::SetAllInt(int v) IMGUI_NOEXCEPT
+void ImGuiStorage::SetAllInt(int v) IM_NOEXCEPT
 {
     for (int i = 0; i < Data.Size; i++)
         Data[i].val_i = v;
@@ -2021,7 +2021,7 @@ void ImGuiStorage::SetAllInt(int v) IMGUI_NOEXCEPT
 //-----------------------------------------------------------------------------
 
 // Helper: Parse and apply text filters. In format "aaaaa[,bbbb][,ccccc]"
-ImGuiTextFilter::ImGuiTextFilter(const char* default_filter) IMGUI_NOEXCEPT
+ImGuiTextFilter::ImGuiTextFilter(const char* default_filter) IM_NOEXCEPT
 {
     if (default_filter)
     {
@@ -2035,7 +2035,7 @@ ImGuiTextFilter::ImGuiTextFilter(const char* default_filter) IMGUI_NOEXCEPT
     }
 }
 
-bool ImGuiTextFilter::Draw(const char* label, float width) IMGUI_NOEXCEPT
+bool ImGuiTextFilter::Draw(const char* label, float width) IM_NOEXCEPT
 {
     if (width != 0.0f)
         ImGui::SetNextItemWidth(width);
@@ -2045,7 +2045,7 @@ bool ImGuiTextFilter::Draw(const char* label, float width) IMGUI_NOEXCEPT
     return value_changed;
 }
 
-void ImGuiTextFilter::ImGuiTextRange::split(char separator, ImVector<ImGuiTextRange>* out) const IMGUI_NOEXCEPT
+void ImGuiTextFilter::ImGuiTextRange::split(char separator, ImVector<ImGuiTextRange>* out) const IM_NOEXCEPT
 {
     out->resize(0);
     const char* wb = b;
@@ -2063,7 +2063,7 @@ void ImGuiTextFilter::ImGuiTextRange::split(char separator, ImVector<ImGuiTextRa
         out->push_back(ImGuiTextRange(wb, we));
 }
 
-void ImGuiTextFilter::Build() IMGUI_NOEXCEPT
+void ImGuiTextFilter::Build() IM_NOEXCEPT
 {
     Filters.resize(0);
     ImGuiTextRange input_range(InputBuf, InputBuf + strlen(InputBuf));
@@ -2084,7 +2084,7 @@ void ImGuiTextFilter::Build() IMGUI_NOEXCEPT
     }
 }
 
-bool ImGuiTextFilter::PassFilter(const char* text, const char* text_end) const IMGUI_NOEXCEPT
+bool ImGuiTextFilter::PassFilter(const char* text, const char* text_end) const IM_NOEXCEPT
 {
     if (Filters.empty())
         return true;
@@ -2134,7 +2134,7 @@ bool ImGuiTextFilter::PassFilter(const char* text, const char* text_end) const I
 
 char ImGuiTextBuffer::EmptyString[1] = { 0 };
 
-void ImGuiTextBuffer::append(const char* str, const char* str_end) IMGUI_NOEXCEPT
+void ImGuiTextBuffer::append(const char* str, const char* str_end) IM_NOEXCEPT
 {
     int len = str_end ? (int)(str_end - str) : (int)strlen(str);
 
@@ -2152,7 +2152,7 @@ void ImGuiTextBuffer::append(const char* str, const char* str_end) IMGUI_NOEXCEP
     Buf[write_off - 1 + len] = 0;
 }
 
-void ImGuiTextBuffer::appendf(const char* fmt, ...) IMGUI_NOEXCEPT
+void ImGuiTextBuffer::appendf(const char* fmt, ...) IM_NOEXCEPT
 {
     va_list args;
     va_start(args, fmt);
@@ -2161,7 +2161,7 @@ void ImGuiTextBuffer::appendf(const char* fmt, ...) IMGUI_NOEXCEPT
 }
 
 // Helper: Text buffer for logging/accumulating text
-void ImGuiTextBuffer::appendfv(const char* fmt, va_list args) IMGUI_NOEXCEPT
+void ImGuiTextBuffer::appendfv(const char* fmt, va_list args) IM_NOEXCEPT
 {
     va_list args_copy;
     va_copy(args_copy, args);
@@ -2195,7 +2195,7 @@ void ImGuiTextBuffer::appendfv(const char* fmt, va_list args) IMGUI_NOEXCEPT
 
 // FIXME-TABLE: This prevents us from using ImGuiListClipper _inside_ a table cell.
 // The problem we have is that without a Begin/End scheme for rows using the clipper is ambiguous.
-static bool GetSkipItemForListClipping() IMGUI_NOEXCEPT
+static bool GetSkipItemForListClipping() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return (g.CurrentTable ? g.CurrentTable->HostSkipItems : g.CurrentWindow->SkipItems);
@@ -2204,7 +2204,7 @@ static bool GetSkipItemForListClipping() IMGUI_NOEXCEPT
 // Helper to calculate coarse clipping of large list of evenly sized items.
 // NB: Prefer using the ImGuiListClipper higher-level helper if you can! Read comments and instructions there on how those use this sort of pattern.
 // NB: 'items_count' is only used to clamp the result, if you don't know your count you can use INT_MAX
-void ImGui::CalcListClipping(int items_count, float items_height, int* out_items_display_start, int* out_items_display_end) IMGUI_NOEXCEPT
+void ImGui::CalcListClipping(int items_count, float items_height, int* out_items_display_start, int* out_items_display_end) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -2244,7 +2244,7 @@ void ImGui::CalcListClipping(int items_count, float items_height, int* out_items
     *out_items_display_end = end;
 }
 
-static void SetCursorPosYAndSetupForPrevLine(float pos_y, float line_height) IMGUI_NOEXCEPT
+static void SetCursorPosYAndSetupForPrevLine(float pos_y, float line_height) IM_NOEXCEPT
 {
     // Set cursor position and a few other things so that SetScrollHereY() and Columns() can work when seeking cursor.
     // FIXME: It is problematic that we have to do that here, because custom/equivalent end-user code would stumble on the same issue.
@@ -2269,13 +2269,13 @@ static void SetCursorPosYAndSetupForPrevLine(float pos_y, float line_height) IMG
     }
 }
 
-ImGuiListClipper::ImGuiListClipper() IMGUI_NOEXCEPT
+ImGuiListClipper::ImGuiListClipper() IM_NOEXCEPT
 {
     memset(this, 0, sizeof(*this));
     ItemsCount = -1;
 }
 
-ImGuiListClipper::~ImGuiListClipper() IMGUI_NOEXCEPT
+ImGuiListClipper::~ImGuiListClipper() IM_NOEXCEPT
 {
     IM_ASSERT(ItemsCount == -1 && "Forgot to call End(), or to Step() until false?");
 }
@@ -2283,7 +2283,7 @@ ImGuiListClipper::~ImGuiListClipper() IMGUI_NOEXCEPT
 // Use case A: Begin() called from constructor with items_height<0, then called again from Step() in StepNo 1
 // Use case B: Begin() called from constructor with items_height>0
 // FIXME-LEGACY: Ideally we should remove the Begin/End functions but they are part of the legacy API we still support. This is why some of the code in Step() calling Begin() and reassign some fields, spaghetti style.
-void ImGuiListClipper::Begin(int items_count, float items_height) IMGUI_NOEXCEPT
+void ImGuiListClipper::Begin(int items_count, float items_height) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -2301,7 +2301,7 @@ void ImGuiListClipper::Begin(int items_count, float items_height) IMGUI_NOEXCEPT
     DisplayEnd = 0;
 }
 
-void ImGuiListClipper::End() IMGUI_NOEXCEPT
+void ImGuiListClipper::End() IM_NOEXCEPT
 {
     if (ItemsCount < 0) // Already ended
         return;
@@ -2313,7 +2313,7 @@ void ImGuiListClipper::End() IMGUI_NOEXCEPT
     StepNo = 3;
 }
 
-bool ImGuiListClipper::Step() IMGUI_NOEXCEPT
+bool ImGuiListClipper::Step() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -2420,13 +2420,13 @@ bool ImGuiListClipper::Step() IMGUI_NOEXCEPT
 // [SECTION] STYLING
 //-----------------------------------------------------------------------------
 
-ImGuiStyle& ImGui::GetStyle() IMGUI_NOEXCEPT
+ImGuiStyle& ImGui::GetStyle() IM_NOEXCEPT
 {
     IM_ASSERT(GImGui != NULL && "No current context. Did you call ImGui::CreateContext() and ImGui::SetCurrentContext() ?");
     return GImGui->Style;
 }
 
-ImU32 ImGui::GetColorU32(ImGuiCol idx, float alpha_mul) IMGUI_NOEXCEPT
+ImU32 ImGui::GetColorU32(ImGuiCol idx, float alpha_mul) IM_NOEXCEPT
 {
     ImGuiStyle& style = GImGui->Style;
     ImVec4 c = style.Colors[idx];
@@ -2434,7 +2434,7 @@ ImU32 ImGui::GetColorU32(ImGuiCol idx, float alpha_mul) IMGUI_NOEXCEPT
     return ColorConvertFloat4ToU32(c);
 }
 
-ImU32 ImGui::GetColorU32(const ImVec4& col) IMGUI_NOEXCEPT
+ImU32 ImGui::GetColorU32(const ImVec4& col) IM_NOEXCEPT
 {
     ImGuiStyle& style = GImGui->Style;
     ImVec4 c = col;
@@ -2442,13 +2442,13 @@ ImU32 ImGui::GetColorU32(const ImVec4& col) IMGUI_NOEXCEPT
     return ColorConvertFloat4ToU32(c);
 }
 
-const ImVec4& ImGui::GetStyleColorVec4(ImGuiCol idx) IMGUI_NOEXCEPT
+const ImVec4& ImGui::GetStyleColorVec4(ImGuiCol idx) IM_NOEXCEPT
 {
     ImGuiStyle& style = GImGui->Style;
     return style.Colors[idx];
 }
 
-ImU32 ImGui::GetColorU32(ImU32 col) IMGUI_NOEXCEPT
+ImU32 ImGui::GetColorU32(ImU32 col) IM_NOEXCEPT
 {
     ImGuiStyle& style = GImGui->Style;
     if (style.Alpha >= 1.0f)
@@ -2459,7 +2459,7 @@ ImU32 ImGui::GetColorU32(ImU32 col) IMGUI_NOEXCEPT
 }
 
 // FIXME: This may incur a round-trip (if the end user got their data from a float4) but eventually we aim to store the in-flight colors as ImU32
-void ImGui::PushStyleColor(ImGuiCol idx, ImU32 col) IMGUI_NOEXCEPT
+void ImGui::PushStyleColor(ImGuiCol idx, ImU32 col) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiColorMod backup;
@@ -2469,7 +2469,7 @@ void ImGui::PushStyleColor(ImGuiCol idx, ImU32 col) IMGUI_NOEXCEPT
     g.Style.Colors[idx] = ColorConvertU32ToFloat4(col);
 }
 
-void ImGui::PushStyleColor(ImGuiCol idx, const ImVec4& col) IMGUI_NOEXCEPT
+void ImGui::PushStyleColor(ImGuiCol idx, const ImVec4& col) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiColorMod backup;
@@ -2479,7 +2479,7 @@ void ImGui::PushStyleColor(ImGuiCol idx, const ImVec4& col) IMGUI_NOEXCEPT
     g.Style.Colors[idx] = col;
 }
 
-void ImGui::PopStyleColor(int count) IMGUI_NOEXCEPT
+void ImGui::PopStyleColor(int count) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     while (count > 0)
@@ -2527,14 +2527,14 @@ static const ImGuiStyleVarInfo GStyleVarInfo[] =
     { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImGuiStyle, SelectableTextAlign) }, // ImGuiStyleVar_SelectableTextAlign
 };
 
-static const ImGuiStyleVarInfo* GetStyleVarInfo(ImGuiStyleVar idx) IMGUI_NOEXCEPT
+static const ImGuiStyleVarInfo* GetStyleVarInfo(ImGuiStyleVar idx) IM_NOEXCEPT
 {
     IM_ASSERT(idx >= 0 && idx < ImGuiStyleVar_COUNT);
     IM_ASSERT(IM_ARRAYSIZE(GStyleVarInfo) == ImGuiStyleVar_COUNT);
     return &GStyleVarInfo[idx];
 }
 
-void ImGui::PushStyleVar(ImGuiStyleVar idx, float val) IMGUI_NOEXCEPT
+void ImGui::PushStyleVar(ImGuiStyleVar idx, float val) IM_NOEXCEPT
 {
     const ImGuiStyleVarInfo* var_info = GetStyleVarInfo(idx);
     if (var_info->Type == ImGuiDataType_Float && var_info->Count == 1)
@@ -2548,7 +2548,7 @@ void ImGui::PushStyleVar(ImGuiStyleVar idx, float val) IMGUI_NOEXCEPT
     IM_ASSERT(0 && "Called PushStyleVar() float variant but variable is not a float!");
 }
 
-void ImGui::PushStyleVar(ImGuiStyleVar idx, const ImVec2& val) IMGUI_NOEXCEPT
+void ImGui::PushStyleVar(ImGuiStyleVar idx, const ImVec2& val) IM_NOEXCEPT
 {
     const ImGuiStyleVarInfo* var_info = GetStyleVarInfo(idx);
     if (var_info->Type == ImGuiDataType_Float && var_info->Count == 2)
@@ -2562,7 +2562,7 @@ void ImGui::PushStyleVar(ImGuiStyleVar idx, const ImVec2& val) IMGUI_NOEXCEPT
     IM_ASSERT(0 && "Called PushStyleVar() ImVec2 variant but variable is not a ImVec2!");
 }
 
-void ImGui::PopStyleVar(int count) IMGUI_NOEXCEPT
+void ImGui::PopStyleVar(int count) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     while (count > 0)
@@ -2578,7 +2578,7 @@ void ImGui::PopStyleVar(int count) IMGUI_NOEXCEPT
     }
 }
 
-const char* ImGui::GetStyleColorName(ImGuiCol idx) IMGUI_NOEXCEPT
+const char* ImGui::GetStyleColorName(ImGuiCol idx) IM_NOEXCEPT
 {
     // Create switch-case from enum with regexp: ImGuiCol_{.*}, --> case ImGuiCol_\1: return "\1";
     switch (idx)
@@ -2649,7 +2649,7 @@ const char* ImGui::GetStyleColorName(ImGuiCol idx) IMGUI_NOEXCEPT
 // Also see imgui_draw.cpp for some more which have been reworked to not rely on ImGui:: context.
 //-----------------------------------------------------------------------------
 
-const char* ImGui::FindRenderedTextEnd(const char* text, const char* text_end) IMGUI_NOEXCEPT
+const char* ImGui::FindRenderedTextEnd(const char* text, const char* text_end) IM_NOEXCEPT
 {
     const char* text_display_end = text;
     if (!text_end)
@@ -2662,7 +2662,7 @@ const char* ImGui::FindRenderedTextEnd(const char* text, const char* text_end) I
 
 // Internal ImGui functions to render text
 // RenderText***() functions calls ImDrawList::AddText() calls ImBitmapFont::RenderText()
-void ImGui::RenderText(ImVec2 pos, const char* text, const char* text_end, bool hide_text_after_hash) IMGUI_NOEXCEPT
+void ImGui::RenderText(ImVec2 pos, const char* text, const char* text_end, bool hide_text_after_hash) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -2688,7 +2688,7 @@ void ImGui::RenderText(ImVec2 pos, const char* text, const char* text_end, bool 
     }
 }
 
-void ImGui::RenderTextWrapped(ImVec2 pos, const char* text, const char* text_end, float wrap_width) IMGUI_NOEXCEPT
+void ImGui::RenderTextWrapped(ImVec2 pos, const char* text, const char* text_end, float wrap_width) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -2706,7 +2706,7 @@ void ImGui::RenderTextWrapped(ImVec2 pos, const char* text, const char* text_end
 
 // Default clip_rect uses (pos_min,pos_max)
 // Handle clipping on CPU immediately (vs typically let the GPU clip the triangles that are overlapping the clipping rectangle edges)
-void ImGui::RenderTextClippedEx(ImDrawList* draw_list, const ImVec2& pos_min, const ImVec2& pos_max, const char* text, const char* text_display_end, const ImVec2* text_size_if_known, const ImVec2& align, const ImRect* clip_rect) IMGUI_NOEXCEPT
+void ImGui::RenderTextClippedEx(ImDrawList* draw_list, const ImVec2& pos_min, const ImVec2& pos_max, const char* text, const char* text_display_end, const ImVec2* text_size_if_known, const ImVec2& align, const ImRect* clip_rect) IM_NOEXCEPT
 {
     // Perform CPU side clipping for single clipped element to avoid using scissor state
     ImVec2 pos = pos_min;
@@ -2734,7 +2734,7 @@ void ImGui::RenderTextClippedEx(ImDrawList* draw_list, const ImVec2& pos_min, co
     }
 }
 
-void ImGui::RenderTextClipped(const ImVec2& pos_min, const ImVec2& pos_max, const char* text, const char* text_end, const ImVec2* text_size_if_known, const ImVec2& align, const ImRect* clip_rect) IMGUI_NOEXCEPT
+void ImGui::RenderTextClipped(const ImVec2& pos_min, const ImVec2& pos_max, const char* text, const char* text_end, const ImVec2* text_size_if_known, const ImVec2& align, const ImRect* clip_rect) IM_NOEXCEPT
 {
     // Hide anything after a '##' string
     const char* text_display_end = FindRenderedTextEnd(text, text_end);
@@ -2753,7 +2753,7 @@ void ImGui::RenderTextClipped(const ImVec2& pos_min, const ImVec2& pos_max, cons
 // Another overly complex function until we reorganize everything into a nice all-in-one helper.
 // This is made more complex because we have dissociated the layout rectangle (pos_min..pos_max) which define _where_ the ellipsis is, from actual clipping of text and limit of the ellipsis display.
 // This is because in the context of tabs we selectively hide part of the text when the Close Button appears, but we don't want the ellipsis to move.
-void ImGui::RenderTextEllipsis(ImDrawList* draw_list, const ImVec2& pos_min, const ImVec2& pos_max, float clip_max_x, float ellipsis_max_x, const char* text, const char* text_end_full, const ImVec2* text_size_if_known) IMGUI_NOEXCEPT
+void ImGui::RenderTextEllipsis(ImDrawList* draw_list, const ImVec2& pos_min, const ImVec2& pos_max, float clip_max_x, float ellipsis_max_x, const char* text, const char* text_end_full, const ImVec2* text_size_if_known) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (text_end_full == NULL)
@@ -2831,7 +2831,7 @@ void ImGui::RenderTextEllipsis(ImDrawList* draw_list, const ImVec2& pos_min, con
 }
 
 // Render a rectangle shaped with optional rounding and borders
-void ImGui::RenderFrame(ImVec2 p_min, ImVec2 p_max, ImU32 fill_col, bool border, float rounding) IMGUI_NOEXCEPT
+void ImGui::RenderFrame(ImVec2 p_min, ImVec2 p_max, ImU32 fill_col, bool border, float rounding) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -2844,7 +2844,7 @@ void ImGui::RenderFrame(ImVec2 p_min, ImVec2 p_max, ImU32 fill_col, bool border,
     }
 }
 
-void ImGui::RenderFrameBorder(ImVec2 p_min, ImVec2 p_max, float rounding) IMGUI_NOEXCEPT
+void ImGui::RenderFrameBorder(ImVec2 p_min, ImVec2 p_max, float rounding) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -2856,7 +2856,7 @@ void ImGui::RenderFrameBorder(ImVec2 p_min, ImVec2 p_max, float rounding) IMGUI_
     }
 }
 
-void ImGui::RenderNavHighlight(const ImRect& bb, ImGuiID id, ImGuiNavHighlightFlags flags) IMGUI_NOEXCEPT
+void ImGui::RenderNavHighlight(const ImRect& bb, ImGuiID id, ImGuiNavHighlightFlags flags) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (id != g.NavId)
@@ -2893,7 +2893,7 @@ void ImGui::RenderNavHighlight(const ImRect& bb, ImGuiID id, ImGuiNavHighlightFl
 //-----------------------------------------------------------------------------
 
 // ImGuiWindow is mostly a dumb struct. It merely has a constructor and a few helper methods
-ImGuiWindow::ImGuiWindow(ImGuiContext* context, const char* name) IMGUI_NOEXCEPT : DrawListInst(NULL)
+ImGuiWindow::ImGuiWindow(ImGuiContext* context, const char* name) IM_NOEXCEPT : DrawListInst(NULL)
 {
     memset(this, 0, sizeof(*this));
     Name = ImStrdup(name);
@@ -2916,7 +2916,7 @@ ImGuiWindow::ImGuiWindow(ImGuiContext* context, const char* name) IMGUI_NOEXCEPT
     DrawList->_OwnerName = Name;
 }
 
-ImGuiWindow::~ImGuiWindow() IMGUI_NOEXCEPT
+ImGuiWindow::~ImGuiWindow() IM_NOEXCEPT
 {
     IM_ASSERT(DrawList == &DrawListInst);
     IM_DELETE(Name);
@@ -2924,7 +2924,7 @@ ImGuiWindow::~ImGuiWindow() IMGUI_NOEXCEPT
         ColumnsStorage[i].~ImGuiOldColumns();
 }
 
-ImGuiID ImGuiWindow::GetID(const char* str, const char* str_end) IMGUI_NOEXCEPT
+ImGuiID ImGuiWindow::GetID(const char* str, const char* str_end) IM_NOEXCEPT
 {
     ImGuiID seed = IDStack.back();
     ImGuiID id = ImHashStr(str, str_end ? (str_end - str) : 0, seed);
@@ -2936,7 +2936,7 @@ ImGuiID ImGuiWindow::GetID(const char* str, const char* str_end) IMGUI_NOEXCEPT
     return id;
 }
 
-ImGuiID ImGuiWindow::GetID(const void* ptr) IMGUI_NOEXCEPT
+ImGuiID ImGuiWindow::GetID(const void* ptr) IM_NOEXCEPT
 {
     ImGuiID seed = IDStack.back();
     ImGuiID id = ImHashData(&ptr, sizeof(void*), seed);
@@ -2948,7 +2948,7 @@ ImGuiID ImGuiWindow::GetID(const void* ptr) IMGUI_NOEXCEPT
     return id;
 }
 
-ImGuiID ImGuiWindow::GetID(int n) IMGUI_NOEXCEPT
+ImGuiID ImGuiWindow::GetID(int n) IM_NOEXCEPT
 {
     ImGuiID seed = IDStack.back();
     ImGuiID id = ImHashData(&n, sizeof(n), seed);
@@ -2960,7 +2960,7 @@ ImGuiID ImGuiWindow::GetID(int n) IMGUI_NOEXCEPT
     return id;
 }
 
-ImGuiID ImGuiWindow::GetIDNoKeepAlive(const char* str, const char* str_end) IMGUI_NOEXCEPT
+ImGuiID ImGuiWindow::GetIDNoKeepAlive(const char* str, const char* str_end) IM_NOEXCEPT
 {
     ImGuiID seed = IDStack.back();
     ImGuiID id = ImHashStr(str, str_end ? (str_end - str) : 0, seed);
@@ -2971,7 +2971,7 @@ ImGuiID ImGuiWindow::GetIDNoKeepAlive(const char* str, const char* str_end) IMGU
     return id;
 }
 
-ImGuiID ImGuiWindow::GetIDNoKeepAlive(const void* ptr) IMGUI_NOEXCEPT
+ImGuiID ImGuiWindow::GetIDNoKeepAlive(const void* ptr) IM_NOEXCEPT
 {
     ImGuiID seed = IDStack.back();
     ImGuiID id = ImHashData(&ptr, sizeof(void*), seed);
@@ -2982,7 +2982,7 @@ ImGuiID ImGuiWindow::GetIDNoKeepAlive(const void* ptr) IMGUI_NOEXCEPT
     return id;
 }
 
-ImGuiID ImGuiWindow::GetIDNoKeepAlive(int n) IMGUI_NOEXCEPT
+ImGuiID ImGuiWindow::GetIDNoKeepAlive(int n) IM_NOEXCEPT
 {
     ImGuiID seed = IDStack.back();
     ImGuiID id = ImHashData(&n, sizeof(n), seed);
@@ -2994,7 +2994,7 @@ ImGuiID ImGuiWindow::GetIDNoKeepAlive(int n) IMGUI_NOEXCEPT
 }
 
 // This is only used in rare/specific situations to manufacture an ID out of nowhere.
-ImGuiID ImGuiWindow::GetIDFromRectangle(const ImRect& r_abs) IMGUI_NOEXCEPT
+ImGuiID ImGuiWindow::GetIDFromRectangle(const ImRect& r_abs) IM_NOEXCEPT
 {
     ImGuiID seed = IDStack.back();
     const int r_rel[4] = { (int)(r_abs.Min.x - Pos.x), (int)(r_abs.Min.y - Pos.y), (int)(r_abs.Max.x - Pos.x), (int)(r_abs.Max.y - Pos.y) };
@@ -3003,7 +3003,7 @@ ImGuiID ImGuiWindow::GetIDFromRectangle(const ImRect& r_abs) IMGUI_NOEXCEPT
     return id;
 }
 
-static void SetCurrentWindow(ImGuiWindow* window) IMGUI_NOEXCEPT
+static void SetCurrentWindow(ImGuiWindow* window) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.CurrentWindow = window;
@@ -3012,7 +3012,7 @@ static void SetCurrentWindow(ImGuiWindow* window) IMGUI_NOEXCEPT
         g.FontSize = g.DrawListSharedData.FontSize = window->CalcFontSize();
 }
 
-void ImGui::GcCompactTransientMiscBuffers() IMGUI_NOEXCEPT
+void ImGui::GcCompactTransientMiscBuffers() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.ItemFlagsStack.clear();
@@ -3024,7 +3024,7 @@ void ImGui::GcCompactTransientMiscBuffers() IMGUI_NOEXCEPT
 // Not freed:
 // - ImGuiWindow, ImGuiWindowSettings, Name, StateStorage, ColumnsStorage (may hold useful data)
 // This should have no noticeable visual effect. When the window reappear however, expect new allocation/buffer growth/copy cost.
-void ImGui::GcCompactTransientWindowBuffers(ImGuiWindow* window) IMGUI_NOEXCEPT
+void ImGui::GcCompactTransientWindowBuffers(ImGuiWindow* window) IM_NOEXCEPT
 {
     window->MemoryCompacted = true;
     window->MemoryDrawListIdxCapacity = window->DrawList->IdxBuffer.Capacity;
@@ -3036,7 +3036,7 @@ void ImGui::GcCompactTransientWindowBuffers(ImGuiWindow* window) IMGUI_NOEXCEPT
     window->DC.TextWrapPosStack.clear();
 }
 
-void ImGui::GcAwakeTransientWindowBuffers(ImGuiWindow* window) IMGUI_NOEXCEPT
+void ImGui::GcAwakeTransientWindowBuffers(ImGuiWindow* window) IM_NOEXCEPT
 {
     // We stored capacity of the ImDrawList buffer to reduce growth-caused allocation/copy when awakening.
     // The other buffers tends to amortize much faster.
@@ -3046,7 +3046,7 @@ void ImGui::GcAwakeTransientWindowBuffers(ImGuiWindow* window) IMGUI_NOEXCEPT
     window->MemoryDrawListIdxCapacity = window->MemoryDrawListVtxCapacity = 0;
 }
 
-void ImGui::SetActiveID(ImGuiID id, ImGuiWindow* window) IMGUI_NOEXCEPT
+void ImGui::SetActiveID(ImGuiID id, ImGuiWindow* window) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.ActiveIdIsJustActivated = (g.ActiveId != id);
@@ -3081,12 +3081,12 @@ void ImGui::SetActiveID(ImGuiID id, ImGuiWindow* window) IMGUI_NOEXCEPT
     g.ActiveIdUsingKeyInputMask = 0x00;
 }
 
-void ImGui::ClearActiveID() IMGUI_NOEXCEPT
+void ImGui::ClearActiveID() IM_NOEXCEPT
 {
     SetActiveID(0, NULL); // g.ActiveId = 0;
 }
 
-void ImGui::SetHoveredID(ImGuiID id) IMGUI_NOEXCEPT
+void ImGui::SetHoveredID(ImGuiID id) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.HoveredId = id;
@@ -3096,13 +3096,13 @@ void ImGui::SetHoveredID(ImGuiID id) IMGUI_NOEXCEPT
         g.HoveredIdTimer = g.HoveredIdNotActiveTimer = 0.0f;
 }
 
-ImGuiID ImGui::GetHoveredID() IMGUI_NOEXCEPT
+ImGuiID ImGui::GetHoveredID() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return g.HoveredId ? g.HoveredId : g.HoveredIdPreviousFrame;
 }
 
-void ImGui::KeepAliveID(ImGuiID id) IMGUI_NOEXCEPT
+void ImGui::KeepAliveID(ImGuiID id) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.ActiveId == id)
@@ -3111,7 +3111,7 @@ void ImGui::KeepAliveID(ImGuiID id) IMGUI_NOEXCEPT
         g.ActiveIdPreviousFrameIsAlive = true;
 }
 
-void ImGui::MarkItemEdited(ImGuiID id) IMGUI_NOEXCEPT
+void ImGui::MarkItemEdited(ImGuiID id) IM_NOEXCEPT
 {
     // This marking is solely to be able to provide info for IsItemDeactivatedAfterEdit().
     // ActiveId might have been released by the time we call this (as in the typical press/release button behavior) but still need need to fill the data.
@@ -3124,7 +3124,7 @@ void ImGui::MarkItemEdited(ImGuiID id) IMGUI_NOEXCEPT
     g.CurrentWindow->DC.LastItemStatusFlags |= ImGuiItemStatusFlags_Edited;
 }
 
-static inline bool IsWindowContentHoverable(ImGuiWindow* window, ImGuiHoveredFlags flags) IMGUI_NOEXCEPT
+static inline bool IsWindowContentHoverable(ImGuiWindow* window, ImGuiHoveredFlags flags) IM_NOEXCEPT
 {
     // An active popup disable hovering on other windows (apart from its own children)
     // FIXME-OPT: This could be cached/stored within the window.
@@ -3146,7 +3146,7 @@ static inline bool IsWindowContentHoverable(ImGuiWindow* window, ImGuiHoveredFla
 // This is roughly matching the behavior of internal-facing ItemHoverable()
 // - we allow hovering to be true when ActiveId==window->MoveID, so that clicking on non-interactive items such as a Text() item still returns true with IsItemHovered()
 // - this should work even for non-interactive items that have no ID, so we cannot use LastItemId
-bool ImGui::IsItemHovered(ImGuiHoveredFlags flags) IMGUI_NOEXCEPT
+bool ImGui::IsItemHovered(ImGuiHoveredFlags flags) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -3190,7 +3190,7 @@ bool ImGui::IsItemHovered(ImGuiHoveredFlags flags) IMGUI_NOEXCEPT
 }
 
 // Internal facing ItemHoverable() used when submitting widgets. Differs slightly from IsItemHovered().
-bool ImGui::ItemHoverable(const ImRect& bb, ImGuiID id) IMGUI_NOEXCEPT
+bool ImGui::ItemHoverable(const ImRect& bb, ImGuiID id) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.HoveredId != 0 && g.HoveredId != id && !g.HoveredIdAllowOverlap)
@@ -3231,7 +3231,7 @@ bool ImGui::ItemHoverable(const ImRect& bb, ImGuiID id) IMGUI_NOEXCEPT
     return true;
 }
 
-bool ImGui::IsClippedEx(const ImRect& bb, ImGuiID id, bool clip_even_when_logged) IMGUI_NOEXCEPT
+bool ImGui::IsClippedEx(const ImRect& bb, ImGuiID id, bool clip_even_when_logged) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -3244,7 +3244,7 @@ bool ImGui::IsClippedEx(const ImRect& bb, ImGuiID id, bool clip_even_when_logged
 
 // This is also inlined in ItemAdd()
 // Note: if ImGuiItemStatusFlags_HasDisplayRect is set, user needs to set window->DC.LastItemDisplayRect!
-void ImGui::SetLastItemData(ImGuiWindow* window, ImGuiID item_id, ImGuiItemStatusFlags item_flags, const ImRect& item_rect) IMGUI_NOEXCEPT
+void ImGui::SetLastItemData(ImGuiWindow* window, ImGuiID item_id, ImGuiItemStatusFlags item_flags, const ImRect& item_rect) IM_NOEXCEPT
 {
     window->DC.LastItemId = item_id;
     window->DC.LastItemStatusFlags = item_flags;
@@ -3252,7 +3252,7 @@ void ImGui::SetLastItemData(ImGuiWindow* window, ImGuiID item_id, ImGuiItemStatu
 }
 
 // Process TAB/Shift+TAB. Be mindful that this function may _clear_ the ActiveID when tabbing out.
-void ImGui::ItemFocusable(ImGuiWindow* window, ImGuiID id) IMGUI_NOEXCEPT
+void ImGui::ItemFocusable(ImGuiWindow* window, ImGuiID id) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(id != 0 && id == window->DC.LastItemId);
@@ -3297,7 +3297,7 @@ void ImGui::ItemFocusable(ImGuiWindow* window, ImGuiID id) IMGUI_NOEXCEPT
     }
 }
 
-float ImGui::CalcWrapWidthForPos(const ImVec2& pos, float wrap_pos_x) IMGUI_NOEXCEPT
+float ImGui::CalcWrapWidthForPos(const ImVec2& pos, float wrap_pos_x) IM_NOEXCEPT
 {
     if (wrap_pos_x < 0.0f)
         return 0.0f;
@@ -3322,7 +3322,7 @@ float ImGui::CalcWrapWidthForPos(const ImVec2& pos, float wrap_pos_x) IMGUI_NOEX
 }
 
 // IM_ALLOC() == ImGui::MemAlloc()
-void* ImGui::MemAlloc(size_t size) IMGUI_NOEXCEPT
+void* ImGui::MemAlloc(size_t size) IM_NOEXCEPT
 {
     if (ImGuiContext* ctx = GImGui)
         ctx->IO.MetricsActiveAllocations++;
@@ -3330,7 +3330,7 @@ void* ImGui::MemAlloc(size_t size) IMGUI_NOEXCEPT
 }
 
 // IM_FREE() == ImGui::MemFree()
-void ImGui::MemFree(void* ptr) IMGUI_NOEXCEPT
+void ImGui::MemFree(void* ptr) IM_NOEXCEPT
 {
     if (ptr)
         if (ImGuiContext* ctx = GImGui)
@@ -3338,32 +3338,32 @@ void ImGui::MemFree(void* ptr) IMGUI_NOEXCEPT
     return (*GImAllocatorFreeFunc)(ptr, GImAllocatorUserData);
 }
 
-const char* ImGui::GetClipboardText() IMGUI_NOEXCEPT
+const char* ImGui::GetClipboardText() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return g.IO.GetClipboardTextFn ? g.IO.GetClipboardTextFn(g.IO.ClipboardUserData) : "";
 }
 
-void ImGui::SetClipboardText(const char* text) IMGUI_NOEXCEPT
+void ImGui::SetClipboardText(const char* text) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.IO.SetClipboardTextFn)
         g.IO.SetClipboardTextFn(g.IO.ClipboardUserData, text);
 }
 
-const char* ImGui::GetVersion() IMGUI_NOEXCEPT
+const char* ImGui::GetVersion() IM_NOEXCEPT
 {
     return IMGUI_VERSION;
 }
 
 // Internal state access - if you want to share Dear ImGui state between modules (e.g. DLL) or allocate it yourself
 // Note that we still point to some static data and members (such as GFontAtlas), so the state instance you end up using will point to the static data within its module
-ImGuiContext* ImGui::GetCurrentContext() IMGUI_NOEXCEPT
+ImGuiContext* ImGui::GetCurrentContext() IM_NOEXCEPT
 {
     return GImGui;
 }
 
-void ImGui::SetCurrentContext(ImGuiContext* ctx) IMGUI_NOEXCEPT
+void ImGui::SetCurrentContext(ImGuiContext* ctx) IM_NOEXCEPT
 {
 #ifdef IMGUI_SET_CURRENT_CONTEXT_FUNC
     IMGUI_SET_CURRENT_CONTEXT_FUNC(ctx); // For custom thread-based hackery you may want to have control over this.
@@ -3372,7 +3372,7 @@ void ImGui::SetCurrentContext(ImGuiContext* ctx) IMGUI_NOEXCEPT
 #endif
 }
 
-void ImGui::SetAllocatorFunctions(ImGuiMemAllocFunc alloc_func, ImGuiMemFreeFunc free_func, void* user_data) IMGUI_NOEXCEPT
+void ImGui::SetAllocatorFunctions(ImGuiMemAllocFunc alloc_func, ImGuiMemFreeFunc free_func, void* user_data) IM_NOEXCEPT
 {
     GImAllocatorAllocFunc = alloc_func;
     GImAllocatorFreeFunc = free_func;
@@ -3380,14 +3380,14 @@ void ImGui::SetAllocatorFunctions(ImGuiMemAllocFunc alloc_func, ImGuiMemFreeFunc
 }
 
 // This is provided to facilitate copying allocators from one static/DLL boundary to another (e.g. retrieve default allocator of your executable address space)
-void ImGui::GetAllocatorFunctions(ImGuiMemAllocFunc* p_alloc_func, ImGuiMemFreeFunc* p_free_func, void** p_user_data) IMGUI_NOEXCEPT
+void ImGui::GetAllocatorFunctions(ImGuiMemAllocFunc* p_alloc_func, ImGuiMemFreeFunc* p_free_func, void** p_user_data) IM_NOEXCEPT
 {
     *p_alloc_func = GImAllocatorAllocFunc;
     *p_free_func = GImAllocatorFreeFunc;
     *p_user_data = GImAllocatorUserData;
 }
 
-ImGuiContext* ImGui::CreateContext(ImFontAtlas* shared_font_atlas) IMGUI_NOEXCEPT
+ImGuiContext* ImGui::CreateContext(ImFontAtlas* shared_font_atlas) IM_NOEXCEPT
 {
     ImGuiContext* ctx = IM_NEW(ImGuiContext)(shared_font_atlas);
     if (GImGui == NULL)
@@ -3396,7 +3396,7 @@ ImGuiContext* ImGui::CreateContext(ImFontAtlas* shared_font_atlas) IMGUI_NOEXCEP
     return ctx;
 }
 
-void ImGui::DestroyContext(ImGuiContext* ctx) IMGUI_NOEXCEPT
+void ImGui::DestroyContext(ImGuiContext* ctx) IM_NOEXCEPT
 {
     if (ctx == NULL)
         ctx = GImGui;
@@ -3407,7 +3407,7 @@ void ImGui::DestroyContext(ImGuiContext* ctx) IMGUI_NOEXCEPT
 }
 
 // No specific ordering/dependency support, will see as needed
-ImGuiID ImGui::AddContextHook(ImGuiContext* ctx, const ImGuiContextHook* hook) IMGUI_NOEXCEPT
+ImGuiID ImGui::AddContextHook(ImGuiContext* ctx, const ImGuiContextHook* hook) IM_NOEXCEPT
 {
     ImGuiContext& g = *ctx;
     IM_ASSERT(hook->Callback != NULL && hook->HookId == 0 && hook->Type != ImGuiContextHookType_PendingRemoval_);
@@ -3417,7 +3417,7 @@ ImGuiID ImGui::AddContextHook(ImGuiContext* ctx, const ImGuiContextHook* hook) I
 }
 
 // Deferred removal, avoiding issue with changing vector while iterating it
-void ImGui::RemoveContextHook(ImGuiContext* ctx, ImGuiID hook_id) IMGUI_NOEXCEPT
+void ImGui::RemoveContextHook(ImGuiContext* ctx, ImGuiID hook_id) IM_NOEXCEPT
 {
     ImGuiContext& g = *ctx;
     IM_ASSERT(hook_id != 0);
@@ -3428,7 +3428,7 @@ void ImGui::RemoveContextHook(ImGuiContext* ctx, ImGuiID hook_id) IMGUI_NOEXCEPT
 
 // Call context hooks (used by e.g. test engine)
 // We assume a small number of hooks so all stored in same array
-void ImGui::CallContextHooks(ImGuiContext* ctx, ImGuiContextHookType hook_type) IMGUI_NOEXCEPT
+void ImGui::CallContextHooks(ImGuiContext* ctx, ImGuiContextHookType hook_type) IM_NOEXCEPT
 {
     ImGuiContext& g = *ctx;
     for (int n = 0; n < g.Hooks.Size; n++)
@@ -3436,31 +3436,31 @@ void ImGui::CallContextHooks(ImGuiContext* ctx, ImGuiContextHookType hook_type) 
             g.Hooks[n].Callback(&g, &g.Hooks[n]);
 }
 
-ImGuiIO& ImGui::GetIO() IMGUI_NOEXCEPT
+ImGuiIO& ImGui::GetIO() IM_NOEXCEPT
 {
     IM_ASSERT(GImGui != NULL && "No current context. Did you call ImGui::CreateContext() and ImGui::SetCurrentContext() ?");
     return GImGui->IO;
 }
 
 // Pass this to your backend rendering function! Valid after Render() and until the next call to NewFrame()
-ImDrawData* ImGui::GetDrawData() IMGUI_NOEXCEPT
+ImDrawData* ImGui::GetDrawData() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiViewportP* viewport = g.Viewports[0];
     return viewport->DrawDataP.Valid ? &viewport->DrawDataP : NULL;
 }
 
-double ImGui::GetTime() IMGUI_NOEXCEPT
+double ImGui::GetTime() IM_NOEXCEPT
 {
     return GImGui->Time;
 }
 
-int ImGui::GetFrameCount() IMGUI_NOEXCEPT
+int ImGui::GetFrameCount() IM_NOEXCEPT
 {
     return GImGui->FrameCount;
 }
 
-static ImDrawList* GetViewportDrawList(ImGuiViewportP* viewport, size_t drawlist_no, const char* drawlist_name) IMGUI_NOEXCEPT
+static ImDrawList* GetViewportDrawList(ImGuiViewportP* viewport, size_t drawlist_no, const char* drawlist_name) IM_NOEXCEPT
 {
     // Create the draw list on demand, because they are not frequently used for all viewports
     ImGuiContext& g = *GImGui;
@@ -3484,34 +3484,34 @@ static ImDrawList* GetViewportDrawList(ImGuiViewportP* viewport, size_t drawlist
     return draw_list;
 }
 
-ImDrawList* ImGui::GetBackgroundDrawList(ImGuiViewport* viewport) IMGUI_NOEXCEPT
+ImDrawList* ImGui::GetBackgroundDrawList(ImGuiViewport* viewport) IM_NOEXCEPT
 {
     return GetViewportDrawList((ImGuiViewportP*)viewport, 0, "##Background");
 }
 
-ImDrawList* ImGui::GetBackgroundDrawList() IMGUI_NOEXCEPT
+ImDrawList* ImGui::GetBackgroundDrawList() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return GetBackgroundDrawList(g.Viewports[0]);
 }
 
-ImDrawList* ImGui::GetForegroundDrawList(ImGuiViewport* viewport) IMGUI_NOEXCEPT
+ImDrawList* ImGui::GetForegroundDrawList(ImGuiViewport* viewport) IM_NOEXCEPT
 {
     return GetViewportDrawList((ImGuiViewportP*)viewport, 1, "##Foreground");
 }
 
-ImDrawList* ImGui::GetForegroundDrawList() IMGUI_NOEXCEPT
+ImDrawList* ImGui::GetForegroundDrawList() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return GetForegroundDrawList(g.Viewports[0]);
 }
 
-ImDrawListSharedData* ImGui::GetDrawListSharedData() IMGUI_NOEXCEPT
+ImDrawListSharedData* ImGui::GetDrawListSharedData() IM_NOEXCEPT
 {
     return &GImGui->DrawListSharedData;
 }
 
-void ImGui::StartMouseMovingWindow(ImGuiWindow* window) IMGUI_NOEXCEPT
+void ImGui::StartMouseMovingWindow(ImGuiWindow* window) IM_NOEXCEPT
 {
     // Set ActiveId even if the _NoMove flag is set. Without it, dragging away from a window with _NoMove would activate hover on other windows.
     // We _also_ call this when clicking in a window empty space when io.ConfigWindowsMoveFromTitleBarOnly is set, but clear g.MovingWindow afterward.
@@ -3535,7 +3535,7 @@ void ImGui::StartMouseMovingWindow(ImGuiWindow* window) IMGUI_NOEXCEPT
 // FIXME: We don't have strong guarantee that g.MovingWindow stay synched with g.ActiveId == g.MovingWindow->MoveId.
 // This is currently enforced by the fact that BeginDragDropSource() is setting all g.ActiveIdUsingXXXX flags to inhibit navigation inputs,
 // but if we should more thoroughly test cases where g.ActiveId or g.MovingWindow gets changed and not the other.
-void ImGui::UpdateMouseMovingWindowNewFrame() IMGUI_NOEXCEPT
+void ImGui::UpdateMouseMovingWindowNewFrame() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.MovingWindow != NULL)
@@ -3575,7 +3575,7 @@ void ImGui::UpdateMouseMovingWindowNewFrame() IMGUI_NOEXCEPT
 
 // Initiate moving window when clicking on empty space or title bar.
 // Handle left-click and right-click focus.
-void ImGui::UpdateMouseMovingWindowEndFrame() IMGUI_NOEXCEPT
+void ImGui::UpdateMouseMovingWindowEndFrame() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.ActiveId != 0 || g.HoveredId != 0)
@@ -3627,12 +3627,12 @@ void ImGui::UpdateMouseMovingWindowEndFrame() IMGUI_NOEXCEPT
     }
 }
 
-static bool IsWindowActiveAndVisible(ImGuiWindow* window) IMGUI_NOEXCEPT
+static bool IsWindowActiveAndVisible(ImGuiWindow* window) IM_NOEXCEPT
 {
     return (window->Active) && (!window->Hidden);
 }
 
-static void ImGui::UpdateMouseInputs() IMGUI_NOEXCEPT
+static void ImGui::UpdateMouseInputs() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -3689,7 +3689,7 @@ static void ImGui::UpdateMouseInputs() IMGUI_NOEXCEPT
     }
 }
 
-static void StartLockWheelingWindow(ImGuiWindow* window) IMGUI_NOEXCEPT
+static void StartLockWheelingWindow(ImGuiWindow* window) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.WheelingWindow == window)
@@ -3699,7 +3699,7 @@ static void StartLockWheelingWindow(ImGuiWindow* window) IMGUI_NOEXCEPT
     g.WheelingWindowTimer = WINDOWS_MOUSE_WHEEL_SCROLL_LOCK_TIMER;
 }
 
-void ImGui::UpdateMouseWheel() IMGUI_NOEXCEPT
+void ImGui::UpdateMouseWheel() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -3784,7 +3784,7 @@ void ImGui::UpdateMouseWheel() IMGUI_NOEXCEPT
     }
 }
 
-void ImGui::UpdateTabFocus() IMGUI_NOEXCEPT
+void ImGui::UpdateTabFocus() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -3823,7 +3823,7 @@ void ImGui::UpdateTabFocus() IMGUI_NOEXCEPT
 }
 
 // The reason this is exposed in imgui_internal.h is: on touch-based system that don't have hovering, we want to dispatch inputs to the right target (imgui vs imgui+app)
-void ImGui::UpdateHoveredWindowAndCaptureFlags() IMGUI_NOEXCEPT
+void ImGui::UpdateHoveredWindowAndCaptureFlags() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.WindowsHoverPadding = ImMax(g.Style.TouchExtraPadding, ImVec2(WINDOWS_HOVER_PADDING, WINDOWS_HOVER_PADDING));
@@ -3885,7 +3885,7 @@ void ImGui::UpdateHoveredWindowAndCaptureFlags() IMGUI_NOEXCEPT
     g.IO.WantTextInput = (g.WantTextInputNextFrame != -1) ? (g.WantTextInputNextFrame != 0) : false;
 }
 
-ImGuiKeyModFlags ImGui::GetMergedKeyModFlags() IMGUI_NOEXCEPT
+ImGuiKeyModFlags ImGui::GetMergedKeyModFlags() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiKeyModFlags key_mod_flags = ImGuiKeyModFlags_None;
@@ -3896,7 +3896,7 @@ ImGuiKeyModFlags ImGui::GetMergedKeyModFlags() IMGUI_NOEXCEPT
     return key_mod_flags;
 }
 
-void ImGui::NewFrame() IMGUI_NOEXCEPT
+void ImGui::NewFrame() IM_NOEXCEPT
 {
     IM_ASSERT(GImGui != NULL && "No current context. Did you call ImGui::CreateContext() and ImGui::SetCurrentContext() ?");
     ImGuiContext& g = *GImGui;
@@ -4099,7 +4099,7 @@ void ImGui::NewFrame() IMGUI_NOEXCEPT
 }
 
 // [DEBUG] Item picker tool - start with DebugStartItemPicker() - useful to visually select an item and break into its call-stack.
-void ImGui::UpdateDebugToolItemPicker() IMGUI_NOEXCEPT
+void ImGui::UpdateDebugToolItemPicker() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.DebugItemPickerBreakId = 0;
@@ -4123,7 +4123,7 @@ void ImGui::UpdateDebugToolItemPicker() IMGUI_NOEXCEPT
     }
 }
 
-void ImGui::Initialize(ImGuiContext* context) IMGUI_NOEXCEPT
+void ImGui::Initialize(ImGuiContext* context) IM_NOEXCEPT
 {
     ImGuiContext& g = *context;
     IM_ASSERT(!g.Initialized && !g.SettingsLoaded);
@@ -4157,7 +4157,7 @@ void ImGui::Initialize(ImGuiContext* context) IMGUI_NOEXCEPT
 }
 
 // This function is merely here to free heap allocations.
-void ImGui::Shutdown(ImGuiContext* context) IMGUI_NOEXCEPT
+void ImGui::Shutdown(ImGuiContext* context) IM_NOEXCEPT
 {
     // The fonts atlas can be used prior to calling NewFrame(), so we clear it even if g.Initialized is FALSE (which would happen if we never called NewFrame)
     ImGuiContext& g = *context;
@@ -4237,7 +4237,7 @@ void ImGui::Shutdown(ImGuiContext* context) IMGUI_NOEXCEPT
 }
 
 // FIXME: Add a more explicit sort order in the window structure.
-static int IMGUI_CDECL ChildWindowComparer(const void* lhs, const void* rhs) IMGUI_NOEXCEPT
+static int IMGUI_CDECL ChildWindowComparer(const void* lhs, const void* rhs) IM_NOEXCEPT
 {
     const ImGuiWindow* const a = *(const ImGuiWindow* const *)lhs;
     const ImGuiWindow* const b = *(const ImGuiWindow* const *)rhs;
@@ -4248,7 +4248,7 @@ static int IMGUI_CDECL ChildWindowComparer(const void* lhs, const void* rhs) IMG
     return (a->BeginOrderWithinParent - b->BeginOrderWithinParent);
 }
 
-static void AddWindowToSortBuffer(ImVector<ImGuiWindow*>* out_sorted_windows, ImGuiWindow* window) IMGUI_NOEXCEPT
+static void AddWindowToSortBuffer(ImVector<ImGuiWindow*>* out_sorted_windows, ImGuiWindow* window) IM_NOEXCEPT
 {
     out_sorted_windows->push_back(window);
     if (window->Active)
@@ -4265,7 +4265,7 @@ static void AddWindowToSortBuffer(ImVector<ImGuiWindow*>* out_sorted_windows, Im
     }
 }
 
-static void AddDrawListToDrawData(ImVector<ImDrawList*>* out_list, ImDrawList* draw_list) IMGUI_NOEXCEPT
+static void AddDrawListToDrawData(ImVector<ImDrawList*>* out_list, ImDrawList* draw_list) IM_NOEXCEPT
 {
     // Remove trailing command if unused.
     // Technically we could return directly instead of popping, but this make things looks neat in Metrics/Debugger window as well.
@@ -4301,7 +4301,7 @@ static void AddDrawListToDrawData(ImVector<ImDrawList*>* out_list, ImDrawList* d
     out_list->push_back(draw_list);
 }
 
-static void AddWindowToDrawData(ImGuiWindow* window, int layer) IMGUI_NOEXCEPT
+static void AddWindowToDrawData(ImGuiWindow* window, int layer) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiViewportP* viewport = g.Viewports[0];
@@ -4316,13 +4316,13 @@ static void AddWindowToDrawData(ImGuiWindow* window, int layer) IMGUI_NOEXCEPT
 }
 
 // Layer is locked for the root window, however child windows may use a different viewport (e.g. extruding menu)
-static void AddRootWindowToDrawData(ImGuiWindow* window) IMGUI_NOEXCEPT
+static void AddRootWindowToDrawData(ImGuiWindow* window) IM_NOEXCEPT
 {
     int layer = (window->Flags & ImGuiWindowFlags_Tooltip) ? 1 : 0;
     AddWindowToDrawData(window, layer);
 }
 
-void ImDrawDataBuilder::FlattenIntoSingleLayer() IMGUI_NOEXCEPT
+void ImDrawDataBuilder::FlattenIntoSingleLayer() IM_NOEXCEPT
 {
     int n = Layers[0].Size;
     int size = n;
@@ -4340,7 +4340,7 @@ void ImDrawDataBuilder::FlattenIntoSingleLayer() IMGUI_NOEXCEPT
     }
 }
 
-static void SetupViewportDrawData(ImGuiViewportP* viewport, ImVector<ImDrawList*>* draw_lists) IMGUI_NOEXCEPT
+static void SetupViewportDrawData(ImGuiViewportP* viewport, ImVector<ImDrawList*>* draw_lists) IM_NOEXCEPT
 {
     ImGuiIO& io = ImGui::GetIO();
     ImDrawData* draw_data = &viewport->DrawDataP;
@@ -4364,14 +4364,14 @@ static void SetupViewportDrawData(ImGuiViewportP* viewport, ImVector<ImDrawList*
 // - If the code here changes, may need to update code of functions like NextColumn() and PushColumnClipRect():
 //   some frequently called functions which to modify both channels and clipping simultaneously tend to use the
 //   more specialized SetWindowClipRectBeforeSetChannel() to avoid extraneous updates of underlying ImDrawCmds.
-void ImGui::PushClipRect(const ImVec2& clip_rect_min, const ImVec2& clip_rect_max, bool intersect_with_current_clip_rect) IMGUI_NOEXCEPT
+void ImGui::PushClipRect(const ImVec2& clip_rect_min, const ImVec2& clip_rect_max, bool intersect_with_current_clip_rect) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     window->DrawList->PushClipRect(clip_rect_min, clip_rect_max, intersect_with_current_clip_rect);
     window->ClipRect = window->DrawList->_ClipRectStack.back();
 }
 
-void ImGui::PopClipRect() IMGUI_NOEXCEPT
+void ImGui::PopClipRect() IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     window->DrawList->PopClipRect();
@@ -4379,7 +4379,7 @@ void ImGui::PopClipRect() IMGUI_NOEXCEPT
 }
 
 // This is normally called by Render(). You may want to call it directly if you want to avoid calling Render() but the gain will be very minimal.
-void ImGui::EndFrame() IMGUI_NOEXCEPT
+void ImGui::EndFrame() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(g.Initialized);
@@ -4461,7 +4461,7 @@ void ImGui::EndFrame() IMGUI_NOEXCEPT
     CallContextHooks(&g, ImGuiContextHookType_EndFramePost);
 }
 
-void ImGui::Render() IMGUI_NOEXCEPT
+void ImGui::Render() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(g.Initialized);
@@ -4523,7 +4523,7 @@ void ImGui::Render() IMGUI_NOEXCEPT
 
 // Calculate text size. Text can be multi-line. Optionally ignore text after a ## marker.
 // CalcTextSize("") should return ImVec2(0.0f, g.FontSize)
-ImVec2 ImGui::CalcTextSize(const char* text, const char* text_end, bool hide_text_after_double_hash, float wrap_width) IMGUI_NOEXCEPT
+ImVec2 ImGui::CalcTextSize(const char* text, const char* text_end, bool hide_text_after_double_hash, float wrap_width) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -4553,7 +4553,7 @@ ImVec2 ImGui::CalcTextSize(const char* text, const char* text_end, bool hide_tex
 // FIXME: Note that we have an inconsequential lag here: OuterRectClipped is updated in Begin(), so windows moved programmatically
 // with SetWindowPos() and not SetNextWindowPos() will have that rectangle lagging by a frame at the time FindHoveredWindow() is
 // called, aka before the next Begin(). Moving window isn't affected.
-static void FindHoveredWindow() IMGUI_NOEXCEPT
+static void FindHoveredWindow() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -4608,7 +4608,7 @@ static void FindHoveredWindow() IMGUI_NOEXCEPT
 // Test if mouse cursor is hovering given rectangle
 // NB- Rectangle is clipped by our current clip setting
 // NB- Expand the rectangle to be generous on imprecise inputs systems (g.Style.TouchExtraPadding)
-bool ImGui::IsMouseHoveringRect(const ImVec2& r_min, const ImVec2& r_max, bool clip) IMGUI_NOEXCEPT
+bool ImGui::IsMouseHoveringRect(const ImVec2& r_min, const ImVec2& r_max, bool clip) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -4624,7 +4624,7 @@ bool ImGui::IsMouseHoveringRect(const ImVec2& r_min, const ImVec2& r_max, bool c
     return true;
 }
 
-int ImGui::GetKeyIndex(ImGuiKey imgui_key) IMGUI_NOEXCEPT
+int ImGui::GetKeyIndex(ImGuiKey imgui_key) IM_NOEXCEPT
 {
     IM_ASSERT(imgui_key >= 0 && imgui_key < ImGuiKey_COUNT);
     ImGuiContext& g = *GImGui;
@@ -4633,7 +4633,7 @@ int ImGui::GetKeyIndex(ImGuiKey imgui_key) IMGUI_NOEXCEPT
 
 // Note that dear imgui doesn't know the semantic of each entry of io.KeysDown[]!
 // Use your own indices/enums according to how your backend/engine stored them into io.KeysDown[]!
-bool ImGui::IsKeyDown(int user_key_index) IMGUI_NOEXCEPT
+bool ImGui::IsKeyDown(int user_key_index) IM_NOEXCEPT
 {
     if (user_key_index < 0)
         return false;
@@ -4646,7 +4646,7 @@ bool ImGui::IsKeyDown(int user_key_index) IMGUI_NOEXCEPT
 // t1 = current time (e.g.: g.Time)
 // An event is triggered at:
 //  t = 0.0f     t = repeat_delay,    t = repeat_delay + repeat_rate*N
-int ImGui::CalcTypematicRepeatAmount(float t0, float t1, float repeat_delay, float repeat_rate) IMGUI_NOEXCEPT
+int ImGui::CalcTypematicRepeatAmount(float t0, float t1, float repeat_delay, float repeat_rate) IM_NOEXCEPT
 {
     if (t1 == 0.0f)
         return 1;
@@ -4660,7 +4660,7 @@ int ImGui::CalcTypematicRepeatAmount(float t0, float t1, float repeat_delay, flo
     return count;
 }
 
-int ImGui::GetKeyPressedAmount(int key_index, float repeat_delay, float repeat_rate) IMGUI_NOEXCEPT
+int ImGui::GetKeyPressedAmount(int key_index, float repeat_delay, float repeat_rate) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (key_index < 0)
@@ -4670,7 +4670,7 @@ int ImGui::GetKeyPressedAmount(int key_index, float repeat_delay, float repeat_r
     return CalcTypematicRepeatAmount(t - g.IO.DeltaTime, t, repeat_delay, repeat_rate);
 }
 
-bool ImGui::IsKeyPressed(int user_key_index, bool repeat) IMGUI_NOEXCEPT
+bool ImGui::IsKeyPressed(int user_key_index, bool repeat) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (user_key_index < 0)
@@ -4684,7 +4684,7 @@ bool ImGui::IsKeyPressed(int user_key_index, bool repeat) IMGUI_NOEXCEPT
     return false;
 }
 
-bool ImGui::IsKeyReleased(int user_key_index) IMGUI_NOEXCEPT
+bool ImGui::IsKeyReleased(int user_key_index) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (user_key_index < 0) return false;
@@ -4692,14 +4692,14 @@ bool ImGui::IsKeyReleased(int user_key_index) IMGUI_NOEXCEPT
     return g.IO.KeysDownDurationPrev[user_key_index] >= 0.0f && !g.IO.KeysDown[user_key_index];
 }
 
-bool ImGui::IsMouseDown(ImGuiMouseButton button) IMGUI_NOEXCEPT
+bool ImGui::IsMouseDown(ImGuiMouseButton button) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(button >= 0 && button < IM_ARRAYSIZE(g.IO.MouseDown));
     return g.IO.MouseDown[button];
 }
 
-bool ImGui::IsMouseClicked(ImGuiMouseButton button, bool repeat) IMGUI_NOEXCEPT
+bool ImGui::IsMouseClicked(ImGuiMouseButton button, bool repeat) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(button >= 0 && button < IM_ARRAYSIZE(g.IO.MouseDown));
@@ -4717,14 +4717,14 @@ bool ImGui::IsMouseClicked(ImGuiMouseButton button, bool repeat) IMGUI_NOEXCEPT
     return false;
 }
 
-bool ImGui::IsMouseReleased(ImGuiMouseButton button) IMGUI_NOEXCEPT
+bool ImGui::IsMouseReleased(ImGuiMouseButton button) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(button >= 0 && button < IM_ARRAYSIZE(g.IO.MouseDown));
     return g.IO.MouseReleased[button];
 }
 
-bool ImGui::IsMouseDoubleClicked(ImGuiMouseButton button) IMGUI_NOEXCEPT
+bool ImGui::IsMouseDoubleClicked(ImGuiMouseButton button) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(button >= 0 && button < IM_ARRAYSIZE(g.IO.MouseDown));
@@ -4733,7 +4733,7 @@ bool ImGui::IsMouseDoubleClicked(ImGuiMouseButton button) IMGUI_NOEXCEPT
 
 // Return if a mouse click/drag went past the given threshold. Valid to call during the MouseReleased frame.
 // [Internal] This doesn't test if the button is pressed
-bool ImGui::IsMouseDragPastThreshold(ImGuiMouseButton button, float lock_threshold) IMGUI_NOEXCEPT
+bool ImGui::IsMouseDragPastThreshold(ImGuiMouseButton button, float lock_threshold) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(button >= 0 && button < IM_ARRAYSIZE(g.IO.MouseDown));
@@ -4742,7 +4742,7 @@ bool ImGui::IsMouseDragPastThreshold(ImGuiMouseButton button, float lock_thresho
     return g.IO.MouseDragMaxDistanceSqr[button] >= lock_threshold * lock_threshold;
 }
 
-bool ImGui::IsMouseDragging(ImGuiMouseButton button, float lock_threshold) IMGUI_NOEXCEPT
+bool ImGui::IsMouseDragging(ImGuiMouseButton button, float lock_threshold) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(button >= 0 && button < IM_ARRAYSIZE(g.IO.MouseDown));
@@ -4751,14 +4751,14 @@ bool ImGui::IsMouseDragging(ImGuiMouseButton button, float lock_threshold) IMGUI
     return IsMouseDragPastThreshold(button, lock_threshold);
 }
 
-ImVec2 ImGui::GetMousePos() IMGUI_NOEXCEPT
+ImVec2 ImGui::GetMousePos() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return g.IO.MousePos;
 }
 
 // NB: prefer to call right after BeginPopup(). At the time Selectable/MenuItem is activated, the popup is already closed!
-ImVec2 ImGui::GetMousePosOnOpeningCurrentPopup() IMGUI_NOEXCEPT
+ImVec2 ImGui::GetMousePosOnOpeningCurrentPopup() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.BeginPopupStack.Size > 0)
@@ -4767,7 +4767,7 @@ ImVec2 ImGui::GetMousePosOnOpeningCurrentPopup() IMGUI_NOEXCEPT
 }
 
 // We typically use ImVec2(-FLT_MAX,-FLT_MAX) to denote an invalid mouse position.
-bool ImGui::IsMousePosValid(const ImVec2* mouse_pos) IMGUI_NOEXCEPT
+bool ImGui::IsMousePosValid(const ImVec2* mouse_pos) IM_NOEXCEPT
 {
     // The assert is only to silence a false-positive in XCode Static Analysis.
     // Because GImGui is not dereferenced in every code path, the static analyzer assume that it may be NULL (which it doesn't for other functions).
@@ -4777,7 +4777,7 @@ bool ImGui::IsMousePosValid(const ImVec2* mouse_pos) IMGUI_NOEXCEPT
     return p.x >= MOUSE_INVALID && p.y >= MOUSE_INVALID;
 }
 
-bool ImGui::IsAnyMouseDown() IMGUI_NOEXCEPT
+bool ImGui::IsAnyMouseDown() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     for (int n = 0; n < IM_ARRAYSIZE(g.IO.MouseDown); n++)
@@ -4789,7 +4789,7 @@ bool ImGui::IsAnyMouseDown() IMGUI_NOEXCEPT
 // Return the delta from the initial clicking position while the mouse button is clicked or was just released.
 // This is locked and return 0.0f until the mouse moves past a distance threshold at least once.
 // NB: This is only valid if IsMousePosValid(). backends in theory should always keep mouse position valid when dragging even outside the client window.
-ImVec2 ImGui::GetMouseDragDelta(ImGuiMouseButton button, float lock_threshold) IMGUI_NOEXCEPT
+ImVec2 ImGui::GetMouseDragDelta(ImGuiMouseButton button, float lock_threshold) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(button >= 0 && button < IM_ARRAYSIZE(g.IO.MouseDown));
@@ -4802,7 +4802,7 @@ ImVec2 ImGui::GetMouseDragDelta(ImGuiMouseButton button, float lock_threshold) I
     return ImVec2(0.0f, 0.0f);
 }
 
-void ImGui::ResetMouseDragDelta(ImGuiMouseButton button) IMGUI_NOEXCEPT
+void ImGui::ResetMouseDragDelta(ImGuiMouseButton button) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(button >= 0 && button < IM_ARRAYSIZE(g.IO.MouseDown));
@@ -4810,27 +4810,27 @@ void ImGui::ResetMouseDragDelta(ImGuiMouseButton button) IMGUI_NOEXCEPT
     g.IO.MouseClickedPos[button] = g.IO.MousePos;
 }
 
-ImGuiMouseCursor ImGui::GetMouseCursor() IMGUI_NOEXCEPT
+ImGuiMouseCursor ImGui::GetMouseCursor() IM_NOEXCEPT
 {
     return GImGui->MouseCursor;
 }
 
-void ImGui::SetMouseCursor(ImGuiMouseCursor cursor_type) IMGUI_NOEXCEPT
+void ImGui::SetMouseCursor(ImGuiMouseCursor cursor_type) IM_NOEXCEPT
 {
     GImGui->MouseCursor = cursor_type;
 }
 
-void ImGui::CaptureKeyboardFromApp(bool capture) IMGUI_NOEXCEPT
+void ImGui::CaptureKeyboardFromApp(bool capture) IM_NOEXCEPT
 {
     GImGui->WantCaptureKeyboardNextFrame = capture ? 1 : 0;
 }
 
-void ImGui::CaptureMouseFromApp(bool capture) IMGUI_NOEXCEPT
+void ImGui::CaptureMouseFromApp(bool capture) IM_NOEXCEPT
 {
     GImGui->WantCaptureMouseNextFrame = capture ? 1 : 0;
 }
 
-bool ImGui::IsItemActive() IMGUI_NOEXCEPT
+bool ImGui::IsItemActive() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.ActiveId)
@@ -4841,7 +4841,7 @@ bool ImGui::IsItemActive() IMGUI_NOEXCEPT
     return false;
 }
 
-bool ImGui::IsItemActivated() IMGUI_NOEXCEPT
+bool ImGui::IsItemActivated() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.ActiveId)
@@ -4853,7 +4853,7 @@ bool ImGui::IsItemActivated() IMGUI_NOEXCEPT
     return false;
 }
 
-bool ImGui::IsItemDeactivated() IMGUI_NOEXCEPT
+bool ImGui::IsItemDeactivated() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -4862,14 +4862,14 @@ bool ImGui::IsItemDeactivated() IMGUI_NOEXCEPT
     return (g.ActiveIdPreviousFrame == window->DC.LastItemId && g.ActiveIdPreviousFrame != 0 && g.ActiveId != window->DC.LastItemId);
 }
 
-bool ImGui::IsItemDeactivatedAfterEdit() IMGUI_NOEXCEPT
+bool ImGui::IsItemDeactivatedAfterEdit() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return IsItemDeactivated() && (g.ActiveIdPreviousFrameHasBeenEditedBefore || (g.ActiveId == 0 && g.ActiveIdHasBeenEditedBefore));
 }
 
 // == GetItemID() == GetFocusID()
-bool ImGui::IsItemFocused() IMGUI_NOEXCEPT
+bool ImGui::IsItemFocused() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -4881,48 +4881,48 @@ bool ImGui::IsItemFocused() IMGUI_NOEXCEPT
 
 // Important: this can be useful but it is NOT equivalent to the behavior of e.g.Button()!
 // Most widgets have specific reactions based on mouse-up/down state, mouse position etc.
-bool ImGui::IsItemClicked(ImGuiMouseButton mouse_button) IMGUI_NOEXCEPT
+bool ImGui::IsItemClicked(ImGuiMouseButton mouse_button) IM_NOEXCEPT
 {
     return IsMouseClicked(mouse_button) && IsItemHovered(ImGuiHoveredFlags_None);
 }
 
-bool ImGui::IsItemToggledOpen() IMGUI_NOEXCEPT
+bool ImGui::IsItemToggledOpen() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return (g.CurrentWindow->DC.LastItemStatusFlags & ImGuiItemStatusFlags_ToggledOpen) ? true : false;
 }
 
-bool ImGui::IsItemToggledSelection() IMGUI_NOEXCEPT
+bool ImGui::IsItemToggledSelection() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return (g.CurrentWindow->DC.LastItemStatusFlags & ImGuiItemStatusFlags_ToggledSelection) ? true : false;
 }
 
-bool ImGui::IsAnyItemHovered() IMGUI_NOEXCEPT
+bool ImGui::IsAnyItemHovered() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return g.HoveredId != 0 || g.HoveredIdPreviousFrame != 0;
 }
 
-bool ImGui::IsAnyItemActive() IMGUI_NOEXCEPT
+bool ImGui::IsAnyItemActive() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return g.ActiveId != 0;
 }
 
-bool ImGui::IsAnyItemFocused() IMGUI_NOEXCEPT
+bool ImGui::IsAnyItemFocused() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return g.NavId != 0 && !g.NavDisableHighlight;
 }
 
-bool ImGui::IsItemVisible() IMGUI_NOEXCEPT
+bool ImGui::IsItemVisible() IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     return window->ClipRect.Overlaps(window->DC.LastItemRect);
 }
 
-bool ImGui::IsItemEdited() IMGUI_NOEXCEPT
+bool ImGui::IsItemEdited() IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     return (window->DC.LastItemStatusFlags & ImGuiItemStatusFlags_Edited) != 0;
@@ -4930,7 +4930,7 @@ bool ImGui::IsItemEdited() IMGUI_NOEXCEPT
 
 // Allow last item to be overlapped by a subsequent item. Both may be activated during the same frame before the later one takes priority.
 // FIXME: Although this is exposed, its interaction and ideal idiom with using ImGuiButtonFlags_AllowItemOverlap flag are extremely confusing, need rework.
-void ImGui::SetItemAllowOverlap() IMGUI_NOEXCEPT
+void ImGui::SetItemAllowOverlap() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiID id = g.CurrentWindow->DC.LastItemId;
@@ -4940,7 +4940,7 @@ void ImGui::SetItemAllowOverlap() IMGUI_NOEXCEPT
         g.ActiveIdAllowOverlap = true;
 }
 
-void ImGui::SetItemUsingMouseWheel() IMGUI_NOEXCEPT
+void ImGui::SetItemUsingMouseWheel() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiID id = g.CurrentWindow->DC.LastItemId;
@@ -4950,25 +4950,25 @@ void ImGui::SetItemUsingMouseWheel() IMGUI_NOEXCEPT
         g.ActiveIdUsingMouseWheel = true;
 }
 
-ImVec2 ImGui::GetItemRectMin() IMGUI_NOEXCEPT
+ImVec2 ImGui::GetItemRectMin() IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     return window->DC.LastItemRect.Min;
 }
 
-ImVec2 ImGui::GetItemRectMax() IMGUI_NOEXCEPT
+ImVec2 ImGui::GetItemRectMax() IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     return window->DC.LastItemRect.Max;
 }
 
-ImVec2 ImGui::GetItemRectSize() IMGUI_NOEXCEPT
+ImVec2 ImGui::GetItemRectSize() IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     return window->DC.LastItemRect.GetSize();
 }
 
-bool ImGui::BeginChildEx(const char* name, ImGuiID id, const ImVec2& size_arg, bool border, ImGuiWindowFlags flags) IMGUI_NOEXCEPT
+bool ImGui::BeginChildEx(const char* name, ImGuiID id, const ImVec2& size_arg, bool border, ImGuiWindowFlags flags) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* parent_window = g.CurrentWindow;
@@ -5018,19 +5018,19 @@ bool ImGui::BeginChildEx(const char* name, ImGuiID id, const ImVec2& size_arg, b
     return ret;
 }
 
-bool ImGui::BeginChild(const char* str_id, const ImVec2& size_arg, bool border, ImGuiWindowFlags extra_flags) IMGUI_NOEXCEPT
+bool ImGui::BeginChild(const char* str_id, const ImVec2& size_arg, bool border, ImGuiWindowFlags extra_flags) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     return BeginChildEx(str_id, window->GetID(str_id), size_arg, border, extra_flags);
 }
 
-bool ImGui::BeginChild(ImGuiID id, const ImVec2& size_arg, bool border, ImGuiWindowFlags extra_flags) IMGUI_NOEXCEPT
+bool ImGui::BeginChild(ImGuiID id, const ImVec2& size_arg, bool border, ImGuiWindowFlags extra_flags) IM_NOEXCEPT
 {
     IM_ASSERT(id != 0);
     return BeginChildEx(NULL, id, size_arg, border, extra_flags);
 }
 
-void ImGui::EndChild() IMGUI_NOEXCEPT
+void ImGui::EndChild() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -5077,7 +5077,7 @@ void ImGui::EndChild() IMGUI_NOEXCEPT
 }
 
 // Helper to create a child window / scrolling region that looks like a normal widget frame.
-bool ImGui::BeginChildFrame(ImGuiID id, const ImVec2& size, ImGuiWindowFlags extra_flags) IMGUI_NOEXCEPT
+bool ImGui::BeginChildFrame(ImGuiID id, const ImVec2& size, ImGuiWindowFlags extra_flags) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     const ImGuiStyle& style = g.Style;
@@ -5091,31 +5091,31 @@ bool ImGui::BeginChildFrame(ImGuiID id, const ImVec2& size, ImGuiWindowFlags ext
     return ret;
 }
 
-void ImGui::EndChildFrame() IMGUI_NOEXCEPT
+void ImGui::EndChildFrame() IM_NOEXCEPT
 {
     EndChild();
 }
 
-static void SetWindowConditionAllowFlags(ImGuiWindow* window, ImGuiCond flags, bool enabled) IMGUI_NOEXCEPT
+static void SetWindowConditionAllowFlags(ImGuiWindow* window, ImGuiCond flags, bool enabled) IM_NOEXCEPT
 {
     window->SetWindowPosAllowFlags       = enabled ? (window->SetWindowPosAllowFlags       | flags) : (window->SetWindowPosAllowFlags       & ~flags);
     window->SetWindowSizeAllowFlags      = enabled ? (window->SetWindowSizeAllowFlags      | flags) : (window->SetWindowSizeAllowFlags      & ~flags);
     window->SetWindowCollapsedAllowFlags = enabled ? (window->SetWindowCollapsedAllowFlags | flags) : (window->SetWindowCollapsedAllowFlags & ~flags);
 }
 
-ImGuiWindow* ImGui::FindWindowByID(ImGuiID id) IMGUI_NOEXCEPT
+ImGuiWindow* ImGui::FindWindowByID(ImGuiID id) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return (ImGuiWindow*)g.WindowsById.GetVoidPtr(id);
 }
 
-ImGuiWindow* ImGui::FindWindowByName(const char* name) IMGUI_NOEXCEPT
+ImGuiWindow* ImGui::FindWindowByName(const char* name) IM_NOEXCEPT
 {
     ImGuiID id = ImHashStr(name);
     return FindWindowByID(id);
 }
 
-static void ApplyWindowSettings(ImGuiWindow* window, ImGuiWindowSettings* settings) IMGUI_NOEXCEPT
+static void ApplyWindowSettings(ImGuiWindow* window, ImGuiWindowSettings* settings) IM_NOEXCEPT
 {
     window->Pos = ImFloor(ImVec2(settings->Pos.x, settings->Pos.y));
     if (settings->Size.x > 0 && settings->Size.y > 0)
@@ -5123,7 +5123,7 @@ static void ApplyWindowSettings(ImGuiWindow* window, ImGuiWindowSettings* settin
     window->Collapsed = settings->Collapsed;
 }
 
-static ImGuiWindow* CreateNewWindow(const char* name, ImGuiWindowFlags flags) IMGUI_NOEXCEPT
+static ImGuiWindow* CreateNewWindow(const char* name, ImGuiWindowFlags flags) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     //IMGUI_DEBUG_LOG("CreateNewWindow '%s', flags = 0x%08X\n", name, flags);
@@ -5175,7 +5175,7 @@ static ImGuiWindow* CreateNewWindow(const char* name, ImGuiWindowFlags flags) IM
     return window;
 }
 
-static ImVec2 CalcWindowSizeAfterConstraint(ImGuiWindow* window, const ImVec2& size_desired) IMGUI_NOEXCEPT
+static ImVec2 CalcWindowSizeAfterConstraint(ImGuiWindow* window, const ImVec2& size_desired) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImVec2 new_size = size_desired;
@@ -5210,7 +5210,7 @@ static ImVec2 CalcWindowSizeAfterConstraint(ImGuiWindow* window, const ImVec2& s
     return new_size;
 }
 
-static void CalcWindowContentSizes(ImGuiWindow* window, ImVec2* content_size_current, ImVec2* content_size_ideal) IMGUI_NOEXCEPT
+static void CalcWindowContentSizes(ImGuiWindow* window, ImVec2* content_size_current, ImVec2* content_size_ideal) IM_NOEXCEPT
 {
     bool preserve_old_content_sizes = false;
     if (window->Collapsed && window->AutoFitFramesX <= 0 && window->AutoFitFramesY <= 0)
@@ -5230,7 +5230,7 @@ static void CalcWindowContentSizes(ImGuiWindow* window, ImVec2* content_size_cur
     content_size_ideal->y = (window->ContentSizeExplicit.y != 0.0f) ? window->ContentSizeExplicit.y : IM_FLOOR(ImMax(window->DC.CursorMaxPos.y, window->DC.IdealMaxPos.y) - window->DC.CursorStartPos.y);
 }
 
-static ImVec2 CalcWindowAutoFitSize(ImGuiWindow* window, const ImVec2& size_contents) IMGUI_NOEXCEPT
+static ImVec2 CalcWindowAutoFitSize(ImGuiWindow* window, const ImVec2& size_contents) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiStyle& style = g.Style;
@@ -5268,7 +5268,7 @@ static ImVec2 CalcWindowAutoFitSize(ImGuiWindow* window, const ImVec2& size_cont
     }
 }
 
-ImVec2 ImGui::CalcWindowNextAutoFitSize(ImGuiWindow* window) IMGUI_NOEXCEPT
+ImVec2 ImGui::CalcWindowNextAutoFitSize(ImGuiWindow* window) IM_NOEXCEPT
 {
     ImVec2 size_contents_current;
     ImVec2 size_contents_ideal;
@@ -5278,7 +5278,7 @@ ImVec2 ImGui::CalcWindowNextAutoFitSize(ImGuiWindow* window) IMGUI_NOEXCEPT
     return size_final;
 }
 
-static ImGuiCol GetWindowBgColorIdxFromFlags(ImGuiWindowFlags flags) IMGUI_NOEXCEPT
+static ImGuiCol GetWindowBgColorIdxFromFlags(ImGuiWindowFlags flags) IM_NOEXCEPT
 {
     if (flags & (ImGuiWindowFlags_Tooltip | ImGuiWindowFlags_Popup))
         return ImGuiCol_PopupBg;
@@ -5287,7 +5287,7 @@ static ImGuiCol GetWindowBgColorIdxFromFlags(ImGuiWindowFlags flags) IMGUI_NOEXC
     return ImGuiCol_WindowBg;
 }
 
-static void CalcResizePosSizeFromAnyCorner(ImGuiWindow* window, const ImVec2& corner_target, const ImVec2& corner_norm, ImVec2* out_pos, ImVec2* out_size) IMGUI_NOEXCEPT
+static void CalcResizePosSizeFromAnyCorner(ImGuiWindow* window, const ImVec2& corner_target, const ImVec2& corner_norm, ImVec2* out_pos, ImVec2* out_size) IM_NOEXCEPT
 {
     ImVec2 pos_min = ImLerp(corner_target, window->Pos, corner_norm);                // Expected window upper-left
     ImVec2 pos_max = ImLerp(window->Pos + window->Size, corner_target, corner_norm); // Expected window lower-right
@@ -5331,7 +5331,7 @@ static const ImGuiResizeBorderDef resize_border_def[4] =
     { ImVec2(0, -1), ImVec2(1, 1), ImVec2(0, 1), IM_PI * 0.50f }  // Down
 };
 
-static ImRect GetResizeBorderRect(ImGuiWindow* window, int border_n, float perp_padding, float thickness) IMGUI_NOEXCEPT
+static ImRect GetResizeBorderRect(ImGuiWindow* window, int border_n, float perp_padding, float thickness) IM_NOEXCEPT
 {
     ImRect rect = window->Rect();
     if (thickness == 0.0f)
@@ -5345,7 +5345,7 @@ static ImRect GetResizeBorderRect(ImGuiWindow* window, int border_n, float perp_
 }
 
 // 0..3: corners (Lower-right, Lower-left, Unused, Unused)
-ImGuiID ImGui::GetWindowResizeCornerID(ImGuiWindow* window, int n) IMGUI_NOEXCEPT
+ImGuiID ImGui::GetWindowResizeCornerID(ImGuiWindow* window, int n) IM_NOEXCEPT
 {
     IM_ASSERT(n >= 0 && n < 4);
     ImGuiID id = window->ID;
@@ -5355,7 +5355,7 @@ ImGuiID ImGui::GetWindowResizeCornerID(ImGuiWindow* window, int n) IMGUI_NOEXCEP
 }
 
 // Borders (Left, Right, Up, Down)
-ImGuiID ImGui::GetWindowResizeBorderID(ImGuiWindow* window, ImGuiDir dir) IMGUI_NOEXCEPT
+ImGuiID ImGui::GetWindowResizeBorderID(ImGuiWindow* window, ImGuiDir dir) IM_NOEXCEPT
 {
     IM_ASSERT(dir >= 0 && dir < 4);
     int n = (int)dir + 4;
@@ -5367,7 +5367,7 @@ ImGuiID ImGui::GetWindowResizeBorderID(ImGuiWindow* window, ImGuiDir dir) IMGUI_
 
 // Handle resize for: Resize Grips, Borders, Gamepad
 // Return true when using auto-fit (double click on resize grip)
-static bool ImGui::UpdateWindowManualResize(ImGuiWindow* window, const ImVec2& size_auto_fit, int* border_held, int resize_grip_count, ImU32 resize_grip_col[4], const ImRect& visibility_rect) IMGUI_NOEXCEPT
+static bool ImGui::UpdateWindowManualResize(ImGuiWindow* window, const ImVec2& size_auto_fit, int* border_held, int resize_grip_count, ImU32 resize_grip_col[4], const ImRect& visibility_rect) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindowFlags flags = window->Flags;
@@ -5497,7 +5497,7 @@ static bool ImGui::UpdateWindowManualResize(ImGuiWindow* window, const ImVec2& s
     return ret_auto_fit;
 }
 
-static inline void ClampWindowRect(ImGuiWindow* window, const ImRect& visibility_rect) IMGUI_NOEXCEPT
+static inline void ClampWindowRect(ImGuiWindow* window, const ImRect& visibility_rect) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImVec2 size_for_clamping = window->Size;
@@ -5506,7 +5506,7 @@ static inline void ClampWindowRect(ImGuiWindow* window, const ImRect& visibility
     window->Pos = ImClamp(window->Pos, visibility_rect.Min - size_for_clamping, visibility_rect.Max);
 }
 
-static void ImGui::RenderWindowOuterBorders(ImGuiWindow* window) IMGUI_NOEXCEPT
+static void ImGui::RenderWindowOuterBorders(ImGuiWindow* window) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     float rounding = window->WindowRounding;
@@ -5532,7 +5532,7 @@ static void ImGui::RenderWindowOuterBorders(ImGuiWindow* window) IMGUI_NOEXCEPT
 
 // Draw background and borders
 // Draw and handle scrollbars
-void ImGui::RenderWindowDecorations(ImGuiWindow* window, const ImRect& title_bar_rect, bool title_bar_is_highlight, int resize_grip_count, const ImU32 resize_grip_col[4], float resize_grip_draw_size) IMGUI_NOEXCEPT
+void ImGui::RenderWindowDecorations(ImGuiWindow* window, const ImRect& title_bar_rect, bool title_bar_is_highlight, int resize_grip_count, const ImU32 resize_grip_col[4], float resize_grip_draw_size) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiStyle& style = g.Style;
@@ -5616,7 +5616,7 @@ void ImGui::RenderWindowDecorations(ImGuiWindow* window, const ImRect& title_bar
 }
 
 // Render title text, collapse button, close button
-void ImGui::RenderWindowTitleBarContents(ImGuiWindow* window, const ImRect& title_bar_rect, const char* name, bool* p_open) IMGUI_NOEXCEPT
+void ImGui::RenderWindowTitleBarContents(ImGuiWindow* window, const ImRect& title_bar_rect, const char* name, bool* p_open) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiStyle& style = g.Style;
@@ -5699,7 +5699,7 @@ void ImGui::RenderWindowTitleBarContents(ImGuiWindow* window, const ImRect& titl
     }
 }
 
-void ImGui::UpdateWindowParentAndRootLinks(ImGuiWindow* window, ImGuiWindowFlags flags, ImGuiWindow* parent_window) IMGUI_NOEXCEPT
+void ImGui::UpdateWindowParentAndRootLinks(ImGuiWindow* window, ImGuiWindowFlags flags, ImGuiWindow* parent_window) IM_NOEXCEPT
 {
     window->ParentWindow = parent_window;
     window->RootWindow = window->RootWindowForTitleBarHighlight = window->RootWindowForNav = window;
@@ -5721,7 +5721,7 @@ void ImGui::UpdateWindowParentAndRootLinks(ImGuiWindow* window, ImGuiWindowFlags
 //   You can use the "##" or "###" markers to use the same label with different id, or same id with different label. See documentation at the top of this file.
 // - Return false when window is collapsed, so you can early out in your code. You always need to call ImGui::End() even if false is returned.
 // - Passing 'bool* p_open' displays a Close button on the upper-right corner of the window, the pointed value will be set to false when the button is pressed.
-bool ImGui::Begin(const char* name, bool* p_open, ImGuiWindowFlags flags) IMGUI_NOEXCEPT
+bool ImGui::Begin(const char* name, bool* p_open, ImGuiWindowFlags flags) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     const ImGuiStyle& style = g.Style;
@@ -6365,7 +6365,7 @@ bool ImGui::Begin(const char* name, bool* p_open, ImGuiWindowFlags flags) IMGUI_
     return !window->SkipItems;
 }
 
-void ImGui::End() IMGUI_NOEXCEPT
+void ImGui::End() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -6399,7 +6399,7 @@ void ImGui::End() IMGUI_NOEXCEPT
     SetCurrentWindow(g.CurrentWindowStack.empty() ? NULL : g.CurrentWindowStack.back());
 }
 
-void ImGui::BringWindowToFocusFront(ImGuiWindow* window) IMGUI_NOEXCEPT
+void ImGui::BringWindowToFocusFront(ImGuiWindow* window) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(window == window->RootWindow);
@@ -6420,7 +6420,7 @@ void ImGui::BringWindowToFocusFront(ImGuiWindow* window) IMGUI_NOEXCEPT
     window->FocusOrder = (short)new_order;
 }
 
-void ImGui::BringWindowToDisplayFront(ImGuiWindow* window) IMGUI_NOEXCEPT
+void ImGui::BringWindowToDisplayFront(ImGuiWindow* window) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* current_front_window = g.Windows.back();
@@ -6435,7 +6435,7 @@ void ImGui::BringWindowToDisplayFront(ImGuiWindow* window) IMGUI_NOEXCEPT
         }
 }
 
-void ImGui::BringWindowToDisplayBack(ImGuiWindow* window) IMGUI_NOEXCEPT
+void ImGui::BringWindowToDisplayBack(ImGuiWindow* window) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.Windows[0] == window)
@@ -6450,7 +6450,7 @@ void ImGui::BringWindowToDisplayBack(ImGuiWindow* window) IMGUI_NOEXCEPT
 }
 
 // Moving window to front of display and set focus (which happens to be back of our sorted list)
-void ImGui::FocusWindow(ImGuiWindow* window) IMGUI_NOEXCEPT
+void ImGui::FocusWindow(ImGuiWindow* window) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -6493,7 +6493,7 @@ void ImGui::FocusWindow(ImGuiWindow* window) IMGUI_NOEXCEPT
         BringWindowToDisplayFront(display_front_window);
 }
 
-void ImGui::FocusTopMostWindowUnderOne(ImGuiWindow* under_this_window, ImGuiWindow* ignore_window) IMGUI_NOEXCEPT
+void ImGui::FocusTopMostWindowUnderOne(ImGuiWindow* under_this_window, ImGuiWindow* ignore_window) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -6515,7 +6515,7 @@ void ImGui::FocusTopMostWindowUnderOne(ImGuiWindow* under_this_window, ImGuiWind
 }
 
 // Important: this alone doesn't alter current ImDrawList state. This is called by PushFont/PopFont only.
-void ImGui::SetCurrentFont(ImFont* font) IMGUI_NOEXCEPT
+void ImGui::SetCurrentFont(ImFont* font) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(font && font->IsLoaded());    // Font Atlas not created. Did you call io.Fonts->GetTexDataAsRGBA32 / GetTexDataAsAlpha8 ?
@@ -6531,7 +6531,7 @@ void ImGui::SetCurrentFont(ImFont* font) IMGUI_NOEXCEPT
     g.DrawListSharedData.FontSize = g.FontSize;
 }
 
-void ImGui::PushFont(ImFont* font) IMGUI_NOEXCEPT
+void ImGui::PushFont(ImFont* font) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (!font)
@@ -6541,7 +6541,7 @@ void ImGui::PushFont(ImFont* font) IMGUI_NOEXCEPT
     g.CurrentWindow->DrawList->PushTextureID(font->ContainerAtlas->TexID);
 }
 
-void  ImGui::PopFont() IMGUI_NOEXCEPT
+void  ImGui::PopFont() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.CurrentWindow->DrawList->PopTextureID();
@@ -6549,7 +6549,7 @@ void  ImGui::PopFont() IMGUI_NOEXCEPT
     SetCurrentFont(g.FontStack.empty() ? GetDefaultFont() : g.FontStack.back());
 }
 
-void ImGui::PushItemFlag(ImGuiItemFlags option, bool enabled) IMGUI_NOEXCEPT
+void ImGui::PushItemFlag(ImGuiItemFlags option, bool enabled) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiItemFlags item_flags = g.CurrentItemFlags;
@@ -6562,7 +6562,7 @@ void ImGui::PushItemFlag(ImGuiItemFlags option, bool enabled) IMGUI_NOEXCEPT
     g.ItemFlagsStack.push_back(item_flags);
 }
 
-void ImGui::PopItemFlag() IMGUI_NOEXCEPT
+void ImGui::PopItemFlag() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(g.ItemFlagsStack.Size > 1); // Too many calls to PopItemFlag() - we always leave a 0 at the bottom of the stack.
@@ -6571,41 +6571,41 @@ void ImGui::PopItemFlag() IMGUI_NOEXCEPT
 }
 
 // FIXME: Look into renaming this once we have settled the new Focus/Activation/TabStop system.
-void ImGui::PushAllowKeyboardFocus(bool allow_keyboard_focus) IMGUI_NOEXCEPT
+void ImGui::PushAllowKeyboardFocus(bool allow_keyboard_focus) IM_NOEXCEPT
 {
     PushItemFlag(ImGuiItemFlags_NoTabStop, !allow_keyboard_focus);
 }
 
-void ImGui::PopAllowKeyboardFocus() IMGUI_NOEXCEPT
+void ImGui::PopAllowKeyboardFocus() IM_NOEXCEPT
 {
     PopItemFlag();
 }
 
-void ImGui::PushButtonRepeat(bool repeat) IMGUI_NOEXCEPT
+void ImGui::PushButtonRepeat(bool repeat) IM_NOEXCEPT
 {
     PushItemFlag(ImGuiItemFlags_ButtonRepeat, repeat);
 }
 
-void ImGui::PopButtonRepeat() IMGUI_NOEXCEPT
+void ImGui::PopButtonRepeat() IM_NOEXCEPT
 {
     PopItemFlag();
 }
 
-void ImGui::PushTextWrapPos(float wrap_pos_x) IMGUI_NOEXCEPT
+void ImGui::PushTextWrapPos(float wrap_pos_x) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     window->DC.TextWrapPosStack.push_back(window->DC.TextWrapPos);
     window->DC.TextWrapPos = wrap_pos_x;
 }
 
-void ImGui::PopTextWrapPos() IMGUI_NOEXCEPT
+void ImGui::PopTextWrapPos() IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     window->DC.TextWrapPos = window->DC.TextWrapPosStack.back();
     window->DC.TextWrapPosStack.pop_back();
 }
 
-bool ImGui::IsWindowChildOf(ImGuiWindow* window, ImGuiWindow* potential_parent) IMGUI_NOEXCEPT
+bool ImGui::IsWindowChildOf(ImGuiWindow* window, ImGuiWindow* potential_parent) IM_NOEXCEPT
 {
     if (window->RootWindow == potential_parent)
         return true;
@@ -6618,7 +6618,7 @@ bool ImGui::IsWindowChildOf(ImGuiWindow* window, ImGuiWindow* potential_parent) 
     return false;
 }
 
-bool ImGui::IsWindowAbove(ImGuiWindow* potential_above, ImGuiWindow* potential_below) IMGUI_NOEXCEPT
+bool ImGui::IsWindowAbove(ImGuiWindow* potential_above, ImGuiWindow* potential_below) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     for (int i = g.Windows.Size - 1; i >= 0; i--)
@@ -6632,7 +6632,7 @@ bool ImGui::IsWindowAbove(ImGuiWindow* potential_above, ImGuiWindow* potential_b
     return false;
 }
 
-bool ImGui::IsWindowHovered(ImGuiHoveredFlags flags) IMGUI_NOEXCEPT
+bool ImGui::IsWindowHovered(ImGuiHoveredFlags flags) IM_NOEXCEPT
 {
     IM_ASSERT((flags & ImGuiHoveredFlags_AllowWhenOverlapped) == 0);   // Flags not supported by this function
     ImGuiContext& g = *GImGui;
@@ -6671,7 +6671,7 @@ bool ImGui::IsWindowHovered(ImGuiHoveredFlags flags) IMGUI_NOEXCEPT
     return true;
 }
 
-bool ImGui::IsWindowFocused(ImGuiFocusedFlags flags) IMGUI_NOEXCEPT
+bool ImGui::IsWindowFocused(ImGuiFocusedFlags flags) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -6695,31 +6695,31 @@ bool ImGui::IsWindowFocused(ImGuiFocusedFlags flags) IMGUI_NOEXCEPT
 // Can we focus this window with CTRL+TAB (or PadMenu + PadFocusPrev/PadFocusNext)
 // Note that NoNavFocus makes the window not reachable with CTRL+TAB but it can still be focused with mouse or programmatically.
 // If you want a window to never be focused, you may use the e.g. NoInputs flag.
-bool ImGui::IsWindowNavFocusable(ImGuiWindow* window) IMGUI_NOEXCEPT
+bool ImGui::IsWindowNavFocusable(ImGuiWindow* window) IM_NOEXCEPT
 {
     return window->WasActive && window == window->RootWindow && !(window->Flags & ImGuiWindowFlags_NoNavFocus);
 }
 
-float ImGui::GetWindowWidth() IMGUI_NOEXCEPT
+float ImGui::GetWindowWidth() IM_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     return window->Size.x;
 }
 
-float ImGui::GetWindowHeight() IMGUI_NOEXCEPT
+float ImGui::GetWindowHeight() IM_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     return window->Size.y;
 }
 
-ImVec2 ImGui::GetWindowPos() IMGUI_NOEXCEPT
+ImVec2 ImGui::GetWindowPos() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
     return window->Pos;
 }
 
-void ImGui::SetWindowPos(ImGuiWindow* window, const ImVec2& pos, ImGuiCond cond) IMGUI_NOEXCEPT
+void ImGui::SetWindowPos(ImGuiWindow* window, const ImVec2& pos, ImGuiCond cond) IM_NOEXCEPT
 {
     // Test condition (NB: bit 0 is always true) and clear flags for next time
     if (cond && (window->SetWindowPosAllowFlags & cond) == 0)
@@ -6739,25 +6739,25 @@ void ImGui::SetWindowPos(ImGuiWindow* window, const ImVec2& pos, ImGuiCond cond)
     window->DC.CursorStartPos += offset;
 }
 
-void ImGui::SetWindowPos(const ImVec2& pos, ImGuiCond cond) IMGUI_NOEXCEPT
+void ImGui::SetWindowPos(const ImVec2& pos, ImGuiCond cond) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     SetWindowPos(window, pos, cond);
 }
 
-void ImGui::SetWindowPos(const char* name, const ImVec2& pos, ImGuiCond cond) IMGUI_NOEXCEPT
+void ImGui::SetWindowPos(const char* name, const ImVec2& pos, ImGuiCond cond) IM_NOEXCEPT
 {
     if (ImGuiWindow* window = FindWindowByName(name))
         SetWindowPos(window, pos, cond);
 }
 
-ImVec2 ImGui::GetWindowSize() IMGUI_NOEXCEPT
+ImVec2 ImGui::GetWindowSize() IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     return window->Size;
 }
 
-void ImGui::SetWindowSize(ImGuiWindow* window, const ImVec2& size, ImGuiCond cond) IMGUI_NOEXCEPT
+void ImGui::SetWindowSize(ImGuiWindow* window, const ImVec2& size, ImGuiCond cond) IM_NOEXCEPT
 {
     // Test condition (NB: bit 0 is always true) and clear flags for next time
     if (cond && (window->SetWindowSizeAllowFlags & cond) == 0)
@@ -6789,18 +6789,18 @@ void ImGui::SetWindowSize(ImGuiWindow* window, const ImVec2& size, ImGuiCond con
     }
 }
 
-void ImGui::SetWindowSize(const ImVec2& size, ImGuiCond cond) IMGUI_NOEXCEPT
+void ImGui::SetWindowSize(const ImVec2& size, ImGuiCond cond) IM_NOEXCEPT
 {
     SetWindowSize(GImGui->CurrentWindow, size, cond);
 }
 
-void ImGui::SetWindowSize(const char* name, const ImVec2& size, ImGuiCond cond) IMGUI_NOEXCEPT
+void ImGui::SetWindowSize(const char* name, const ImVec2& size, ImGuiCond cond) IM_NOEXCEPT
 {
     if (ImGuiWindow* window = FindWindowByName(name))
         SetWindowSize(window, size, cond);
 }
 
-void ImGui::SetWindowCollapsed(ImGuiWindow* window, bool collapsed, ImGuiCond cond) IMGUI_NOEXCEPT
+void ImGui::SetWindowCollapsed(ImGuiWindow* window, bool collapsed, ImGuiCond cond) IM_NOEXCEPT
 {
     // Test condition (NB: bit 0 is always true) and clear flags for next time
     if (cond && (window->SetWindowCollapsedAllowFlags & cond) == 0)
@@ -6811,42 +6811,42 @@ void ImGui::SetWindowCollapsed(ImGuiWindow* window, bool collapsed, ImGuiCond co
     window->Collapsed = collapsed;
 }
 
-void ImGui::SetWindowHitTestHole(ImGuiWindow* window, const ImVec2& pos, const ImVec2& size) IMGUI_NOEXCEPT
+void ImGui::SetWindowHitTestHole(ImGuiWindow* window, const ImVec2& pos, const ImVec2& size) IM_NOEXCEPT
 {
     IM_ASSERT(window->HitTestHoleSize.x == 0);     // We don't support multiple holes/hit test filters
     window->HitTestHoleSize = ImVec2ih(size);
     window->HitTestHoleOffset = ImVec2ih(pos - window->Pos);
 }
 
-void ImGui::SetWindowCollapsed(bool collapsed, ImGuiCond cond) IMGUI_NOEXCEPT
+void ImGui::SetWindowCollapsed(bool collapsed, ImGuiCond cond) IM_NOEXCEPT
 {
     SetWindowCollapsed(GImGui->CurrentWindow, collapsed, cond);
 }
 
-bool ImGui::IsWindowCollapsed() IMGUI_NOEXCEPT
+bool ImGui::IsWindowCollapsed() IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     return window->Collapsed;
 }
 
-bool ImGui::IsWindowAppearing() IMGUI_NOEXCEPT
+bool ImGui::IsWindowAppearing() IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     return window->Appearing;
 }
 
-void ImGui::SetWindowCollapsed(const char* name, bool collapsed, ImGuiCond cond) IMGUI_NOEXCEPT
+void ImGui::SetWindowCollapsed(const char* name, bool collapsed, ImGuiCond cond) IM_NOEXCEPT
 {
     if (ImGuiWindow* window = FindWindowByName(name))
         SetWindowCollapsed(window, collapsed, cond);
 }
 
-void ImGui::SetWindowFocus() IMGUI_NOEXCEPT
+void ImGui::SetWindowFocus() IM_NOEXCEPT
 {
     FocusWindow(GImGui->CurrentWindow);
 }
 
-void ImGui::SetWindowFocus(const char* name) IMGUI_NOEXCEPT
+void ImGui::SetWindowFocus(const char* name) IM_NOEXCEPT
 {
     if (name)
     {
@@ -6859,7 +6859,7 @@ void ImGui::SetWindowFocus(const char* name) IMGUI_NOEXCEPT
     }
 }
 
-void ImGui::SetNextWindowPos(const ImVec2& pos, ImGuiCond cond, const ImVec2& pivot) IMGUI_NOEXCEPT
+void ImGui::SetNextWindowPos(const ImVec2& pos, ImGuiCond cond, const ImVec2& pivot) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(cond == 0 || ImIsPowerOfTwo(cond)); // Make sure the user doesn't attempt to combine multiple condition flags.
@@ -6869,7 +6869,7 @@ void ImGui::SetNextWindowPos(const ImVec2& pos, ImGuiCond cond, const ImVec2& pi
     g.NextWindowData.PosCond = cond ? cond : ImGuiCond_Always;
 }
 
-void ImGui::SetNextWindowSize(const ImVec2& size, ImGuiCond cond) IMGUI_NOEXCEPT
+void ImGui::SetNextWindowSize(const ImVec2& size, ImGuiCond cond) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(cond == 0 || ImIsPowerOfTwo(cond)); // Make sure the user doesn't attempt to combine multiple condition flags.
@@ -6878,7 +6878,7 @@ void ImGui::SetNextWindowSize(const ImVec2& size, ImGuiCond cond) IMGUI_NOEXCEPT
     g.NextWindowData.SizeCond = cond ? cond : ImGuiCond_Always;
 }
 
-void ImGui::SetNextWindowSizeConstraints(const ImVec2& size_min, const ImVec2& size_max, ImGuiSizeCallback custom_callback, void* custom_callback_user_data) IMGUI_NOEXCEPT
+void ImGui::SetNextWindowSizeConstraints(const ImVec2& size_min, const ImVec2& size_max, ImGuiSizeCallback custom_callback, void* custom_callback_user_data) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.NextWindowData.Flags |= ImGuiNextWindowDataFlags_HasSizeConstraint;
@@ -6889,21 +6889,21 @@ void ImGui::SetNextWindowSizeConstraints(const ImVec2& size_min, const ImVec2& s
 
 // Content size = inner scrollable rectangle, padded with WindowPadding.
 // SetNextWindowContentSize(ImVec2(100,100) + ImGuiWindowFlags_AlwaysAutoResize will always allow submitting a 100x100 item.
-void ImGui::SetNextWindowContentSize(const ImVec2& size) IMGUI_NOEXCEPT
+void ImGui::SetNextWindowContentSize(const ImVec2& size) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.NextWindowData.Flags |= ImGuiNextWindowDataFlags_HasContentSize;
     g.NextWindowData.ContentSizeVal = ImFloor(size);
 }
 
-void ImGui::SetNextWindowScroll(const ImVec2& scroll) IMGUI_NOEXCEPT
+void ImGui::SetNextWindowScroll(const ImVec2& scroll) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.NextWindowData.Flags |= ImGuiNextWindowDataFlags_HasScroll;
     g.NextWindowData.ScrollVal = scroll;
 }
 
-void ImGui::SetNextWindowCollapsed(bool collapsed, ImGuiCond cond) IMGUI_NOEXCEPT
+void ImGui::SetNextWindowCollapsed(bool collapsed, ImGuiCond cond) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(cond == 0 || ImIsPowerOfTwo(cond)); // Make sure the user doesn't attempt to combine multiple condition flags.
@@ -6912,41 +6912,41 @@ void ImGui::SetNextWindowCollapsed(bool collapsed, ImGuiCond cond) IMGUI_NOEXCEP
     g.NextWindowData.CollapsedCond = cond ? cond : ImGuiCond_Always;
 }
 
-void ImGui::SetNextWindowFocus() IMGUI_NOEXCEPT
+void ImGui::SetNextWindowFocus() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.NextWindowData.Flags |= ImGuiNextWindowDataFlags_HasFocus;
 }
 
-void ImGui::SetNextWindowBgAlpha(float alpha) IMGUI_NOEXCEPT
+void ImGui::SetNextWindowBgAlpha(float alpha) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.NextWindowData.Flags |= ImGuiNextWindowDataFlags_HasBgAlpha;
     g.NextWindowData.BgAlphaVal = alpha;
 }
 
-ImDrawList* ImGui::GetWindowDrawList() IMGUI_NOEXCEPT
+ImDrawList* ImGui::GetWindowDrawList() IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     return window->DrawList;
 }
 
-ImFont* ImGui::GetFont() IMGUI_NOEXCEPT
+ImFont* ImGui::GetFont() IM_NOEXCEPT
 {
     return GImGui->Font;
 }
 
-float ImGui::GetFontSize() IMGUI_NOEXCEPT
+float ImGui::GetFontSize() IM_NOEXCEPT
 {
     return GImGui->FontSize;
 }
 
-ImVec2 ImGui::GetFontTexUvWhitePixel() IMGUI_NOEXCEPT
+ImVec2 ImGui::GetFontTexUvWhitePixel() IM_NOEXCEPT
 {
     return GImGui->DrawListSharedData.TexUvWhitePixel;
 }
 
-void ImGui::SetWindowFontScale(float scale) IMGUI_NOEXCEPT
+void ImGui::SetWindowFontScale(float scale) IM_NOEXCEPT
 {
     IM_ASSERT(scale > 0.0f);
     ImGuiContext& g = *GImGui;
@@ -6955,13 +6955,13 @@ void ImGui::SetWindowFontScale(float scale) IMGUI_NOEXCEPT
     g.FontSize = g.DrawListSharedData.FontSize = window->CalcFontSize();
 }
 
-void ImGui::ActivateItem(ImGuiID id) IMGUI_NOEXCEPT
+void ImGui::ActivateItem(ImGuiID id) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.NavNextActivateId = id;
 }
 
-void ImGui::PushFocusScope(ImGuiID id) IMGUI_NOEXCEPT
+void ImGui::PushFocusScope(ImGuiID id) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -6969,7 +6969,7 @@ void ImGui::PushFocusScope(ImGuiID id) IMGUI_NOEXCEPT
     window->DC.NavFocusScopeIdCurrent = id;
 }
 
-void ImGui::PopFocusScope() IMGUI_NOEXCEPT
+void ImGui::PopFocusScope() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -6978,7 +6978,7 @@ void ImGui::PopFocusScope() IMGUI_NOEXCEPT
     g.FocusScopeStack.pop_back();
 }
 
-void ImGui::SetKeyboardFocusHere(int offset) IMGUI_NOEXCEPT
+void ImGui::SetKeyboardFocusHere(int offset) IM_NOEXCEPT
 {
     IM_ASSERT(offset >= -1);    // -1 is allowed but not below
     ImGuiContext& g = *GImGui;
@@ -6988,7 +6988,7 @@ void ImGui::SetKeyboardFocusHere(int offset) IMGUI_NOEXCEPT
     g.TabFocusRequestNextCounterTabStop = INT_MAX;
 }
 
-void ImGui::SetItemDefaultFocus() IMGUI_NOEXCEPT
+void ImGui::SetItemDefaultFocus() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7005,19 +7005,19 @@ void ImGui::SetItemDefaultFocus() IMGUI_NOEXCEPT
     }
 }
 
-void ImGui::SetStateStorage(ImGuiStorage* tree) IMGUI_NOEXCEPT
+void ImGui::SetStateStorage(ImGuiStorage* tree) IM_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     window->DC.StateStorage = tree ? tree : &window->StateStorage;
 }
 
-ImGuiStorage* ImGui::GetStateStorage() IMGUI_NOEXCEPT
+ImGuiStorage* ImGui::GetStateStorage() IM_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     return window->DC.StateStorage;
 }
 
-void ImGui::PushID(const char* str_id) IMGUI_NOEXCEPT
+void ImGui::PushID(const char* str_id) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7025,7 +7025,7 @@ void ImGui::PushID(const char* str_id) IMGUI_NOEXCEPT
     window->IDStack.push_back(id);
 }
 
-void ImGui::PushID(const char* str_id_begin, const char* str_id_end) IMGUI_NOEXCEPT
+void ImGui::PushID(const char* str_id_begin, const char* str_id_end) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7033,7 +7033,7 @@ void ImGui::PushID(const char* str_id_begin, const char* str_id_end) IMGUI_NOEXC
     window->IDStack.push_back(id);
 }
 
-void ImGui::PushID(const void* ptr_id) IMGUI_NOEXCEPT
+void ImGui::PushID(const void* ptr_id) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7041,7 +7041,7 @@ void ImGui::PushID(const void* ptr_id) IMGUI_NOEXCEPT
     window->IDStack.push_back(id);
 }
 
-void ImGui::PushID(int int_id) IMGUI_NOEXCEPT
+void ImGui::PushID(int int_id) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7050,7 +7050,7 @@ void ImGui::PushID(int int_id) IMGUI_NOEXCEPT
 }
 
 // Push a given id value ignoring the ID stack as a seed.
-void ImGui::PushOverrideID(ImGuiID id) IMGUI_NOEXCEPT
+void ImGui::PushOverrideID(ImGuiID id) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7060,7 +7060,7 @@ void ImGui::PushOverrideID(ImGuiID id) IMGUI_NOEXCEPT
 // Helper to avoid a common series of PushOverrideID -> GetID() -> PopID() call
 // (note that when using this pattern, TestEngine's "Stack Tool" will tend to not display the intermediate stack level.
 //  for that to work we would need to do PushOverrideID() -> ItemAdd() -> PopID() which would alter widget code a little more)
-ImGuiID ImGui::GetIDWithSeed(const char* str, const char* str_end, ImGuiID seed) IMGUI_NOEXCEPT
+ImGuiID ImGui::GetIDWithSeed(const char* str, const char* str_end, ImGuiID seed) IM_NOEXCEPT
 {
     ImGuiID id = ImHashStr(str, str_end ? (str_end - str) : 0, seed);
     ImGui::KeepAliveID(id);
@@ -7071,38 +7071,38 @@ ImGuiID ImGui::GetIDWithSeed(const char* str, const char* str_end, ImGuiID seed)
     return id;
 }
 
-void ImGui::PopID() IMGUI_NOEXCEPT
+void ImGui::PopID() IM_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     IM_ASSERT(window->IDStack.Size > 1); // Too many PopID(), or could be popping in a wrong/different window?
     window->IDStack.pop_back();
 }
 
-ImGuiID ImGui::GetID(const char* str_id) IMGUI_NOEXCEPT
+ImGuiID ImGui::GetID(const char* str_id) IM_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     return window->GetID(str_id);
 }
 
-ImGuiID ImGui::GetID(const char* str_id_begin, const char* str_id_end) IMGUI_NOEXCEPT
+ImGuiID ImGui::GetID(const char* str_id_begin, const char* str_id_end) IM_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     return window->GetID(str_id_begin, str_id_end);
 }
 
-ImGuiID ImGui::GetID(const void* ptr_id) IMGUI_NOEXCEPT
+ImGuiID ImGui::GetID(const void* ptr_id) IM_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     return window->GetID(ptr_id);
 }
 
-bool ImGui::IsRectVisible(const ImVec2& size) IMGUI_NOEXCEPT
+bool ImGui::IsRectVisible(const ImVec2& size) IM_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     return window->ClipRect.Overlaps(ImRect(window->DC.CursorPos, window->DC.CursorPos + size));
 }
 
-bool ImGui::IsRectVisible(const ImVec2& rect_min, const ImVec2& rect_max) IMGUI_NOEXCEPT
+bool ImGui::IsRectVisible(const ImVec2& rect_min, const ImVec2& rect_max) IM_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     return window->ClipRect.Overlaps(ImRect(rect_min, rect_max));
@@ -7118,7 +7118,7 @@ bool ImGui::IsRectVisible(const ImVec2& rect_min, const ImVec2& rect_max) IMGUI_
 // If the user has inconsistent compilation settings, imgui configuration #define, packing pragma, etc. your user code
 // may see different structures than what imgui.cpp sees, which is problematic.
 // We usually require settings to be in imconfig.h to make sure that they are accessible to all compilation units involved with Dear ImGui.
-bool ImGui::DebugCheckVersionAndDataLayout(const char* version, size_t sz_io, size_t sz_style, size_t sz_vec2, size_t sz_vec4, size_t sz_vert, size_t sz_idx) IMGUI_NOEXCEPT
+bool ImGui::DebugCheckVersionAndDataLayout(const char* version, size_t sz_io, size_t sz_style, size_t sz_vec2, size_t sz_vec4, size_t sz_vert, size_t sz_idx) IM_NOEXCEPT
 {
     bool error = false;
     if (strcmp(version, IMGUI_VERSION) != 0) { error = true; IM_ASSERT(strcmp(version, IMGUI_VERSION) == 0 && "Mismatched version string!"); }
@@ -7131,7 +7131,7 @@ bool ImGui::DebugCheckVersionAndDataLayout(const char* version, size_t sz_io, si
     return !error;
 }
 
-static void ImGui::ErrorCheckNewFrameSanityChecks() IMGUI_NOEXCEPT
+static void ImGui::ErrorCheckNewFrameSanityChecks() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -7168,7 +7168,7 @@ static void ImGui::ErrorCheckNewFrameSanityChecks() IMGUI_NOEXCEPT
         g.IO.ConfigWindowsResizeFromEdges = false;
 }
 
-static void ImGui::ErrorCheckEndFrameSanityChecks() IMGUI_NOEXCEPT
+static void ImGui::ErrorCheckEndFrameSanityChecks() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -7209,7 +7209,7 @@ static void ImGui::ErrorCheckEndFrameSanityChecks() IMGUI_NOEXCEPT
 // This is generally flawed as we are not necessarily End/Popping things in the right order.
 // FIXME: Can't recover from inside BeginTabItem/EndTabItem yet.
 // FIXME: Can't recover from interleaved BeginTabBar/Begin
-void    ImGui::ErrorCheckEndFrameRecover(ImGuiErrorLogCallback log_callback, void* user_data) IMGUI_NOEXCEPT
+void    ImGui::ErrorCheckEndFrameRecover(ImGuiErrorLogCallback log_callback, void* user_data) IM_NOEXCEPT
 {
     // PVS-Studio V1044 is "Loop break conditions do not depend on the number of iterations"
     ImGuiContext& g = *GImGui;
@@ -7279,7 +7279,7 @@ void    ImGui::ErrorCheckEndFrameRecover(ImGuiErrorLogCallback log_callback, voi
 }
 
 // Save current stack sizes for later compare
-void ImGuiStackSizes::SetToCurrentState() IMGUI_NOEXCEPT
+void ImGuiStackSizes::SetToCurrentState() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7293,7 +7293,7 @@ void ImGuiStackSizes::SetToCurrentState() IMGUI_NOEXCEPT
 }
 
 // Compare to detect usage errors
-void ImGuiStackSizes::CompareWithCurrentState() IMGUI_NOEXCEPT
+void ImGuiStackSizes::CompareWithCurrentState() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7350,7 +7350,7 @@ void ImGuiStackSizes::CompareWithCurrentState() IMGUI_NOEXCEPT
 // Advance cursor given item size for layout.
 // Register minimum needed size so it can extend the bounding box used for auto-fit calculation.
 // See comments in ItemAdd() about how/why the size provided to ItemSize() vs ItemAdd() may often different.
-void ImGui::ItemSize(const ImVec2& size, float text_baseline_y) IMGUI_NOEXCEPT
+void ImGui::ItemSize(const ImVec2& size, float text_baseline_y) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7383,7 +7383,7 @@ void ImGui::ItemSize(const ImVec2& size, float text_baseline_y) IMGUI_NOEXCEPT
         SameLine();
 }
 
-void ImGui::ItemSize(const ImRect& bb, float text_baseline_y) IMGUI_NOEXCEPT
+void ImGui::ItemSize(const ImRect& bb, float text_baseline_y) IM_NOEXCEPT
 {
     ItemSize(bb.GetSize(), text_baseline_y);
 }
@@ -7391,7 +7391,7 @@ void ImGui::ItemSize(const ImRect& bb, float text_baseline_y) IMGUI_NOEXCEPT
 // Declare item bounding box for clipping and interaction.
 // Note that the size can be different than the one provided to ItemSize(). Typically, widgets that spread over available surface
 // declare their minimum size requirement to ItemSize() and provide a larger region to ItemAdd() which is used drawing/interaction.
-bool ImGui::ItemAdd(const ImRect& bb, ImGuiID id, const ImRect* nav_bb_arg, ImGuiItemAddFlags flags) IMGUI_NOEXCEPT
+bool ImGui::ItemAdd(const ImRect& bb, ImGuiID id, const ImRect* nav_bb_arg, ImGuiItemAddFlags flags) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7456,7 +7456,7 @@ bool ImGui::ItemAdd(const ImRect& bb, ImGuiID id, const ImRect* nav_bb_arg, ImGu
 //      offset_from_start_x != 0 : align to specified x position (relative to window/group left)
 //      spacing_w < 0            : use default spacing if pos_x == 0, no spacing if pos_x != 0
 //      spacing_w >= 0           : enforce spacing amount
-void ImGui::SameLine(float offset_from_start_x, float spacing_w) IMGUI_NOEXCEPT
+void ImGui::SameLine(float offset_from_start_x, float spacing_w) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -7479,13 +7479,13 @@ void ImGui::SameLine(float offset_from_start_x, float spacing_w) IMGUI_NOEXCEPT
     window->DC.CurrLineTextBaseOffset = window->DC.PrevLineTextBaseOffset;
 }
 
-ImVec2 ImGui::GetCursorScreenPos() IMGUI_NOEXCEPT
+ImVec2 ImGui::GetCursorScreenPos() IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     return window->DC.CursorPos;
 }
 
-void ImGui::SetCursorScreenPos(const ImVec2& pos) IMGUI_NOEXCEPT
+void ImGui::SetCursorScreenPos(const ImVec2& pos) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     window->DC.CursorPos = pos;
@@ -7494,52 +7494,52 @@ void ImGui::SetCursorScreenPos(const ImVec2& pos) IMGUI_NOEXCEPT
 
 // User generally sees positions in window coordinates. Internally we store CursorPos in absolute screen coordinates because it is more convenient.
 // Conversion happens as we pass the value to user, but it makes our naming convention confusing because GetCursorPos() == (DC.CursorPos - window.Pos). May want to rename 'DC.CursorPos'.
-ImVec2 ImGui::GetCursorPos() IMGUI_NOEXCEPT
+ImVec2 ImGui::GetCursorPos() IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     return window->DC.CursorPos - window->Pos + window->Scroll;
 }
 
-float ImGui::GetCursorPosX() IMGUI_NOEXCEPT
+float ImGui::GetCursorPosX() IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     return window->DC.CursorPos.x - window->Pos.x + window->Scroll.x;
 }
 
-float ImGui::GetCursorPosY() IMGUI_NOEXCEPT
+float ImGui::GetCursorPosY() IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     return window->DC.CursorPos.y - window->Pos.y + window->Scroll.y;
 }
 
-void ImGui::SetCursorPos(const ImVec2& local_pos) IMGUI_NOEXCEPT
+void ImGui::SetCursorPos(const ImVec2& local_pos) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     window->DC.CursorPos = window->Pos - window->Scroll + local_pos;
     window->DC.CursorMaxPos = ImMax(window->DC.CursorMaxPos, window->DC.CursorPos);
 }
 
-void ImGui::SetCursorPosX(float x) IMGUI_NOEXCEPT
+void ImGui::SetCursorPosX(float x) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     window->DC.CursorPos.x = window->Pos.x - window->Scroll.x + x;
     window->DC.CursorMaxPos.x = ImMax(window->DC.CursorMaxPos.x, window->DC.CursorPos.x);
 }
 
-void ImGui::SetCursorPosY(float y) IMGUI_NOEXCEPT
+void ImGui::SetCursorPosY(float y) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     window->DC.CursorPos.y = window->Pos.y - window->Scroll.y + y;
     window->DC.CursorMaxPos.y = ImMax(window->DC.CursorMaxPos.y, window->DC.CursorPos.y);
 }
 
-ImVec2 ImGui::GetCursorStartPos() IMGUI_NOEXCEPT
+ImVec2 ImGui::GetCursorStartPos() IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     return window->DC.CursorStartPos - window->Pos;
 }
 
-void ImGui::Indent(float indent_w) IMGUI_NOEXCEPT
+void ImGui::Indent(float indent_w) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = GetCurrentWindow();
@@ -7547,7 +7547,7 @@ void ImGui::Indent(float indent_w) IMGUI_NOEXCEPT
     window->DC.CursorPos.x = window->Pos.x + window->DC.Indent.x + window->DC.ColumnsOffset.x;
 }
 
-void ImGui::Unindent(float indent_w) IMGUI_NOEXCEPT
+void ImGui::Unindent(float indent_w) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = GetCurrentWindow();
@@ -7556,7 +7556,7 @@ void ImGui::Unindent(float indent_w) IMGUI_NOEXCEPT
 }
 
 // Affect large frame+labels widgets only.
-void ImGui::SetNextItemWidth(float item_width) IMGUI_NOEXCEPT
+void ImGui::SetNextItemWidth(float item_width) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.NextItemData.Flags |= ImGuiNextItemDataFlags_HasWidth;
@@ -7564,7 +7564,7 @@ void ImGui::SetNextItemWidth(float item_width) IMGUI_NOEXCEPT
 }
 
 // FIXME: Remove the == 0.0f behavior?
-void ImGui::PushItemWidth(float item_width) IMGUI_NOEXCEPT
+void ImGui::PushItemWidth(float item_width) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7573,7 +7573,7 @@ void ImGui::PushItemWidth(float item_width) IMGUI_NOEXCEPT
     g.NextItemData.Flags &= ~ImGuiNextItemDataFlags_HasWidth;
 }
 
-void ImGui::PushMultiItemsWidths(int components, float w_full) IMGUI_NOEXCEPT
+void ImGui::PushMultiItemsWidths(int components, float w_full) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7588,7 +7588,7 @@ void ImGui::PushMultiItemsWidths(int components, float w_full) IMGUI_NOEXCEPT
     g.NextItemData.Flags &= ~ImGuiNextItemDataFlags_HasWidth;
 }
 
-void ImGui::PopItemWidth() IMGUI_NOEXCEPT
+void ImGui::PopItemWidth() IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     window->DC.ItemWidth = window->DC.ItemWidthStack.back();
@@ -7597,7 +7597,7 @@ void ImGui::PopItemWidth() IMGUI_NOEXCEPT
 
 // Calculate default item width given value passed to PushItemWidth() or SetNextItemWidth().
 // The SetNextItemWidth() data is generally cleared/consumed by ItemAdd() or NextItemData.ClearFlags()
-float ImGui::CalcItemWidth() IMGUI_NOEXCEPT
+float ImGui::CalcItemWidth() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7619,7 +7619,7 @@ float ImGui::CalcItemWidth() IMGUI_NOEXCEPT
 // Those two functions CalcItemWidth vs CalcItemSize are awkwardly named because they are not fully symmetrical.
 // Note that only CalcItemWidth() is publicly exposed.
 // The 4.0f here may be changed to match CalcItemWidth() and/or BeginChild() (right now we have a mismatch which is harmless but undesirable)
-ImVec2 ImGui::CalcItemSize(ImVec2 size, float default_w, float default_h) IMGUI_NOEXCEPT
+ImVec2 ImGui::CalcItemSize(ImVec2 size, float default_w, float default_h) IM_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
 
@@ -7640,25 +7640,25 @@ ImVec2 ImGui::CalcItemSize(ImVec2 size, float default_w, float default_h) IMGUI_
     return size;
 }
 
-float ImGui::GetTextLineHeight() IMGUI_NOEXCEPT
+float ImGui::GetTextLineHeight() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return g.FontSize;
 }
 
-float ImGui::GetTextLineHeightWithSpacing() IMGUI_NOEXCEPT
+float ImGui::GetTextLineHeightWithSpacing() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return g.FontSize + g.Style.ItemSpacing.y;
 }
 
-float ImGui::GetFrameHeight() IMGUI_NOEXCEPT
+float ImGui::GetFrameHeight() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return g.FontSize + g.Style.FramePadding.y * 2.0f;
 }
 
-float ImGui::GetFrameHeightWithSpacing() IMGUI_NOEXCEPT
+float ImGui::GetFrameHeightWithSpacing() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return g.FontSize + g.Style.FramePadding.y * 2.0f + g.Style.ItemSpacing.y;
@@ -7667,7 +7667,7 @@ float ImGui::GetFrameHeightWithSpacing() IMGUI_NOEXCEPT
 // FIXME: All the Contents Region function are messy or misleading. WE WILL AIM TO OBSOLETE ALL OF THEM WITH A NEW "WORK RECT" API. Thanks for your patience!
 
 // FIXME: This is in window space (not screen space!).
-ImVec2 ImGui::GetContentRegionMax() IMGUI_NOEXCEPT
+ImVec2 ImGui::GetContentRegionMax() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7678,7 +7678,7 @@ ImVec2 ImGui::GetContentRegionMax() IMGUI_NOEXCEPT
 }
 
 // [Internal] Absolute coordinate. Saner. This is not exposed until we finishing refactoring work rect features.
-ImVec2 ImGui::GetContentRegionMaxAbs() IMGUI_NOEXCEPT
+ImVec2 ImGui::GetContentRegionMaxAbs() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7688,26 +7688,26 @@ ImVec2 ImGui::GetContentRegionMaxAbs() IMGUI_NOEXCEPT
     return mx;
 }
 
-ImVec2 ImGui::GetContentRegionAvail() IMGUI_NOEXCEPT
+ImVec2 ImGui::GetContentRegionAvail() IM_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     return GetContentRegionMaxAbs() - window->DC.CursorPos;
 }
 
 // In window space (not screen space!)
-ImVec2 ImGui::GetWindowContentRegionMin() IMGUI_NOEXCEPT
+ImVec2 ImGui::GetWindowContentRegionMin() IM_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     return window->ContentRegionRect.Min - window->Pos;
 }
 
-ImVec2 ImGui::GetWindowContentRegionMax() IMGUI_NOEXCEPT
+ImVec2 ImGui::GetWindowContentRegionMax() IM_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     return window->ContentRegionRect.Max - window->Pos;
 }
 
-float ImGui::GetWindowContentRegionWidth() IMGUI_NOEXCEPT
+float ImGui::GetWindowContentRegionWidth() IM_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     return window->ContentRegionRect.GetWidth();
@@ -7715,7 +7715,7 @@ float ImGui::GetWindowContentRegionWidth() IMGUI_NOEXCEPT
 
 // Lock horizontal starting position + capture group bounding box into one "item" (so you can use IsItemHovered() or layout primitives such as SameLine() on whole group, etc.)
 // Groups are currently a mishmash of functionalities which should perhaps be clarified and separated.
-void ImGui::BeginGroup() IMGUI_NOEXCEPT
+void ImGui::BeginGroup() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7742,7 +7742,7 @@ void ImGui::BeginGroup() IMGUI_NOEXCEPT
         g.LogLinePosY = -FLT_MAX; // To enforce a carriage return
 }
 
-void ImGui::EndGroup() IMGUI_NOEXCEPT
+void ImGui::EndGroup() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7811,7 +7811,7 @@ void ImGui::EndGroup() IMGUI_NOEXCEPT
 // So the difference between WindowPadding and ItemSpacing will be in the visible area after scrolling.
 // When we refactor the scrolling API this may be configurable with a flag?
 // Note that the effect for this won't be visible on X axis with default Style settings as WindowPadding.x == ItemSpacing.x by default.
-static float CalcScrollEdgeSnap(float target, float snap_min, float snap_max, float snap_threshold, float center_ratio) IMGUI_NOEXCEPT
+static float CalcScrollEdgeSnap(float target, float snap_min, float snap_max, float snap_threshold, float center_ratio) IM_NOEXCEPT
 {
     if (target <= snap_min + snap_threshold)
         return ImLerp(snap_min, target, center_ratio);
@@ -7820,7 +7820,7 @@ static float CalcScrollEdgeSnap(float target, float snap_min, float snap_max, fl
     return target;
 }
 
-static ImVec2 CalcNextScrollFromScrollTargetAndClamp(ImGuiWindow* window) IMGUI_NOEXCEPT
+static ImVec2 CalcNextScrollFromScrollTargetAndClamp(ImGuiWindow* window) IM_NOEXCEPT
 {
     ImVec2 scroll = window->Scroll;
     if (window->ScrollTarget.x < FLT_MAX)
@@ -7860,7 +7860,7 @@ static ImVec2 CalcNextScrollFromScrollTargetAndClamp(ImGuiWindow* window) IMGUI_
 }
 
 // Scroll to keep newly navigated item fully into view
-ImVec2 ImGui::ScrollToBringRectIntoView(ImGuiWindow* window, const ImRect& item_rect) IMGUI_NOEXCEPT
+ImVec2 ImGui::ScrollToBringRectIntoView(ImGuiWindow* window, const ImRect& item_rect) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImRect window_rect(window->InnerRect.Min - ImVec2(1, 1), window->InnerRect.Max + ImVec2(1, 1));
@@ -7889,51 +7889,51 @@ ImVec2 ImGui::ScrollToBringRectIntoView(ImGuiWindow* window, const ImRect& item_
     return delta_scroll;
 }
 
-float ImGui::GetScrollX() IMGUI_NOEXCEPT
+float ImGui::GetScrollX() IM_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     return window->Scroll.x;
 }
 
-float ImGui::GetScrollY() IMGUI_NOEXCEPT
+float ImGui::GetScrollY() IM_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     return window->Scroll.y;
 }
 
-float ImGui::GetScrollMaxX() IMGUI_NOEXCEPT
+float ImGui::GetScrollMaxX() IM_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     return window->ScrollMax.x;
 }
 
-float ImGui::GetScrollMaxY() IMGUI_NOEXCEPT
+float ImGui::GetScrollMaxY() IM_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     return window->ScrollMax.y;
 }
 
-void ImGui::SetScrollX(ImGuiWindow* window, float scroll_x) IMGUI_NOEXCEPT
+void ImGui::SetScrollX(ImGuiWindow* window, float scroll_x) IM_NOEXCEPT
 {
     window->ScrollTarget.x = scroll_x;
     window->ScrollTargetCenterRatio.x = 0.0f;
     window->ScrollTargetEdgeSnapDist.x = 0.0f;
 }
 
-void ImGui::SetScrollY(ImGuiWindow* window, float scroll_y) IMGUI_NOEXCEPT
+void ImGui::SetScrollY(ImGuiWindow* window, float scroll_y) IM_NOEXCEPT
 {
     window->ScrollTarget.y = scroll_y;
     window->ScrollTargetCenterRatio.y = 0.0f;
     window->ScrollTargetEdgeSnapDist.y = 0.0f;
 }
 
-void ImGui::SetScrollX(float scroll_x) IMGUI_NOEXCEPT
+void ImGui::SetScrollX(float scroll_x) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     SetScrollX(g.CurrentWindow, scroll_x);
 }
 
-void ImGui::SetScrollY(float scroll_y) IMGUI_NOEXCEPT
+void ImGui::SetScrollY(float scroll_y) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     SetScrollY(g.CurrentWindow, scroll_y);
@@ -7949,7 +7949,7 @@ void ImGui::SetScrollY(float scroll_y) IMGUI_NOEXCEPT
 //  - SetScrollFromPosY(0.0f) == SetScrollY(0.0f + scroll.y) == has no effect!
 //  - SetScrollFromPosY(-scroll.y) == SetScrollY(-scroll.y + scroll.y) == SetScrollY(0.0f) == reset scroll. Of course writing SetScrollY(0.0f) directly then makes more sense
 // We store a target position so centering and clamping can occur on the next frame when we are guaranteed to have a known window size
-void ImGui::SetScrollFromPosX(ImGuiWindow* window, float local_x, float center_x_ratio) IMGUI_NOEXCEPT
+void ImGui::SetScrollFromPosX(ImGuiWindow* window, float local_x, float center_x_ratio) IM_NOEXCEPT
 {
     IM_ASSERT(center_x_ratio >= 0.0f && center_x_ratio <= 1.0f);
     window->ScrollTarget.x = IM_FLOOR(local_x + window->Scroll.x); // Convert local position to scroll offset
@@ -7957,7 +7957,7 @@ void ImGui::SetScrollFromPosX(ImGuiWindow* window, float local_x, float center_x
     window->ScrollTargetEdgeSnapDist.x = 0.0f;
 }
 
-void ImGui::SetScrollFromPosY(ImGuiWindow* window, float local_y, float center_y_ratio) IMGUI_NOEXCEPT
+void ImGui::SetScrollFromPosY(ImGuiWindow* window, float local_y, float center_y_ratio) IM_NOEXCEPT
 {
     IM_ASSERT(center_y_ratio >= 0.0f && center_y_ratio <= 1.0f);
     const float decoration_up_height = window->TitleBarHeight() + window->MenuBarHeight(); // FIXME: Would be nice to have a more standardized access to our scrollable/client rect;
@@ -7967,20 +7967,20 @@ void ImGui::SetScrollFromPosY(ImGuiWindow* window, float local_y, float center_y
     window->ScrollTargetEdgeSnapDist.y = 0.0f;
 }
 
-void ImGui::SetScrollFromPosX(float local_x, float center_x_ratio) IMGUI_NOEXCEPT
+void ImGui::SetScrollFromPosX(float local_x, float center_x_ratio) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     SetScrollFromPosX(g.CurrentWindow, local_x, center_x_ratio);
 }
 
-void ImGui::SetScrollFromPosY(float local_y, float center_y_ratio) IMGUI_NOEXCEPT
+void ImGui::SetScrollFromPosY(float local_y, float center_y_ratio) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     SetScrollFromPosY(g.CurrentWindow, local_y, center_y_ratio);
 }
 
 // center_x_ratio: 0.0f left of last item, 0.5f horizontal center of last item, 1.0f right of last item.
-void ImGui::SetScrollHereX(float center_x_ratio) IMGUI_NOEXCEPT
+void ImGui::SetScrollHereX(float center_x_ratio) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7993,7 +7993,7 @@ void ImGui::SetScrollHereX(float center_x_ratio) IMGUI_NOEXCEPT
 }
 
 // center_y_ratio: 0.0f top of last item, 0.5f vertical center of last item, 1.0f bottom of last item.
-void ImGui::SetScrollHereY(float center_y_ratio) IMGUI_NOEXCEPT
+void ImGui::SetScrollHereY(float center_y_ratio) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -8009,12 +8009,12 @@ void ImGui::SetScrollHereY(float center_y_ratio) IMGUI_NOEXCEPT
 // [SECTION] TOOLTIPS
 //-----------------------------------------------------------------------------
 
-void ImGui::BeginTooltip() IMGUI_NOEXCEPT
+void ImGui::BeginTooltip() IM_NOEXCEPT
 {
     BeginTooltipEx(ImGuiWindowFlags_None, ImGuiTooltipFlags_None);
 }
 
-void ImGui::BeginTooltipEx(ImGuiWindowFlags extra_flags, ImGuiTooltipFlags tooltip_flags) IMGUI_NOEXCEPT
+void ImGui::BeginTooltipEx(ImGuiWindowFlags extra_flags, ImGuiTooltipFlags tooltip_flags) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -8046,20 +8046,20 @@ void ImGui::BeginTooltipEx(ImGuiWindowFlags extra_flags, ImGuiTooltipFlags toolt
     Begin(window_name, NULL, flags | extra_flags);
 }
 
-void ImGui::EndTooltip() IMGUI_NOEXCEPT
+void ImGui::EndTooltip() IM_NOEXCEPT
 {
     IM_ASSERT(GetCurrentWindowRead()->Flags & ImGuiWindowFlags_Tooltip);   // Mismatched BeginTooltip()/EndTooltip() calls
     End();
 }
 
-void ImGui::SetTooltipV(const char* fmt, va_list args) IMGUI_NOEXCEPT
+void ImGui::SetTooltipV(const char* fmt, va_list args) IM_NOEXCEPT
 {
     BeginTooltipEx(0, ImGuiTooltipFlags_OverridePreviousTooltip);
     TextV(fmt, args);
     EndTooltip();
 }
 
-void ImGui::SetTooltip(const char* fmt, ...) IMGUI_NOEXCEPT
+void ImGui::SetTooltip(const char* fmt, ...) IM_NOEXCEPT
 {
     va_list args;
     va_start(args, fmt);
@@ -8072,7 +8072,7 @@ void ImGui::SetTooltip(const char* fmt, ...) IMGUI_NOEXCEPT
 //-----------------------------------------------------------------------------
 
 // Supported flags: ImGuiPopupFlags_AnyPopupId, ImGuiPopupFlags_AnyPopupLevel
-bool ImGui::IsPopupOpen(ImGuiID id, ImGuiPopupFlags popup_flags) IMGUI_NOEXCEPT
+bool ImGui::IsPopupOpen(ImGuiID id, ImGuiPopupFlags popup_flags) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (popup_flags & ImGuiPopupFlags_AnyPopupId)
@@ -8103,7 +8103,7 @@ bool ImGui::IsPopupOpen(ImGuiID id, ImGuiPopupFlags popup_flags) IMGUI_NOEXCEPT
     }
 }
 
-bool ImGui::IsPopupOpen(const char* str_id, ImGuiPopupFlags popup_flags) IMGUI_NOEXCEPT
+bool ImGui::IsPopupOpen(const char* str_id, ImGuiPopupFlags popup_flags) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiID id = (popup_flags & ImGuiPopupFlags_AnyPopupId) ? 0 : g.CurrentWindow->GetID(str_id);
@@ -8112,7 +8112,7 @@ bool ImGui::IsPopupOpen(const char* str_id, ImGuiPopupFlags popup_flags) IMGUI_N
     return IsPopupOpen(id, popup_flags);
 }
 
-ImGuiWindow* ImGui::GetTopMostPopupModal() IMGUI_NOEXCEPT
+ImGuiWindow* ImGui::GetTopMostPopupModal() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     for (int n = g.OpenPopupStack.Size - 1; n >= 0; n--)
@@ -8122,13 +8122,13 @@ ImGuiWindow* ImGui::GetTopMostPopupModal() IMGUI_NOEXCEPT
     return NULL;
 }
 
-void ImGui::OpenPopup(const char* str_id, ImGuiPopupFlags popup_flags) IMGUI_NOEXCEPT
+void ImGui::OpenPopup(const char* str_id, ImGuiPopupFlags popup_flags) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     OpenPopupEx(g.CurrentWindow->GetID(str_id), popup_flags);
 }
 
-void ImGui::OpenPopup(ImGuiID id, ImGuiPopupFlags popup_flags) IMGUI_NOEXCEPT
+void ImGui::OpenPopup(ImGuiID id, ImGuiPopupFlags popup_flags) IM_NOEXCEPT
 {
     OpenPopupEx(id, popup_flags);
 }
@@ -8137,7 +8137,7 @@ void ImGui::OpenPopup(ImGuiID id, ImGuiPopupFlags popup_flags) IMGUI_NOEXCEPT
 // Popups are closed when user click outside, or activate a pressable item, or CloseCurrentPopup() is called within a BeginPopup()/EndPopup() block.
 // Popup identifiers are relative to the current ID-stack (so OpenPopup and BeginPopup needs to be at the same level).
 // One open popup per level of the popup hierarchy (NB: when assigning we reset the Window member of ImGuiPopupRef to NULL)
-void ImGui::OpenPopupEx(ImGuiID id, ImGuiPopupFlags popup_flags) IMGUI_NOEXCEPT
+void ImGui::OpenPopupEx(ImGuiID id, ImGuiPopupFlags popup_flags) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* parent_window = g.CurrentWindow;
@@ -8186,7 +8186,7 @@ void ImGui::OpenPopupEx(ImGuiID id, ImGuiPopupFlags popup_flags) IMGUI_NOEXCEPT
 
 // When popups are stacked, clicking on a lower level popups puts focus back to it and close popups above it.
 // This function closes any popups that are over 'ref_window'.
-void ImGui::ClosePopupsOverWindow(ImGuiWindow* ref_window, bool restore_focus_to_window_under_popup) IMGUI_NOEXCEPT
+void ImGui::ClosePopupsOverWindow(ImGuiWindow* ref_window, bool restore_focus_to_window_under_popup) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.OpenPopupStack.Size == 0)
@@ -8230,7 +8230,7 @@ void ImGui::ClosePopupsOverWindow(ImGuiWindow* ref_window, bool restore_focus_to
     }
 }
 
-void ImGui::ClosePopupToLevel(int remaining, bool restore_focus_to_window_under_popup) IMGUI_NOEXCEPT
+void ImGui::ClosePopupToLevel(int remaining, bool restore_focus_to_window_under_popup) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IMGUI_DEBUG_LOG_POPUP("ClosePopupToLevel(%d), restore_focus_to_window_under_popup=%d\n", remaining, restore_focus_to_window_under_popup);
@@ -8258,7 +8258,7 @@ void ImGui::ClosePopupToLevel(int remaining, bool restore_focus_to_window_under_
 }
 
 // Close the popup we have begin-ed into.
-void ImGui::CloseCurrentPopup() IMGUI_NOEXCEPT
+void ImGui::CloseCurrentPopup() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     int popup_idx = g.BeginPopupStack.Size - 1;
@@ -8289,7 +8289,7 @@ void ImGui::CloseCurrentPopup() IMGUI_NOEXCEPT
 }
 
 // Attention! BeginPopup() adds default flags which BeginPopupEx()!
-bool ImGui::BeginPopupEx(ImGuiID id, ImGuiWindowFlags flags) IMGUI_NOEXCEPT
+bool ImGui::BeginPopupEx(ImGuiID id, ImGuiWindowFlags flags) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (!IsPopupOpen(id, ImGuiPopupFlags_None))
@@ -8312,7 +8312,7 @@ bool ImGui::BeginPopupEx(ImGuiID id, ImGuiWindowFlags flags) IMGUI_NOEXCEPT
     return is_open;
 }
 
-bool ImGui::BeginPopup(const char* str_id, ImGuiWindowFlags flags) IMGUI_NOEXCEPT
+bool ImGui::BeginPopup(const char* str_id, ImGuiWindowFlags flags) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.OpenPopupStack.Size <= g.BeginPopupStack.Size) // Early out for performance
@@ -8326,7 +8326,7 @@ bool ImGui::BeginPopup(const char* str_id, ImGuiWindowFlags flags) IMGUI_NOEXCEP
 
 // If 'p_open' is specified for a modal popup window, the popup will have a regular close button which will close the popup.
 // Note that popup visibility status is owned by Dear ImGui (and manipulated with e.g. OpenPopup) so the actual value of *p_open is meaningless here.
-bool ImGui::BeginPopupModal(const char* name, bool* p_open, ImGuiWindowFlags flags) IMGUI_NOEXCEPT
+bool ImGui::BeginPopupModal(const char* name, bool* p_open, ImGuiWindowFlags flags) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -8358,7 +8358,7 @@ bool ImGui::BeginPopupModal(const char* name, bool* p_open, ImGuiWindowFlags fla
     return is_open;
 }
 
-void ImGui::EndPopup() IMGUI_NOEXCEPT
+void ImGui::EndPopup() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -8379,7 +8379,7 @@ void ImGui::EndPopup() IMGUI_NOEXCEPT
 
 // Helper to open a popup if mouse button is released over the item
 // - This is essentially the same as BeginPopupContextItem() but without the trailing BeginPopup()
-void ImGui::OpenPopupOnItemClick(const char* str_id, ImGuiPopupFlags popup_flags) IMGUI_NOEXCEPT
+void ImGui::OpenPopupOnItemClick(const char* str_id, ImGuiPopupFlags popup_flags) IM_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     int mouse_button = (popup_flags & ImGuiPopupFlags_MouseButtonMask_);
@@ -8407,7 +8407,7 @@ void ImGui::OpenPopupOnItemClick(const char* str_id, ImGuiPopupFlags popup_flags
 //           OpenPopup(id);
 //       return BeginPopup(id);
 //   The main difference being that this is tweaked to avoid computing the ID twice.
-bool ImGui::BeginPopupContextItem(const char* str_id, ImGuiPopupFlags popup_flags) IMGUI_NOEXCEPT
+bool ImGui::BeginPopupContextItem(const char* str_id, ImGuiPopupFlags popup_flags) IM_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     if (window->SkipItems)
@@ -8420,7 +8420,7 @@ bool ImGui::BeginPopupContextItem(const char* str_id, ImGuiPopupFlags popup_flag
     return BeginPopupEx(id, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoSavedSettings);
 }
 
-bool ImGui::BeginPopupContextWindow(const char* str_id, ImGuiPopupFlags popup_flags) IMGUI_NOEXCEPT
+bool ImGui::BeginPopupContextWindow(const char* str_id, ImGuiPopupFlags popup_flags) IM_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     if (!str_id)
@@ -8433,7 +8433,7 @@ bool ImGui::BeginPopupContextWindow(const char* str_id, ImGuiPopupFlags popup_fl
     return BeginPopupEx(id, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoSavedSettings);
 }
 
-bool ImGui::BeginPopupContextVoid(const char* str_id, ImGuiPopupFlags popup_flags) IMGUI_NOEXCEPT
+bool ImGui::BeginPopupContextVoid(const char* str_id, ImGuiPopupFlags popup_flags) IM_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     if (!str_id)
@@ -8451,7 +8451,7 @@ bool ImGui::BeginPopupContextVoid(const char* str_id, ImGuiPopupFlags popup_flag
 // (r_outer is usually equivalent to the viewport rectangle minus padding, but when multi-viewports are enabled and monitor
 //  information are available, it may represent the entire platform monitor from the frame of reference of the current viewport.
 //  this allows us to have tooltips/popups displayed out of the parent viewport.)
-ImVec2 ImGui::FindBestWindowPosForPopupEx(const ImVec2& ref_pos, const ImVec2& size, ImGuiDir* last_dir, const ImRect& r_outer, const ImRect& r_avoid, ImGuiPopupPositionPolicy policy) IMGUI_NOEXCEPT
+ImVec2 ImGui::FindBestWindowPosForPopupEx(const ImVec2& ref_pos, const ImVec2& size, ImGuiDir* last_dir, const ImRect& r_outer, const ImRect& r_avoid, ImGuiPopupPositionPolicy policy) IM_NOEXCEPT
 {
     ImVec2 base_pos_clamped = ImClamp(ref_pos, r_outer.Min, r_outer.Max - size);
     //GetForegroundDrawList()->AddRect(r_avoid.Min, r_avoid.Max, IM_COL32(255,0,0,255));
@@ -8526,7 +8526,7 @@ ImVec2 ImGui::FindBestWindowPosForPopupEx(const ImVec2& ref_pos, const ImVec2& s
 }
 
 // Note that this is used for popups, which can overlap the non work-area of individual viewports.
-ImRect ImGui::GetWindowAllowedExtentRect(ImGuiWindow* window) IMGUI_NOEXCEPT
+ImRect ImGui::GetWindowAllowedExtentRect(ImGuiWindow* window) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_UNUSED(window);
@@ -8536,7 +8536,7 @@ ImRect ImGui::GetWindowAllowedExtentRect(ImGuiWindow* window) IMGUI_NOEXCEPT
     return r_screen;
 }
 
-ImVec2 ImGui::FindBestWindowPosForPopup(ImGuiWindow* window) IMGUI_NOEXCEPT
+ImVec2 ImGui::FindBestWindowPosForPopup(ImGuiWindow* window) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -8581,7 +8581,7 @@ ImVec2 ImGui::FindBestWindowPosForPopup(ImGuiWindow* window) IMGUI_NOEXCEPT
 //-----------------------------------------------------------------------------
 
 // FIXME-NAV: The existence of SetNavID vs SetFocusID properly needs to be clarified/reworked.
-void ImGui::SetNavID(ImGuiID id, ImGuiNavLayer nav_layer, ImGuiID focus_scope_id, const ImRect& rect_rel) IMGUI_NOEXCEPT
+void ImGui::SetNavID(ImGuiID id, ImGuiNavLayer nav_layer, ImGuiID focus_scope_id, const ImRect& rect_rel) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(g.NavWindow != NULL);
@@ -8595,7 +8595,7 @@ void ImGui::SetNavID(ImGuiID id, ImGuiNavLayer nav_layer, ImGuiID focus_scope_id
     //g.NavDisableMouseHover = g.NavMousePosDirty = true;
 }
 
-void ImGui::SetFocusID(ImGuiID id, ImGuiWindow* window) IMGUI_NOEXCEPT
+void ImGui::SetFocusID(ImGuiID id, ImGuiWindow* window) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(id != 0);
@@ -8619,14 +8619,14 @@ void ImGui::SetFocusID(ImGuiID id, ImGuiWindow* window) IMGUI_NOEXCEPT
         g.NavDisableHighlight = true;
 }
 
-ImGuiDir ImGetDirQuadrantFromDelta(float dx, float dy) IMGUI_NOEXCEPT
+ImGuiDir ImGetDirQuadrantFromDelta(float dx, float dy) IM_NOEXCEPT
 {
     if (ImFabs(dx) > ImFabs(dy))
         return (dx > 0.0f) ? ImGuiDir_Right : ImGuiDir_Left;
     return (dy > 0.0f) ? ImGuiDir_Down : ImGuiDir_Up;
 }
 
-static float inline NavScoreItemDistInterval(float a0, float a1, float b0, float b1) IMGUI_NOEXCEPT
+static float inline NavScoreItemDistInterval(float a0, float a1, float b0, float b1) IM_NOEXCEPT
 {
     if (a1 < b0)
         return a1 - b0;
@@ -8635,7 +8635,7 @@ static float inline NavScoreItemDistInterval(float a0, float a1, float b0, float
     return 0.0f;
 }
 
-static void inline NavClampRectToVisibleAreaForMoveDir(ImGuiDir move_dir, ImRect& r, const ImRect& clip_rect) IMGUI_NOEXCEPT
+static void inline NavClampRectToVisibleAreaForMoveDir(ImGuiDir move_dir, ImRect& r, const ImRect& clip_rect) IM_NOEXCEPT
 {
     if (move_dir == ImGuiDir_Left || move_dir == ImGuiDir_Right)
     {
@@ -8650,7 +8650,7 @@ static void inline NavClampRectToVisibleAreaForMoveDir(ImGuiDir move_dir, ImRect
 }
 
 // Scoring function for gamepad/keyboard directional navigation. Based on https://gist.github.com/rygorous/6981057
-static bool ImGui::NavScoreItem(ImGuiNavItemData* result, ImRect cand) IMGUI_NOEXCEPT
+static bool ImGui::NavScoreItem(ImGuiNavItemData* result, ImRect cand) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -8781,7 +8781,7 @@ static bool ImGui::NavScoreItem(ImGuiNavItemData* result, ImRect cand) IMGUI_NOE
     return new_best;
 }
 
-static void ImGui::NavApplyItemToResult(ImGuiNavItemData* result, ImGuiWindow* window, ImGuiID id, const ImRect& nav_bb_rel) IMGUI_NOEXCEPT
+static void ImGui::NavApplyItemToResult(ImGuiNavItemData* result, ImGuiWindow* window, ImGuiID id, const ImRect& nav_bb_rel) IM_NOEXCEPT
 {
     result->Window = window;
     result->ID = id;
@@ -8790,7 +8790,7 @@ static void ImGui::NavApplyItemToResult(ImGuiNavItemData* result, ImGuiWindow* w
 }
 
 // We get there when either NavId == id, or when g.NavAnyRequest is set (which is updated by NavUpdateAnyRequestFlag above)
-static void ImGui::NavProcessItem(ImGuiWindow* window, const ImRect& nav_bb, const ImGuiID id) IMGUI_NOEXCEPT
+static void ImGui::NavProcessItem(ImGuiWindow* window, const ImRect& nav_bb, const ImGuiID id) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     //if (!g.IO.NavActive)  // [2017/10/06] Removed this possibly redundant test but I am not sure of all the side-effects yet. Some of the feature here will need to work regardless of using a _NoNavInputs flag.
@@ -8850,20 +8850,20 @@ static void ImGui::NavProcessItem(ImGuiWindow* window, const ImRect& nav_bb, con
     }
 }
 
-bool ImGui::NavMoveRequestButNoResultYet() IMGUI_NOEXCEPT
+bool ImGui::NavMoveRequestButNoResultYet() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return g.NavMoveRequest && g.NavMoveResultLocal.ID == 0 && g.NavMoveResultOther.ID == 0;
 }
 
-void ImGui::NavMoveRequestCancel() IMGUI_NOEXCEPT
+void ImGui::NavMoveRequestCancel() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.NavMoveRequest = false;
     NavUpdateAnyRequestFlag();
 }
 
-void ImGui::NavMoveRequestForward(ImGuiDir move_dir, ImGuiDir clip_dir, const ImRect& bb_rel, ImGuiNavMoveFlags move_flags) IMGUI_NOEXCEPT
+void ImGui::NavMoveRequestForward(ImGuiDir move_dir, ImGuiDir clip_dir, const ImRect& bb_rel, ImGuiNavMoveFlags move_flags) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(g.NavMoveRequestForward == ImGuiNavForward_None);
@@ -8875,7 +8875,7 @@ void ImGui::NavMoveRequestForward(ImGuiDir move_dir, ImGuiDir clip_dir, const Im
     g.NavWindow->NavRectRel[g.NavLayer] = bb_rel;
 }
 
-void ImGui::NavMoveRequestTryWrapping(ImGuiWindow* window, ImGuiNavMoveFlags move_flags) IMGUI_NOEXCEPT
+void ImGui::NavMoveRequestTryWrapping(ImGuiWindow* window, ImGuiNavMoveFlags move_flags) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -8887,7 +8887,7 @@ void ImGui::NavMoveRequestTryWrapping(ImGuiWindow* window, ImGuiNavMoveFlags mov
 
 // FIXME: This could be replaced by updating a frame number in each window when (window == NavWindow) and (NavLayer == 0).
 // This way we could find the last focused window among our children. It would be much less confusing this way?
-static void ImGui::NavSaveLastChildNavWindowIntoParent(ImGuiWindow* nav_window) IMGUI_NOEXCEPT
+static void ImGui::NavSaveLastChildNavWindowIntoParent(ImGuiWindow* nav_window) IM_NOEXCEPT
 {
     ImGuiWindow* parent = nav_window;
     while (parent && parent->RootWindow != parent && (parent->Flags & (ImGuiWindowFlags_Popup | ImGuiWindowFlags_ChildMenu)) == 0)
@@ -8898,14 +8898,14 @@ static void ImGui::NavSaveLastChildNavWindowIntoParent(ImGuiWindow* nav_window) 
 
 // Restore the last focused child.
 // Call when we are expected to land on the Main Layer (0) after FocusWindow()
-static ImGuiWindow* ImGui::NavRestoreLastChildNavWindow(ImGuiWindow* window) IMGUI_NOEXCEPT
+static ImGuiWindow* ImGui::NavRestoreLastChildNavWindow(ImGuiWindow* window) IM_NOEXCEPT
 {
     if (window->NavLastChildNavWindow && window->NavLastChildNavWindow->WasActive)
         return window->NavLastChildNavWindow;
     return window;
 }
 
-void ImGui::NavRestoreLayer(ImGuiNavLayer layer) IMGUI_NOEXCEPT
+void ImGui::NavRestoreLayer(ImGuiNavLayer layer) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (layer == ImGuiNavLayer_Main)
@@ -8924,7 +8924,7 @@ void ImGui::NavRestoreLayer(ImGuiNavLayer layer) IMGUI_NOEXCEPT
     }
 }
 
-static inline void ImGui::NavUpdateAnyRequestFlag() IMGUI_NOEXCEPT
+static inline void ImGui::NavUpdateAnyRequestFlag() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.NavAnyRequest = g.NavMoveRequest || g.NavInitRequest || (IMGUI_DEBUG_NAV_SCORING && g.NavWindow != NULL);
@@ -8933,7 +8933,7 @@ static inline void ImGui::NavUpdateAnyRequestFlag() IMGUI_NOEXCEPT
 }
 
 // This needs to be called before we submit any widget (aka in or before Begin)
-void ImGui::NavInitWindow(ImGuiWindow* window, bool force_reinit) IMGUI_NOEXCEPT
+void ImGui::NavInitWindow(ImGuiWindow* window, bool force_reinit) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(window == g.NavWindow);
@@ -8964,7 +8964,7 @@ void ImGui::NavInitWindow(ImGuiWindow* window, bool force_reinit) IMGUI_NOEXCEPT
     }
 }
 
-static ImVec2 ImGui::NavCalcPreferredRefPos() IMGUI_NOEXCEPT
+static ImVec2 ImGui::NavCalcPreferredRefPos() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.NavDisableHighlight || !g.NavDisableMouseHover || !g.NavWindow)
@@ -8984,7 +8984,7 @@ static ImVec2 ImGui::NavCalcPreferredRefPos() IMGUI_NOEXCEPT
     }
 }
 
-float ImGui::GetNavInputAmount(ImGuiNavInput n, ImGuiInputReadMode mode) IMGUI_NOEXCEPT
+float ImGui::GetNavInputAmount(ImGuiNavInput n, ImGuiInputReadMode mode) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (mode == ImGuiInputReadMode_Down)
@@ -9006,7 +9006,7 @@ float ImGui::GetNavInputAmount(ImGuiNavInput n, ImGuiInputReadMode mode) IMGUI_N
     return 0.0f;
 }
 
-ImVec2 ImGui::GetNavInputAmount2d(ImGuiNavDirSourceFlags dir_sources, ImGuiInputReadMode mode, float slow_factor, float fast_factor) IMGUI_NOEXCEPT
+ImVec2 ImGui::GetNavInputAmount2d(ImGuiNavDirSourceFlags dir_sources, ImGuiInputReadMode mode, float slow_factor, float fast_factor) IM_NOEXCEPT
 {
     ImVec2 delta(0.0f, 0.0f);
     if (dir_sources & ImGuiNavDirSourceFlags_Keyboard)
@@ -9022,7 +9022,7 @@ ImVec2 ImGui::GetNavInputAmount2d(ImGuiNavDirSourceFlags dir_sources, ImGuiInput
     return delta;
 }
 
-static void ImGui::NavUpdate() IMGUI_NOEXCEPT
+static void ImGui::NavUpdate() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiIO& io = g.IO;
@@ -9303,7 +9303,7 @@ static void ImGui::NavUpdate() IMGUI_NOEXCEPT
 #endif
 }
 
-static void ImGui::NavUpdateInitResult() IMGUI_NOEXCEPT
+static void ImGui::NavUpdateInitResult() IM_NOEXCEPT
 {
     // In very rare cases g.NavWindow may be null (e.g. clearing focus after requesting an init request, which does happen when releasing Alt while clicking on void)
     ImGuiContext& g = *GImGui;
@@ -9322,7 +9322,7 @@ static void ImGui::NavUpdateInitResult() IMGUI_NOEXCEPT
 }
 
 // Apply result from previous frame navigation directional move request
-static void ImGui::NavUpdateMoveResult() IMGUI_NOEXCEPT
+static void ImGui::NavUpdateMoveResult() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.NavMoveResultLocal.ID == 0 && g.NavMoveResultOther.ID == 0)
@@ -9387,7 +9387,7 @@ static void ImGui::NavUpdateMoveResult() IMGUI_NOEXCEPT
 }
 
 // Handle PageUp/PageDown/Home/End keys
-static float ImGui::NavUpdatePageUpPageDown() IMGUI_NOEXCEPT
+static float ImGui::NavUpdatePageUpPageDown() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiIO& io = g.IO;
@@ -9460,7 +9460,7 @@ static float ImGui::NavUpdatePageUpPageDown() IMGUI_NOEXCEPT
     return 0.0f;
 }
 
-static void ImGui::NavEndFrame() IMGUI_NOEXCEPT
+static void ImGui::NavEndFrame() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -9522,7 +9522,7 @@ static void ImGui::NavEndFrame() IMGUI_NOEXCEPT
     }
 }
 
-static int ImGui::FindWindowFocusIndex(ImGuiWindow* window) IMGUI_NOEXCEPT
+static int ImGui::FindWindowFocusIndex(ImGuiWindow* window) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_UNUSED(g);
@@ -9531,7 +9531,7 @@ static int ImGui::FindWindowFocusIndex(ImGuiWindow* window) IMGUI_NOEXCEPT
     return order;
 }
 
-static ImGuiWindow* FindWindowNavFocusable(int i_start, int i_stop, int dir)  IMGUI_NOEXCEPT  // FIXME-OPT O(N)
+static ImGuiWindow* FindWindowNavFocusable(int i_start, int i_stop, int dir)  IM_NOEXCEPT  // FIXME-OPT O(N)
 {
     ImGuiContext& g = *GImGui;
     for (int i = i_start; i >= 0 && i < g.WindowsFocusOrder.Size && i != i_stop; i += dir)
@@ -9540,7 +9540,7 @@ static ImGuiWindow* FindWindowNavFocusable(int i_start, int i_stop, int dir)  IM
     return NULL;
 }
 
-static void NavUpdateWindowingHighlightWindow(int focus_change_dir) IMGUI_NOEXCEPT
+static void NavUpdateWindowingHighlightWindow(int focus_change_dir) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(g.NavWindowingTarget);
@@ -9559,7 +9559,7 @@ static void NavUpdateWindowingHighlightWindow(int focus_change_dir) IMGUI_NOEXCE
 // Windowing management mode
 // Keyboard: CTRL+Tab (change focus/move/resize), Alt (toggle menu layer)
 // Gamepad:  Hold Menu/Square (change focus/move/resize), Tap Menu/Square (toggle menu layer)
-static void ImGui::NavUpdateWindowing() IMGUI_NOEXCEPT
+static void ImGui::NavUpdateWindowing() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* apply_focus_window = NULL;
@@ -9705,7 +9705,7 @@ static void ImGui::NavUpdateWindowing() IMGUI_NOEXCEPT
 }
 
 // Window has already passed the IsWindowNavFocusable()
-static const char* GetFallbackWindowNameForWindowingList(ImGuiWindow* window) IMGUI_NOEXCEPT
+static const char* GetFallbackWindowNameForWindowingList(ImGuiWindow* window) IM_NOEXCEPT
 {
     if (window->Flags & ImGuiWindowFlags_Popup)
         return "(Popup)";
@@ -9715,7 +9715,7 @@ static const char* GetFallbackWindowNameForWindowingList(ImGuiWindow* window) IM
 }
 
 // Overlay displayed when using CTRL+TAB. Called by EndFrame().
-void ImGui::NavUpdateWindowingOverlay() IMGUI_NOEXCEPT
+void ImGui::NavUpdateWindowingOverlay() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(g.NavWindowingTarget != NULL);
@@ -9750,7 +9750,7 @@ void ImGui::NavUpdateWindowingOverlay() IMGUI_NOEXCEPT
 // [SECTION] DRAG AND DROP
 //-----------------------------------------------------------------------------
 
-void ImGui::ClearDragDrop() IMGUI_NOEXCEPT
+void ImGui::ClearDragDrop() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.DragDropActive = false;
@@ -9771,7 +9771,7 @@ void ImGui::ClearDragDrop() IMGUI_NOEXCEPT
 // - We then pull and use the mouse button that was used to activate the item and use it to carry on the drag.
 // If the item has no identifier:
 // - Currently always assume left mouse button.
-bool ImGui::BeginDragDropSource(ImGuiDragDropFlags flags) IMGUI_NOEXCEPT
+bool ImGui::BeginDragDropSource(ImGuiDragDropFlags flags) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -9885,7 +9885,7 @@ bool ImGui::BeginDragDropSource(ImGuiDragDropFlags flags) IMGUI_NOEXCEPT
     return false;
 }
 
-void ImGui::EndDragDropSource() IMGUI_NOEXCEPT
+void ImGui::EndDragDropSource() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(g.DragDropActive);
@@ -9901,7 +9901,7 @@ void ImGui::EndDragDropSource() IMGUI_NOEXCEPT
 }
 
 // Use 'cond' to choose to submit payload on drag start or every frame
-bool ImGui::SetDragDropPayload(const char* type, const void* data, size_t data_size, ImGuiCond cond) IMGUI_NOEXCEPT
+bool ImGui::SetDragDropPayload(const char* type, const void* data, size_t data_size, ImGuiCond cond) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiPayload& payload = g.DragDropPayload;
@@ -9944,7 +9944,7 @@ bool ImGui::SetDragDropPayload(const char* type, const void* data, size_t data_s
     return (g.DragDropAcceptFrameCount == g.FrameCount) || (g.DragDropAcceptFrameCount == g.FrameCount - 1);
 }
 
-bool ImGui::BeginDragDropTargetCustom(const ImRect& bb, ImGuiID id) IMGUI_NOEXCEPT
+bool ImGui::BeginDragDropTargetCustom(const ImRect& bb, ImGuiID id) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (!g.DragDropActive)
@@ -9971,7 +9971,7 @@ bool ImGui::BeginDragDropTargetCustom(const ImRect& bb, ImGuiID id) IMGUI_NOEXCE
 // 1) we use LastItemRectHoveredRect which handles items that pushes a temporarily clip rectangle in their code. Calling BeginDragDropTargetCustom(LastItemRect) would not handle them.
 // 2) and it's faster. as this code may be very frequently called, we want to early out as fast as we can.
 // Also note how the HoveredWindow test is positioned differently in both functions (in both functions we optimize for the cheapest early out case)
-bool ImGui::BeginDragDropTarget() IMGUI_NOEXCEPT
+bool ImGui::BeginDragDropTarget() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (!g.DragDropActive)
@@ -9998,13 +9998,13 @@ bool ImGui::BeginDragDropTarget() IMGUI_NOEXCEPT
     return true;
 }
 
-bool ImGui::IsDragDropPayloadBeingAccepted() IMGUI_NOEXCEPT
+bool ImGui::IsDragDropPayloadBeingAccepted() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return g.DragDropActive && g.DragDropAcceptIdPrev != 0;
 }
 
-const ImGuiPayload* ImGui::AcceptDragDropPayload(const char* type, ImGuiDragDropFlags flags) IMGUI_NOEXCEPT
+const ImGuiPayload* ImGui::AcceptDragDropPayload(const char* type, ImGuiDragDropFlags flags) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -10047,14 +10047,14 @@ const ImGuiPayload* ImGui::AcceptDragDropPayload(const char* type, ImGuiDragDrop
     return &payload;
 }
 
-const ImGuiPayload* ImGui::GetDragDropPayload() IMGUI_NOEXCEPT
+const ImGuiPayload* ImGui::GetDragDropPayload() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return g.DragDropActive ? &g.DragDropPayload : NULL;
 }
 
 // We don't really use/need this now, but added it for the sake of consistency and because we might need it later.
-void ImGui::EndDragDropTarget() IMGUI_NOEXCEPT
+void ImGui::EndDragDropTarget() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(g.DragDropActive);
@@ -10070,7 +10070,7 @@ void ImGui::EndDragDropTarget() IMGUI_NOEXCEPT
 //-----------------------------------------------------------------------------
 
 // Pass text data straight to log (without being displayed)
-static inline void LogTextV(ImGuiContext& g, const char* fmt, va_list args) IMGUI_NOEXCEPT
+static inline void LogTextV(ImGuiContext& g, const char* fmt, va_list args) IM_NOEXCEPT
 {
     if (g.LogFile)
     {
@@ -10084,7 +10084,7 @@ static inline void LogTextV(ImGuiContext& g, const char* fmt, va_list args) IMGU
     }
 }
 
-void ImGui::LogText(const char* fmt, ...) IMGUI_NOEXCEPT
+void ImGui::LogText(const char* fmt, ...) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (!g.LogEnabled)
@@ -10096,7 +10096,7 @@ void ImGui::LogText(const char* fmt, ...) IMGUI_NOEXCEPT
     va_end(args);
 }
 
-void ImGui::LogTextV(const char* fmt, va_list args) IMGUI_NOEXCEPT
+void ImGui::LogTextV(const char* fmt, va_list args) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (!g.LogEnabled)
@@ -10108,7 +10108,7 @@ void ImGui::LogTextV(const char* fmt, va_list args) IMGUI_NOEXCEPT
 // Internal version that takes a position to decide on newline placement and pad items according to their depth.
 // We split text into individual lines to add current tree level padding
 // FIXME: This code is a little complicated perhaps, considering simplifying the whole system.
-void ImGui::LogRenderedText(const ImVec2* ref_pos, const char* text, const char* text_end) IMGUI_NOEXCEPT
+void ImGui::LogRenderedText(const ImVec2* ref_pos, const char* text, const char* text_end) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -10167,7 +10167,7 @@ void ImGui::LogRenderedText(const ImVec2* ref_pos, const char* text, const char*
 }
 
 // Start logging/capturing text output
-void ImGui::LogBegin(ImGuiLogType type, int auto_open_depth) IMGUI_NOEXCEPT
+void ImGui::LogBegin(ImGuiLogType type, int auto_open_depth) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -10184,14 +10184,14 @@ void ImGui::LogBegin(ImGuiLogType type, int auto_open_depth) IMGUI_NOEXCEPT
 }
 
 // Important: doesn't copy underlying data, use carefully (prefix/suffix must be in scope at the time of the next LogRenderedText)
-void ImGui::LogSetNextTextDecoration(const char* prefix, const char* suffix) IMGUI_NOEXCEPT
+void ImGui::LogSetNextTextDecoration(const char* prefix, const char* suffix) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.LogNextPrefix = prefix;
     g.LogNextSuffix = suffix;
 }
 
-void ImGui::LogToTTY(int auto_open_depth) IMGUI_NOEXCEPT
+void ImGui::LogToTTY(int auto_open_depth) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.LogEnabled)
@@ -10204,7 +10204,7 @@ void ImGui::LogToTTY(int auto_open_depth) IMGUI_NOEXCEPT
 }
 
 // Start logging/capturing text output to given file
-void ImGui::LogToFile(int auto_open_depth, const char* filename) IMGUI_NOEXCEPT
+void ImGui::LogToFile(int auto_open_depth, const char* filename) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.LogEnabled)
@@ -10229,7 +10229,7 @@ void ImGui::LogToFile(int auto_open_depth, const char* filename) IMGUI_NOEXCEPT
 }
 
 // Start logging/capturing text output to clipboard
-void ImGui::LogToClipboard(int auto_open_depth) IMGUI_NOEXCEPT
+void ImGui::LogToClipboard(int auto_open_depth) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.LogEnabled)
@@ -10237,7 +10237,7 @@ void ImGui::LogToClipboard(int auto_open_depth) IMGUI_NOEXCEPT
     LogBegin(ImGuiLogType_Clipboard, auto_open_depth);
 }
 
-void ImGui::LogToBuffer(int auto_open_depth) IMGUI_NOEXCEPT
+void ImGui::LogToBuffer(int auto_open_depth) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.LogEnabled)
@@ -10245,7 +10245,7 @@ void ImGui::LogToBuffer(int auto_open_depth) IMGUI_NOEXCEPT
     LogBegin(ImGuiLogType_Buffer, auto_open_depth);
 }
 
-void ImGui::LogFinish() IMGUI_NOEXCEPT
+void ImGui::LogFinish() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (!g.LogEnabled)
@@ -10281,7 +10281,7 @@ void ImGui::LogFinish() IMGUI_NOEXCEPT
 
 // Helper to display logging buttons
 // FIXME-OBSOLETE: We should probably obsolete this and let the user have their own helper (this is one of the oldest function alive!)
-void ImGui::LogButtons() IMGUI_NOEXCEPT
+void ImGui::LogButtons() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -10327,7 +10327,7 @@ void ImGui::LogButtons() IMGUI_NOEXCEPT
 //-----------------------------------------------------------------------------
 
 // Called by NewFrame()
-void ImGui::UpdateSettings() IMGUI_NOEXCEPT
+void ImGui::UpdateSettings() IM_NOEXCEPT
 {
     // Load settings on first frame (if not explicitly loaded manually before)
     ImGuiContext& g = *GImGui;
@@ -10354,14 +10354,14 @@ void ImGui::UpdateSettings() IMGUI_NOEXCEPT
     }
 }
 
-void ImGui::MarkIniSettingsDirty() IMGUI_NOEXCEPT
+void ImGui::MarkIniSettingsDirty() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.SettingsDirtyTimer <= 0.0f)
         g.SettingsDirtyTimer = g.IO.IniSavingRate;
 }
 
-void ImGui::MarkIniSettingsDirty(ImGuiWindow* window) IMGUI_NOEXCEPT
+void ImGui::MarkIniSettingsDirty(ImGuiWindow* window) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (!(window->Flags & ImGuiWindowFlags_NoSavedSettings))
@@ -10369,7 +10369,7 @@ void ImGui::MarkIniSettingsDirty(ImGuiWindow* window) IMGUI_NOEXCEPT
             g.SettingsDirtyTimer = g.IO.IniSavingRate;
 }
 
-ImGuiWindowSettings* ImGui::CreateNewWindowSettings(const char* name) IMGUI_NOEXCEPT
+ImGuiWindowSettings* ImGui::CreateNewWindowSettings(const char* name) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -10391,7 +10391,7 @@ ImGuiWindowSettings* ImGui::CreateNewWindowSettings(const char* name) IMGUI_NOEX
     return settings;
 }
 
-ImGuiWindowSettings* ImGui::FindWindowSettings(ImGuiID id) IMGUI_NOEXCEPT
+ImGuiWindowSettings* ImGui::FindWindowSettings(ImGuiID id) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     for (ImGuiWindowSettings* settings = g.SettingsWindows.begin(); settings != NULL; settings = g.SettingsWindows.next_chunk(settings))
@@ -10400,14 +10400,14 @@ ImGuiWindowSettings* ImGui::FindWindowSettings(ImGuiID id) IMGUI_NOEXCEPT
     return NULL;
 }
 
-ImGuiWindowSettings* ImGui::FindOrCreateWindowSettings(const char* name) IMGUI_NOEXCEPT
+ImGuiWindowSettings* ImGui::FindOrCreateWindowSettings(const char* name) IM_NOEXCEPT
 {
     if (ImGuiWindowSettings* settings = FindWindowSettings(ImHashStr(name)))
         return settings;
     return CreateNewWindowSettings(name);
 }
 
-ImGuiSettingsHandler* ImGui::FindSettingsHandler(const char* type_name) IMGUI_NOEXCEPT
+ImGuiSettingsHandler* ImGui::FindSettingsHandler(const char* type_name) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     const ImGuiID type_hash = ImHashStr(type_name);
@@ -10417,7 +10417,7 @@ ImGuiSettingsHandler* ImGui::FindSettingsHandler(const char* type_name) IMGUI_NO
     return NULL;
 }
 
-void ImGui::ClearIniSettings() IMGUI_NOEXCEPT
+void ImGui::ClearIniSettings() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.SettingsIniData.clear();
@@ -10426,7 +10426,7 @@ void ImGui::ClearIniSettings() IMGUI_NOEXCEPT
             g.SettingsHandlers[handler_n].ClearAllFn(&g, &g.SettingsHandlers[handler_n]);
 }
 
-void ImGui::LoadIniSettingsFromDisk(const char* ini_filename) IMGUI_NOEXCEPT
+void ImGui::LoadIniSettingsFromDisk(const char* ini_filename) IM_NOEXCEPT
 {
     size_t file_data_size = 0;
     char* file_data = (char*)ImFileLoadToMemory(ini_filename, "rb", &file_data_size);
@@ -10437,7 +10437,7 @@ void ImGui::LoadIniSettingsFromDisk(const char* ini_filename) IMGUI_NOEXCEPT
 }
 
 // Zero-tolerance, no error reporting, cheap .ini parsing
-void ImGui::LoadIniSettingsFromMemory(const char* ini_data, size_t ini_size) IMGUI_NOEXCEPT
+void ImGui::LoadIniSettingsFromMemory(const char* ini_data, size_t ini_size) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(g.Initialized);
@@ -10507,7 +10507,7 @@ void ImGui::LoadIniSettingsFromMemory(const char* ini_data, size_t ini_size) IMG
             g.SettingsHandlers[handler_n].ApplyAllFn(&g, &g.SettingsHandlers[handler_n]);
 }
 
-void ImGui::SaveIniSettingsToDisk(const char* ini_filename) IMGUI_NOEXCEPT
+void ImGui::SaveIniSettingsToDisk(const char* ini_filename) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.SettingsDirtyTimer = 0.0f;
@@ -10524,7 +10524,7 @@ void ImGui::SaveIniSettingsToDisk(const char* ini_filename) IMGUI_NOEXCEPT
 }
 
 // Call registered handlers (e.g. SettingsHandlerWindow_WriteAll() + custom handlers) to write their stuff into a text buffer
-const char* ImGui::SaveIniSettingsToMemory(size_t* out_size) IMGUI_NOEXCEPT
+const char* ImGui::SaveIniSettingsToMemory(size_t* out_size) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.SettingsDirtyTimer = 0.0f;
@@ -10540,7 +10540,7 @@ const char* ImGui::SaveIniSettingsToMemory(size_t* out_size) IMGUI_NOEXCEPT
     return g.SettingsIniData.c_str();
 }
 
-static void WindowSettingsHandler_ClearAll(ImGuiContext* ctx, ImGuiSettingsHandler*) IMGUI_NOEXCEPT
+static void WindowSettingsHandler_ClearAll(ImGuiContext* ctx, ImGuiSettingsHandler*) IM_NOEXCEPT
 {
     ImGuiContext& g = *ctx;
     for (int i = 0; i != g.Windows.Size; i++)
@@ -10548,7 +10548,7 @@ static void WindowSettingsHandler_ClearAll(ImGuiContext* ctx, ImGuiSettingsHandl
     g.SettingsWindows.clear();
 }
 
-static void* WindowSettingsHandler_ReadOpen(ImGuiContext*, ImGuiSettingsHandler*, const char* name) IMGUI_NOEXCEPT
+static void* WindowSettingsHandler_ReadOpen(ImGuiContext*, ImGuiSettingsHandler*, const char* name) IM_NOEXCEPT
 {
     ImGuiWindowSettings* settings = ImGui::FindOrCreateWindowSettings(name);
     ImGuiID id = settings->ID;
@@ -10558,7 +10558,7 @@ static void* WindowSettingsHandler_ReadOpen(ImGuiContext*, ImGuiSettingsHandler*
     return (void*)settings;
 }
 
-static void WindowSettingsHandler_ReadLine(ImGuiContext*, ImGuiSettingsHandler*, void* entry, const char* line) IMGUI_NOEXCEPT
+static void WindowSettingsHandler_ReadLine(ImGuiContext*, ImGuiSettingsHandler*, void* entry, const char* line) IM_NOEXCEPT
 {
     ImGuiWindowSettings* settings = (ImGuiWindowSettings*)entry;
     int x, y;
@@ -10569,7 +10569,7 @@ static void WindowSettingsHandler_ReadLine(ImGuiContext*, ImGuiSettingsHandler*,
 }
 
 // Apply to existing windows (if any)
-static void WindowSettingsHandler_ApplyAll(ImGuiContext* ctx, ImGuiSettingsHandler*) IMGUI_NOEXCEPT
+static void WindowSettingsHandler_ApplyAll(ImGuiContext* ctx, ImGuiSettingsHandler*) IM_NOEXCEPT
 {
     ImGuiContext& g = *ctx;
     for (ImGuiWindowSettings* settings = g.SettingsWindows.begin(); settings != NULL; settings = g.SettingsWindows.next_chunk(settings))
@@ -10581,7 +10581,7 @@ static void WindowSettingsHandler_ApplyAll(ImGuiContext* ctx, ImGuiSettingsHandl
         }
 }
 
-static void WindowSettingsHandler_WriteAll(ImGuiContext* ctx, ImGuiSettingsHandler* handler, ImGuiTextBuffer* buf) IMGUI_NOEXCEPT
+static void WindowSettingsHandler_WriteAll(ImGuiContext* ctx, ImGuiSettingsHandler* handler, ImGuiTextBuffer* buf) IM_NOEXCEPT
 {
     // Gather data from windows that were active during this session
     // (if a window wasn't opened in this session we preserve its settings)
@@ -10626,14 +10626,14 @@ static void WindowSettingsHandler_WriteAll(ImGuiContext* ctx, ImGuiSettingsHandl
 // (this section is more complete in the 'docking' branch)
 //-----------------------------------------------------------------------------
 
-ImGuiViewport* ImGui::GetMainViewport() IMGUI_NOEXCEPT
+ImGuiViewport* ImGui::GetMainViewport() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return g.Viewports[0];
 }
 
 // Update viewports and monitor infos
-static void ImGui::UpdateViewportsNewFrame() IMGUI_NOEXCEPT
+static void ImGui::UpdateViewportsNewFrame() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(g.Viewports.Size == 1);
@@ -10677,7 +10677,7 @@ static void ImGui::UpdateViewportsNewFrame() IMGUI_NOEXCEPT
 
 // Win32 clipboard implementation
 // We use g.ClipboardHandlerData for temporary storage to ensure it is freed on Shutdown()
-static const char* GetClipboardTextFn_DefaultImpl(void*) IMGUI_NOEXCEPT
+static const char* GetClipboardTextFn_DefaultImpl(void*) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.ClipboardHandlerData.clear();
@@ -10700,7 +10700,7 @@ static const char* GetClipboardTextFn_DefaultImpl(void*) IMGUI_NOEXCEPT
     return g.ClipboardHandlerData.Data;
 }
 
-static void SetClipboardTextFn_DefaultImpl(void*, const char* text) IMGUI_NOEXCEPT
+static void SetClipboardTextFn_DefaultImpl(void*, const char* text) IM_NOEXCEPT
 {
     if (!::OpenClipboard(NULL))
         return;
@@ -10727,7 +10727,7 @@ static PasteboardRef main_clipboard = 0;
 
 // OSX clipboard implementation
 // If you enable this you will need to add '-framework ApplicationServices' to your linker command-line!
-static void SetClipboardTextFn_DefaultImpl(void*, const char* text) IMGUI_NOEXCEPT
+static void SetClipboardTextFn_DefaultImpl(void*, const char* text) IM_NOEXCEPT
 {
     if (!main_clipboard)
         PasteboardCreate(kPasteboardClipboard, &main_clipboard);
@@ -10740,7 +10740,7 @@ static void SetClipboardTextFn_DefaultImpl(void*, const char* text) IMGUI_NOEXCE
     }
 }
 
-static const char* GetClipboardTextFn_DefaultImpl(void*) IMGUI_NOEXCEPT
+static const char* GetClipboardTextFn_DefaultImpl(void*) IM_NOEXCEPT
 {
     if (!main_clipboard)
         PasteboardCreate(kPasteboardClipboard, &main_clipboard);
@@ -10776,13 +10776,13 @@ static const char* GetClipboardTextFn_DefaultImpl(void*) IMGUI_NOEXCEPT
 #else
 
 // Local Dear ImGui-only clipboard implementation, if user hasn't defined better clipboard handlers.
-static const char* GetClipboardTextFn_DefaultImpl(void*) IMGUI_NOEXCEPT
+static const char* GetClipboardTextFn_DefaultImpl(void*) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return g.ClipboardHandlerData.empty() ? NULL : g.ClipboardHandlerData.begin();
 }
 
-static void SetClipboardTextFn_DefaultImpl(void*, const char* text) IMGUI_NOEXCEPT
+static void SetClipboardTextFn_DefaultImpl(void*, const char* text) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     g.ClipboardHandlerData.clear();
@@ -10802,7 +10802,7 @@ static void SetClipboardTextFn_DefaultImpl(void*, const char* text) IMGUI_NOEXCE
 #pragma comment(lib, "imm32")
 #endif
 
-static void ImeSetInputScreenPosFn_DefaultImpl(int x, int y) IMGUI_NOEXCEPT
+static void ImeSetInputScreenPosFn_DefaultImpl(int x, int y) IM_NOEXCEPT
 {
     // Notify OS Input Method Editor of text input position
     ImGuiIO& io = ImGui::GetIO();
@@ -10820,7 +10820,7 @@ static void ImeSetInputScreenPosFn_DefaultImpl(int x, int y) IMGUI_NOEXCEPT
 
 #else
 
-static void ImeSetInputScreenPosFn_DefaultImpl(int, int) IMGUI_NOEXCEPT {}
+static void ImeSetInputScreenPosFn_DefaultImpl(int, int) IM_NOEXCEPT {}
 
 #endif
 
@@ -10844,7 +10844,7 @@ static void ImeSetInputScreenPosFn_DefaultImpl(int, int) IMGUI_NOEXCEPT {}
 
 #ifndef IMGUI_DISABLE_METRICS_WINDOW
 
-void ImGui::DebugRenderViewportThumbnail(ImDrawList* draw_list, ImGuiViewportP* viewport, const ImRect& bb) IMGUI_NOEXCEPT
+void ImGui::DebugRenderViewportThumbnail(ImDrawList* draw_list, ImGuiViewportP* viewport, const ImRect& bb) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -10874,7 +10874,7 @@ void ImGui::DebugRenderViewportThumbnail(ImDrawList* draw_list, ImGuiViewportP* 
     draw_list->AddRect(bb.Min, bb.Max, GetColorU32(ImGuiCol_Border, alpha_mul));
 }
 
-static void RenderViewportsThumbnails() IMGUI_NOEXCEPT
+static void RenderViewportsThumbnails() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -10896,7 +10896,7 @@ static void RenderViewportsThumbnails() IMGUI_NOEXCEPT
 }
 
 // Avoid naming collision with imgui_demo.cpp's HelpMarker() for unity builds.
-static void MetricsHelpMarker(const char* desc) IMGUI_NOEXCEPT
+static void MetricsHelpMarker(const char* desc) IM_NOEXCEPT
 {
     ImGui::TextDisabled("(?)");
     if (ImGui::IsItemHovered())
@@ -10909,7 +10909,7 @@ static void MetricsHelpMarker(const char* desc) IMGUI_NOEXCEPT
     }
 }
 
-void ImGui::ShowMetricsWindow(bool* p_open) IMGUI_NOEXCEPT
+void ImGui::ShowMetricsWindow(bool* p_open) IM_NOEXCEPT
 {
     if (!Begin("Dear ImGui Metrics/Debugger", p_open))
     {
@@ -11272,7 +11272,7 @@ void ImGui::ShowMetricsWindow(bool* p_open) IMGUI_NOEXCEPT
 }
 
 // [DEBUG] Display contents of Columns
-void ImGui::DebugNodeColumns(ImGuiOldColumns* columns) IMGUI_NOEXCEPT
+void ImGui::DebugNodeColumns(ImGuiOldColumns* columns) IM_NOEXCEPT
 {
     if (!TreeNode((void*)(uintptr_t)columns->ID, "Columns Id: 0x%08X, Count: %d, Flags: 0x%04X", columns->ID, columns->Count, columns->Flags))
         return;
@@ -11283,7 +11283,7 @@ void ImGui::DebugNodeColumns(ImGuiOldColumns* columns) IMGUI_NOEXCEPT
 }
 
 // [DEBUG] Display contents of ImDrawList
-void ImGui::DebugNodeDrawList(ImGuiWindow* window, const ImDrawList* draw_list, const char* label) IMGUI_NOEXCEPT
+void ImGui::DebugNodeDrawList(ImGuiWindow* window, const ImDrawList* draw_list, const char* label) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiMetricsConfig* cfg = &g.DebugMetricsConfig;
@@ -11377,7 +11377,7 @@ void ImGui::DebugNodeDrawList(ImGuiWindow* window, const ImDrawList* draw_list, 
 }
 
 // [DEBUG] Display mesh/aabb of a ImDrawCmd
-void ImGui::DebugNodeDrawCmdShowMeshAndBoundingBox(ImDrawList* out_draw_list, const ImDrawList* draw_list, const ImDrawCmd* draw_cmd, bool show_mesh, bool show_aabb) IMGUI_NOEXCEPT
+void ImGui::DebugNodeDrawCmdShowMeshAndBoundingBox(ImDrawList* out_draw_list, const ImDrawList* draw_list, const ImDrawCmd* draw_cmd, bool show_mesh, bool show_aabb) IM_NOEXCEPT
 {
     IM_ASSERT(show_mesh || show_aabb);
     ImDrawIdx* idx_buffer = (draw_list->IdxBuffer.Size > 0) ? draw_list->IdxBuffer.Data : NULL;
@@ -11406,7 +11406,7 @@ void ImGui::DebugNodeDrawCmdShowMeshAndBoundingBox(ImDrawList* out_draw_list, co
 }
 
 // [DEBUG] Display contents of ImGuiStorage
-void ImGui::DebugNodeStorage(ImGuiStorage* storage, const char* label) IMGUI_NOEXCEPT
+void ImGui::DebugNodeStorage(ImGuiStorage* storage, const char* label) IM_NOEXCEPT
 {
     if (!TreeNode(label, "%s: %d entries, %d bytes", label, storage->Data.Size, storage->Data.size_in_bytes()))
         return;
@@ -11419,7 +11419,7 @@ void ImGui::DebugNodeStorage(ImGuiStorage* storage, const char* label) IMGUI_NOE
 }
 
 // [DEBUG] Display contents of ImGuiTabBar
-void ImGui::DebugNodeTabBar(ImGuiTabBar* tab_bar, const char* label) IMGUI_NOEXCEPT
+void ImGui::DebugNodeTabBar(ImGuiTabBar* tab_bar, const char* label) IM_NOEXCEPT
 {
     // Standalone tab bars (not associated to docking/windows functionality) currently hold no discernible strings.
     char buf[256];
@@ -11454,7 +11454,7 @@ void ImGui::DebugNodeTabBar(ImGuiTabBar* tab_bar, const char* label) IMGUI_NOEXC
     }
 }
 
-void ImGui::DebugNodeViewport(ImGuiViewportP* viewport) IMGUI_NOEXCEPT
+void ImGui::DebugNodeViewport(ImGuiViewportP* viewport) IM_NOEXCEPT
 {
     SetNextItemOpen(true, ImGuiCond_Once);
     if (TreeNode("viewport0", "Viewport #%d", 0))
@@ -11474,7 +11474,7 @@ void ImGui::DebugNodeViewport(ImGuiViewportP* viewport) IMGUI_NOEXCEPT
     }
 }
 
-void ImGui::DebugNodeWindow(ImGuiWindow* window, const char* label) IMGUI_NOEXCEPT
+void ImGui::DebugNodeWindow(ImGuiWindow* window, const char* label) IM_NOEXCEPT
 {
     if (window == NULL)
     {
@@ -11532,13 +11532,13 @@ void ImGui::DebugNodeWindow(ImGuiWindow* window, const char* label) IMGUI_NOEXCE
     TreePop();
 }
 
-void ImGui::DebugNodeWindowSettings(ImGuiWindowSettings* settings) IMGUI_NOEXCEPT
+void ImGui::DebugNodeWindowSettings(ImGuiWindowSettings* settings) IM_NOEXCEPT
 {
     Text("0x%08X \"%s\" Pos (%d,%d) Size (%d,%d) Collapsed=%d",
         settings->ID, settings->GetName(), settings->Pos.x, settings->Pos.y, settings->Size.x, settings->Size.y, settings->Collapsed);
 }
 
-void ImGui::DebugNodeWindowsList(ImVector<ImGuiWindow*>* windows, const char* label) IMGUI_NOEXCEPT
+void ImGui::DebugNodeWindowsList(ImVector<ImGuiWindow*>* windows, const char* label) IM_NOEXCEPT
 {
     if (!TreeNode(label, "%s (%d)", label, windows->Size))
         return;
@@ -11554,16 +11554,16 @@ void ImGui::DebugNodeWindowsList(ImVector<ImGuiWindow*>* windows, const char* la
 
 #else
 
-void ImGui::ShowMetricsWindow(bool*)                      IMGUI_NOEXCEPT {}
-void ImGui::DebugNodeColumns(ImGuiOldColumns*)            IMGUI_NOEXCEPT {}
-void ImGui::DebugNodeDrawList(ImGuiWindow*, const ImDrawList*, const char*) IMGUI_NOEXCEPT {}
-void ImGui::DebugNodeDrawCmdShowMeshAndBoundingBox(ImDrawList*, const ImDrawList*, const ImDrawCmd*, bool, bool) IMGUI_NOEXCEPT {}
-void ImGui::DebugNodeStorage(ImGuiStorage*, const char*)  IMGUI_NOEXCEPT {}
-void ImGui::DebugNodeTabBar(ImGuiTabBar*, const char*)    IMGUI_NOEXCEPT {}
-void ImGui::DebugNodeWindow(ImGuiWindow*, const char*)    IMGUI_NOEXCEPT {}
-void ImGui::DebugNodeWindowSettings(ImGuiWindowSettings*) IMGUI_NOEXCEPT {}
-void ImGui::DebugNodeWindowsList(ImVector<ImGuiWindow*>*, const char*) IMGUI_NOEXCEPT {}
-void ImGui::DebugNodeViewport(ImGuiViewportP*)            IMGUI_NOEXCEPT {}
+void ImGui::ShowMetricsWindow(bool*)                      IM_NOEXCEPT {}
+void ImGui::DebugNodeColumns(ImGuiOldColumns*)            IM_NOEXCEPT {}
+void ImGui::DebugNodeDrawList(ImGuiWindow*, const ImDrawList*, const char*) IM_NOEXCEPT {}
+void ImGui::DebugNodeDrawCmdShowMeshAndBoundingBox(ImDrawList*, const ImDrawList*, const ImDrawCmd*, bool, bool) IM_NOEXCEPT {}
+void ImGui::DebugNodeStorage(ImGuiStorage*, const char*)  IM_NOEXCEPT {}
+void ImGui::DebugNodeTabBar(ImGuiTabBar*, const char*)    IM_NOEXCEPT {}
+void ImGui::DebugNodeWindow(ImGuiWindow*, const char*)    IM_NOEXCEPT {}
+void ImGui::DebugNodeWindowSettings(ImGuiWindowSettings*) IM_NOEXCEPT {}
+void ImGui::DebugNodeWindowsList(ImVector<ImGuiWindow*>*, const char*) IM_NOEXCEPT {}
+void ImGui::DebugNodeViewport(ImGuiViewportP*)            IM_NOEXCEPT {}
 
 #endif
 

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -2283,7 +2283,7 @@ ImGuiListClipper::~ImGuiListClipper()
 // Use case A: Begin() called from constructor with items_height<0, then called again from Step() in StepNo 1
 // Use case B: Begin() called from constructor with items_height>0
 // FIXME-LEGACY: Ideally we should remove the Begin/End functions but they are part of the legacy API we still support. This is why some of the code in Step() calling Begin() and reassign some fields, spaghetti style.
-void ImGuiListClipper::Begin(int items_count, float items_height)
+void ImGuiListClipper::Begin(int items_count, float items_height) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -2301,7 +2301,7 @@ void ImGuiListClipper::Begin(int items_count, float items_height)
     DisplayEnd = 0;
 }
 
-void ImGuiListClipper::End()
+void ImGuiListClipper::End() IMGUI_NOEXCEPT
 {
     if (ItemsCount < 0) // Already ended
         return;
@@ -3322,7 +3322,7 @@ float ImGui::CalcWrapWidthForPos(const ImVec2& pos, float wrap_pos_x)
 }
 
 // IM_ALLOC() == ImGui::MemAlloc()
-void* ImGui::MemAlloc(size_t size)
+void* ImGui::MemAlloc(size_t size) IMGUI_NOEXCEPT
 {
     if (ImGuiContext* ctx = GImGui)
         ctx->IO.MetricsActiveAllocations++;
@@ -3330,7 +3330,7 @@ void* ImGui::MemAlloc(size_t size)
 }
 
 // IM_FREE() == ImGui::MemFree()
-void ImGui::MemFree(void* ptr)
+void ImGui::MemFree(void* ptr) IMGUI_NOEXCEPT
 {
     if (ptr)
         if (ImGuiContext* ctx = GImGui)
@@ -5018,19 +5018,19 @@ bool ImGui::BeginChildEx(const char* name, ImGuiID id, const ImVec2& size_arg, b
     return ret;
 }
 
-bool ImGui::BeginChild(const char* str_id, const ImVec2& size_arg, bool border, ImGuiWindowFlags extra_flags)
+bool ImGui::BeginChild(const char* str_id, const ImVec2& size_arg, bool border, ImGuiWindowFlags extra_flags) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     return BeginChildEx(str_id, window->GetID(str_id), size_arg, border, extra_flags);
 }
 
-bool ImGui::BeginChild(ImGuiID id, const ImVec2& size_arg, bool border, ImGuiWindowFlags extra_flags)
+bool ImGui::BeginChild(ImGuiID id, const ImVec2& size_arg, bool border, ImGuiWindowFlags extra_flags) IMGUI_NOEXCEPT
 {
     IM_ASSERT(id != 0);
     return BeginChildEx(NULL, id, size_arg, border, extra_flags);
 }
 
-void ImGui::EndChild()
+void ImGui::EndChild() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -5077,7 +5077,7 @@ void ImGui::EndChild()
 }
 
 // Helper to create a child window / scrolling region that looks like a normal widget frame.
-bool ImGui::BeginChildFrame(ImGuiID id, const ImVec2& size, ImGuiWindowFlags extra_flags)
+bool ImGui::BeginChildFrame(ImGuiID id, const ImVec2& size, ImGuiWindowFlags extra_flags) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     const ImGuiStyle& style = g.Style;
@@ -5091,7 +5091,7 @@ bool ImGui::BeginChildFrame(ImGuiID id, const ImVec2& size, ImGuiWindowFlags ext
     return ret;
 }
 
-void ImGui::EndChildFrame()
+void ImGui::EndChildFrame() IMGUI_NOEXCEPT
 {
     EndChild();
 }
@@ -5721,7 +5721,7 @@ void ImGui::UpdateWindowParentAndRootLinks(ImGuiWindow* window, ImGuiWindowFlags
 //   You can use the "##" or "###" markers to use the same label with different id, or same id with different label. See documentation at the top of this file.
 // - Return false when window is collapsed, so you can early out in your code. You always need to call ImGui::End() even if false is returned.
 // - Passing 'bool* p_open' displays a Close button on the upper-right corner of the window, the pointed value will be set to false when the button is pressed.
-bool ImGui::Begin(const char* name, bool* p_open, ImGuiWindowFlags flags)
+bool ImGui::Begin(const char* name, bool* p_open, ImGuiWindowFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     const ImGuiStyle& style = g.Style;
@@ -6365,7 +6365,7 @@ bool ImGui::Begin(const char* name, bool* p_open, ImGuiWindowFlags flags)
     return !window->SkipItems;
 }
 
-void ImGui::End()
+void ImGui::End() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7715,7 +7715,7 @@ float ImGui::GetWindowContentRegionWidth()
 
 // Lock horizontal starting position + capture group bounding box into one "item" (so you can use IsItemHovered() or layout primitives such as SameLine() on whole group, etc.)
 // Groups are currently a mishmash of functionalities which should perhaps be clarified and separated.
-void ImGui::BeginGroup()
+void ImGui::BeginGroup() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7742,7 +7742,7 @@ void ImGui::BeginGroup()
         g.LogLinePosY = -FLT_MAX; // To enforce a carriage return
 }
 
-void ImGui::EndGroup()
+void ImGui::EndGroup() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -8009,7 +8009,7 @@ void ImGui::SetScrollHereY(float center_y_ratio)
 // [SECTION] TOOLTIPS
 //-----------------------------------------------------------------------------
 
-void ImGui::BeginTooltip()
+void ImGui::BeginTooltip() IMGUI_NOEXCEPT
 {
     BeginTooltipEx(ImGuiWindowFlags_None, ImGuiTooltipFlags_None);
 }
@@ -8046,7 +8046,7 @@ void ImGui::BeginTooltipEx(ImGuiWindowFlags extra_flags, ImGuiTooltipFlags toolt
     Begin(window_name, NULL, flags | extra_flags);
 }
 
-void ImGui::EndTooltip()
+void ImGui::EndTooltip() IMGUI_NOEXCEPT
 {
     IM_ASSERT(GetCurrentWindowRead()->Flags & ImGuiWindowFlags_Tooltip);   // Mismatched BeginTooltip()/EndTooltip() calls
     End();
@@ -8312,7 +8312,7 @@ bool ImGui::BeginPopupEx(ImGuiID id, ImGuiWindowFlags flags)
     return is_open;
 }
 
-bool ImGui::BeginPopup(const char* str_id, ImGuiWindowFlags flags)
+bool ImGui::BeginPopup(const char* str_id, ImGuiWindowFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.OpenPopupStack.Size <= g.BeginPopupStack.Size) // Early out for performance
@@ -8326,7 +8326,7 @@ bool ImGui::BeginPopup(const char* str_id, ImGuiWindowFlags flags)
 
 // If 'p_open' is specified for a modal popup window, the popup will have a regular close button which will close the popup.
 // Note that popup visibility status is owned by Dear ImGui (and manipulated with e.g. OpenPopup) so the actual value of *p_open is meaningless here.
-bool ImGui::BeginPopupModal(const char* name, bool* p_open, ImGuiWindowFlags flags)
+bool ImGui::BeginPopupModal(const char* name, bool* p_open, ImGuiWindowFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -8358,7 +8358,7 @@ bool ImGui::BeginPopupModal(const char* name, bool* p_open, ImGuiWindowFlags fla
     return is_open;
 }
 
-void ImGui::EndPopup()
+void ImGui::EndPopup() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -8407,7 +8407,7 @@ void ImGui::OpenPopupOnItemClick(const char* str_id, ImGuiPopupFlags popup_flags
 //           OpenPopup(id);
 //       return BeginPopup(id);
 //   The main difference being that this is tweaked to avoid computing the ID twice.
-bool ImGui::BeginPopupContextItem(const char* str_id, ImGuiPopupFlags popup_flags)
+bool ImGui::BeginPopupContextItem(const char* str_id, ImGuiPopupFlags popup_flags) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     if (window->SkipItems)
@@ -8420,7 +8420,7 @@ bool ImGui::BeginPopupContextItem(const char* str_id, ImGuiPopupFlags popup_flag
     return BeginPopupEx(id, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoSavedSettings);
 }
 
-bool ImGui::BeginPopupContextWindow(const char* str_id, ImGuiPopupFlags popup_flags)
+bool ImGui::BeginPopupContextWindow(const char* str_id, ImGuiPopupFlags popup_flags) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     if (!str_id)
@@ -8433,7 +8433,7 @@ bool ImGui::BeginPopupContextWindow(const char* str_id, ImGuiPopupFlags popup_fl
     return BeginPopupEx(id, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoSavedSettings);
 }
 
-bool ImGui::BeginPopupContextVoid(const char* str_id, ImGuiPopupFlags popup_flags)
+bool ImGui::BeginPopupContextVoid(const char* str_id, ImGuiPopupFlags popup_flags) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GImGui->CurrentWindow;
     if (!str_id)
@@ -9771,7 +9771,7 @@ void ImGui::ClearDragDrop()
 // - We then pull and use the mouse button that was used to activate the item and use it to carry on the drag.
 // If the item has no identifier:
 // - Currently always assume left mouse button.
-bool ImGui::BeginDragDropSource(ImGuiDragDropFlags flags)
+bool ImGui::BeginDragDropSource(ImGuiDragDropFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -9885,7 +9885,7 @@ bool ImGui::BeginDragDropSource(ImGuiDragDropFlags flags)
     return false;
 }
 
-void ImGui::EndDragDropSource()
+void ImGui::EndDragDropSource() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(g.DragDropActive);
@@ -9971,7 +9971,7 @@ bool ImGui::BeginDragDropTargetCustom(const ImRect& bb, ImGuiID id)
 // 1) we use LastItemRectHoveredRect which handles items that pushes a temporarily clip rectangle in their code. Calling BeginDragDropTargetCustom(LastItemRect) would not handle them.
 // 2) and it's faster. as this code may be very frequently called, we want to early out as fast as we can.
 // Also note how the HoveredWindow test is positioned differently in both functions (in both functions we optimize for the cheapest early out case)
-bool ImGui::BeginDragDropTarget()
+bool ImGui::BeginDragDropTarget() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (!g.DragDropActive)
@@ -10054,7 +10054,7 @@ const ImGuiPayload* ImGui::GetDragDropPayload()
 }
 
 // We don't really use/need this now, but added it for the sake of consistency and because we might need it later.
-void ImGui::EndDragDropTarget()
+void ImGui::EndDragDropTarget() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(g.DragDropActive);

--- a/imgui.h
+++ b/imgui.h
@@ -46,9 +46,8 @@ Index of this file:
 #include "imconfig.h"
 #endif
 
-// If you want to use the 'noexcept' specifier, #define IMGUI_NOEX
-#ifndef IMGUI_NOEXCEPT
-# define IMGUI_NOEXCEPT
+#ifndef IM_NOEXCEPT
+# define IM_NOEXCEPT
 #endif
 
 #ifndef IMGUI_DISABLE
@@ -218,8 +217,8 @@ typedef void (*ImGuiSizeCallback)(ImGuiSizeCallbackData* data);             // C
 typedef void* (*ImGuiMemAllocFunc)(size_t sz, void* user_data);             // Function signature for ImGui::SetAllocatorFunctions()
 typedef void (*ImGuiMemFreeFunc)(void* ptr, void* user_data);               // Function signature for ImGui::SetAllocatorFunctions()
 #else
-using ImGuiMemAllocFunc = void(*)(size_t sz, void* user_data) IMGUI_NOEXCEPT;
-using ImGuiMemFreeFunc = void(*)(void* ptr, void* user_data) IMGUI_NOEXCEPT;
+using ImGuiMemAllocFunc = void(*)(size_t sz, void* user_data) IM_NOEXCEPT;
+using ImGuiMemFreeFunc = void(*)(void* ptr, void* user_data) IM_NOEXCEPT;
 #endif
 
 // Character types
@@ -256,10 +255,10 @@ IM_MSVC_RUNTIME_CHECKS_OFF
 struct ImVec2
 {
     float                                   x, y;
-    ImVec2() IMGUI_NOEXCEPT                             { x = y = 0.0f; }
-    ImVec2(float _x, float _y) IMGUI_NOEXCEPT           { x = _x; y = _y; }
-    float  operator[] (size_t idx) const IMGUI_NOEXCEPT { IM_ASSERT(idx <= 1); return (&x)[idx]; }    // We very rarely use this [] operator, the assert overhead is fine.
-    float& operator[] (size_t idx) IMGUI_NOEXCEPT       { IM_ASSERT(idx <= 1); return (&x)[idx]; }    // We very rarely use this [] operator, the assert overhead is fine.
+    ImVec2() IM_NOEXCEPT                             { x = y = 0.0f; }
+    ImVec2(float _x, float _y) IM_NOEXCEPT           { x = _x; y = _y; }
+    float  operator[] (size_t idx) const IM_NOEXCEPT { IM_ASSERT(idx <= 1); return (&x)[idx]; }    // We very rarely use this [] operator, the assert overhead is fine.
+    float& operator[] (size_t idx) IM_NOEXCEPT       { IM_ASSERT(idx <= 1); return (&x)[idx]; }    // We very rarely use this [] operator, the assert overhead is fine.
 #ifdef IM_VEC2_CLASS_EXTRA
     IM_VEC2_CLASS_EXTRA     // Define additional constructors and implicit cast operators in imconfig.h to convert back and forth between your math types and ImVec2.
 #endif
@@ -269,8 +268,8 @@ struct ImVec2
 struct ImVec4
 {
     float                                           x, y, z, w;
-    ImVec4() IMGUI_NOEXCEPT                                       { x = y = z = w = 0.0f; }
-    ImVec4(float _x, float _y, float _z, float _w) IMGUI_NOEXCEPT { x = _x; y = _y; z = _z; w = _w; }
+    ImVec4() IM_NOEXCEPT                                       { x = y = z = w = 0.0f; }
+    ImVec4(float _x, float _y, float _z, float _w) IM_NOEXCEPT { x = _x; y = _y; z = _z; w = _w; }
 #ifdef IM_VEC4_CLASS_EXTRA
     IM_VEC4_CLASS_EXTRA     // Define additional constructors and implicit cast operators in imconfig.h to convert back and forth between your math types and ImVec4.
 #endif
@@ -288,33 +287,33 @@ namespace ImGui
     // - Each context create its own ImFontAtlas by default. You may instance one yourself and pass it to CreateContext() to share a font atlas between contexts.
     // - DLL users: heaps and globals are not shared across DLL boundaries! You will need to call SetCurrentContext() + SetAllocatorFunctions()
     //   for each static/DLL boundary you are calling from. Read "Context and Memory Allocators" section of imgui.cpp for details.
-    IMGUI_API ImGuiContext* CreateContext(ImFontAtlas* shared_font_atlas = NULL) IMGUI_NOEXCEPT;
-    IMGUI_API void          DestroyContext(ImGuiContext* ctx = NULL)             IMGUI_NOEXCEPT;   // NULL = destroy current context
-    IMGUI_API ImGuiContext* GetCurrentContext()                                  IMGUI_NOEXCEPT;
-    IMGUI_API void          SetCurrentContext(ImGuiContext* ctx)                 IMGUI_NOEXCEPT;
+    IMGUI_API ImGuiContext* CreateContext(ImFontAtlas* shared_font_atlas = NULL) IM_NOEXCEPT;
+    IMGUI_API void          DestroyContext(ImGuiContext* ctx = NULL)             IM_NOEXCEPT;   // NULL = destroy current context
+    IMGUI_API ImGuiContext* GetCurrentContext()                                  IM_NOEXCEPT;
+    IMGUI_API void          SetCurrentContext(ImGuiContext* ctx)                 IM_NOEXCEPT;
 
     // Main
-    IMGUI_API ImGuiIO&      GetIO()         IMGUI_NOEXCEPT;  // access the IO structure (mouse/keyboard/gamepad inputs, time, various configuration options/flags)
-    IMGUI_API ImGuiStyle&   GetStyle()      IMGUI_NOEXCEPT;  // access the Style structure (colors, sizes). Always use PushStyleCol(), PushStyleVar() to modify style mid-frame!
-    IMGUI_API void          NewFrame()      IMGUI_NOEXCEPT;  // start a new Dear ImGui frame, you can submit any command from this point until Render()/EndFrame().
-    IMGUI_API void          EndFrame()      IMGUI_NOEXCEPT;  // ends the Dear ImGui frame. automatically called by Render(). If you don't need to render data (skipping rendering) you may call EndFrame() without Render()... but you'll have wasted CPU already! If you don't need to render, better to not create any windows and not call NewFrame() at all!
-    IMGUI_API void          Render()        IMGUI_NOEXCEPT;  // ends the Dear ImGui frame, finalize the draw data. You can then get call GetDrawData().
-    IMGUI_API ImDrawData*   GetDrawData()   IMGUI_NOEXCEPT;  // valid after Render() and until the next call to NewFrame(). this is what you have to render.
+    IMGUI_API ImGuiIO&      GetIO()         IM_NOEXCEPT;  // access the IO structure (mouse/keyboard/gamepad inputs, time, various configuration options/flags)
+    IMGUI_API ImGuiStyle&   GetStyle()      IM_NOEXCEPT;  // access the Style structure (colors, sizes). Always use PushStyleCol(), PushStyleVar() to modify style mid-frame!
+    IMGUI_API void          NewFrame()      IM_NOEXCEPT;  // start a new Dear ImGui frame, you can submit any command from this point until Render()/EndFrame().
+    IMGUI_API void          EndFrame()      IM_NOEXCEPT;  // ends the Dear ImGui frame. automatically called by Render(). If you don't need to render data (skipping rendering) you may call EndFrame() without Render()... but you'll have wasted CPU already! If you don't need to render, better to not create any windows and not call NewFrame() at all!
+    IMGUI_API void          Render()        IM_NOEXCEPT;  // ends the Dear ImGui frame, finalize the draw data. You can then get call GetDrawData().
+    IMGUI_API ImDrawData*   GetDrawData()   IM_NOEXCEPT;  // valid after Render() and until the next call to NewFrame(). this is what you have to render.
 
     // Demo, Debug, Information
-    IMGUI_API void          ShowDemoWindow(bool* p_open = NULL)        IMGUI_NOEXCEPT;  // create Demo window. demonstrate most ImGui features. call this to learn about the library! try to make it always available in your application!
-    IMGUI_API void          ShowMetricsWindow(bool* p_open = NULL)     IMGUI_NOEXCEPT;  // create Metrics/Debugger window. display Dear ImGui internals: windows, draw commands, various internal state, etc.
-    IMGUI_API void          ShowAboutWindow(bool* p_open = NULL)       IMGUI_NOEXCEPT;  // create About window. display Dear ImGui version, credits and build/system information.
-    IMGUI_API void          ShowStyleEditor(ImGuiStyle* ref = NULL)    IMGUI_NOEXCEPT;  // add style editor block (not a window). you can pass in a reference ImGuiStyle structure to compare to, revert to and save to (else it uses the default style)
-    IMGUI_API bool          ShowStyleSelector(const char* label)       IMGUI_NOEXCEPT;  // add style selector block (not a window), essentially a combo listing the default styles.
-    IMGUI_API void          ShowFontSelector(const char* label)        IMGUI_NOEXCEPT;  // add font selector block (not a window), essentially a combo listing the loaded fonts.
-    IMGUI_API void          ShowUserGuide()                            IMGUI_NOEXCEPT;  // add basic help/info block (not a window): how to manipulate ImGui as a end-user (mouse/keyboard controls).
-    IMGUI_API const char*   GetVersion()                               IMGUI_NOEXCEPT;  // get the compiled version string e.g. "1.80 WIP" (essentially the value for IMGUI_VERSION from the compiled version of imgui.cpp)
+    IMGUI_API void          ShowDemoWindow(bool* p_open = NULL)        IM_NOEXCEPT;  // create Demo window. demonstrate most ImGui features. call this to learn about the library! try to make it always available in your application!
+    IMGUI_API void          ShowMetricsWindow(bool* p_open = NULL)     IM_NOEXCEPT;  // create Metrics/Debugger window. display Dear ImGui internals: windows, draw commands, various internal state, etc.
+    IMGUI_API void          ShowAboutWindow(bool* p_open = NULL)       IM_NOEXCEPT;  // create About window. display Dear ImGui version, credits and build/system information.
+    IMGUI_API void          ShowStyleEditor(ImGuiStyle* ref = NULL)    IM_NOEXCEPT;  // add style editor block (not a window). you can pass in a reference ImGuiStyle structure to compare to, revert to and save to (else it uses the default style)
+    IMGUI_API bool          ShowStyleSelector(const char* label)       IM_NOEXCEPT;  // add style selector block (not a window), essentially a combo listing the default styles.
+    IMGUI_API void          ShowFontSelector(const char* label)        IM_NOEXCEPT;  // add font selector block (not a window), essentially a combo listing the loaded fonts.
+    IMGUI_API void          ShowUserGuide()                            IM_NOEXCEPT;  // add basic help/info block (not a window): how to manipulate ImGui as a end-user (mouse/keyboard controls).
+    IMGUI_API const char*   GetVersion()                               IM_NOEXCEPT;  // get the compiled version string e.g. "1.80 WIP" (essentially the value for IMGUI_VERSION from the compiled version of imgui.cpp)
 
     // Styles
-    IMGUI_API void          StyleColorsDark(ImGuiStyle* dst = NULL)    IMGUI_NOEXCEPT;  // new, recommended style (default)
-    IMGUI_API void          StyleColorsLight(ImGuiStyle* dst = NULL)   IMGUI_NOEXCEPT;  // best used with borders and a custom, thicker font
-    IMGUI_API void          StyleColorsClassic(ImGuiStyle* dst = NULL) IMGUI_NOEXCEPT;  // classic imgui style
+    IMGUI_API void          StyleColorsDark(ImGuiStyle* dst = NULL)    IM_NOEXCEPT;  // new, recommended style (default)
+    IMGUI_API void          StyleColorsLight(ImGuiStyle* dst = NULL)   IM_NOEXCEPT;  // best used with borders and a custom, thicker font
+    IMGUI_API void          StyleColorsClassic(ImGuiStyle* dst = NULL) IM_NOEXCEPT;  // classic imgui style
 
     // Windows
     // - Begin() = push window to the stack and start appending to it. End() = pop window from the stack.
@@ -328,8 +327,8 @@ namespace ImGui
     //    BeginPopup/EndPopup, etc. where the EndXXX call should only be called if the corresponding BeginXXX function
     //    returned true. Begin and BeginChild are the only odd ones out. Will be fixed in a future update.]
     // - Note that the bottom of window stack always contains a window called "Debug".
-    IMGUI_API bool          Begin(const char* name, bool* p_open = NULL, ImGuiWindowFlags flags = 0) IMGUI_NOEXCEPT;
-    IMGUI_API void          End() IMGUI_NOEXCEPT;
+    IMGUI_API bool          Begin(const char* name, bool* p_open = NULL, ImGuiWindowFlags flags = 0) IM_NOEXCEPT;
+    IMGUI_API void          End() IM_NOEXCEPT;
 
     // Child Windows
     // - Use child windows to begin into a self-contained independent scrolling/clipping regions within a host window. Child windows can embed their own child.
@@ -339,91 +338,91 @@ namespace ImGui
     //   [Important: due to legacy reason, this is inconsistent with most other functions such as BeginMenu/EndMenu,
     //    BeginPopup/EndPopup, etc. where the EndXXX call should only be called if the corresponding BeginXXX function
     //    returned true. Begin and BeginChild are the only odd ones out. Will be fixed in a future update.]
-    IMGUI_API bool          BeginChild(const char* str_id, const ImVec2& size = ImVec2(0, 0), bool border = false, ImGuiWindowFlags flags = 0) IMGUI_NOEXCEPT;
-    IMGUI_API bool          BeginChild(ImGuiID id, const ImVec2& size = ImVec2(0, 0), bool border = false, ImGuiWindowFlags flags = 0) IMGUI_NOEXCEPT;
-    IMGUI_API void          EndChild() IMGUI_NOEXCEPT;
+    IMGUI_API bool          BeginChild(const char* str_id, const ImVec2& size = ImVec2(0, 0), bool border = false, ImGuiWindowFlags flags = 0) IM_NOEXCEPT;
+    IMGUI_API bool          BeginChild(ImGuiID id, const ImVec2& size = ImVec2(0, 0), bool border = false, ImGuiWindowFlags flags = 0) IM_NOEXCEPT;
+    IMGUI_API void          EndChild() IM_NOEXCEPT;
 
     // Windows Utilities
     // - 'current window' = the window we are appending into while inside a Begin()/End() block. 'next window' = next window we will Begin() into.
-    IMGUI_API bool          IsWindowAppearing()                        IMGUI_NOEXCEPT;
-    IMGUI_API bool          IsWindowCollapsed()                        IMGUI_NOEXCEPT;
-    IMGUI_API bool          IsWindowFocused(ImGuiFocusedFlags flags=0) IMGUI_NOEXCEPT;  // is current window focused? or its root/child, depending on flags. see flags for options.
-    IMGUI_API bool          IsWindowHovered(ImGuiHoveredFlags flags=0) IMGUI_NOEXCEPT;  // is current window hovered (and typically: not blocked by a popup/modal)? see flags for options. NB: If you are trying to check whether your mouse should be dispatched to imgui or to your app, you should use the 'io.WantCaptureMouse' boolean for that! Please read the FAQ!
-    IMGUI_API ImDrawList*   GetWindowDrawList()                        IMGUI_NOEXCEPT;  // get draw list associated to the current window, to append your own drawing primitives
-    IMGUI_API ImVec2        GetWindowPos()                             IMGUI_NOEXCEPT;  // get current window position in screen space (useful if you want to do your own drawing via the DrawList API)
-    IMGUI_API ImVec2        GetWindowSize()                            IMGUI_NOEXCEPT;  // get current window size
-    IMGUI_API float         GetWindowWidth()                           IMGUI_NOEXCEPT;  // get current window width (shortcut for GetWindowSize().x)
-    IMGUI_API float         GetWindowHeight()                          IMGUI_NOEXCEPT;  // get current window height (shortcut for GetWindowSize().y)
+    IMGUI_API bool          IsWindowAppearing()                        IM_NOEXCEPT;
+    IMGUI_API bool          IsWindowCollapsed()                        IM_NOEXCEPT;
+    IMGUI_API bool          IsWindowFocused(ImGuiFocusedFlags flags=0) IM_NOEXCEPT;  // is current window focused? or its root/child, depending on flags. see flags for options.
+    IMGUI_API bool          IsWindowHovered(ImGuiHoveredFlags flags=0) IM_NOEXCEPT;  // is current window hovered (and typically: not blocked by a popup/modal)? see flags for options. NB: If you are trying to check whether your mouse should be dispatched to imgui or to your app, you should use the 'io.WantCaptureMouse' boolean for that! Please read the FAQ!
+    IMGUI_API ImDrawList*   GetWindowDrawList()                        IM_NOEXCEPT;  // get draw list associated to the current window, to append your own drawing primitives
+    IMGUI_API ImVec2        GetWindowPos()                             IM_NOEXCEPT;  // get current window position in screen space (useful if you want to do your own drawing via the DrawList API)
+    IMGUI_API ImVec2        GetWindowSize()                            IM_NOEXCEPT;  // get current window size
+    IMGUI_API float         GetWindowWidth()                           IM_NOEXCEPT;  // get current window width (shortcut for GetWindowSize().x)
+    IMGUI_API float         GetWindowHeight()                          IM_NOEXCEPT;  // get current window height (shortcut for GetWindowSize().y)
 
     // Prefer using SetNextXXX functions (before Begin) rather that SetXXX functions (after Begin).
-    IMGUI_API void          SetNextWindowPos(const ImVec2& pos, ImGuiCond cond = 0, const ImVec2& pivot = ImVec2(0, 0)) IMGUI_NOEXCEPT; // set next window position. call before Begin(). use pivot=(0.5f,0.5f) to center on given point, etc.
-    IMGUI_API void          SetNextWindowSize(const ImVec2& size, ImGuiCond cond = 0)                IMGUI_NOEXCEPT;                  // set next window size. set axis to 0.0f to force an auto-fit on this axis. call before Begin()
-    IMGUI_API void          SetNextWindowSizeConstraints(const ImVec2& size_min, const ImVec2& size_max, ImGuiSizeCallback custom_callback = NULL, void* custom_callback_data = NULL) IMGUI_NOEXCEPT; // set next window size limits. use -1,-1 on either X/Y axis to preserve the current size. Sizes will be rounded down. Use callback to apply non-trivial programmatic constraints.
-    IMGUI_API void          SetNextWindowContentSize(const ImVec2& size)                             IMGUI_NOEXCEPT;  // set next window content size (~ scrollable client area, which enforce the range of scrollbars). Not including window decorations (title bar, menu bar, etc.) nor WindowPadding. set an axis to 0.0f to leave it automatic. call before Begin()
-    IMGUI_API void          SetNextWindowCollapsed(bool collapsed, ImGuiCond cond = 0)               IMGUI_NOEXCEPT;  // set next window collapsed state. call before Begin()
-    IMGUI_API void          SetNextWindowFocus()                                                     IMGUI_NOEXCEPT;  // set next window to be focused / top-most. call before Begin()
-    IMGUI_API void          SetNextWindowBgAlpha(float alpha)                                        IMGUI_NOEXCEPT;  // set next window background color alpha. helper to easily override the Alpha component of ImGuiCol_WindowBg/ChildBg/PopupBg. you may also use ImGuiWindowFlags_NoBackground.
-    IMGUI_API void          SetWindowPos(const ImVec2& pos, ImGuiCond cond = 0)                      IMGUI_NOEXCEPT;  // (not recommended) set current window position - call within Begin()/End(). prefer using SetNextWindowPos(), as this may incur tearing and side-effects.
-    IMGUI_API void          SetWindowSize(const ImVec2& size, ImGuiCond cond = 0)                    IMGUI_NOEXCEPT;  // (not recommended) set current window size - call within Begin()/End(). set to ImVec2(0, 0) to force an auto-fit. prefer using SetNextWindowSize(), as this may incur tearing and minor side-effects.
-    IMGUI_API void          SetWindowCollapsed(bool collapsed, ImGuiCond cond = 0)                   IMGUI_NOEXCEPT;  // (not recommended) set current window collapsed state. prefer using SetNextWindowCollapsed().
-    IMGUI_API void          SetWindowFocus()                                                         IMGUI_NOEXCEPT;  // (not recommended) set current window to be focused / top-most. prefer using SetNextWindowFocus().
-    IMGUI_API void          SetWindowFontScale(float scale) IMGUI_NOEXCEPT;                                           // set font scale. Adjust IO.FontGlobalScale if you want to scale all windows. This is an old API! For correct scaling, prefer to reload font + rebuild ImFontAtlas + call style.ScaleAllSizes().
-    IMGUI_API void          SetWindowPos(const char* name, const ImVec2& pos, ImGuiCond cond = 0)    IMGUI_NOEXCEPT;  // set named window position.
-    IMGUI_API void          SetWindowSize(const char* name, const ImVec2& size, ImGuiCond cond = 0)  IMGUI_NOEXCEPT;  // set named window size. set axis to 0.0f to force an auto-fit on this axis.
-    IMGUI_API void          SetWindowCollapsed(const char* name, bool collapsed, ImGuiCond cond = 0) IMGUI_NOEXCEPT;  // set named window collapsed state
-    IMGUI_API void          SetWindowFocus(const char* name)                                         IMGUI_NOEXCEPT;  // set named window to be focused / top-most. use NULL to remove focus.
+    IMGUI_API void          SetNextWindowPos(const ImVec2& pos, ImGuiCond cond = 0, const ImVec2& pivot = ImVec2(0, 0)) IM_NOEXCEPT; // set next window position. call before Begin(). use pivot=(0.5f,0.5f) to center on given point, etc.
+    IMGUI_API void          SetNextWindowSize(const ImVec2& size, ImGuiCond cond = 0)                IM_NOEXCEPT;                  // set next window size. set axis to 0.0f to force an auto-fit on this axis. call before Begin()
+    IMGUI_API void          SetNextWindowSizeConstraints(const ImVec2& size_min, const ImVec2& size_max, ImGuiSizeCallback custom_callback = NULL, void* custom_callback_data = NULL) IM_NOEXCEPT; // set next window size limits. use -1,-1 on either X/Y axis to preserve the current size. Sizes will be rounded down. Use callback to apply non-trivial programmatic constraints.
+    IMGUI_API void          SetNextWindowContentSize(const ImVec2& size)                             IM_NOEXCEPT;  // set next window content size (~ scrollable client area, which enforce the range of scrollbars). Not including window decorations (title bar, menu bar, etc.) nor WindowPadding. set an axis to 0.0f to leave it automatic. call before Begin()
+    IMGUI_API void          SetNextWindowCollapsed(bool collapsed, ImGuiCond cond = 0)               IM_NOEXCEPT;  // set next window collapsed state. call before Begin()
+    IMGUI_API void          SetNextWindowFocus()                                                     IM_NOEXCEPT;  // set next window to be focused / top-most. call before Begin()
+    IMGUI_API void          SetNextWindowBgAlpha(float alpha)                                        IM_NOEXCEPT;  // set next window background color alpha. helper to easily override the Alpha component of ImGuiCol_WindowBg/ChildBg/PopupBg. you may also use ImGuiWindowFlags_NoBackground.
+    IMGUI_API void          SetWindowPos(const ImVec2& pos, ImGuiCond cond = 0)                      IM_NOEXCEPT;  // (not recommended) set current window position - call within Begin()/End(). prefer using SetNextWindowPos(), as this may incur tearing and side-effects.
+    IMGUI_API void          SetWindowSize(const ImVec2& size, ImGuiCond cond = 0)                    IM_NOEXCEPT;  // (not recommended) set current window size - call within Begin()/End(). set to ImVec2(0, 0) to force an auto-fit. prefer using SetNextWindowSize(), as this may incur tearing and minor side-effects.
+    IMGUI_API void          SetWindowCollapsed(bool collapsed, ImGuiCond cond = 0)                   IM_NOEXCEPT;  // (not recommended) set current window collapsed state. prefer using SetNextWindowCollapsed().
+    IMGUI_API void          SetWindowFocus()                                                         IM_NOEXCEPT;  // (not recommended) set current window to be focused / top-most. prefer using SetNextWindowFocus().
+    IMGUI_API void          SetWindowFontScale(float scale) IM_NOEXCEPT;                                           // set font scale. Adjust IO.FontGlobalScale if you want to scale all windows. This is an old API! For correct scaling, prefer to reload font + rebuild ImFontAtlas + call style.ScaleAllSizes().
+    IMGUI_API void          SetWindowPos(const char* name, const ImVec2& pos, ImGuiCond cond = 0)    IM_NOEXCEPT;  // set named window position.
+    IMGUI_API void          SetWindowSize(const char* name, const ImVec2& size, ImGuiCond cond = 0)  IM_NOEXCEPT;  // set named window size. set axis to 0.0f to force an auto-fit on this axis.
+    IMGUI_API void          SetWindowCollapsed(const char* name, bool collapsed, ImGuiCond cond = 0) IM_NOEXCEPT;  // set named window collapsed state
+    IMGUI_API void          SetWindowFocus(const char* name)                                         IM_NOEXCEPT;  // set named window to be focused / top-most. use NULL to remove focus.
 
     // Content region
     // - Retrieve available space from a given point. GetContentRegionAvail() is frequently useful.
     // - Those functions are bound to be redesigned (they are confusing, incomplete and the Min/Max return values are in local window coordinates which increases confusion)
-    IMGUI_API ImVec2        GetContentRegionAvail()       IMGUI_NOEXCEPT;                   // == GetContentRegionMax() - GetCursorPos()
-    IMGUI_API ImVec2        GetContentRegionMax()         IMGUI_NOEXCEPT;                   // current content boundaries (typically window boundaries including scrolling, or current column boundaries), in windows coordinates
-    IMGUI_API ImVec2        GetWindowContentRegionMin()   IMGUI_NOEXCEPT;                   // content boundaries min (roughly (0,0)-Scroll), in window coordinates
-    IMGUI_API ImVec2        GetWindowContentRegionMax()   IMGUI_NOEXCEPT;                   // content boundaries max (roughly (0,0)+Size-Scroll) where Size can be override with SetNextWindowContentSize(), in window coordinates
-    IMGUI_API float         GetWindowContentRegionWidth() IMGUI_NOEXCEPT;
+    IMGUI_API ImVec2        GetContentRegionAvail()       IM_NOEXCEPT;                   // == GetContentRegionMax() - GetCursorPos()
+    IMGUI_API ImVec2        GetContentRegionMax()         IM_NOEXCEPT;                   // current content boundaries (typically window boundaries including scrolling, or current column boundaries), in windows coordinates
+    IMGUI_API ImVec2        GetWindowContentRegionMin()   IM_NOEXCEPT;                   // content boundaries min (roughly (0,0)-Scroll), in window coordinates
+    IMGUI_API ImVec2        GetWindowContentRegionMax()   IM_NOEXCEPT;                   // content boundaries max (roughly (0,0)+Size-Scroll) where Size can be override with SetNextWindowContentSize(), in window coordinates
+    IMGUI_API float         GetWindowContentRegionWidth() IM_NOEXCEPT;
 
     // Windows Scrolling
-    IMGUI_API float         GetScrollX()                                IMGUI_NOEXCEPT;     // get scrolling amount [0 .. GetScrollMaxX()]
-    IMGUI_API float         GetScrollY()                                IMGUI_NOEXCEPT;     // get scrolling amount [0 .. GetScrollMaxY()]
-    IMGUI_API void          SetScrollX(float scroll_x)                  IMGUI_NOEXCEPT;     // set scrolling amount [0 .. GetScrollMaxX()]
-    IMGUI_API void          SetScrollY(float scroll_y)                  IMGUI_NOEXCEPT;     // set scrolling amount [0 .. GetScrollMaxY()]
-    IMGUI_API float         GetScrollMaxX()                             IMGUI_NOEXCEPT;     // get maximum scrolling amount ~~ ContentSize.x - WindowSize.x - DecorationsSize.x
-    IMGUI_API float         GetScrollMaxY()                             IMGUI_NOEXCEPT;     // get maximum scrolling amount ~~ ContentSize.y - WindowSize.y - DecorationsSize.y
-    IMGUI_API void          SetScrollHereX(float center_x_ratio = 0.5f) IMGUI_NOEXCEPT;     // adjust scrolling amount to make current cursor position visible. center_x_ratio=0.0: left, 0.5: center, 1.0: right. When using to make a "default/current item" visible, consider using SetItemDefaultFocus() instead.
-    IMGUI_API void          SetScrollHereY(float center_y_ratio = 0.5f) IMGUI_NOEXCEPT;     // adjust scrolling amount to make current cursor position visible. center_y_ratio=0.0: top, 0.5: center, 1.0: bottom. When using to make a "default/current item" visible, consider using SetItemDefaultFocus() instead.
-    IMGUI_API void          SetScrollFromPosX(float local_x, float center_x_ratio = 0.5f) IMGUI_NOEXCEPT;  // adjust scrolling amount to make given position visible. Generally GetCursorStartPos() + offset to compute a valid position.
-    IMGUI_API void          SetScrollFromPosY(float local_y, float center_y_ratio = 0.5f) IMGUI_NOEXCEPT;  // adjust scrolling amount to make given position visible. Generally GetCursorStartPos() + offset to compute a valid position.
+    IMGUI_API float         GetScrollX()                                IM_NOEXCEPT;     // get scrolling amount [0 .. GetScrollMaxX()]
+    IMGUI_API float         GetScrollY()                                IM_NOEXCEPT;     // get scrolling amount [0 .. GetScrollMaxY()]
+    IMGUI_API void          SetScrollX(float scroll_x)                  IM_NOEXCEPT;     // set scrolling amount [0 .. GetScrollMaxX()]
+    IMGUI_API void          SetScrollY(float scroll_y)                  IM_NOEXCEPT;     // set scrolling amount [0 .. GetScrollMaxY()]
+    IMGUI_API float         GetScrollMaxX()                             IM_NOEXCEPT;     // get maximum scrolling amount ~~ ContentSize.x - WindowSize.x - DecorationsSize.x
+    IMGUI_API float         GetScrollMaxY()                             IM_NOEXCEPT;     // get maximum scrolling amount ~~ ContentSize.y - WindowSize.y - DecorationsSize.y
+    IMGUI_API void          SetScrollHereX(float center_x_ratio = 0.5f) IM_NOEXCEPT;     // adjust scrolling amount to make current cursor position visible. center_x_ratio=0.0: left, 0.5: center, 1.0: right. When using to make a "default/current item" visible, consider using SetItemDefaultFocus() instead.
+    IMGUI_API void          SetScrollHereY(float center_y_ratio = 0.5f) IM_NOEXCEPT;     // adjust scrolling amount to make current cursor position visible. center_y_ratio=0.0: top, 0.5: center, 1.0: bottom. When using to make a "default/current item" visible, consider using SetItemDefaultFocus() instead.
+    IMGUI_API void          SetScrollFromPosX(float local_x, float center_x_ratio = 0.5f) IM_NOEXCEPT;  // adjust scrolling amount to make given position visible. Generally GetCursorStartPos() + offset to compute a valid position.
+    IMGUI_API void          SetScrollFromPosY(float local_y, float center_y_ratio = 0.5f) IM_NOEXCEPT;  // adjust scrolling amount to make given position visible. Generally GetCursorStartPos() + offset to compute a valid position.
 
     // Parameters stacks (shared)
-    IMGUI_API void          PushFont(ImFont* font)                             IMGUI_NOEXCEPT;  // use NULL as a shortcut to push default font
-    IMGUI_API void          PopFont()                                          IMGUI_NOEXCEPT;
-    IMGUI_API void          PushStyleColor(ImGuiCol idx, ImU32 col)            IMGUI_NOEXCEPT;  // modify a style color. always use this if you modify the style after NewFrame().
-    IMGUI_API void          PushStyleColor(ImGuiCol idx, const ImVec4& col)    IMGUI_NOEXCEPT;
-    IMGUI_API void          PopStyleColor(int count = 1)                       IMGUI_NOEXCEPT;
-    IMGUI_API void          PushStyleVar(ImGuiStyleVar idx, float val)         IMGUI_NOEXCEPT;  // modify a style float variable. always use this if you modify the style after NewFrame().
-    IMGUI_API void          PushStyleVar(ImGuiStyleVar idx, const ImVec2& val) IMGUI_NOEXCEPT;  // modify a style ImVec2 variable. always use this if you modify the style after NewFrame().
-    IMGUI_API void          PopStyleVar(int count = 1)                         IMGUI_NOEXCEPT;
-    IMGUI_API void          PushAllowKeyboardFocus(bool allow_keyboard_focus)  IMGUI_NOEXCEPT;  // == tab stop enable. Allow focusing using TAB/Shift-TAB, enabled by default but you can disable it for certain widgets
-    IMGUI_API void          PopAllowKeyboardFocus()                            IMGUI_NOEXCEPT;
-    IMGUI_API void          PushButtonRepeat(bool repeat)                      IMGUI_NOEXCEPT;  // in 'repeat' mode, Button*() functions return repeated true in a typematic manner (using io.KeyRepeatDelay/io.KeyRepeatRate setting). Note that you can call IsItemActive() after any Button() to tell if the button is held in the current frame.
-    IMGUI_API void          PopButtonRepeat()                                  IMGUI_NOEXCEPT;
+    IMGUI_API void          PushFont(ImFont* font)                             IM_NOEXCEPT;  // use NULL as a shortcut to push default font
+    IMGUI_API void          PopFont()                                          IM_NOEXCEPT;
+    IMGUI_API void          PushStyleColor(ImGuiCol idx, ImU32 col)            IM_NOEXCEPT;  // modify a style color. always use this if you modify the style after NewFrame().
+    IMGUI_API void          PushStyleColor(ImGuiCol idx, const ImVec4& col)    IM_NOEXCEPT;
+    IMGUI_API void          PopStyleColor(int count = 1)                       IM_NOEXCEPT;
+    IMGUI_API void          PushStyleVar(ImGuiStyleVar idx, float val)         IM_NOEXCEPT;  // modify a style float variable. always use this if you modify the style after NewFrame().
+    IMGUI_API void          PushStyleVar(ImGuiStyleVar idx, const ImVec2& val) IM_NOEXCEPT;  // modify a style ImVec2 variable. always use this if you modify the style after NewFrame().
+    IMGUI_API void          PopStyleVar(int count = 1)                         IM_NOEXCEPT;
+    IMGUI_API void          PushAllowKeyboardFocus(bool allow_keyboard_focus)  IM_NOEXCEPT;  // == tab stop enable. Allow focusing using TAB/Shift-TAB, enabled by default but you can disable it for certain widgets
+    IMGUI_API void          PopAllowKeyboardFocus()                            IM_NOEXCEPT;
+    IMGUI_API void          PushButtonRepeat(bool repeat)                      IM_NOEXCEPT;  // in 'repeat' mode, Button*() functions return repeated true in a typematic manner (using io.KeyRepeatDelay/io.KeyRepeatRate setting). Note that you can call IsItemActive() after any Button() to tell if the button is held in the current frame.
+    IMGUI_API void          PopButtonRepeat()                                  IM_NOEXCEPT;
 
     // Parameters stacks (current window)
-    IMGUI_API void          PushItemWidth(float item_width)                    IMGUI_NOEXCEPT;  // push width of items for common large "item+label" widgets. >0.0f: width in pixels, <0.0f align xx pixels to the right of window (so -FLT_MIN always align width to the right side).
-    IMGUI_API void          PopItemWidth()                                     IMGUI_NOEXCEPT;
-    IMGUI_API void          SetNextItemWidth(float item_width)                 IMGUI_NOEXCEPT;  // set width of the _next_ common large "item+label" widget. >0.0f: width in pixels, <0.0f align xx pixels to the right of window (so -FLT_MIN always align width to the right side)
-    IMGUI_API float         CalcItemWidth()                                    IMGUI_NOEXCEPT;  // width of item given pushed settings and current cursor position. NOT necessarily the width of last item unlike most 'Item' functions.
-    IMGUI_API void          PushTextWrapPos(float wrap_local_pos_x = 0.0f)     IMGUI_NOEXCEPT;  // push word-wrapping position for Text*() commands. < 0.0f: no wrapping; 0.0f: wrap to end of window (or column); > 0.0f: wrap at 'wrap_pos_x' position in window local space
-    IMGUI_API void          PopTextWrapPos()                                   IMGUI_NOEXCEPT;
+    IMGUI_API void          PushItemWidth(float item_width)                    IM_NOEXCEPT;  // push width of items for common large "item+label" widgets. >0.0f: width in pixels, <0.0f align xx pixels to the right of window (so -FLT_MIN always align width to the right side).
+    IMGUI_API void          PopItemWidth()                                     IM_NOEXCEPT;
+    IMGUI_API void          SetNextItemWidth(float item_width)                 IM_NOEXCEPT;  // set width of the _next_ common large "item+label" widget. >0.0f: width in pixels, <0.0f align xx pixels to the right of window (so -FLT_MIN always align width to the right side)
+    IMGUI_API float         CalcItemWidth()                                    IM_NOEXCEPT;  // width of item given pushed settings and current cursor position. NOT necessarily the width of last item unlike most 'Item' functions.
+    IMGUI_API void          PushTextWrapPos(float wrap_local_pos_x = 0.0f)     IM_NOEXCEPT;  // push word-wrapping position for Text*() commands. < 0.0f: no wrapping; 0.0f: wrap to end of window (or column); > 0.0f: wrap at 'wrap_pos_x' position in window local space
+    IMGUI_API void          PopTextWrapPos()                                   IM_NOEXCEPT;
 
     // Style read access
-    IMGUI_API ImFont*       GetFont()                                          IMGUI_NOEXCEPT;  // get current font
-    IMGUI_API float         GetFontSize()                                      IMGUI_NOEXCEPT;  // get current font size (= height in pixels) of current font with current scale applied
-    IMGUI_API ImVec2        GetFontTexUvWhitePixel()                           IMGUI_NOEXCEPT;  // get UV coordinate for a while pixel, useful to draw custom shapes via the ImDrawList API
-    IMGUI_API ImU32         GetColorU32(ImGuiCol idx, float alpha_mul = 1.0f)  IMGUI_NOEXCEPT;  // retrieve given style color with style alpha applied and optional extra alpha multiplier, packed as a 32-bit value suitable for ImDrawList
-    IMGUI_API ImU32         GetColorU32(const ImVec4& col)                     IMGUI_NOEXCEPT;  // retrieve given color with style alpha applied, packed as a 32-bit value suitable for ImDrawList
-    IMGUI_API ImU32         GetColorU32(ImU32 col)                             IMGUI_NOEXCEPT;  // retrieve given color with style alpha applied, packed as a 32-bit value suitable for ImDrawList
-    IMGUI_API const ImVec4& GetStyleColorVec4(ImGuiCol idx)                    IMGUI_NOEXCEPT;  // retrieve style color as stored in ImGuiStyle structure. use to feed back into PushStyleColor(), otherwise use GetColorU32() to get style color with style alpha baked in.
+    IMGUI_API ImFont*       GetFont()                                          IM_NOEXCEPT;  // get current font
+    IMGUI_API float         GetFontSize()                                      IM_NOEXCEPT;  // get current font size (= height in pixels) of current font with current scale applied
+    IMGUI_API ImVec2        GetFontTexUvWhitePixel()                           IM_NOEXCEPT;  // get UV coordinate for a while pixel, useful to draw custom shapes via the ImDrawList API
+    IMGUI_API ImU32         GetColorU32(ImGuiCol idx, float alpha_mul = 1.0f)  IM_NOEXCEPT;  // retrieve given style color with style alpha applied and optional extra alpha multiplier, packed as a 32-bit value suitable for ImDrawList
+    IMGUI_API ImU32         GetColorU32(const ImVec4& col)                     IM_NOEXCEPT;  // retrieve given color with style alpha applied, packed as a 32-bit value suitable for ImDrawList
+    IMGUI_API ImU32         GetColorU32(ImU32 col)                             IM_NOEXCEPT;  // retrieve given color with style alpha applied, packed as a 32-bit value suitable for ImDrawList
+    IMGUI_API const ImVec4& GetStyleColorVec4(ImGuiCol idx)                    IM_NOEXCEPT;  // retrieve style color as stored in ImGuiStyle structure. use to feed back into PushStyleColor(), otherwise use GetColorU32() to get style color with style alpha baked in.
 
     // Cursor / Layout
     // - By "cursor" we mean the current output position.
@@ -432,29 +431,29 @@ namespace ImGui
     // - Attention! We currently have inconsistencies between window-local and absolute positions we will aim to fix with future API:
     //    Window-local coordinates:   SameLine(), GetCursorPos(), SetCursorPos(), GetCursorStartPos(), GetContentRegionMax(), GetWindowContentRegion*(), PushTextWrapPos()
     //    Absolute coordinate:        GetCursorScreenPos(), SetCursorScreenPos(), all ImDrawList:: functions.
-    IMGUI_API void          Separator()                                        IMGUI_NOEXCEPT;  // separator, generally horizontal. inside a menu bar or in horizontal layout mode, this becomes a vertical separator.
-    IMGUI_API void          SameLine(float offset_from_start_x=0.0f, float spacing=-1.0f) IMGUI_NOEXCEPT;  // call between widgets or groups to layout them horizontally. X position given in window coordinates.
-    IMGUI_API void          NewLine()                                          IMGUI_NOEXCEPT;  // undo a SameLine() or force a new line when in an horizontal-layout context.
-    IMGUI_API void          Spacing()                                          IMGUI_NOEXCEPT;  // add vertical spacing.
-    IMGUI_API void          Dummy(const ImVec2& size)                          IMGUI_NOEXCEPT;  // add a dummy item of given size. unlike InvisibleButton(), Dummy() won't take the mouse click or be navigable into.
-    IMGUI_API void          Indent(float indent_w = 0.0f)                      IMGUI_NOEXCEPT;  // move content position toward the right, by indent_w, or style.IndentSpacing if indent_w <= 0
-    IMGUI_API void          Unindent(float indent_w = 0.0f)                    IMGUI_NOEXCEPT;  // move content position back to the left, by indent_w, or style.IndentSpacing if indent_w <= 0
-    IMGUI_API void          BeginGroup() IMGUI_NOEXCEPT;                                    // lock horizontal starting position
-    IMGUI_API void          EndGroup() IMGUI_NOEXCEPT;                                      // unlock horizontal starting position + capture the whole group bounding box into one "item" (so you can use IsItemHovered() or layout primitives such as SameLine() on whole group, etc.)
-    IMGUI_API ImVec2        GetCursorPos()                                     IMGUI_NOEXCEPT;  // cursor position in window coordinates (relative to window position)
-    IMGUI_API float         GetCursorPosX()                                    IMGUI_NOEXCEPT;  //   (some functions are using window-relative coordinates, such as: GetCursorPos, GetCursorStartPos, GetContentRegionMax, GetWindowContentRegion* etc.
-    IMGUI_API float         GetCursorPosY()                                    IMGUI_NOEXCEPT;  //    other functions such as GetCursorScreenPos or everything in ImDrawList::
-    IMGUI_API void          SetCursorPos(const ImVec2& local_pos)              IMGUI_NOEXCEPT;  //    are using the main, absolute coordinate system.
-    IMGUI_API void          SetCursorPosX(float local_x)                       IMGUI_NOEXCEPT;  //    GetWindowPos() + GetCursorPos() == GetCursorScreenPos() etc.)
-    IMGUI_API void          SetCursorPosY(float local_y)                       IMGUI_NOEXCEPT;  //
-    IMGUI_API ImVec2        GetCursorStartPos()                                IMGUI_NOEXCEPT;  // initial cursor position in window coordinates
-    IMGUI_API ImVec2        GetCursorScreenPos()                               IMGUI_NOEXCEPT;  // cursor position in absolute coordinates (useful to work with ImDrawList API). generally top-left == GetMainViewport()->Pos == (0,0) in single viewport mode, and bottom-right == GetMainViewport()->Pos+Size == io.DisplaySize in single-viewport mode.
-    IMGUI_API void          SetCursorScreenPos(const ImVec2& pos)              IMGUI_NOEXCEPT;  // cursor position in absolute coordinates
-    IMGUI_API void          AlignTextToFramePadding()                          IMGUI_NOEXCEPT;  // vertically align upcoming text baseline to FramePadding.y so that it will align properly to regularly framed items (call if you have text on a line before a framed item)
-    IMGUI_API float         GetTextLineHeight()                                IMGUI_NOEXCEPT;  // ~ FontSize
-    IMGUI_API float         GetTextLineHeightWithSpacing()                     IMGUI_NOEXCEPT;  // ~ FontSize + style.ItemSpacing.y (distance in pixels between 2 consecutive lines of text)
-    IMGUI_API float         GetFrameHeight()                                   IMGUI_NOEXCEPT;  // ~ FontSize + style.FramePadding.y * 2
-    IMGUI_API float         GetFrameHeightWithSpacing()                        IMGUI_NOEXCEPT;  // ~ FontSize + style.FramePadding.y * 2 + style.ItemSpacing.y (distance in pixels between 2 consecutive lines of framed widgets)
+    IMGUI_API void          Separator()                                        IM_NOEXCEPT;  // separator, generally horizontal. inside a menu bar or in horizontal layout mode, this becomes a vertical separator.
+    IMGUI_API void          SameLine(float offset_from_start_x=0.0f, float spacing=-1.0f) IM_NOEXCEPT;  // call between widgets or groups to layout them horizontally. X position given in window coordinates.
+    IMGUI_API void          NewLine()                                          IM_NOEXCEPT;  // undo a SameLine() or force a new line when in an horizontal-layout context.
+    IMGUI_API void          Spacing()                                          IM_NOEXCEPT;  // add vertical spacing.
+    IMGUI_API void          Dummy(const ImVec2& size)                          IM_NOEXCEPT;  // add a dummy item of given size. unlike InvisibleButton(), Dummy() won't take the mouse click or be navigable into.
+    IMGUI_API void          Indent(float indent_w = 0.0f)                      IM_NOEXCEPT;  // move content position toward the right, by indent_w, or style.IndentSpacing if indent_w <= 0
+    IMGUI_API void          Unindent(float indent_w = 0.0f)                    IM_NOEXCEPT;  // move content position back to the left, by indent_w, or style.IndentSpacing if indent_w <= 0
+    IMGUI_API void          BeginGroup() IM_NOEXCEPT;                                    // lock horizontal starting position
+    IMGUI_API void          EndGroup() IM_NOEXCEPT;                                      // unlock horizontal starting position + capture the whole group bounding box into one "item" (so you can use IsItemHovered() or layout primitives such as SameLine() on whole group, etc.)
+    IMGUI_API ImVec2        GetCursorPos()                                     IM_NOEXCEPT;  // cursor position in window coordinates (relative to window position)
+    IMGUI_API float         GetCursorPosX()                                    IM_NOEXCEPT;  //   (some functions are using window-relative coordinates, such as: GetCursorPos, GetCursorStartPos, GetContentRegionMax, GetWindowContentRegion* etc.
+    IMGUI_API float         GetCursorPosY()                                    IM_NOEXCEPT;  //    other functions such as GetCursorScreenPos or everything in ImDrawList::
+    IMGUI_API void          SetCursorPos(const ImVec2& local_pos)              IM_NOEXCEPT;  //    are using the main, absolute coordinate system.
+    IMGUI_API void          SetCursorPosX(float local_x)                       IM_NOEXCEPT;  //    GetWindowPos() + GetCursorPos() == GetCursorScreenPos() etc.)
+    IMGUI_API void          SetCursorPosY(float local_y)                       IM_NOEXCEPT;  //
+    IMGUI_API ImVec2        GetCursorStartPos()                                IM_NOEXCEPT;  // initial cursor position in window coordinates
+    IMGUI_API ImVec2        GetCursorScreenPos()                               IM_NOEXCEPT;  // cursor position in absolute coordinates (useful to work with ImDrawList API). generally top-left == GetMainViewport()->Pos == (0,0) in single viewport mode, and bottom-right == GetMainViewport()->Pos+Size == io.DisplaySize in single-viewport mode.
+    IMGUI_API void          SetCursorScreenPos(const ImVec2& pos)              IM_NOEXCEPT;  // cursor position in absolute coordinates
+    IMGUI_API void          AlignTextToFramePadding()                          IM_NOEXCEPT;  // vertically align upcoming text baseline to FramePadding.y so that it will align properly to regularly framed items (call if you have text on a line before a framed item)
+    IMGUI_API float         GetTextLineHeight()                                IM_NOEXCEPT;  // ~ FontSize
+    IMGUI_API float         GetTextLineHeightWithSpacing()                     IM_NOEXCEPT;  // ~ FontSize + style.ItemSpacing.y (distance in pixels between 2 consecutive lines of text)
+    IMGUI_API float         GetFrameHeight()                                   IM_NOEXCEPT;  // ~ FontSize + style.FramePadding.y * 2
+    IMGUI_API float         GetFrameHeightWithSpacing()                        IM_NOEXCEPT;  // ~ FontSize + style.FramePadding.y * 2 + style.ItemSpacing.y (distance in pixels between 2 consecutive lines of framed widgets)
 
     // ID stack/scopes
     // - Read the FAQ for more details about how ID are handled in dear imgui. If you are creating widgets in a loop you most
@@ -463,55 +462,55 @@ namespace ImGui
     // - You can also use the "Label##foobar" syntax within widget label to distinguish them from each others.
     // - In this header file we use the "label"/"name" terminology to denote a string that will be displayed and used as an ID,
     //   whereas "str_id" denote a string that is only used as an ID and not normally displayed.
-    IMGUI_API void          PushID(const char* str_id)                                      IMGUI_NOEXCEPT;  // push string into the ID stack (will hash string).
-    IMGUI_API void          PushID(const char* str_id_begin, const char* str_id_end)        IMGUI_NOEXCEPT;  // push string into the ID stack (will hash string).
-    IMGUI_API void          PushID(const void* ptr_id)                                      IMGUI_NOEXCEPT;  // push pointer into the ID stack (will hash pointer).
-    IMGUI_API void          PushID(int int_id)                                              IMGUI_NOEXCEPT;  // push integer into the ID stack (will hash integer).
-    IMGUI_API void          PopID()                                                         IMGUI_NOEXCEPT;  // pop from the ID stack.
-    IMGUI_API ImGuiID       GetID(const char* str_id)                                       IMGUI_NOEXCEPT;  // calculate unique ID (hash of whole ID stack + given parameter). e.g. if you want to query into ImGuiStorage yourself
-    IMGUI_API ImGuiID       GetID(const char* str_id_begin, const char* str_id_end)         IMGUI_NOEXCEPT;
-    IMGUI_API ImGuiID       GetID(const void* ptr_id)                                       IMGUI_NOEXCEPT;
+    IMGUI_API void          PushID(const char* str_id)                                      IM_NOEXCEPT;  // push string into the ID stack (will hash string).
+    IMGUI_API void          PushID(const char* str_id_begin, const char* str_id_end)        IM_NOEXCEPT;  // push string into the ID stack (will hash string).
+    IMGUI_API void          PushID(const void* ptr_id)                                      IM_NOEXCEPT;  // push pointer into the ID stack (will hash pointer).
+    IMGUI_API void          PushID(int int_id)                                              IM_NOEXCEPT;  // push integer into the ID stack (will hash integer).
+    IMGUI_API void          PopID()                                                         IM_NOEXCEPT;  // pop from the ID stack.
+    IMGUI_API ImGuiID       GetID(const char* str_id)                                       IM_NOEXCEPT;  // calculate unique ID (hash of whole ID stack + given parameter). e.g. if you want to query into ImGuiStorage yourself
+    IMGUI_API ImGuiID       GetID(const char* str_id_begin, const char* str_id_end)         IM_NOEXCEPT;
+    IMGUI_API ImGuiID       GetID(const void* ptr_id)                                       IM_NOEXCEPT;
 
     // Widgets: Text
-    IMGUI_API void          TextUnformatted(const char* text, const char* text_end = NULL)  IMGUI_NOEXCEPT;  // raw text without formatting. Roughly equivalent to Text("%s", text) but: A) doesn't require null terminated string if 'text_end' is specified, B) it's faster, no memory copy is done, no buffer size limits, recommended for long chunks of text.
-    IMGUI_API void          Text(const char* fmt, ...)                                      IMGUI_NOEXCEPT  IM_FMTARGS(1); // formatted text
-    IMGUI_API void          TextV(const char* fmt, va_list args)                            IMGUI_NOEXCEPT  IM_FMTLIST(1);
-    IMGUI_API void          TextColored(const ImVec4& col, const char* fmt, ...)            IMGUI_NOEXCEPT  IM_FMTARGS(2); // shortcut for PushStyleColor(ImGuiCol_Text, col); Text(fmt, ...); PopStyleColor();
-    IMGUI_API void          TextColoredV(const ImVec4& col, const char* fmt, va_list args)  IMGUI_NOEXCEPT  IM_FMTLIST(2);
-    IMGUI_API void          TextDisabled(const char* fmt, ...)                              IMGUI_NOEXCEPT  IM_FMTARGS(1); // shortcut for PushStyleColor(ImGuiCol_Text, style.Colors[ImGuiCol_TextDisabled]); Text(fmt, ...); PopStyleColor();
-    IMGUI_API void          TextDisabledV(const char* fmt, va_list args)                    IMGUI_NOEXCEPT  IM_FMTLIST(1);
-    IMGUI_API void          TextWrapped(const char* fmt, ...)                               IMGUI_NOEXCEPT  IM_FMTARGS(1); // shortcut for PushTextWrapPos(0.0f); Text(fmt, ...); PopTextWrapPos();. Note that this won't work on an auto-resizing window if there's no other widgets to extend the window width, yoy may need to set a size using SetNextWindowSize().
-    IMGUI_API void          TextWrappedV(const char* fmt, va_list args)                     IMGUI_NOEXCEPT  IM_FMTLIST(1);
-    IMGUI_API void          LabelText(const char* label, const char* fmt, ...)              IMGUI_NOEXCEPT  IM_FMTARGS(2); // display text+label aligned the same way as value+label widgets
-    IMGUI_API void          LabelTextV(const char* label, const char* fmt, va_list args)    IMGUI_NOEXCEPT  IM_FMTLIST(2);
-    IMGUI_API void          BulletText(const char* fmt, ...)                                IMGUI_NOEXCEPT  IM_FMTARGS(1); // shortcut for Bullet()+Text()
-    IMGUI_API void          BulletTextV(const char* fmt, va_list args)                      IMGUI_NOEXCEPT  IM_FMTLIST(1);
+    IMGUI_API void          TextUnformatted(const char* text, const char* text_end = NULL)  IM_NOEXCEPT;  // raw text without formatting. Roughly equivalent to Text("%s", text) but: A) doesn't require null terminated string if 'text_end' is specified, B) it's faster, no memory copy is done, no buffer size limits, recommended for long chunks of text.
+    IMGUI_API void          Text(const char* fmt, ...)                                      IM_NOEXCEPT  IM_FMTARGS(1); // formatted text
+    IMGUI_API void          TextV(const char* fmt, va_list args)                            IM_NOEXCEPT  IM_FMTLIST(1);
+    IMGUI_API void          TextColored(const ImVec4& col, const char* fmt, ...)            IM_NOEXCEPT  IM_FMTARGS(2); // shortcut for PushStyleColor(ImGuiCol_Text, col); Text(fmt, ...); PopStyleColor();
+    IMGUI_API void          TextColoredV(const ImVec4& col, const char* fmt, va_list args)  IM_NOEXCEPT  IM_FMTLIST(2);
+    IMGUI_API void          TextDisabled(const char* fmt, ...)                              IM_NOEXCEPT  IM_FMTARGS(1); // shortcut for PushStyleColor(ImGuiCol_Text, style.Colors[ImGuiCol_TextDisabled]); Text(fmt, ...); PopStyleColor();
+    IMGUI_API void          TextDisabledV(const char* fmt, va_list args)                    IM_NOEXCEPT  IM_FMTLIST(1);
+    IMGUI_API void          TextWrapped(const char* fmt, ...)                               IM_NOEXCEPT  IM_FMTARGS(1); // shortcut for PushTextWrapPos(0.0f); Text(fmt, ...); PopTextWrapPos();. Note that this won't work on an auto-resizing window if there's no other widgets to extend the window width, yoy may need to set a size using SetNextWindowSize().
+    IMGUI_API void          TextWrappedV(const char* fmt, va_list args)                     IM_NOEXCEPT  IM_FMTLIST(1);
+    IMGUI_API void          LabelText(const char* label, const char* fmt, ...)              IM_NOEXCEPT  IM_FMTARGS(2); // display text+label aligned the same way as value+label widgets
+    IMGUI_API void          LabelTextV(const char* label, const char* fmt, va_list args)    IM_NOEXCEPT  IM_FMTLIST(2);
+    IMGUI_API void          BulletText(const char* fmt, ...)                                IM_NOEXCEPT  IM_FMTARGS(1); // shortcut for Bullet()+Text()
+    IMGUI_API void          BulletTextV(const char* fmt, va_list args)                      IM_NOEXCEPT  IM_FMTLIST(1);
 
     // Widgets: Main
     // - Most widgets return true when the value has been changed or when pressed/selected
     // - You may also use one of the many IsItemXXX functions (e.g. IsItemActive, IsItemHovered, etc.) to query widget state.
-    IMGUI_API bool          Button(const char* label, const ImVec2& size = ImVec2(0, 0))    IMGUI_NOEXCEPT;  // button
-    IMGUI_API bool          SmallButton(const char* label)                                  IMGUI_NOEXCEPT;  // button with FramePadding=(0,0) to easily embed within text
-    IMGUI_API bool          InvisibleButton(const char* str_id, const ImVec2& size, ImGuiButtonFlags flags = 0) IMGUI_NOEXCEPT;  // flexible button behavior without the visuals, frequently useful to build custom behaviors using the public api (along with IsItemActive, IsItemHovered, etc.)
-    IMGUI_API bool          ArrowButton(const char* str_id, ImGuiDir dir)                   IMGUI_NOEXCEPT;  // square button with an arrow shape
-    IMGUI_API void          Image(ImTextureID user_texture_id, const ImVec2& size, const ImVec2& uv0 = ImVec2(0, 0), const ImVec2& uv1 = ImVec2(1,1), const ImVec4& tint_col = ImVec4(1,1,1,1), const ImVec4& border_col = ImVec4(0,0,0,0)) IMGUI_NOEXCEPT;
-    IMGUI_API bool          ImageButton(ImTextureID user_texture_id, const ImVec2& size, const ImVec2& uv0 = ImVec2(0, 0),  const ImVec2& uv1 = ImVec2(1,1), int frame_padding = -1, const ImVec4& bg_col = ImVec4(0,0,0,0), const ImVec4& tint_col = ImVec4(1,1,1,1)) IMGUI_NOEXCEPT;  // <0 frame_padding uses default frame padding settings. 0 for no padding
-    IMGUI_API bool          Checkbox(const char* label, bool* v)                            IMGUI_NOEXCEPT;
-    IMGUI_API bool          CheckboxFlags(const char* label, int* flags, int flags_value)   IMGUI_NOEXCEPT;
-    IMGUI_API bool          CheckboxFlags(const char* label, unsigned int* flags, unsigned int flags_value) IMGUI_NOEXCEPT;
-    IMGUI_API bool          RadioButton(const char* label, bool active)                     IMGUI_NOEXCEPT;  // use with e.g. if (RadioButton("one", my_value==1)) { my_value = 1; }
-    IMGUI_API bool          RadioButton(const char* label, int* v, int v_button)            IMGUI_NOEXCEPT;  // shortcut to handle the above pattern when value is an integer
-    IMGUI_API void          ProgressBar(float fraction, const ImVec2& size_arg = ImVec2(-FLT_MIN, 0), const char* overlay = NULL) IMGUI_NOEXCEPT;
-    IMGUI_API void          Bullet()                                                        IMGUI_NOEXCEPT;  // draw a small circle + keep the cursor on the same line. advance cursor x position by GetTreeNodeToLabelSpacing(), same distance that TreeNode() uses
+    IMGUI_API bool          Button(const char* label, const ImVec2& size = ImVec2(0, 0))    IM_NOEXCEPT;  // button
+    IMGUI_API bool          SmallButton(const char* label)                                  IM_NOEXCEPT;  // button with FramePadding=(0,0) to easily embed within text
+    IMGUI_API bool          InvisibleButton(const char* str_id, const ImVec2& size, ImGuiButtonFlags flags = 0) IM_NOEXCEPT;  // flexible button behavior without the visuals, frequently useful to build custom behaviors using the public api (along with IsItemActive, IsItemHovered, etc.)
+    IMGUI_API bool          ArrowButton(const char* str_id, ImGuiDir dir)                   IM_NOEXCEPT;  // square button with an arrow shape
+    IMGUI_API void          Image(ImTextureID user_texture_id, const ImVec2& size, const ImVec2& uv0 = ImVec2(0, 0), const ImVec2& uv1 = ImVec2(1,1), const ImVec4& tint_col = ImVec4(1,1,1,1), const ImVec4& border_col = ImVec4(0,0,0,0)) IM_NOEXCEPT;
+    IMGUI_API bool          ImageButton(ImTextureID user_texture_id, const ImVec2& size, const ImVec2& uv0 = ImVec2(0, 0),  const ImVec2& uv1 = ImVec2(1,1), int frame_padding = -1, const ImVec4& bg_col = ImVec4(0,0,0,0), const ImVec4& tint_col = ImVec4(1,1,1,1)) IM_NOEXCEPT;  // <0 frame_padding uses default frame padding settings. 0 for no padding
+    IMGUI_API bool          Checkbox(const char* label, bool* v)                            IM_NOEXCEPT;
+    IMGUI_API bool          CheckboxFlags(const char* label, int* flags, int flags_value)   IM_NOEXCEPT;
+    IMGUI_API bool          CheckboxFlags(const char* label, unsigned int* flags, unsigned int flags_value) IM_NOEXCEPT;
+    IMGUI_API bool          RadioButton(const char* label, bool active)                     IM_NOEXCEPT;  // use with e.g. if (RadioButton("one", my_value==1)) { my_value = 1; }
+    IMGUI_API bool          RadioButton(const char* label, int* v, int v_button)            IM_NOEXCEPT;  // shortcut to handle the above pattern when value is an integer
+    IMGUI_API void          ProgressBar(float fraction, const ImVec2& size_arg = ImVec2(-FLT_MIN, 0), const char* overlay = NULL) IM_NOEXCEPT;
+    IMGUI_API void          Bullet()                                                        IM_NOEXCEPT;  // draw a small circle + keep the cursor on the same line. advance cursor x position by GetTreeNodeToLabelSpacing(), same distance that TreeNode() uses
 
     // Widgets: Combo Box
     // - The BeginCombo()/EndCombo() api allows you to manage your contents and selection state however you want it, by creating e.g. Selectable() items.
     // - The old Combo() api are helpers over BeginCombo()/EndCombo() which are kept available for convenience purpose. This is analogous to how ListBox are created.
-    IMGUI_API bool          BeginCombo(const char* label, const char* preview_value, ImGuiComboFlags flags = 0) IMGUI_NOEXCEPT;
-    IMGUI_API void          EndCombo() IMGUI_NOEXCEPT; // only call EndCombo() if BeginCombo() returns true!
-    IMGUI_API bool          Combo(const char* label, int* current_item, const char* const items[], int items_count, int popup_max_height_in_items = -1) IMGUI_NOEXCEPT;
-    IMGUI_API bool          Combo(const char* label, int* current_item, const char* items_separated_by_zeros, int popup_max_height_in_items = -1) IMGUI_NOEXCEPT;      // Separate items with \0 within a string, end item-list with \0\0. e.g. "One\0Two\0Three\0"
-    IMGUI_API bool          Combo(const char* label, int* current_item, bool(*items_getter)(void* data, int idx, const char** out_text), void* data, int items_count, int popup_max_height_in_items = -1) IMGUI_NOEXCEPT;
+    IMGUI_API bool          BeginCombo(const char* label, const char* preview_value, ImGuiComboFlags flags = 0) IM_NOEXCEPT;
+    IMGUI_API void          EndCombo() IM_NOEXCEPT; // only call EndCombo() if BeginCombo() returns true!
+    IMGUI_API bool          Combo(const char* label, int* current_item, const char* const items[], int items_count, int popup_max_height_in_items = -1) IM_NOEXCEPT;
+    IMGUI_API bool          Combo(const char* label, int* current_item, const char* items_separated_by_zeros, int popup_max_height_in_items = -1) IM_NOEXCEPT;      // Separate items with \0 within a string, end item-list with \0\0. e.g. "One\0Two\0Three\0"
+    IMGUI_API bool          Combo(const char* label, int* current_item, bool(*items_getter)(void* data, int idx, const char** out_text), void* data, int items_count, int popup_max_height_in_items = -1) IM_NOEXCEPT;
 
     // Widgets: Drag Sliders
     // - CTRL+Click on any drag box to turn them into an input box. Manually input values aren't clamped and can go off-bounds.
@@ -524,18 +523,18 @@ namespace ImGui
     // - We use the same sets of flags for DragXXX() and SliderXXX() functions as the features are the same and it makes it easier to swap them.
     // - Legacy: Pre-1.78 there are DragXXX() function signatures that takes a final `float power=1.0f' argument instead of the `ImGuiSliderFlags flags=0' argument.
     //   If you get a warning converting a float to ImGuiSliderFlags, read https://github.com/ocornut/imgui/issues/3361
-    IMGUI_API bool          DragFloat(const char* label, float* v, float v_speed = 1.0f, float v_min = 0.0f, float v_max = 0.0f, const char* format = "%.3f", ImGuiSliderFlags flags = 0)    IMGUI_NOEXCEPT;     // If v_min >= v_max we have no bound
-    IMGUI_API bool          DragFloat2(const char* label, float v[2], float v_speed = 1.0f, float v_min = 0.0f, float v_max = 0.0f, const char* format = "%.3f", ImGuiSliderFlags flags = 0) IMGUI_NOEXCEPT;
-    IMGUI_API bool          DragFloat3(const char* label, float v[3], float v_speed = 1.0f, float v_min = 0.0f, float v_max = 0.0f, const char* format = "%.3f", ImGuiSliderFlags flags = 0) IMGUI_NOEXCEPT;
-    IMGUI_API bool          DragFloat4(const char* label, float v[4], float v_speed = 1.0f, float v_min = 0.0f, float v_max = 0.0f, const char* format = "%.3f", ImGuiSliderFlags flags = 0) IMGUI_NOEXCEPT;
-    IMGUI_API bool          DragFloatRange2(const char* label, float* v_current_min, float* v_current_max, float v_speed = 1.0f, float v_min = 0.0f, float v_max = 0.0f, const char* format = "%.3f", const char* format_max = NULL, ImGuiSliderFlags flags = 0) IMGUI_NOEXCEPT;
-    IMGUI_API bool          DragInt(const char* label, int* v, float v_speed = 1.0f, int v_min = 0, int v_max = 0, const char* format = "%d", ImGuiSliderFlags flags = 0) IMGUI_NOEXCEPT;  // If v_min >= v_max we have no bound
-    IMGUI_API bool          DragInt2(const char* label, int v[2], float v_speed = 1.0f, int v_min = 0, int v_max = 0, const char* format = "%d", ImGuiSliderFlags flags = 0) IMGUI_NOEXCEPT;
-    IMGUI_API bool          DragInt3(const char* label, int v[3], float v_speed = 1.0f, int v_min = 0, int v_max = 0, const char* format = "%d", ImGuiSliderFlags flags = 0) IMGUI_NOEXCEPT;
-    IMGUI_API bool          DragInt4(const char* label, int v[4], float v_speed = 1.0f, int v_min = 0, int v_max = 0, const char* format = "%d", ImGuiSliderFlags flags = 0) IMGUI_NOEXCEPT;
-    IMGUI_API bool          DragIntRange2(const char* label, int* v_current_min, int* v_current_max, float v_speed = 1.0f, int v_min = 0, int v_max = 0, const char* format = "%d", const char* format_max = NULL, ImGuiSliderFlags flags = 0) IMGUI_NOEXCEPT;
-    IMGUI_API bool          DragScalar(const char* label, ImGuiDataType data_type, void* p_data, float v_speed = 1.0f, const void* p_min = NULL, const void* p_max = NULL, const char* format = NULL, ImGuiSliderFlags flags = 0) IMGUI_NOEXCEPT;
-    IMGUI_API bool          DragScalarN(const char* label, ImGuiDataType data_type, void* p_data, int components, float v_speed = 1.0f, const void* p_min = NULL, const void* p_max = NULL, const char* format = NULL, ImGuiSliderFlags flags = 0) IMGUI_NOEXCEPT;
+    IMGUI_API bool          DragFloat(const char* label, float* v, float v_speed = 1.0f, float v_min = 0.0f, float v_max = 0.0f, const char* format = "%.3f", ImGuiSliderFlags flags = 0)    IM_NOEXCEPT;     // If v_min >= v_max we have no bound
+    IMGUI_API bool          DragFloat2(const char* label, float v[2], float v_speed = 1.0f, float v_min = 0.0f, float v_max = 0.0f, const char* format = "%.3f", ImGuiSliderFlags flags = 0) IM_NOEXCEPT;
+    IMGUI_API bool          DragFloat3(const char* label, float v[3], float v_speed = 1.0f, float v_min = 0.0f, float v_max = 0.0f, const char* format = "%.3f", ImGuiSliderFlags flags = 0) IM_NOEXCEPT;
+    IMGUI_API bool          DragFloat4(const char* label, float v[4], float v_speed = 1.0f, float v_min = 0.0f, float v_max = 0.0f, const char* format = "%.3f", ImGuiSliderFlags flags = 0) IM_NOEXCEPT;
+    IMGUI_API bool          DragFloatRange2(const char* label, float* v_current_min, float* v_current_max, float v_speed = 1.0f, float v_min = 0.0f, float v_max = 0.0f, const char* format = "%.3f", const char* format_max = NULL, ImGuiSliderFlags flags = 0) IM_NOEXCEPT;
+    IMGUI_API bool          DragInt(const char* label, int* v, float v_speed = 1.0f, int v_min = 0, int v_max = 0, const char* format = "%d", ImGuiSliderFlags flags = 0) IM_NOEXCEPT;  // If v_min >= v_max we have no bound
+    IMGUI_API bool          DragInt2(const char* label, int v[2], float v_speed = 1.0f, int v_min = 0, int v_max = 0, const char* format = "%d", ImGuiSliderFlags flags = 0) IM_NOEXCEPT;
+    IMGUI_API bool          DragInt3(const char* label, int v[3], float v_speed = 1.0f, int v_min = 0, int v_max = 0, const char* format = "%d", ImGuiSliderFlags flags = 0) IM_NOEXCEPT;
+    IMGUI_API bool          DragInt4(const char* label, int v[4], float v_speed = 1.0f, int v_min = 0, int v_max = 0, const char* format = "%d", ImGuiSliderFlags flags = 0) IM_NOEXCEPT;
+    IMGUI_API bool          DragIntRange2(const char* label, int* v_current_min, int* v_current_max, float v_speed = 1.0f, int v_min = 0, int v_max = 0, const char* format = "%d", const char* format_max = NULL, ImGuiSliderFlags flags = 0) IM_NOEXCEPT;
+    IMGUI_API bool          DragScalar(const char* label, ImGuiDataType data_type, void* p_data, float v_speed = 1.0f, const void* p_min = NULL, const void* p_max = NULL, const char* format = NULL, ImGuiSliderFlags flags = 0) IM_NOEXCEPT;
+    IMGUI_API bool          DragScalarN(const char* label, ImGuiDataType data_type, void* p_data, int components, float v_speed = 1.0f, const void* p_min = NULL, const void* p_max = NULL, const char* format = NULL, ImGuiSliderFlags flags = 0) IM_NOEXCEPT;
 
     // Widgets: Regular Sliders
     // - CTRL+Click on any slider to turn them into an input box. Manually input values aren't clamped and can go off-bounds.
@@ -543,74 +542,74 @@ namespace ImGui
     // - Format string may also be set to NULL or use the default format ("%f" or "%d").
     // - Legacy: Pre-1.78 there are SliderXXX() function signatures that takes a final `float power=1.0f' argument instead of the `ImGuiSliderFlags flags=0' argument.
     //   If you get a warning converting a float to ImGuiSliderFlags, read https://github.com/ocornut/imgui/issues/3361
-    IMGUI_API bool          SliderFloat(const char* label, float* v, float v_min, float v_max, const char* format = "%.3f", ImGuiSliderFlags flags = 0)    IMGUI_NOEXCEPT;  // adjust format to decorate the value with a prefix or a suffix for in-slider labels or unit display.
-    IMGUI_API bool          SliderFloat2(const char* label, float v[2], float v_min, float v_max, const char* format = "%.3f", ImGuiSliderFlags flags = 0) IMGUI_NOEXCEPT;
-    IMGUI_API bool          SliderFloat3(const char* label, float v[3], float v_min, float v_max, const char* format = "%.3f", ImGuiSliderFlags flags = 0) IMGUI_NOEXCEPT;
-    IMGUI_API bool          SliderFloat4(const char* label, float v[4], float v_min, float v_max, const char* format = "%.3f", ImGuiSliderFlags flags = 0) IMGUI_NOEXCEPT;
-    IMGUI_API bool          SliderAngle(const char* label, float* v_rad, float v_degrees_min = -360.0f, float v_degrees_max = +360.0f, const char* format = "%.0f deg", ImGuiSliderFlags flags = 0)                  IMGUI_NOEXCEPT;
-    IMGUI_API bool          SliderInt(const char* label, int* v, int v_min, int v_max, const char* format = "%d", ImGuiSliderFlags flags = 0)              IMGUI_NOEXCEPT;
-    IMGUI_API bool          SliderInt2(const char* label, int v[2], int v_min, int v_max, const char* format = "%d", ImGuiSliderFlags flags = 0)           IMGUI_NOEXCEPT;
-    IMGUI_API bool          SliderInt3(const char* label, int v[3], int v_min, int v_max, const char* format = "%d", ImGuiSliderFlags flags = 0)           IMGUI_NOEXCEPT;
-    IMGUI_API bool          SliderInt4(const char* label, int v[4], int v_min, int v_max, const char* format = "%d", ImGuiSliderFlags flags = 0)           IMGUI_NOEXCEPT;
-    IMGUI_API bool          SliderScalar(const char* label, ImGuiDataType data_type, void* p_data, const void* p_min, const void* p_max, const char* format = NULL, ImGuiSliderFlags flags = 0)                      IMGUI_NOEXCEPT;
-    IMGUI_API bool          SliderScalarN(const char* label, ImGuiDataType data_type, void* p_data, int components, const void* p_min, const void* p_max, const char* format = NULL, ImGuiSliderFlags flags = 0)     IMGUI_NOEXCEPT;
-    IMGUI_API bool          VSliderFloat(const char* label, const ImVec2& size, float* v, float v_min, float v_max, const char* format = "%.3f", ImGuiSliderFlags flags = 0) IMGUI_NOEXCEPT;
-    IMGUI_API bool          VSliderInt(const char* label, const ImVec2& size, int* v, int v_min, int v_max, const char* format = "%d", ImGuiSliderFlags flags = 0)           IMGUI_NOEXCEPT;
-    IMGUI_API bool          VSliderScalar(const char* label, const ImVec2& size, ImGuiDataType data_type, void* p_data, const void* p_min, const void* p_max, const char* format = NULL, ImGuiSliderFlags flags = 0) IMGUI_NOEXCEPT;
+    IMGUI_API bool          SliderFloat(const char* label, float* v, float v_min, float v_max, const char* format = "%.3f", ImGuiSliderFlags flags = 0)    IM_NOEXCEPT;  // adjust format to decorate the value with a prefix or a suffix for in-slider labels or unit display.
+    IMGUI_API bool          SliderFloat2(const char* label, float v[2], float v_min, float v_max, const char* format = "%.3f", ImGuiSliderFlags flags = 0) IM_NOEXCEPT;
+    IMGUI_API bool          SliderFloat3(const char* label, float v[3], float v_min, float v_max, const char* format = "%.3f", ImGuiSliderFlags flags = 0) IM_NOEXCEPT;
+    IMGUI_API bool          SliderFloat4(const char* label, float v[4], float v_min, float v_max, const char* format = "%.3f", ImGuiSliderFlags flags = 0) IM_NOEXCEPT;
+    IMGUI_API bool          SliderAngle(const char* label, float* v_rad, float v_degrees_min = -360.0f, float v_degrees_max = +360.0f, const char* format = "%.0f deg", ImGuiSliderFlags flags = 0)                  IM_NOEXCEPT;
+    IMGUI_API bool          SliderInt(const char* label, int* v, int v_min, int v_max, const char* format = "%d", ImGuiSliderFlags flags = 0)              IM_NOEXCEPT;
+    IMGUI_API bool          SliderInt2(const char* label, int v[2], int v_min, int v_max, const char* format = "%d", ImGuiSliderFlags flags = 0)           IM_NOEXCEPT;
+    IMGUI_API bool          SliderInt3(const char* label, int v[3], int v_min, int v_max, const char* format = "%d", ImGuiSliderFlags flags = 0)           IM_NOEXCEPT;
+    IMGUI_API bool          SliderInt4(const char* label, int v[4], int v_min, int v_max, const char* format = "%d", ImGuiSliderFlags flags = 0)           IM_NOEXCEPT;
+    IMGUI_API bool          SliderScalar(const char* label, ImGuiDataType data_type, void* p_data, const void* p_min, const void* p_max, const char* format = NULL, ImGuiSliderFlags flags = 0)                      IM_NOEXCEPT;
+    IMGUI_API bool          SliderScalarN(const char* label, ImGuiDataType data_type, void* p_data, int components, const void* p_min, const void* p_max, const char* format = NULL, ImGuiSliderFlags flags = 0)     IM_NOEXCEPT;
+    IMGUI_API bool          VSliderFloat(const char* label, const ImVec2& size, float* v, float v_min, float v_max, const char* format = "%.3f", ImGuiSliderFlags flags = 0) IM_NOEXCEPT;
+    IMGUI_API bool          VSliderInt(const char* label, const ImVec2& size, int* v, int v_min, int v_max, const char* format = "%d", ImGuiSliderFlags flags = 0)           IM_NOEXCEPT;
+    IMGUI_API bool          VSliderScalar(const char* label, const ImVec2& size, ImGuiDataType data_type, void* p_data, const void* p_min, const void* p_max, const char* format = NULL, ImGuiSliderFlags flags = 0) IM_NOEXCEPT;
 
     // Widgets: Input with Keyboard
     // - If you want to use InputText() with std::string or any custom dynamic string type, see misc/cpp/imgui_stdlib.h and comments in imgui_demo.cpp.
     // - Most of the ImGuiInputTextFlags flags are only useful for InputText() and not for InputFloatX, InputIntX, InputDouble etc.
-    IMGUI_API bool          InputText(const char* label, char* buf, size_t buf_size, ImGuiInputTextFlags flags = 0, ImGuiInputTextCallback callback = NULL, void* user_data = NULL)                                                    IMGUI_NOEXCEPT;
-    IMGUI_API bool          InputTextMultiline(const char* label, char* buf, size_t buf_size, const ImVec2& size = ImVec2(0, 0), ImGuiInputTextFlags flags = 0, ImGuiInputTextCallback callback = NULL, void* user_data = NULL)        IMGUI_NOEXCEPT;
-    IMGUI_API bool          InputTextWithHint(const char* label, const char* hint, char* buf, size_t buf_size, ImGuiInputTextFlags flags = 0, ImGuiInputTextCallback callback = NULL, void* user_data = NULL)                          IMGUI_NOEXCEPT;
-    IMGUI_API bool          InputFloat(const char* label, float* v, float step = 0.0f, float step_fast = 0.0f, const char* format = "%.3f", ImGuiInputTextFlags flags = 0)                                                             IMGUI_NOEXCEPT;
-    IMGUI_API bool          InputFloat2(const char* label, float v[2], const char* format = "%.3f", ImGuiInputTextFlags flags = 0) IMGUI_NOEXCEPT;
-    IMGUI_API bool          InputFloat3(const char* label, float v[3], const char* format = "%.3f", ImGuiInputTextFlags flags = 0) IMGUI_NOEXCEPT;
-    IMGUI_API bool          InputFloat4(const char* label, float v[4], const char* format = "%.3f", ImGuiInputTextFlags flags = 0) IMGUI_NOEXCEPT;
-    IMGUI_API bool          InputInt(const char* label, int* v, int step = 1, int step_fast = 100, ImGuiInputTextFlags flags = 0)  IMGUI_NOEXCEPT;
-    IMGUI_API bool          InputInt2(const char* label, int v[2], ImGuiInputTextFlags flags = 0)                                  IMGUI_NOEXCEPT;
-    IMGUI_API bool          InputInt3(const char* label, int v[3], ImGuiInputTextFlags flags = 0)                                  IMGUI_NOEXCEPT;
-    IMGUI_API bool          InputInt4(const char* label, int v[4], ImGuiInputTextFlags flags = 0)                                  IMGUI_NOEXCEPT;
-    IMGUI_API bool          InputDouble(const char* label, double* v, double step = 0.0, double step_fast = 0.0, const char* format = "%.6f", ImGuiInputTextFlags flags = 0)                                                            IMGUI_NOEXCEPT;
-    IMGUI_API bool          InputScalar(const char* label, ImGuiDataType data_type, void* p_data, const void* p_step = NULL, const void* p_step_fast = NULL, const char* format = NULL, ImGuiInputTextFlags flags = 0)                  IMGUI_NOEXCEPT;
-    IMGUI_API bool          InputScalarN(const char* label, ImGuiDataType data_type, void* p_data, int components, const void* p_step = NULL, const void* p_step_fast = NULL, const char* format = NULL, ImGuiInputTextFlags flags = 0) IMGUI_NOEXCEPT;
+    IMGUI_API bool          InputText(const char* label, char* buf, size_t buf_size, ImGuiInputTextFlags flags = 0, ImGuiInputTextCallback callback = NULL, void* user_data = NULL)                                                    IM_NOEXCEPT;
+    IMGUI_API bool          InputTextMultiline(const char* label, char* buf, size_t buf_size, const ImVec2& size = ImVec2(0, 0), ImGuiInputTextFlags flags = 0, ImGuiInputTextCallback callback = NULL, void* user_data = NULL)        IM_NOEXCEPT;
+    IMGUI_API bool          InputTextWithHint(const char* label, const char* hint, char* buf, size_t buf_size, ImGuiInputTextFlags flags = 0, ImGuiInputTextCallback callback = NULL, void* user_data = NULL)                          IM_NOEXCEPT;
+    IMGUI_API bool          InputFloat(const char* label, float* v, float step = 0.0f, float step_fast = 0.0f, const char* format = "%.3f", ImGuiInputTextFlags flags = 0)                                                             IM_NOEXCEPT;
+    IMGUI_API bool          InputFloat2(const char* label, float v[2], const char* format = "%.3f", ImGuiInputTextFlags flags = 0) IM_NOEXCEPT;
+    IMGUI_API bool          InputFloat3(const char* label, float v[3], const char* format = "%.3f", ImGuiInputTextFlags flags = 0) IM_NOEXCEPT;
+    IMGUI_API bool          InputFloat4(const char* label, float v[4], const char* format = "%.3f", ImGuiInputTextFlags flags = 0) IM_NOEXCEPT;
+    IMGUI_API bool          InputInt(const char* label, int* v, int step = 1, int step_fast = 100, ImGuiInputTextFlags flags = 0)  IM_NOEXCEPT;
+    IMGUI_API bool          InputInt2(const char* label, int v[2], ImGuiInputTextFlags flags = 0)                                  IM_NOEXCEPT;
+    IMGUI_API bool          InputInt3(const char* label, int v[3], ImGuiInputTextFlags flags = 0)                                  IM_NOEXCEPT;
+    IMGUI_API bool          InputInt4(const char* label, int v[4], ImGuiInputTextFlags flags = 0)                                  IM_NOEXCEPT;
+    IMGUI_API bool          InputDouble(const char* label, double* v, double step = 0.0, double step_fast = 0.0, const char* format = "%.6f", ImGuiInputTextFlags flags = 0)                                                            IM_NOEXCEPT;
+    IMGUI_API bool          InputScalar(const char* label, ImGuiDataType data_type, void* p_data, const void* p_step = NULL, const void* p_step_fast = NULL, const char* format = NULL, ImGuiInputTextFlags flags = 0)                  IM_NOEXCEPT;
+    IMGUI_API bool          InputScalarN(const char* label, ImGuiDataType data_type, void* p_data, int components, const void* p_step = NULL, const void* p_step_fast = NULL, const char* format = NULL, ImGuiInputTextFlags flags = 0) IM_NOEXCEPT;
 
     // Widgets: Color Editor/Picker (tip: the ColorEdit* functions have a little color square that can be left-clicked to open a picker, and right-clicked to open an option menu.)
     // - Note that in C++ a 'float v[X]' function argument is the _same_ as 'float* v', the array syntax is just a way to document the number of elements that are expected to be accessible.
     // - You can pass the address of a first float element out of a contiguous structure, e.g. &myvector.x
-    IMGUI_API bool          ColorEdit3(const char* label, float col[3], ImGuiColorEditFlags flags = 0)   IMGUI_NOEXCEPT;
-    IMGUI_API bool          ColorEdit4(const char* label, float col[4], ImGuiColorEditFlags flags = 0)   IMGUI_NOEXCEPT;
-    IMGUI_API bool          ColorPicker3(const char* label, float col[3], ImGuiColorEditFlags flags = 0) IMGUI_NOEXCEPT;
-    IMGUI_API bool          ColorPicker4(const char* label, float col[4], ImGuiColorEditFlags flags = 0, const float* ref_col = NULL) IMGUI_NOEXCEPT;
-    IMGUI_API bool          ColorButton(const char* desc_id, const ImVec4& col, ImGuiColorEditFlags flags = 0, ImVec2 size = ImVec2(0, 0)) IMGUI_NOEXCEPT;  // display a color square/button, hover for details, return true when pressed.
-    IMGUI_API void          SetColorEditOptions(ImGuiColorEditFlags flags)                               IMGUI_NOEXCEPT;  // initialize current options (generally on application startup) if you want to select a default format, picker type, etc. User will be able to change many settings, unless you pass the _NoOptions flag to your calls.
+    IMGUI_API bool          ColorEdit3(const char* label, float col[3], ImGuiColorEditFlags flags = 0)   IM_NOEXCEPT;
+    IMGUI_API bool          ColorEdit4(const char* label, float col[4], ImGuiColorEditFlags flags = 0)   IM_NOEXCEPT;
+    IMGUI_API bool          ColorPicker3(const char* label, float col[3], ImGuiColorEditFlags flags = 0) IM_NOEXCEPT;
+    IMGUI_API bool          ColorPicker4(const char* label, float col[4], ImGuiColorEditFlags flags = 0, const float* ref_col = NULL) IM_NOEXCEPT;
+    IMGUI_API bool          ColorButton(const char* desc_id, const ImVec4& col, ImGuiColorEditFlags flags = 0, ImVec2 size = ImVec2(0, 0)) IM_NOEXCEPT;  // display a color square/button, hover for details, return true when pressed.
+    IMGUI_API void          SetColorEditOptions(ImGuiColorEditFlags flags)                               IM_NOEXCEPT;  // initialize current options (generally on application startup) if you want to select a default format, picker type, etc. User will be able to change many settings, unless you pass the _NoOptions flag to your calls.
 
     // Widgets: Trees
     // - TreeNode functions return true when the node is open, in which case you need to also call TreePop() when you are finished displaying the tree node contents.
-    IMGUI_API bool          TreeNode(const char* label)                                                              IMGUI_NOEXCEPT;
-    IMGUI_API bool          TreeNode(const char* str_id, const char* fmt, ...)                                       IMGUI_NOEXCEPT IM_FMTARGS(2);   // helper variation to easily decorelate the id from the displayed string. Read the FAQ about why and how to use ID. to align arbitrary text at the same level as a TreeNode() you can use Bullet().
-    IMGUI_API bool          TreeNode(const void* ptr_id, const char* fmt, ...)                                       IMGUI_NOEXCEPT IM_FMTARGS(2);   // "
-    IMGUI_API bool          TreeNodeV(const char* str_id, const char* fmt, va_list args)                             IMGUI_NOEXCEPT IM_FMTLIST(2);
-    IMGUI_API bool          TreeNodeV(const void* ptr_id, const char* fmt, va_list args)                             IMGUI_NOEXCEPT IM_FMTLIST(2);
-    IMGUI_API bool          TreeNodeEx(const char* label, ImGuiTreeNodeFlags flags = 0)                              IMGUI_NOEXCEPT;
-    IMGUI_API bool          TreeNodeEx(const char* str_id, ImGuiTreeNodeFlags flags, const char* fmt, ...)           IMGUI_NOEXCEPT IM_FMTARGS(3);
-    IMGUI_API bool          TreeNodeEx(const void* ptr_id, ImGuiTreeNodeFlags flags, const char* fmt, ...)           IMGUI_NOEXCEPT IM_FMTARGS(3);
-    IMGUI_API bool          TreeNodeExV(const char* str_id, ImGuiTreeNodeFlags flags, const char* fmt, va_list args) IMGUI_NOEXCEPT IM_FMTLIST(3);
-    IMGUI_API bool          TreeNodeExV(const void* ptr_id, ImGuiTreeNodeFlags flags, const char* fmt, va_list args) IMGUI_NOEXCEPT IM_FMTLIST(3);
-    IMGUI_API void          TreePush(const char* str_id)                                      IMGUI_NOEXCEPT;  // ~ Indent()+PushId(). Already called by TreeNode() when returning true, but you can call TreePush/TreePop yourself if desired.
-    IMGUI_API void          TreePush(const void* ptr_id = NULL)                               IMGUI_NOEXCEPT;  // "
-    IMGUI_API void          TreePop()                                                         IMGUI_NOEXCEPT;  // ~ Unindent()+PopId()
-    IMGUI_API float         GetTreeNodeToLabelSpacing()                                       IMGUI_NOEXCEPT;  // horizontal distance preceding label when using TreeNode*() or Bullet() == (g.FontSize + style.FramePadding.x*2) for a regular unframed TreeNode
-    IMGUI_API bool          CollapsingHeader(const char* label, ImGuiTreeNodeFlags flags = 0) IMGUI_NOEXCEPT;  // if returning 'true' the header is open. doesn't indent nor push on ID stack. user doesn't have to call TreePop().
-    IMGUI_API bool          CollapsingHeader(const char* label, bool* p_visible, ImGuiTreeNodeFlags flags = 0) IMGUI_NOEXCEPT; // when 'p_visible != NULL': if '*p_visible==true' display an additional small close button on upper right of the header which will set the bool to false when clicked, if '*p_visible==false' don't display the header.
-    IMGUI_API void          SetNextItemOpen(bool is_open, ImGuiCond cond = 0)                 IMGUI_NOEXCEPT;  // set next TreeNode/CollapsingHeader open state.
+    IMGUI_API bool          TreeNode(const char* label)                                                              IM_NOEXCEPT;
+    IMGUI_API bool          TreeNode(const char* str_id, const char* fmt, ...)                                       IM_NOEXCEPT IM_FMTARGS(2);   // helper variation to easily decorelate the id from the displayed string. Read the FAQ about why and how to use ID. to align arbitrary text at the same level as a TreeNode() you can use Bullet().
+    IMGUI_API bool          TreeNode(const void* ptr_id, const char* fmt, ...)                                       IM_NOEXCEPT IM_FMTARGS(2);   // "
+    IMGUI_API bool          TreeNodeV(const char* str_id, const char* fmt, va_list args)                             IM_NOEXCEPT IM_FMTLIST(2);
+    IMGUI_API bool          TreeNodeV(const void* ptr_id, const char* fmt, va_list args)                             IM_NOEXCEPT IM_FMTLIST(2);
+    IMGUI_API bool          TreeNodeEx(const char* label, ImGuiTreeNodeFlags flags = 0)                              IM_NOEXCEPT;
+    IMGUI_API bool          TreeNodeEx(const char* str_id, ImGuiTreeNodeFlags flags, const char* fmt, ...)           IM_NOEXCEPT IM_FMTARGS(3);
+    IMGUI_API bool          TreeNodeEx(const void* ptr_id, ImGuiTreeNodeFlags flags, const char* fmt, ...)           IM_NOEXCEPT IM_FMTARGS(3);
+    IMGUI_API bool          TreeNodeExV(const char* str_id, ImGuiTreeNodeFlags flags, const char* fmt, va_list args) IM_NOEXCEPT IM_FMTLIST(3);
+    IMGUI_API bool          TreeNodeExV(const void* ptr_id, ImGuiTreeNodeFlags flags, const char* fmt, va_list args) IM_NOEXCEPT IM_FMTLIST(3);
+    IMGUI_API void          TreePush(const char* str_id)                                      IM_NOEXCEPT;  // ~ Indent()+PushId(). Already called by TreeNode() when returning true, but you can call TreePush/TreePop yourself if desired.
+    IMGUI_API void          TreePush(const void* ptr_id = NULL)                               IM_NOEXCEPT;  // "
+    IMGUI_API void          TreePop()                                                         IM_NOEXCEPT;  // ~ Unindent()+PopId()
+    IMGUI_API float         GetTreeNodeToLabelSpacing()                                       IM_NOEXCEPT;  // horizontal distance preceding label when using TreeNode*() or Bullet() == (g.FontSize + style.FramePadding.x*2) for a regular unframed TreeNode
+    IMGUI_API bool          CollapsingHeader(const char* label, ImGuiTreeNodeFlags flags = 0) IM_NOEXCEPT;  // if returning 'true' the header is open. doesn't indent nor push on ID stack. user doesn't have to call TreePop().
+    IMGUI_API bool          CollapsingHeader(const char* label, bool* p_visible, ImGuiTreeNodeFlags flags = 0) IM_NOEXCEPT; // when 'p_visible != NULL': if '*p_visible==true' display an additional small close button on upper right of the header which will set the bool to false when clicked, if '*p_visible==false' don't display the header.
+    IMGUI_API void          SetNextItemOpen(bool is_open, ImGuiCond cond = 0)                 IM_NOEXCEPT;  // set next TreeNode/CollapsingHeader open state.
 
     // Widgets: Selectables
     // - A selectable highlights when hovered, and can display another color when selected.
     // - Neighbors selectable extend their highlight bounds in order to leave no gap between them. This is so a series of selected Selectable appear contiguous.
-    IMGUI_API bool          Selectable(const char* label, bool selected = false, ImGuiSelectableFlags flags = 0, const ImVec2& size = ImVec2(0, 0)) IMGUI_NOEXCEPT;  // "bool selected" carry the selection state (read-only). Selectable() is clicked is returns true so you can modify your selection state. size.x==0.0: use remaining width, size.x>0.0: specify width. size.y==0.0: use label height, size.y>0.0: specify height
-    IMGUI_API bool          Selectable(const char* label, bool* p_selected, ImGuiSelectableFlags flags = 0, const ImVec2& size = ImVec2(0, 0))      IMGUI_NOEXCEPT;  // "bool* p_selected" point to the selection state (read-write), as a convenient helper.
+    IMGUI_API bool          Selectable(const char* label, bool selected = false, ImGuiSelectableFlags flags = 0, const ImVec2& size = ImVec2(0, 0)) IM_NOEXCEPT;  // "bool selected" carry the selection state (read-only). Selectable() is clicked is returns true so you can modify your selection state. size.x==0.0: use remaining width, size.x>0.0: specify width. size.y==0.0: use label height, size.y>0.0: specify height
+    IMGUI_API bool          Selectable(const char* label, bool* p_selected, ImGuiSelectableFlags flags = 0, const ImVec2& size = ImVec2(0, 0))      IM_NOEXCEPT;  // "bool* p_selected" point to the selection state (read-write), as a convenient helper.
 
     // Widgets: List Boxes
     // - This is essentially a thin wrapper to using BeginChild/EndChild with some stylistic changes.
@@ -618,45 +617,45 @@ namespace ImGui
     // - The simplified/old ListBox() api are helpers over BeginListBox()/EndListBox() which are kept available for convenience purpose. This is analoguous to how Combos are created.
     // - Choose frame width:   size.x > 0.0f: custom  /  size.x < 0.0f or -FLT_MIN: right-align   /  size.x = 0.0f (default): use current ItemWidth
     // - Choose frame height:  size.y > 0.0f: custom  /  size.y < 0.0f or -FLT_MIN: bottom-align  /  size.y = 0.0f (default): arbitrary default height which can fit ~7 items
-    IMGUI_API bool          BeginListBox(const char* label, const ImVec2& size = ImVec2(0, 0)) IMGUI_NOEXCEPT; // open a framed scrolling region
-    IMGUI_API void          EndListBox() IMGUI_NOEXCEPT;                                                       // only call EndListBox() if BeginListBox() returned true!
-    IMGUI_API bool          ListBox(const char* label, int* current_item, const char* const items[], int items_count, int height_in_items = -1) IMGUI_NOEXCEPT;
-    IMGUI_API bool          ListBox(const char* label, int* current_item, bool (*items_getter)(void* data, int idx, const char** out_text), void* data, int items_count, int height_in_items = -1) IMGUI_NOEXCEPT;
+    IMGUI_API bool          BeginListBox(const char* label, const ImVec2& size = ImVec2(0, 0)) IM_NOEXCEPT; // open a framed scrolling region
+    IMGUI_API void          EndListBox() IM_NOEXCEPT;                                                       // only call EndListBox() if BeginListBox() returned true!
+    IMGUI_API bool          ListBox(const char* label, int* current_item, const char* const items[], int items_count, int height_in_items = -1) IM_NOEXCEPT;
+    IMGUI_API bool          ListBox(const char* label, int* current_item, bool (*items_getter)(void* data, int idx, const char** out_text), void* data, int items_count, int height_in_items = -1) IM_NOEXCEPT;
 
     // Widgets: Data Plotting
     // - Consider using ImPlot (https://github.com/epezent/implot)
-    IMGUI_API void          PlotLines(const char* label, const float* values, int values_count, int values_offset = 0, const char* overlay_text = NULL, float scale_min = FLT_MAX, float scale_max = FLT_MAX, ImVec2 graph_size = ImVec2(0, 0), int stride = sizeof(float))            IMGUI_NOEXCEPT;
-    IMGUI_API void          PlotLines(const char* label, float(*values_getter)(void* data, int idx), void* data, int values_count, int values_offset = 0, const char* overlay_text = NULL, float scale_min = FLT_MAX, float scale_max = FLT_MAX, ImVec2 graph_size = ImVec2(0, 0))     IMGUI_NOEXCEPT;
-    IMGUI_API void          PlotHistogram(const char* label, const float* values, int values_count, int values_offset = 0, const char* overlay_text = NULL, float scale_min = FLT_MAX, float scale_max = FLT_MAX, ImVec2 graph_size = ImVec2(0, 0), int stride = sizeof(float))        IMGUI_NOEXCEPT;
-    IMGUI_API void          PlotHistogram(const char* label, float(*values_getter)(void* data, int idx), void* data, int values_count, int values_offset = 0, const char* overlay_text = NULL, float scale_min = FLT_MAX, float scale_max = FLT_MAX, ImVec2 graph_size = ImVec2(0, 0)) IMGUI_NOEXCEPT;
+    IMGUI_API void          PlotLines(const char* label, const float* values, int values_count, int values_offset = 0, const char* overlay_text = NULL, float scale_min = FLT_MAX, float scale_max = FLT_MAX, ImVec2 graph_size = ImVec2(0, 0), int stride = sizeof(float))            IM_NOEXCEPT;
+    IMGUI_API void          PlotLines(const char* label, float(*values_getter)(void* data, int idx), void* data, int values_count, int values_offset = 0, const char* overlay_text = NULL, float scale_min = FLT_MAX, float scale_max = FLT_MAX, ImVec2 graph_size = ImVec2(0, 0))     IM_NOEXCEPT;
+    IMGUI_API void          PlotHistogram(const char* label, const float* values, int values_count, int values_offset = 0, const char* overlay_text = NULL, float scale_min = FLT_MAX, float scale_max = FLT_MAX, ImVec2 graph_size = ImVec2(0, 0), int stride = sizeof(float))        IM_NOEXCEPT;
+    IMGUI_API void          PlotHistogram(const char* label, float(*values_getter)(void* data, int idx), void* data, int values_count, int values_offset = 0, const char* overlay_text = NULL, float scale_min = FLT_MAX, float scale_max = FLT_MAX, ImVec2 graph_size = ImVec2(0, 0)) IM_NOEXCEPT;
 
     // Widgets: Value() Helpers.
     // - Those are merely shortcut to calling Text() with a format string. Output single value in "name: value" format (tip: freely declare more in your code to handle your types. you can add functions to the ImGui namespace)
-    IMGUI_API void          Value(const char* prefix, bool b)                                   IMGUI_NOEXCEPT;
-    IMGUI_API void          Value(const char* prefix, int v)                                    IMGUI_NOEXCEPT;
-    IMGUI_API void          Value(const char* prefix, unsigned int v)                           IMGUI_NOEXCEPT;
-    IMGUI_API void          Value(const char* prefix, float v, const char* float_format = NULL) IMGUI_NOEXCEPT;
+    IMGUI_API void          Value(const char* prefix, bool b)                                   IM_NOEXCEPT;
+    IMGUI_API void          Value(const char* prefix, int v)                                    IM_NOEXCEPT;
+    IMGUI_API void          Value(const char* prefix, unsigned int v)                           IM_NOEXCEPT;
+    IMGUI_API void          Value(const char* prefix, float v, const char* float_format = NULL) IM_NOEXCEPT;
 
     // Widgets: Menus
     // - Use BeginMenuBar() on a window ImGuiWindowFlags_MenuBar to append to its menu bar.
     // - Use BeginMainMenuBar() to create a menu bar at the top of the screen and append to it.
     // - Use BeginMenu() to create a menu. You can call BeginMenu() multiple time with the same identifier to append more items to it.
     // - Not that MenuItem() keyboardshortcuts are displayed as a convenience but _not processed_ by Dear ImGui at the moment.
-    IMGUI_API bool          BeginMenuBar() IMGUI_NOEXCEPT;                                                                         // append to menu-bar of current window (requires ImGuiWindowFlags_MenuBar flag set on parent window).
-    IMGUI_API void          EndMenuBar() IMGUI_NOEXCEPT;                                                                           // only call EndMenuBar() if BeginMenuBar() returns true!
-    IMGUI_API bool          BeginMainMenuBar() IMGUI_NOEXCEPT;                                                                     // create and append to a full screen menu-bar.
-    IMGUI_API void          EndMainMenuBar() IMGUI_NOEXCEPT;                                                                       // only call EndMainMenuBar() if BeginMainMenuBar() returns true!
-    IMGUI_API bool          BeginMenu(const char* label, bool enabled = true) IMGUI_NOEXCEPT;                                      // create a sub-menu entry. only call EndMenu() if this returns true!
-    IMGUI_API void          EndMenu() IMGUI_NOEXCEPT;                                                          					   // only call EndMenu() if BeginMenu() returns true!
-    IMGUI_API bool          MenuItem(const char* label, const char* shortcut = NULL, bool selected = false, bool enabled = true) IMGUI_NOEXCEPT;  // return true when activated.
-    IMGUI_API bool          MenuItem(const char* label, const char* shortcut, bool* p_selected, bool enabled = true)             IMGUI_NOEXCEPT;  // return true when activated + toggle (*p_selected) if p_selected != NULL
+    IMGUI_API bool          BeginMenuBar() IM_NOEXCEPT;                                                                         // append to menu-bar of current window (requires ImGuiWindowFlags_MenuBar flag set on parent window).
+    IMGUI_API void          EndMenuBar() IM_NOEXCEPT;                                                                           // only call EndMenuBar() if BeginMenuBar() returns true!
+    IMGUI_API bool          BeginMainMenuBar() IM_NOEXCEPT;                                                                     // create and append to a full screen menu-bar.
+    IMGUI_API void          EndMainMenuBar() IM_NOEXCEPT;                                                                       // only call EndMainMenuBar() if BeginMainMenuBar() returns true!
+    IMGUI_API bool          BeginMenu(const char* label, bool enabled = true) IM_NOEXCEPT;                                      // create a sub-menu entry. only call EndMenu() if this returns true!
+    IMGUI_API void          EndMenu() IM_NOEXCEPT;                                                          					   // only call EndMenu() if BeginMenu() returns true!
+    IMGUI_API bool          MenuItem(const char* label, const char* shortcut = NULL, bool selected = false, bool enabled = true) IM_NOEXCEPT;  // return true when activated.
+    IMGUI_API bool          MenuItem(const char* label, const char* shortcut, bool* p_selected, bool enabled = true)             IM_NOEXCEPT;  // return true when activated + toggle (*p_selected) if p_selected != NULL
 
     // Tooltips
     // - Tooltip are windows following the mouse. They do not take focus away.
-    IMGUI_API void          BeginTooltip() IMGUI_NOEXCEPT;                                      // begin/append a tooltip window. to create full-featured tooltip (with any kind of items).
-    IMGUI_API void          EndTooltip() IMGUI_NOEXCEPT;
-    IMGUI_API void          SetTooltip(const char* fmt, ...)           IMGUI_NOEXCEPT IM_FMTARGS(1);       // set a text-only tooltip, typically use with ImGui::IsItemHovered(). override any previous call to SetTooltip().
-    IMGUI_API void          SetTooltipV(const char* fmt, va_list args) IMGUI_NOEXCEPT IM_FMTLIST(1);
+    IMGUI_API void          BeginTooltip() IM_NOEXCEPT;                                      // begin/append a tooltip window. to create full-featured tooltip (with any kind of items).
+    IMGUI_API void          EndTooltip() IM_NOEXCEPT;
+    IMGUI_API void          SetTooltip(const char* fmt, ...)           IM_NOEXCEPT IM_FMTARGS(1);       // set a text-only tooltip, typically use with ImGui::IsItemHovered(). override any previous call to SetTooltip().
+    IMGUI_API void          SetTooltipV(const char* fmt, va_list args) IM_NOEXCEPT IM_FMTLIST(1);
 
     // Popups, Modals
     //  - They block normal mouse hovering detection (and therefore most mouse interactions) behind them.
@@ -669,9 +668,9 @@ namespace ImGui
     // Popups: begin/end functions
     //  - BeginPopup(): query popup state, if open start appending into the window. Call EndPopup() afterwards. ImGuiWindowFlags are forwarded to the window.
     //  - BeginPopupModal(): block every interactions behind the window, cannot be closed by user, add a dimming background, has a title bar.
-    IMGUI_API bool          BeginPopup(const char* str_id, ImGuiWindowFlags flags = 0) IMGUI_NOEXCEPT;                         // return true if the popup is open, and you can start outputting to it.
-    IMGUI_API bool          BeginPopupModal(const char* name, bool* p_open = NULL, ImGuiWindowFlags flags = 0) IMGUI_NOEXCEPT; // return true if the modal is open, and you can start outputting to it.
-    IMGUI_API void          EndPopup() IMGUI_NOEXCEPT;                                                                         // only call EndPopup() if BeginPopupXXX() returns true!
+    IMGUI_API bool          BeginPopup(const char* str_id, ImGuiWindowFlags flags = 0) IM_NOEXCEPT;                         // return true if the popup is open, and you can start outputting to it.
+    IMGUI_API bool          BeginPopupModal(const char* name, bool* p_open = NULL, ImGuiWindowFlags flags = 0) IM_NOEXCEPT; // return true if the modal is open, and you can start outputting to it.
+    IMGUI_API void          EndPopup() IM_NOEXCEPT;                                                                         // only call EndPopup() if BeginPopupXXX() returns true!
     // Popups: open/close functions
     //  - OpenPopup(): set popup state to open. ImGuiPopupFlags are available for opening options.
     //  - If not modal: they can be closed by clicking anywhere outside them, or by pressing ESCAPE.
@@ -679,23 +678,23 @@ namespace ImGui
     //  - CloseCurrentPopup() is called by default by Selectable()/MenuItem() when activated (FIXME: need some options).
     //  - Use ImGuiPopupFlags_NoOpenOverExistingPopup to avoid opening a popup if there's already one at the same level. This is equivalent to e.g. testing for !IsAnyPopupOpen() prior to OpenPopup().
     //  - Use IsWindowAppearing() after BeginPopup() to tell if a window just opened.
-    IMGUI_API void          OpenPopup(const char* str_id, ImGuiPopupFlags popup_flags = 0)                      IMGUI_NOEXCEPT;  // call to mark popup as open (don't call every frame!).
-    IMGUI_API void          OpenPopup(ImGuiID id, ImGuiPopupFlags popup_flags = 0)                              IMGUI_NOEXCEPT;  // id overload to facilitate calling from nested stacks
-    IMGUI_API void          OpenPopupOnItemClick(const char* str_id = NULL, ImGuiPopupFlags popup_flags = 1)    IMGUI_NOEXCEPT;  // helper to open popup when clicked on last item. Default to ImGuiPopupFlags_MouseButtonRight == 1. (note: actually triggers on the mouse _released_ event to be consistent with popup behaviors)
-    IMGUI_API void          CloseCurrentPopup()                                                                 IMGUI_NOEXCEPT;  // manually close the popup we have begin-ed into.
+    IMGUI_API void          OpenPopup(const char* str_id, ImGuiPopupFlags popup_flags = 0)                      IM_NOEXCEPT;  // call to mark popup as open (don't call every frame!).
+    IMGUI_API void          OpenPopup(ImGuiID id, ImGuiPopupFlags popup_flags = 0)                              IM_NOEXCEPT;  // id overload to facilitate calling from nested stacks
+    IMGUI_API void          OpenPopupOnItemClick(const char* str_id = NULL, ImGuiPopupFlags popup_flags = 1)    IM_NOEXCEPT;  // helper to open popup when clicked on last item. Default to ImGuiPopupFlags_MouseButtonRight == 1. (note: actually triggers on the mouse _released_ event to be consistent with popup behaviors)
+    IMGUI_API void          CloseCurrentPopup()                                                                 IM_NOEXCEPT;  // manually close the popup we have begin-ed into.
     // Popups: open+begin combined functions helpers
     //  - Helpers to do OpenPopup+BeginPopup where the Open action is triggered by e.g. hovering an item and right-clicking.
     //  - They are convenient to easily create context menus, hence the name.
     //  - IMPORTANT: Notice that BeginPopupContextXXX takes ImGuiPopupFlags just like OpenPopup() and unlike BeginPopup(). For full consistency, we may add ImGuiWindowFlags to the BeginPopupContextXXX functions in the future.
     //  - IMPORTANT: we exceptionally default their flags to 1 (== ImGuiPopupFlags_MouseButtonRight) for backward compatibility with older API taking 'int mouse_button = 1' parameter, so if you add other flags remember to re-add the ImGuiPopupFlags_MouseButtonRight.
-    IMGUI_API bool          BeginPopupContextItem(const char* str_id = NULL, ImGuiPopupFlags popup_flags = 1) IMGUI_NOEXCEPT;  // open+begin popup when clicked on last item. Use str_id==NULL to associate the popup to previous item. If you want to use that on a non-interactive item such as Text() you need to pass in an explicit ID here. read comments in .cpp!
-    IMGUI_API bool          BeginPopupContextWindow(const char* str_id = NULL, ImGuiPopupFlags popup_flags = 1) IMGUI_NOEXCEPT;  // open+begin popup when clicked on current window.
-    IMGUI_API bool          BeginPopupContextVoid(const char* str_id = NULL, ImGuiPopupFlags popup_flags = 1) IMGUI_NOEXCEPT;  // open+begin popup when clicked in void (where there are no windows).
+    IMGUI_API bool          BeginPopupContextItem(const char* str_id = NULL, ImGuiPopupFlags popup_flags = 1) IM_NOEXCEPT;  // open+begin popup when clicked on last item. Use str_id==NULL to associate the popup to previous item. If you want to use that on a non-interactive item such as Text() you need to pass in an explicit ID here. read comments in .cpp!
+    IMGUI_API bool          BeginPopupContextWindow(const char* str_id = NULL, ImGuiPopupFlags popup_flags = 1) IM_NOEXCEPT;  // open+begin popup when clicked on current window.
+    IMGUI_API bool          BeginPopupContextVoid(const char* str_id = NULL, ImGuiPopupFlags popup_flags = 1) IM_NOEXCEPT;  // open+begin popup when clicked in void (where there are no windows).
     // Popups: query functions
     //  - IsPopupOpen(): return true if the popup is open at the current BeginPopup() level of the popup stack.
     //  - IsPopupOpen() with ImGuiPopupFlags_AnyPopupId: return true if any popup is open at the current BeginPopup() level of the popup stack.
     //  - IsPopupOpen() with ImGuiPopupFlags_AnyPopupId + ImGuiPopupFlags_AnyPopupLevel: return true if any popup is open.
-    IMGUI_API bool          IsPopupOpen(const char* str_id, ImGuiPopupFlags flags = 0)                           IMGUI_NOEXCEPT;  // return true if the popup is open.
+    IMGUI_API bool          IsPopupOpen(const char* str_id, ImGuiPopupFlags flags = 0)                           IM_NOEXCEPT;  // return true if the popup is open.
 
     // Tables
     // [BETA API] API may evolve slightly! If you use this, please update to the next version when it comes out!
@@ -722,11 +721,11 @@ namespace ImGui
     //        TableNextRow()                           -> Text("Hello 0")                                               // Not OK! Missing TableSetColumnIndex() or TableNextColumn()! Text will not appear!
     //        --------------------------------------------------------------------------------------------------------
     // - 5. Call EndTable()
-    IMGUI_API bool          BeginTable(const char* str_id, int column, ImGuiTableFlags flags = 0, const ImVec2& outer_size = ImVec2(0.0f, 0.0f), float inner_width = 0.0f) IMGUI_NOEXCEPT;
-    IMGUI_API void          EndTable() IMGUI_NOEXCEPT;                                 // only call EndTable() if BeginTable() returns true!
-    IMGUI_API void          TableNextRow(ImGuiTableRowFlags row_flags = 0, float min_row_height = 0.0f) IMGUI_NOEXCEPT;  // append into the first cell of a new row.
-    IMGUI_API bool          TableNextColumn()                                                           IMGUI_NOEXCEPT;  // append into the next column (or first column of next row if currently in last column). Return true when column is visible.
-    IMGUI_API bool          TableSetColumnIndex(int column_n)                                           IMGUI_NOEXCEPT;  // append into the specified column. Return true when column is visible.
+    IMGUI_API bool          BeginTable(const char* str_id, int column, ImGuiTableFlags flags = 0, const ImVec2& outer_size = ImVec2(0.0f, 0.0f), float inner_width = 0.0f) IM_NOEXCEPT;
+    IMGUI_API void          EndTable() IM_NOEXCEPT;                                 // only call EndTable() if BeginTable() returns true!
+    IMGUI_API void          TableNextRow(ImGuiTableRowFlags row_flags = 0, float min_row_height = 0.0f) IM_NOEXCEPT;  // append into the first cell of a new row.
+    IMGUI_API bool          TableNextColumn()                                                           IM_NOEXCEPT;  // append into the next column (or first column of next row if currently in last column). Return true when column is visible.
+    IMGUI_API bool          TableSetColumnIndex(int column_n)                                           IM_NOEXCEPT;  // append into the specified column. Return true when column is visible.
     // Tables: Headers & Columns declaration
     // - Use TableSetupColumn() to specify label, resizing policy, default width/weight, id, various other flags etc.
     // - Use TableHeadersRow() to create a header row and automatically submit a TableHeader() for each column.
@@ -735,185 +734,185 @@ namespace ImGui
     // - You may manually submit headers using TableNextRow() + TableHeader() calls, but this is only useful in
     //   some advanced use cases (e.g. adding custom widgets in header row).
     // - Use TableSetupScrollFreeze() to lock columns/rows so they stay visible when scrolled.
-    IMGUI_API void          TableSetupColumn(const char* label, ImGuiTableColumnFlags flags = 0, float init_width_or_weight = 0.0f, ImGuiID user_id = 0) IMGUI_NOEXCEPT;
-    IMGUI_API void          TableSetupScrollFreeze(int cols, int rows)                                  IMGUI_NOEXCEPT;  // lock columns/rows so they stay visible when scrolled.
-    IMGUI_API void          TableHeadersRow()                                                           IMGUI_NOEXCEPT;  // submit all headers cells based on data provided to TableSetupColumn() + submit context menu
-    IMGUI_API void          TableHeader(const char* label)                                              IMGUI_NOEXCEPT;  // submit one header cell manually (rarely used)
+    IMGUI_API void          TableSetupColumn(const char* label, ImGuiTableColumnFlags flags = 0, float init_width_or_weight = 0.0f, ImGuiID user_id = 0) IM_NOEXCEPT;
+    IMGUI_API void          TableSetupScrollFreeze(int cols, int rows)                                  IM_NOEXCEPT;  // lock columns/rows so they stay visible when scrolled.
+    IMGUI_API void          TableHeadersRow()                                                           IM_NOEXCEPT;  // submit all headers cells based on data provided to TableSetupColumn() + submit context menu
+    IMGUI_API void          TableHeader(const char* label)                                              IM_NOEXCEPT;  // submit one header cell manually (rarely used)
     // Tables: Sorting
     // - Call TableGetSortSpecs() to retrieve latest sort specs for the table. NULL when not sorting.
     // - When 'SpecsDirty == true' you should sort your data. It will be true when sorting specs have changed
     //   since last call, or the first time. Make sure to set 'SpecsDirty = false' after sorting, else you may
     //   wastefully sort your data every frame!
     // - Lifetime: don't hold on this pointer over multiple frames or past any subsequent call to BeginTable().
-    IMGUI_API ImGuiTableSortSpecs*  TableGetSortSpecs()                                                 IMGUI_NOEXCEPT;  // get latest sort specs for the table (NULL if not sorting).
+    IMGUI_API ImGuiTableSortSpecs*  TableGetSortSpecs()                                                 IM_NOEXCEPT;  // get latest sort specs for the table (NULL if not sorting).
     // Tables: Miscellaneous functions
     // - Functions args 'int column_n' treat the default value of -1 as the same as passing the current column index.
-    IMGUI_API int                   TableGetColumnCount()                                               IMGUI_NOEXCEPT;  // return number of columns (value passed to BeginTable)
-    IMGUI_API int                   TableGetColumnIndex()                                               IMGUI_NOEXCEPT;  // return current column index.
-    IMGUI_API int                   TableGetRowIndex()                                                  IMGUI_NOEXCEPT;  // return current row index.
-    IMGUI_API const char*           TableGetColumnName(int column_n = -1)                               IMGUI_NOEXCEPT;  // return "" if column didn't have a name declared by TableSetupColumn(). Pass -1 to use current column.
-    IMGUI_API ImGuiTableColumnFlags TableGetColumnFlags(int column_n = -1)                              IMGUI_NOEXCEPT;  // return column flags so you can query their Enabled/Visible/Sorted/Hovered status flags. Pass -1 to use current column.
-    IMGUI_API void                  TableSetColumnEnabled(int column_n, bool v)                         IMGUI_NOEXCEPT;  // change enabled/disabled state of a column, set to false to hide the column. Note that end-user can use the context menu to change this themselves (right-click in headers, or right-click in columns body with ImGuiTableFlags_ContextMenuInBody)
-    IMGUI_API void                  TableSetBgColor(ImGuiTableBgTarget target, ImU32 color, int column_n = -1) IMGUI_NOEXCEPT;  // change the color of a cell, row, or column. See ImGuiTableBgTarget_ flags for details.
+    IMGUI_API int                   TableGetColumnCount()                                               IM_NOEXCEPT;  // return number of columns (value passed to BeginTable)
+    IMGUI_API int                   TableGetColumnIndex()                                               IM_NOEXCEPT;  // return current column index.
+    IMGUI_API int                   TableGetRowIndex()                                                  IM_NOEXCEPT;  // return current row index.
+    IMGUI_API const char*           TableGetColumnName(int column_n = -1)                               IM_NOEXCEPT;  // return "" if column didn't have a name declared by TableSetupColumn(). Pass -1 to use current column.
+    IMGUI_API ImGuiTableColumnFlags TableGetColumnFlags(int column_n = -1)                              IM_NOEXCEPT;  // return column flags so you can query their Enabled/Visible/Sorted/Hovered status flags. Pass -1 to use current column.
+    IMGUI_API void                  TableSetColumnEnabled(int column_n, bool v)                         IM_NOEXCEPT;  // change enabled/disabled state of a column, set to false to hide the column. Note that end-user can use the context menu to change this themselves (right-click in headers, or right-click in columns body with ImGuiTableFlags_ContextMenuInBody)
+    IMGUI_API void                  TableSetBgColor(ImGuiTableBgTarget target, ImU32 color, int column_n = -1) IM_NOEXCEPT;  // change the color of a cell, row, or column. See ImGuiTableBgTarget_ flags for details.
 
     // Legacy Columns API (2020: prefer using Tables!)
     // - You can also use SameLine(pos_x) to mimic simplified columns.
-    IMGUI_API void          Columns(int count = 1, const char* id = NULL, bool border = true)           IMGUI_NOEXCEPT;
-    IMGUI_API void          NextColumn()                                                                IMGUI_NOEXCEPT;  // next column, defaults to current row or next row if the current row is finished
-    IMGUI_API int           GetColumnIndex()                                                            IMGUI_NOEXCEPT;  // get current column index
-    IMGUI_API float         GetColumnWidth(int column_index = -1)                                       IMGUI_NOEXCEPT;  // get column width (in pixels). pass -1 to use current column
-    IMGUI_API void          SetColumnWidth(int column_index, float width)                               IMGUI_NOEXCEPT;  // set column width (in pixels). pass -1 to use current column
-    IMGUI_API float         GetColumnOffset(int column_index = -1)                                      IMGUI_NOEXCEPT;  // get position of column line (in pixels, from the left side of the contents region). pass -1 to use current column, otherwise 0..GetColumnsCount() inclusive. column 0 is typically 0.0f
-    IMGUI_API void          SetColumnOffset(int column_index, float offset_x)                           IMGUI_NOEXCEPT;  // set position of column line (in pixels, from the left side of the contents region). pass -1 to use current column
-    IMGUI_API int           GetColumnsCount()                                                           IMGUI_NOEXCEPT;
+    IMGUI_API void          Columns(int count = 1, const char* id = NULL, bool border = true)           IM_NOEXCEPT;
+    IMGUI_API void          NextColumn()                                                                IM_NOEXCEPT;  // next column, defaults to current row or next row if the current row is finished
+    IMGUI_API int           GetColumnIndex()                                                            IM_NOEXCEPT;  // get current column index
+    IMGUI_API float         GetColumnWidth(int column_index = -1)                                       IM_NOEXCEPT;  // get column width (in pixels). pass -1 to use current column
+    IMGUI_API void          SetColumnWidth(int column_index, float width)                               IM_NOEXCEPT;  // set column width (in pixels). pass -1 to use current column
+    IMGUI_API float         GetColumnOffset(int column_index = -1)                                      IM_NOEXCEPT;  // get position of column line (in pixels, from the left side of the contents region). pass -1 to use current column, otherwise 0..GetColumnsCount() inclusive. column 0 is typically 0.0f
+    IMGUI_API void          SetColumnOffset(int column_index, float offset_x)                           IM_NOEXCEPT;  // set position of column line (in pixels, from the left side of the contents region). pass -1 to use current column
+    IMGUI_API int           GetColumnsCount()                                                           IM_NOEXCEPT;
 
     // Tab Bars, Tabs
-    IMGUI_API bool          BeginTabBar(const char* str_id, ImGuiTabBarFlags flags = 0) IMGUI_NOEXCEPT;        // create and append into a TabBar
-    IMGUI_API void          EndTabBar() IMGUI_NOEXCEPT;                                                        // only call EndTabBar() if BeginTabBar() returns true!
-    IMGUI_API bool          BeginTabItem(const char* label, bool* p_open = NULL, ImGuiTabItemFlags flags = 0) IMGUI_NOEXCEPT;  // create a Tab. Returns true if the Tab is selected.
-    IMGUI_API void          EndTabItem() IMGUI_NOEXCEPT;                                                       // only call EndTabItem() if BeginTabItem() returns true!
-    IMGUI_API bool          TabItemButton(const char* label, ImGuiTabItemFlags flags = 0)                 IMGUI_NOEXCEPT;  // create a Tab behaving like a button. return true when clicked. cannot be selected in the tab bar.
-    IMGUI_API void          SetTabItemClosed(const char* tab_or_docked_window_label)                      IMGUI_NOEXCEPT;  // notify TabBar or Docking system of a closed tab/window ahead (useful to reduce visual flicker on reorderable tab bars). For tab-bar: call after BeginTabBar() and before Tab submissions. Otherwise call with a window name.
+    IMGUI_API bool          BeginTabBar(const char* str_id, ImGuiTabBarFlags flags = 0) IM_NOEXCEPT;        // create and append into a TabBar
+    IMGUI_API void          EndTabBar() IM_NOEXCEPT;                                                        // only call EndTabBar() if BeginTabBar() returns true!
+    IMGUI_API bool          BeginTabItem(const char* label, bool* p_open = NULL, ImGuiTabItemFlags flags = 0) IM_NOEXCEPT;  // create a Tab. Returns true if the Tab is selected.
+    IMGUI_API void          EndTabItem() IM_NOEXCEPT;                                                       // only call EndTabItem() if BeginTabItem() returns true!
+    IMGUI_API bool          TabItemButton(const char* label, ImGuiTabItemFlags flags = 0)                 IM_NOEXCEPT;  // create a Tab behaving like a button. return true when clicked. cannot be selected in the tab bar.
+    IMGUI_API void          SetTabItemClosed(const char* tab_or_docked_window_label)                      IM_NOEXCEPT;  // notify TabBar or Docking system of a closed tab/window ahead (useful to reduce visual flicker on reorderable tab bars). For tab-bar: call after BeginTabBar() and before Tab submissions. Otherwise call with a window name.
 
     // Logging/Capture
     // - All text output from the interface can be captured into tty/file/clipboard. By default, tree nodes are automatically opened during logging.
-    IMGUI_API void          LogToTTY(int auto_open_depth = -1)                                            IMGUI_NOEXCEPT;  // start logging to tty (stdout)
-    IMGUI_API void          LogToFile(int auto_open_depth = -1, const char* filename = NULL)              IMGUI_NOEXCEPT;  // start logging to file
-    IMGUI_API void          LogToClipboard(int auto_open_depth = -1)                                      IMGUI_NOEXCEPT;  // start logging to OS clipboard
-    IMGUI_API void          LogFinish()                                                                   IMGUI_NOEXCEPT;  // stop logging (close file, etc.)
-    IMGUI_API void          LogButtons()                                                                  IMGUI_NOEXCEPT;  // helper to display buttons for logging to tty/file/clipboard
-    IMGUI_API void          LogText(const char* fmt, ...)                                                 IMGUI_NOEXCEPT IM_FMTARGS(1);  // pass text data straight to log (without being displayed)
-    IMGUI_API void          LogTextV(const char* fmt, va_list args)                                       IMGUI_NOEXCEPT IM_FMTLIST(1);
+    IMGUI_API void          LogToTTY(int auto_open_depth = -1)                                            IM_NOEXCEPT;  // start logging to tty (stdout)
+    IMGUI_API void          LogToFile(int auto_open_depth = -1, const char* filename = NULL)              IM_NOEXCEPT;  // start logging to file
+    IMGUI_API void          LogToClipboard(int auto_open_depth = -1)                                      IM_NOEXCEPT;  // start logging to OS clipboard
+    IMGUI_API void          LogFinish()                                                                   IM_NOEXCEPT;  // stop logging (close file, etc.)
+    IMGUI_API void          LogButtons()                                                                  IM_NOEXCEPT;  // helper to display buttons for logging to tty/file/clipboard
+    IMGUI_API void          LogText(const char* fmt, ...)                                                 IM_NOEXCEPT IM_FMTARGS(1);  // pass text data straight to log (without being displayed)
+    IMGUI_API void          LogTextV(const char* fmt, va_list args)                                       IM_NOEXCEPT IM_FMTLIST(1);
 
     // Drag and Drop
     // - On source items, call BeginDragDropSource(), if it returns true also call SetDragDropPayload() + EndDragDropSource().
     // - On target candidates, call BeginDragDropTarget(), if it returns true also call AcceptDragDropPayload() + EndDragDropTarget().
     // - If you stop calling BeginDragDropSource() the payload is preserved however it won't have a preview tooltip (we currently display a fallback "..." tooltip, see #1725)
     // - An item can be both drag source and drop target.
-    IMGUI_API bool          BeginDragDropSource(ImGuiDragDropFlags flags = 0) IMGUI_NOEXCEPT;                       // call after submitting an item which may be dragged. when this return true, you can call SetDragDropPayload() + EndDragDropSource()
-    IMGUI_API bool          SetDragDropPayload(const char* type, const void* data, size_t sz, ImGuiCond cond = 0) IMGUI_NOEXCEPT;  // type is a user defined string of maximum 32 characters. Strings starting with '_' are reserved for dear imgui internal types. Data is copied and held by imgui.
-    IMGUI_API void          EndDragDropSource() IMGUI_NOEXCEPT;                                                     // only call EndDragDropSource() if BeginDragDropSource() returns true!
-    IMGUI_API bool                  BeginDragDropTarget() IMGUI_NOEXCEPT;                                           // call after submitting an item that may receive a payload. If this returns true, you can call AcceptDragDropPayload() + EndDragDropTarget()
-    IMGUI_API const ImGuiPayload*   AcceptDragDropPayload(const char* type, ImGuiDragDropFlags flags = 0) IMGUI_NOEXCEPT;   // accept contents of a given type. If ImGuiDragDropFlags_AcceptBeforeDelivery is set you can peek into the payload before the mouse button is released.
-    IMGUI_API void                  EndDragDropTarget() IMGUI_NOEXCEPT;                                             // only call EndDragDropTarget() if BeginDragDropTarget() returns true!
-    IMGUI_API const ImGuiPayload*   GetDragDropPayload()                                                  IMGUI_NOEXCEPT;   // peek directly into the current payload from anywhere. may return NULL. use ImGuiPayload::IsDataType() to test for the payload type.
+    IMGUI_API bool          BeginDragDropSource(ImGuiDragDropFlags flags = 0) IM_NOEXCEPT;                       // call after submitting an item which may be dragged. when this return true, you can call SetDragDropPayload() + EndDragDropSource()
+    IMGUI_API bool          SetDragDropPayload(const char* type, const void* data, size_t sz, ImGuiCond cond = 0) IM_NOEXCEPT;  // type is a user defined string of maximum 32 characters. Strings starting with '_' are reserved for dear imgui internal types. Data is copied and held by imgui.
+    IMGUI_API void          EndDragDropSource() IM_NOEXCEPT;                                                     // only call EndDragDropSource() if BeginDragDropSource() returns true!
+    IMGUI_API bool                  BeginDragDropTarget() IM_NOEXCEPT;                                           // call after submitting an item that may receive a payload. If this returns true, you can call AcceptDragDropPayload() + EndDragDropTarget()
+    IMGUI_API const ImGuiPayload*   AcceptDragDropPayload(const char* type, ImGuiDragDropFlags flags = 0) IM_NOEXCEPT;   // accept contents of a given type. If ImGuiDragDropFlags_AcceptBeforeDelivery is set you can peek into the payload before the mouse button is released.
+    IMGUI_API void                  EndDragDropTarget() IM_NOEXCEPT;                                             // only call EndDragDropTarget() if BeginDragDropTarget() returns true!
+    IMGUI_API const ImGuiPayload*   GetDragDropPayload()                                                  IM_NOEXCEPT;   // peek directly into the current payload from anywhere. may return NULL. use ImGuiPayload::IsDataType() to test for the payload type.
 
     // Clipping
     // - Mouse hovering is affected by ImGui::PushClipRect() calls, unlike direct calls to ImDrawList::PushClipRect() which are render only.
-    IMGUI_API void          PushClipRect(const ImVec2& clip_rect_min, const ImVec2& clip_rect_max, bool intersect_with_current_clip_rect) IMGUI_NOEXCEPT;
-    IMGUI_API void          PopClipRect() IMGUI_NOEXCEPT;
+    IMGUI_API void          PushClipRect(const ImVec2& clip_rect_min, const ImVec2& clip_rect_max, bool intersect_with_current_clip_rect) IM_NOEXCEPT;
+    IMGUI_API void          PopClipRect() IM_NOEXCEPT;
 
     // Focus, Activation
     // - Prefer using "SetItemDefaultFocus()" over "if (IsWindowAppearing()) SetScrollHereY()" when applicable to signify "this is the default item"
-    IMGUI_API void          SetItemDefaultFocus() IMGUI_NOEXCEPT;                                              // make last item the default focused item of a window.
-    IMGUI_API void          SetKeyboardFocusHere(int offset = 0) IMGUI_NOEXCEPT;                               // focus keyboard on the next widget. Use positive 'offset' to access sub components of a multiple component widget. Use -1 to access previous widget.
+    IMGUI_API void          SetItemDefaultFocus() IM_NOEXCEPT;                                              // make last item the default focused item of a window.
+    IMGUI_API void          SetKeyboardFocusHere(int offset = 0) IM_NOEXCEPT;                               // focus keyboard on the next widget. Use positive 'offset' to access sub components of a multiple component widget. Use -1 to access previous widget.
 
     // Item/Widgets Utilities and Query Functions
     // - Most of the functions are referring to the previous Item that has been submitted.
     // - See Demo Window under "Widgets->Querying Status" for an interactive visualization of most of those functions.
-    IMGUI_API bool          IsItemHovered(ImGuiHoveredFlags flags = 0)                                    IMGUI_NOEXCEPT;  // is the last item hovered? (and usable, aka not blocked by a popup, etc.). See ImGuiHoveredFlags for more options.
-    IMGUI_API bool          IsItemActive()                                                                IMGUI_NOEXCEPT;  // is the last item active? (e.g. button being held, text field being edited. This will continuously return true while holding mouse button on an item. Items that don't interact will always return false)
-    IMGUI_API bool          IsItemFocused()                                                               IMGUI_NOEXCEPT;  // is the last item focused for keyboard/gamepad navigation?
-    IMGUI_API bool          IsItemClicked(ImGuiMouseButton mouse_button = 0)                              IMGUI_NOEXCEPT;  // is the last item hovered and mouse clicked on? (**)  == IsMouseClicked(mouse_button) && IsItemHovered()Important. (**) this it NOT equivalent to the behavior of e.g. Button(). Read comments in function definition.
-    IMGUI_API bool          IsItemVisible()                                                               IMGUI_NOEXCEPT;  // is the last item visible? (items may be out of sight because of clipping/scrolling)
-    IMGUI_API bool          IsItemEdited()                                                                IMGUI_NOEXCEPT;  // did the last item modify its underlying value this frame? or was pressed? This is generally the same as the "bool" return value of many widgets.
-    IMGUI_API bool          IsItemActivated()                                                             IMGUI_NOEXCEPT;  // was the last item just made active (item was previously inactive).
-    IMGUI_API bool          IsItemDeactivated()                                                           IMGUI_NOEXCEPT;  // was the last item just made inactive (item was previously active). Useful for Undo/Redo patterns with widgets that requires continuous editing.
-    IMGUI_API bool          IsItemDeactivatedAfterEdit()                                                  IMGUI_NOEXCEPT;  // was the last item just made inactive and made a value change when it was active? (e.g. Slider/Drag moved). Useful for Undo/Redo patterns with widgets that requires continuous editing. Note that you may get false positives (some widgets such as Combo()/ListBox()/Selectable() will return true even when clicking an already selected item).
-    IMGUI_API bool          IsItemToggledOpen()                                                           IMGUI_NOEXCEPT;  // was the last item open state toggled? set by TreeNode().
-    IMGUI_API bool          IsAnyItemHovered()                                                            IMGUI_NOEXCEPT;  // is any item hovered?
-    IMGUI_API bool          IsAnyItemActive()                                                             IMGUI_NOEXCEPT;  // is any item active?
-    IMGUI_API bool          IsAnyItemFocused()                                                            IMGUI_NOEXCEPT;  // is any item focused?
-    IMGUI_API ImVec2        GetItemRectMin()                                                              IMGUI_NOEXCEPT;  // get upper-left bounding rectangle of the last item (screen space)
-    IMGUI_API ImVec2        GetItemRectMax()                                                              IMGUI_NOEXCEPT;  // get lower-right bounding rectangle of the last item (screen space)
-    IMGUI_API ImVec2        GetItemRectSize()                                                             IMGUI_NOEXCEPT;  // get size of last item
-    IMGUI_API void          SetItemAllowOverlap()                                                         IMGUI_NOEXCEPT;  // allow last item to be overlapped by a subsequent item. sometimes useful with invisible buttons, selectables, etc. to catch unused area.
+    IMGUI_API bool          IsItemHovered(ImGuiHoveredFlags flags = 0)                                    IM_NOEXCEPT;  // is the last item hovered? (and usable, aka not blocked by a popup, etc.). See ImGuiHoveredFlags for more options.
+    IMGUI_API bool          IsItemActive()                                                                IM_NOEXCEPT;  // is the last item active? (e.g. button being held, text field being edited. This will continuously return true while holding mouse button on an item. Items that don't interact will always return false)
+    IMGUI_API bool          IsItemFocused()                                                               IM_NOEXCEPT;  // is the last item focused for keyboard/gamepad navigation?
+    IMGUI_API bool          IsItemClicked(ImGuiMouseButton mouse_button = 0)                              IM_NOEXCEPT;  // is the last item hovered and mouse clicked on? (**)  == IsMouseClicked(mouse_button) && IsItemHovered()Important. (**) this it NOT equivalent to the behavior of e.g. Button(). Read comments in function definition.
+    IMGUI_API bool          IsItemVisible()                                                               IM_NOEXCEPT;  // is the last item visible? (items may be out of sight because of clipping/scrolling)
+    IMGUI_API bool          IsItemEdited()                                                                IM_NOEXCEPT;  // did the last item modify its underlying value this frame? or was pressed? This is generally the same as the "bool" return value of many widgets.
+    IMGUI_API bool          IsItemActivated()                                                             IM_NOEXCEPT;  // was the last item just made active (item was previously inactive).
+    IMGUI_API bool          IsItemDeactivated()                                                           IM_NOEXCEPT;  // was the last item just made inactive (item was previously active). Useful for Undo/Redo patterns with widgets that requires continuous editing.
+    IMGUI_API bool          IsItemDeactivatedAfterEdit()                                                  IM_NOEXCEPT;  // was the last item just made inactive and made a value change when it was active? (e.g. Slider/Drag moved). Useful for Undo/Redo patterns with widgets that requires continuous editing. Note that you may get false positives (some widgets such as Combo()/ListBox()/Selectable() will return true even when clicking an already selected item).
+    IMGUI_API bool          IsItemToggledOpen()                                                           IM_NOEXCEPT;  // was the last item open state toggled? set by TreeNode().
+    IMGUI_API bool          IsAnyItemHovered()                                                            IM_NOEXCEPT;  // is any item hovered?
+    IMGUI_API bool          IsAnyItemActive()                                                             IM_NOEXCEPT;  // is any item active?
+    IMGUI_API bool          IsAnyItemFocused()                                                            IM_NOEXCEPT;  // is any item focused?
+    IMGUI_API ImVec2        GetItemRectMin()                                                              IM_NOEXCEPT;  // get upper-left bounding rectangle of the last item (screen space)
+    IMGUI_API ImVec2        GetItemRectMax()                                                              IM_NOEXCEPT;  // get lower-right bounding rectangle of the last item (screen space)
+    IMGUI_API ImVec2        GetItemRectSize()                                                             IM_NOEXCEPT;  // get size of last item
+    IMGUI_API void          SetItemAllowOverlap()                                                         IM_NOEXCEPT;  // allow last item to be overlapped by a subsequent item. sometimes useful with invisible buttons, selectables, etc. to catch unused area.
 
     // Viewports
     // - Currently represents the Platform Window created by the application which is hosting our Dear ImGui windows.
     // - In 'docking' branch with multi-viewport enabled, we extend this concept to have multiple active viewports.
     // - In the future we will extend this concept further to also represent Platform Monitor and support a "no main platform window" operation mode.
-    IMGUI_API ImGuiViewport* GetMainViewport() IMGUI_NOEXCEPT;                                                 // return primary/default viewport. This can never be NULL.
+    IMGUI_API ImGuiViewport* GetMainViewport() IM_NOEXCEPT;                                                 // return primary/default viewport. This can never be NULL.
 
     // Miscellaneous Utilities
-    IMGUI_API bool          IsRectVisible(const ImVec2& size)                                             IMGUI_NOEXCEPT;  // test if rectangle (of given size, starting from cursor position) is visible / not clipped.
-    IMGUI_API bool          IsRectVisible(const ImVec2& rect_min, const ImVec2& rect_max)                 IMGUI_NOEXCEPT;  // test if rectangle (in screen space) is visible / not clipped. to perform coarse clipping on user's side.
-    IMGUI_API double        GetTime()                                                                     IMGUI_NOEXCEPT;  // get global imgui time. incremented by io.DeltaTime every frame.
-    IMGUI_API int           GetFrameCount()                                                               IMGUI_NOEXCEPT;  // get global imgui frame count. incremented by 1 every frame.
-    IMGUI_API ImDrawList*   GetBackgroundDrawList()                                                       IMGUI_NOEXCEPT;  // this draw list will be the first rendering one. Useful to quickly draw shapes/text behind dear imgui contents.
-    IMGUI_API ImDrawList*   GetForegroundDrawList()                                                       IMGUI_NOEXCEPT;  // this draw list will be the last rendered one. Useful to quickly draw shapes/text over dear imgui contents.
-    IMGUI_API ImDrawListSharedData* GetDrawListSharedData()                                               IMGUI_NOEXCEPT;  // you may use this when creating your own ImDrawList instances.
-    IMGUI_API const char*   GetStyleColorName(ImGuiCol idx)                                               IMGUI_NOEXCEPT;  // get a string corresponding to the enum value (for display, saving, etc.).
-    IMGUI_API void          SetStateStorage(ImGuiStorage* storage)                                        IMGUI_NOEXCEPT;  // replace current window storage with our own (if you want to manipulate it yourself, typically clear subsection of it)
-    IMGUI_API ImGuiStorage* GetStateStorage()                                                             IMGUI_NOEXCEPT;
-    IMGUI_API void          CalcListClipping(int items_count, float items_height, int* out_items_display_start, int* out_items_display_end) IMGUI_NOEXCEPT;  // calculate coarse clipping for large list of evenly sized items. Prefer using the ImGuiListClipper higher-level helper if you can.
-    IMGUI_API bool          BeginChildFrame(ImGuiID id, const ImVec2& size, ImGuiWindowFlags flags = 0) IMGUI_NOEXCEPT;  // helper to create a child window / scrolling region that looks like a normal widget frame
-    IMGUI_API void          EndChildFrame() IMGUI_NOEXCEPT;                                     // always call EndChildFrame() regardless of BeginChildFrame() return values (which indicates a collapsed/clipped window)
+    IMGUI_API bool          IsRectVisible(const ImVec2& size)                                             IM_NOEXCEPT;  // test if rectangle (of given size, starting from cursor position) is visible / not clipped.
+    IMGUI_API bool          IsRectVisible(const ImVec2& rect_min, const ImVec2& rect_max)                 IM_NOEXCEPT;  // test if rectangle (in screen space) is visible / not clipped. to perform coarse clipping on user's side.
+    IMGUI_API double        GetTime()                                                                     IM_NOEXCEPT;  // get global imgui time. incremented by io.DeltaTime every frame.
+    IMGUI_API int           GetFrameCount()                                                               IM_NOEXCEPT;  // get global imgui frame count. incremented by 1 every frame.
+    IMGUI_API ImDrawList*   GetBackgroundDrawList()                                                       IM_NOEXCEPT;  // this draw list will be the first rendering one. Useful to quickly draw shapes/text behind dear imgui contents.
+    IMGUI_API ImDrawList*   GetForegroundDrawList()                                                       IM_NOEXCEPT;  // this draw list will be the last rendered one. Useful to quickly draw shapes/text over dear imgui contents.
+    IMGUI_API ImDrawListSharedData* GetDrawListSharedData()                                               IM_NOEXCEPT;  // you may use this when creating your own ImDrawList instances.
+    IMGUI_API const char*   GetStyleColorName(ImGuiCol idx)                                               IM_NOEXCEPT;  // get a string corresponding to the enum value (for display, saving, etc.).
+    IMGUI_API void          SetStateStorage(ImGuiStorage* storage)                                        IM_NOEXCEPT;  // replace current window storage with our own (if you want to manipulate it yourself, typically clear subsection of it)
+    IMGUI_API ImGuiStorage* GetStateStorage()                                                             IM_NOEXCEPT;
+    IMGUI_API void          CalcListClipping(int items_count, float items_height, int* out_items_display_start, int* out_items_display_end) IM_NOEXCEPT;  // calculate coarse clipping for large list of evenly sized items. Prefer using the ImGuiListClipper higher-level helper if you can.
+    IMGUI_API bool          BeginChildFrame(ImGuiID id, const ImVec2& size, ImGuiWindowFlags flags = 0) IM_NOEXCEPT;  // helper to create a child window / scrolling region that looks like a normal widget frame
+    IMGUI_API void          EndChildFrame() IM_NOEXCEPT;                                     // always call EndChildFrame() regardless of BeginChildFrame() return values (which indicates a collapsed/clipped window)
 
     // Text Utilities
-    IMGUI_API ImVec2        CalcTextSize(const char* text, const char* text_end = NULL, bool hide_text_after_double_hash = false, float wrap_width = -1.0f) IMGUI_NOEXCEPT;
+    IMGUI_API ImVec2        CalcTextSize(const char* text, const char* text_end = NULL, bool hide_text_after_double_hash = false, float wrap_width = -1.0f) IM_NOEXCEPT;
 
     // Color Utilities
-    IMGUI_API ImVec4        ColorConvertU32ToFloat4(ImU32 in)                                                         IMGUI_NOEXCEPT;
-    IMGUI_API ImU32         ColorConvertFloat4ToU32(const ImVec4& in)                                                 IMGUI_NOEXCEPT;
-    IMGUI_API void          ColorConvertRGBtoHSV(float r, float g, float b, float& out_h, float& out_s, float& out_v) IMGUI_NOEXCEPT;
-    IMGUI_API void          ColorConvertHSVtoRGB(float h, float s, float v, float& out_r, float& out_g, float& out_b) IMGUI_NOEXCEPT;
+    IMGUI_API ImVec4        ColorConvertU32ToFloat4(ImU32 in)                                                         IM_NOEXCEPT;
+    IMGUI_API ImU32         ColorConvertFloat4ToU32(const ImVec4& in)                                                 IM_NOEXCEPT;
+    IMGUI_API void          ColorConvertRGBtoHSV(float r, float g, float b, float& out_h, float& out_s, float& out_v) IM_NOEXCEPT;
+    IMGUI_API void          ColorConvertHSVtoRGB(float h, float s, float v, float& out_r, float& out_g, float& out_b) IM_NOEXCEPT;
 
     // Inputs Utilities: Keyboard
     // - For 'int user_key_index' you can use your own indices/enums according to how your backend/engine stored them in io.KeysDown[].
     // - We don't know the meaning of those value. You can use GetKeyIndex() to map a ImGuiKey_ value into the user index.
-    IMGUI_API int           GetKeyIndex(ImGuiKey imgui_key)                                    IMGUI_NOEXCEPT;  // map ImGuiKey_* values into user's key index. == io.KeyMap[key]
-    IMGUI_API bool          IsKeyDown(int user_key_index)                                      IMGUI_NOEXCEPT;  // is key being held. == io.KeysDown[user_key_index].
-    IMGUI_API bool          IsKeyPressed(int user_key_index, bool repeat = true)               IMGUI_NOEXCEPT;  // was key pressed (went from !Down to Down)? if repeat=true, uses io.KeyRepeatDelay / KeyRepeatRate
-    IMGUI_API bool          IsKeyReleased(int user_key_index)                                  IMGUI_NOEXCEPT;  // was key released (went from Down to !Down)?
-    IMGUI_API int           GetKeyPressedAmount(int key_index, float repeat_delay, float rate) IMGUI_NOEXCEPT;  // uses provided repeat rate/delay. return a count, most often 0 or 1 but might be >1 if RepeatRate is small enough that DeltaTime > RepeatRate
-    IMGUI_API void          CaptureKeyboardFromApp(bool want_capture_keyboard_value = true)    IMGUI_NOEXCEPT;  // attention: misleading name! manually override io.WantCaptureKeyboard flag next frame (said flag is entirely left for your application to handle). e.g. force capture keyboard when your widget is being hovered. This is equivalent to setting "io.WantCaptureKeyboard = want_capture_keyboard_value"; after the next NewFrame() call.
+    IMGUI_API int           GetKeyIndex(ImGuiKey imgui_key)                                    IM_NOEXCEPT;  // map ImGuiKey_* values into user's key index. == io.KeyMap[key]
+    IMGUI_API bool          IsKeyDown(int user_key_index)                                      IM_NOEXCEPT;  // is key being held. == io.KeysDown[user_key_index].
+    IMGUI_API bool          IsKeyPressed(int user_key_index, bool repeat = true)               IM_NOEXCEPT;  // was key pressed (went from !Down to Down)? if repeat=true, uses io.KeyRepeatDelay / KeyRepeatRate
+    IMGUI_API bool          IsKeyReleased(int user_key_index)                                  IM_NOEXCEPT;  // was key released (went from Down to !Down)?
+    IMGUI_API int           GetKeyPressedAmount(int key_index, float repeat_delay, float rate) IM_NOEXCEPT;  // uses provided repeat rate/delay. return a count, most often 0 or 1 but might be >1 if RepeatRate is small enough that DeltaTime > RepeatRate
+    IMGUI_API void          CaptureKeyboardFromApp(bool want_capture_keyboard_value = true)    IM_NOEXCEPT;  // attention: misleading name! manually override io.WantCaptureKeyboard flag next frame (said flag is entirely left for your application to handle). e.g. force capture keyboard when your widget is being hovered. This is equivalent to setting "io.WantCaptureKeyboard = want_capture_keyboard_value"; after the next NewFrame() call.
 
     // Inputs Utilities: Mouse
     // - To refer to a mouse button, you may use named enums in your code e.g. ImGuiMouseButton_Left, ImGuiMouseButton_Right.
     // - You can also use regular integer: it is forever guaranteed that 0=Left, 1=Right, 2=Middle.
     // - Dragging operations are only reported after mouse has moved a certain distance away from the initial clicking position (see 'lock_threshold' and 'io.MouseDraggingThreshold')
-    IMGUI_API bool          IsMouseDown(ImGuiMouseButton button) IMGUI_NOEXCEPT;                               // is mouse button held?
-    IMGUI_API bool          IsMouseClicked(ImGuiMouseButton button, bool repeat = false) IMGUI_NOEXCEPT;       // did mouse button clicked? (went from !Down to Down)
-    IMGUI_API bool          IsMouseReleased(ImGuiMouseButton button) IMGUI_NOEXCEPT;                           // did mouse button released? (went from Down to !Down)
-    IMGUI_API bool          IsMouseDoubleClicked(ImGuiMouseButton button) IMGUI_NOEXCEPT;                      // did mouse button double-clicked? (note that a double-click will also report IsMouseClicked() == true)
-    IMGUI_API bool          IsMouseHoveringRect(const ImVec2& r_min, const ImVec2& r_max, bool clip = true) IMGUI_NOEXCEPT;// is mouse hovering given bounding rect (in screen space). clipped by current clipping settings, but disregarding of other consideration of focus/window ordering/popup-block.
-    IMGUI_API bool          IsMousePosValid(const ImVec2* mouse_pos = NULL) IMGUI_NOEXCEPT;                    // by convention we use (-FLT_MAX,-FLT_MAX) to denote that there is no mouse available
-    IMGUI_API bool          IsAnyMouseDown() IMGUI_NOEXCEPT;                                                   // is any mouse button held?
-    IMGUI_API ImVec2        GetMousePos() IMGUI_NOEXCEPT;                                                      // shortcut to ImGui::GetIO().MousePos provided by user, to be consistent with other calls
-    IMGUI_API ImVec2        GetMousePosOnOpeningCurrentPopup() IMGUI_NOEXCEPT;                                 // retrieve mouse position at the time of opening popup we have BeginPopup() into (helper to avoid user backing that value themselves)
-    IMGUI_API bool          IsMouseDragging(ImGuiMouseButton button, float lock_threshold = -1.0f) IMGUI_NOEXCEPT;         // is mouse dragging? (if lock_threshold < -1.0f, uses io.MouseDraggingThreshold)
-    IMGUI_API ImVec2        GetMouseDragDelta(ImGuiMouseButton button = 0, float lock_threshold = -1.0f) IMGUI_NOEXCEPT;   // return the delta from the initial clicking position while the mouse button is pressed or was just released. This is locked and return 0.0f until the mouse moves past a distance threshold at least once (if lock_threshold < -1.0f, uses io.MouseDraggingThreshold)
-    IMGUI_API void          ResetMouseDragDelta(ImGuiMouseButton button = 0) IMGUI_NOEXCEPT;                   //
-    IMGUI_API ImGuiMouseCursor GetMouseCursor() IMGUI_NOEXCEPT;                                                // get desired cursor type, reset in ImGui::NewFrame(), this is updated during the frame. valid before Render(). If you use software rendering by setting io.MouseDrawCursor ImGui will render those for you
-    IMGUI_API void          SetMouseCursor(ImGuiMouseCursor cursor_type) IMGUI_NOEXCEPT;                       // set desired cursor type
-    IMGUI_API void          CaptureMouseFromApp(bool want_capture_mouse_value = true) IMGUI_NOEXCEPT;          // attention: misleading name! manually override io.WantCaptureMouse flag next frame (said flag is entirely left for your application to handle). This is equivalent to setting "io.WantCaptureMouse = want_capture_mouse_value;" after the next NewFrame() call.
+    IMGUI_API bool          IsMouseDown(ImGuiMouseButton button) IM_NOEXCEPT;                               // is mouse button held?
+    IMGUI_API bool          IsMouseClicked(ImGuiMouseButton button, bool repeat = false) IM_NOEXCEPT;       // did mouse button clicked? (went from !Down to Down)
+    IMGUI_API bool          IsMouseReleased(ImGuiMouseButton button) IM_NOEXCEPT;                           // did mouse button released? (went from Down to !Down)
+    IMGUI_API bool          IsMouseDoubleClicked(ImGuiMouseButton button) IM_NOEXCEPT;                      // did mouse button double-clicked? (note that a double-click will also report IsMouseClicked() == true)
+    IMGUI_API bool          IsMouseHoveringRect(const ImVec2& r_min, const ImVec2& r_max, bool clip = true) IM_NOEXCEPT;// is mouse hovering given bounding rect (in screen space). clipped by current clipping settings, but disregarding of other consideration of focus/window ordering/popup-block.
+    IMGUI_API bool          IsMousePosValid(const ImVec2* mouse_pos = NULL) IM_NOEXCEPT;                    // by convention we use (-FLT_MAX,-FLT_MAX) to denote that there is no mouse available
+    IMGUI_API bool          IsAnyMouseDown() IM_NOEXCEPT;                                                   // is any mouse button held?
+    IMGUI_API ImVec2        GetMousePos() IM_NOEXCEPT;                                                      // shortcut to ImGui::GetIO().MousePos provided by user, to be consistent with other calls
+    IMGUI_API ImVec2        GetMousePosOnOpeningCurrentPopup() IM_NOEXCEPT;                                 // retrieve mouse position at the time of opening popup we have BeginPopup() into (helper to avoid user backing that value themselves)
+    IMGUI_API bool          IsMouseDragging(ImGuiMouseButton button, float lock_threshold = -1.0f) IM_NOEXCEPT;         // is mouse dragging? (if lock_threshold < -1.0f, uses io.MouseDraggingThreshold)
+    IMGUI_API ImVec2        GetMouseDragDelta(ImGuiMouseButton button = 0, float lock_threshold = -1.0f) IM_NOEXCEPT;   // return the delta from the initial clicking position while the mouse button is pressed or was just released. This is locked and return 0.0f until the mouse moves past a distance threshold at least once (if lock_threshold < -1.0f, uses io.MouseDraggingThreshold)
+    IMGUI_API void          ResetMouseDragDelta(ImGuiMouseButton button = 0) IM_NOEXCEPT;                   //
+    IMGUI_API ImGuiMouseCursor GetMouseCursor() IM_NOEXCEPT;                                                // get desired cursor type, reset in ImGui::NewFrame(), this is updated during the frame. valid before Render(). If you use software rendering by setting io.MouseDrawCursor ImGui will render those for you
+    IMGUI_API void          SetMouseCursor(ImGuiMouseCursor cursor_type) IM_NOEXCEPT;                       // set desired cursor type
+    IMGUI_API void          CaptureMouseFromApp(bool want_capture_mouse_value = true) IM_NOEXCEPT;          // attention: misleading name! manually override io.WantCaptureMouse flag next frame (said flag is entirely left for your application to handle). This is equivalent to setting "io.WantCaptureMouse = want_capture_mouse_value;" after the next NewFrame() call.
 
     // Clipboard Utilities
     // - Also see the LogToClipboard() function to capture GUI into clipboard, or easily output text data to the clipboard.
-    IMGUI_API const char*   GetClipboardText() IMGUI_NOEXCEPT;
-    IMGUI_API void          SetClipboardText(const char* text) IMGUI_NOEXCEPT;
+    IMGUI_API const char*   GetClipboardText() IM_NOEXCEPT;
+    IMGUI_API void          SetClipboardText(const char* text) IM_NOEXCEPT;
 
     // Settings/.Ini Utilities
     // - The disk functions are automatically called if io.IniFilename != NULL (default is "imgui.ini").
     // - Set io.IniFilename to NULL to load/save manually. Read io.WantSaveIniSettings description about handling .ini saving manually.
-    IMGUI_API void          LoadIniSettingsFromDisk(const char* ini_filename) IMGUI_NOEXCEPT;                  // call after CreateContext() and before the first call to NewFrame(). NewFrame() automatically calls LoadIniSettingsFromDisk(io.IniFilename).
-    IMGUI_API void          LoadIniSettingsFromMemory(const char* ini_data, size_t ini_size=0) IMGUI_NOEXCEPT; // call after CreateContext() and before the first call to NewFrame() to provide .ini data from your own data source.
-    IMGUI_API void          SaveIniSettingsToDisk(const char* ini_filename) IMGUI_NOEXCEPT;                    // this is automatically called (if io.IniFilename is not empty) a few seconds after any modification that should be reflected in the .ini file (and also by DestroyContext).
-    IMGUI_API const char*   SaveIniSettingsToMemory(size_t* out_ini_size = NULL) IMGUI_NOEXCEPT;               // return a zero-terminated string with the .ini data which you can save by your own mean. call when io.WantSaveIniSettings is set, then save data by your own mean and clear io.WantSaveIniSettings.
+    IMGUI_API void          LoadIniSettingsFromDisk(const char* ini_filename) IM_NOEXCEPT;                  // call after CreateContext() and before the first call to NewFrame(). NewFrame() automatically calls LoadIniSettingsFromDisk(io.IniFilename).
+    IMGUI_API void          LoadIniSettingsFromMemory(const char* ini_data, size_t ini_size=0) IM_NOEXCEPT; // call after CreateContext() and before the first call to NewFrame() to provide .ini data from your own data source.
+    IMGUI_API void          SaveIniSettingsToDisk(const char* ini_filename) IM_NOEXCEPT;                    // this is automatically called (if io.IniFilename is not empty) a few seconds after any modification that should be reflected in the .ini file (and also by DestroyContext).
+    IMGUI_API const char*   SaveIniSettingsToMemory(size_t* out_ini_size = NULL) IM_NOEXCEPT;               // return a zero-terminated string with the .ini data which you can save by your own mean. call when io.WantSaveIniSettings is set, then save data by your own mean and clear io.WantSaveIniSettings.
 
     // Debug Utilities
     // - This is used by the IMGUI_CHECKVERSION() macro.
-    IMGUI_API bool          DebugCheckVersionAndDataLayout(const char* version_str, size_t sz_io, size_t sz_style, size_t sz_vec2, size_t sz_vec4, size_t sz_drawvert, size_t sz_drawidx) IMGUI_NOEXCEPT; // This is called by IMGUI_CHECKVERSION() macro.
+    IMGUI_API bool          DebugCheckVersionAndDataLayout(const char* version_str, size_t sz_io, size_t sz_style, size_t sz_vec2, size_t sz_vec4, size_t sz_drawvert, size_t sz_drawidx) IM_NOEXCEPT; // This is called by IMGUI_CHECKVERSION() macro.
 
     // Memory Allocators
     // - Those functions are not reliant on the current context.
     // - DLL users: heaps and globals are not shared across DLL boundaries! You will need to call SetCurrentContext() + SetAllocatorFunctions()
     //   for each static/DLL boundary you are calling from. Read "Context and Memory Allocators" section of imgui.cpp for more details.
-    IMGUI_API void          SetAllocatorFunctions(ImGuiMemAllocFunc alloc_func, ImGuiMemFreeFunc free_func, void* user_data = NULL) IMGUI_NOEXCEPT;
-    IMGUI_API void          GetAllocatorFunctions(ImGuiMemAllocFunc* p_alloc_func, ImGuiMemFreeFunc* p_free_func, void** p_user_data) IMGUI_NOEXCEPT;
-    IMGUI_API void*         MemAlloc(size_t size) IMGUI_NOEXCEPT;
-    IMGUI_API void          MemFree(void* ptr) IMGUI_NOEXCEPT;
+    IMGUI_API void          SetAllocatorFunctions(ImGuiMemAllocFunc alloc_func, ImGuiMemFreeFunc free_func, void* user_data = NULL) IM_NOEXCEPT;
+    IMGUI_API void          GetAllocatorFunctions(ImGuiMemAllocFunc* p_alloc_func, ImGuiMemFreeFunc* p_free_func, void** p_user_data) IM_NOEXCEPT;
+    IMGUI_API void*         MemAlloc(size_t size) IM_NOEXCEPT;
+    IMGUI_API void          MemFree(void* ptr) IM_NOEXCEPT;
 
 } // namespace ImGui
 
@@ -1641,8 +1640,8 @@ enum ImGuiCond_
 //-----------------------------------------------------------------------------
 
 struct ImNewWrapper {};
-inline void* operator new(size_t, ImNewWrapper, void* ptr) IMGUI_NOEXCEPT { return ptr; }
-inline void  operator delete(void*, ImNewWrapper, void*)   IMGUI_NOEXCEPT {} // This is only required so we can use the symmetrical new()
+inline void* operator new(size_t, ImNewWrapper, void* ptr) IM_NOEXCEPT { return ptr; }
+inline void  operator delete(void*, ImNewWrapper, void*)   IM_NOEXCEPT {} // This is only required so we can use the symmetrical new()
 #define IM_ALLOC(_SIZE)                     ImGui::MemAlloc(_SIZE)
 #define IM_FREE(_PTR)                       ImGui::MemFree(_PTR)
 #define IM_PLACEMENT_NEW(_PTR)              new(ImNewWrapper(), _PTR)
@@ -1674,50 +1673,50 @@ struct ImVector
     typedef const value_type*   const_iterator;
 
     // Constructors, destructor
-    inline ImVector()                                        IMGUI_NOEXCEPT { Size = Capacity = 0; Data = NULL; }
-    inline ImVector(const ImVector<T>& src)                  IMGUI_NOEXCEPT { Size = Capacity = 0; Data = NULL; operator=(src); }
-    inline ImVector<T>& operator=(const ImVector<T>& src)    IMGUI_NOEXCEPT { clear(); resize(src.Size); memcpy(Data, src.Data, (size_t)Size * sizeof(T)); return *this; }
-    inline ~ImVector()                                       IMGUI_NOEXCEPT { if (Data) IM_FREE(Data); }
+    inline ImVector()                                        IM_NOEXCEPT { Size = Capacity = 0; Data = NULL; }
+    inline ImVector(const ImVector<T>& src)                  IM_NOEXCEPT { Size = Capacity = 0; Data = NULL; operator=(src); }
+    inline ImVector<T>& operator=(const ImVector<T>& src)    IM_NOEXCEPT { clear(); resize(src.Size); memcpy(Data, src.Data, (size_t)Size * sizeof(T)); return *this; }
+    inline ~ImVector()                                       IM_NOEXCEPT { if (Data) IM_FREE(Data); }
 
-    inline bool         empty() const                        IMGUI_NOEXCEPT { return Size == 0; }
-    inline int          size() const                         IMGUI_NOEXCEPT { return Size; }
-    inline int          size_in_bytes() const                IMGUI_NOEXCEPT { return Size * (int)sizeof(T); }
-    inline int          max_size() const                     IMGUI_NOEXCEPT { return 0x7FFFFFFF / (int)sizeof(T); }
-    inline int          capacity() const                     IMGUI_NOEXCEPT { return Capacity; }
-    inline T&           operator[](int i)                    IMGUI_NOEXCEPT { IM_ASSERT(i >= 0 && i < Size); return Data[i]; }
-    inline const T&     operator[](int i) const              IMGUI_NOEXCEPT { IM_ASSERT(i >= 0 && i < Size); return Data[i]; }
+    inline bool         empty() const                        IM_NOEXCEPT { return Size == 0; }
+    inline int          size() const                         IM_NOEXCEPT { return Size; }
+    inline int          size_in_bytes() const                IM_NOEXCEPT { return Size * (int)sizeof(T); }
+    inline int          max_size() const                     IM_NOEXCEPT { return 0x7FFFFFFF / (int)sizeof(T); }
+    inline int          capacity() const                     IM_NOEXCEPT { return Capacity; }
+    inline T&           operator[](int i)                    IM_NOEXCEPT { IM_ASSERT(i >= 0 && i < Size); return Data[i]; }
+    inline const T&     operator[](int i) const              IM_NOEXCEPT { IM_ASSERT(i >= 0 && i < Size); return Data[i]; }
 
-    inline void         clear()                              IMGUI_NOEXCEPT { if (Data) { Size = Capacity = 0; IM_FREE(Data); Data = NULL; } }
-    inline T*           begin()                              IMGUI_NOEXCEPT { return Data; }
-    inline const T*     begin() const                        IMGUI_NOEXCEPT { return Data; }
-    inline T*           end()                                IMGUI_NOEXCEPT { return Data + Size; }
-    inline const T*     end() const                          IMGUI_NOEXCEPT { return Data + Size; }
-    inline T&           front()                              IMGUI_NOEXCEPT { IM_ASSERT(Size > 0); return Data[0]; }
-    inline const T&     front() const                        IMGUI_NOEXCEPT { IM_ASSERT(Size > 0); return Data[0]; }
-    inline T&           back()                               IMGUI_NOEXCEPT { IM_ASSERT(Size > 0); return Data[Size - 1]; }
-    inline const T&     back() const                         IMGUI_NOEXCEPT { IM_ASSERT(Size > 0); return Data[Size - 1]; }
-    inline void         swap(ImVector<T>& rhs)               IMGUI_NOEXCEPT { int rhs_size = rhs.Size; rhs.Size = Size; Size = rhs_size; int rhs_cap = rhs.Capacity; rhs.Capacity = Capacity; Capacity = rhs_cap; T* rhs_data = rhs.Data; rhs.Data = Data; Data = rhs_data; }
+    inline void         clear()                              IM_NOEXCEPT { if (Data) { Size = Capacity = 0; IM_FREE(Data); Data = NULL; } }
+    inline T*           begin()                              IM_NOEXCEPT { return Data; }
+    inline const T*     begin() const                        IM_NOEXCEPT { return Data; }
+    inline T*           end()                                IM_NOEXCEPT { return Data + Size; }
+    inline const T*     end() const                          IM_NOEXCEPT { return Data + Size; }
+    inline T&           front()                              IM_NOEXCEPT { IM_ASSERT(Size > 0); return Data[0]; }
+    inline const T&     front() const                        IM_NOEXCEPT { IM_ASSERT(Size > 0); return Data[0]; }
+    inline T&           back()                               IM_NOEXCEPT { IM_ASSERT(Size > 0); return Data[Size - 1]; }
+    inline const T&     back() const                         IM_NOEXCEPT { IM_ASSERT(Size > 0); return Data[Size - 1]; }
+    inline void         swap(ImVector<T>& rhs)               IM_NOEXCEPT { int rhs_size = rhs.Size; rhs.Size = Size; Size = rhs_size; int rhs_cap = rhs.Capacity; rhs.Capacity = Capacity; Capacity = rhs_cap; T* rhs_data = rhs.Data; rhs.Data = Data; Data = rhs_data; }
 
-    inline int          _grow_capacity(int sz) const         IMGUI_NOEXCEPT { int new_capacity = Capacity ? (Capacity + Capacity / 2) : 8; return new_capacity > sz ? new_capacity : sz; }
-    inline void         resize(int new_size)                 IMGUI_NOEXCEPT { if (new_size > Capacity) reserve(_grow_capacity(new_size)); Size = new_size; }
-    inline void         resize(int new_size, const T& v)     IMGUI_NOEXCEPT { if (new_size > Capacity) reserve(_grow_capacity(new_size)); if (new_size > Size) for (int n = Size; n < new_size; n++) memcpy(&Data[n], &v, sizeof(v)); Size = new_size; }
-    inline void         shrink(int new_size)                 IMGUI_NOEXCEPT { IM_ASSERT(new_size <= Size); Size = new_size; } // Resize a vector to a smaller size, guaranteed not to cause a reallocation
-    inline void         reserve(int new_capacity)            IMGUI_NOEXCEPT { if (new_capacity <= Capacity) return; T* new_data = (T*)IM_ALLOC((size_t)new_capacity * sizeof(T)); if (Data) { memcpy(new_data, Data, (size_t)Size * sizeof(T)); IM_FREE(Data); } Data = new_data; Capacity = new_capacity; }
+    inline int          _grow_capacity(int sz) const         IM_NOEXCEPT { int new_capacity = Capacity ? (Capacity + Capacity / 2) : 8; return new_capacity > sz ? new_capacity : sz; }
+    inline void         resize(int new_size)                 IM_NOEXCEPT { if (new_size > Capacity) reserve(_grow_capacity(new_size)); Size = new_size; }
+    inline void         resize(int new_size, const T& v)     IM_NOEXCEPT { if (new_size > Capacity) reserve(_grow_capacity(new_size)); if (new_size > Size) for (int n = Size; n < new_size; n++) memcpy(&Data[n], &v, sizeof(v)); Size = new_size; }
+    inline void         shrink(int new_size)                 IM_NOEXCEPT { IM_ASSERT(new_size <= Size); Size = new_size; } // Resize a vector to a smaller size, guaranteed not to cause a reallocation
+    inline void         reserve(int new_capacity)            IM_NOEXCEPT { if (new_capacity <= Capacity) return; T* new_data = (T*)IM_ALLOC((size_t)new_capacity * sizeof(T)); if (Data) { memcpy(new_data, Data, (size_t)Size * sizeof(T)); IM_FREE(Data); } Data = new_data; Capacity = new_capacity; }
 
     // NB: It is illegal to call push_back/push_front/insert with a reference pointing inside the ImVector data itself! e.g. v.push_back(v[10]) is forbidden.
-    inline void         push_back(const T& v)                IMGUI_NOEXCEPT { if (Size == Capacity) reserve(_grow_capacity(Size + 1)); memcpy(&Data[Size], &v, sizeof(v)); Size++; }
-    inline void         pop_back()                           IMGUI_NOEXCEPT { IM_ASSERT(Size > 0); Size--; }
-    inline void         push_front(const T& v)               IMGUI_NOEXCEPT { if (Size == 0) push_back(v); else insert(Data, v); }
-    inline T*           erase(const T* it)                   IMGUI_NOEXCEPT { IM_ASSERT(it >= Data && it < Data + Size); const ptrdiff_t off = it - Data; memmove(Data + off, Data + off + 1, ((size_t)Size - (size_t)off - 1) * sizeof(T)); Size--; return Data + off; }
-    inline T*           erase(const T* it, const T* it_last) IMGUI_NOEXCEPT { IM_ASSERT(it >= Data && it < Data + Size && it_last > it && it_last <= Data + Size); const ptrdiff_t count = it_last - it; const ptrdiff_t off = it - Data; memmove(Data + off, Data + off + count, ((size_t)Size - (size_t)off - count) * sizeof(T)); Size -= (int)count; return Data + off; }
-    inline T*           erase_unsorted(const T* it)          IMGUI_NOEXCEPT { IM_ASSERT(it >= Data && it < Data + Size);  const ptrdiff_t off = it - Data; if (it < Data + Size - 1) memcpy(Data + off, Data + Size - 1, sizeof(T)); Size--; return Data + off; }
-    inline T*           insert(const T* it, const T& v)      IMGUI_NOEXCEPT { IM_ASSERT(it >= Data && it <= Data + Size); const ptrdiff_t off = it - Data; if (Size == Capacity) reserve(_grow_capacity(Size + 1)); if (off < (int)Size) memmove(Data + off + 1, Data + off, ((size_t)Size - (size_t)off) * sizeof(T)); memcpy(&Data[off], &v, sizeof(v)); Size++; return Data + off; }
-    inline bool         contains(const T& v) const           IMGUI_NOEXCEPT { const T* data = Data;  const T* data_end = Data + Size; while (data < data_end) if (*data++ == v) return true; return false; }
-    inline T*           find(const T& v)                     IMGUI_NOEXCEPT { T* data = Data;  const T* data_end = Data + Size; while (data < data_end) if (*data == v) break; else ++data; return data; }
-    inline const T*     find(const T& v) const               IMGUI_NOEXCEPT { const T* data = Data;  const T* data_end = Data + Size; while (data < data_end) if (*data == v) break; else ++data; return data; }
-    inline bool         find_erase(const T& v)               IMGUI_NOEXCEPT { const T* it = find(v); if (it < Data + Size) { erase(it); return true; } return false; }
-    inline bool         find_erase_unsorted(const T& v)      IMGUI_NOEXCEPT { const T* it = find(v); if (it < Data + Size) { erase_unsorted(it); return true; } return false; }
-    inline int          index_from_ptr(const T* it) const    IMGUI_NOEXCEPT { IM_ASSERT(it >= Data && it < Data + Size); const ptrdiff_t off = it - Data; return (int)off; }
+    inline void         push_back(const T& v)                IM_NOEXCEPT { if (Size == Capacity) reserve(_grow_capacity(Size + 1)); memcpy(&Data[Size], &v, sizeof(v)); Size++; }
+    inline void         pop_back()                           IM_NOEXCEPT { IM_ASSERT(Size > 0); Size--; }
+    inline void         push_front(const T& v)               IM_NOEXCEPT { if (Size == 0) push_back(v); else insert(Data, v); }
+    inline T*           erase(const T* it)                   IM_NOEXCEPT { IM_ASSERT(it >= Data && it < Data + Size); const ptrdiff_t off = it - Data; memmove(Data + off, Data + off + 1, ((size_t)Size - (size_t)off - 1) * sizeof(T)); Size--; return Data + off; }
+    inline T*           erase(const T* it, const T* it_last) IM_NOEXCEPT { IM_ASSERT(it >= Data && it < Data + Size && it_last > it && it_last <= Data + Size); const ptrdiff_t count = it_last - it; const ptrdiff_t off = it - Data; memmove(Data + off, Data + off + count, ((size_t)Size - (size_t)off - count) * sizeof(T)); Size -= (int)count; return Data + off; }
+    inline T*           erase_unsorted(const T* it)          IM_NOEXCEPT { IM_ASSERT(it >= Data && it < Data + Size);  const ptrdiff_t off = it - Data; if (it < Data + Size - 1) memcpy(Data + off, Data + Size - 1, sizeof(T)); Size--; return Data + off; }
+    inline T*           insert(const T* it, const T& v)      IM_NOEXCEPT { IM_ASSERT(it >= Data && it <= Data + Size); const ptrdiff_t off = it - Data; if (Size == Capacity) reserve(_grow_capacity(Size + 1)); if (off < (int)Size) memmove(Data + off + 1, Data + off, ((size_t)Size - (size_t)off) * sizeof(T)); memcpy(&Data[off], &v, sizeof(v)); Size++; return Data + off; }
+    inline bool         contains(const T& v) const           IM_NOEXCEPT { const T* data = Data;  const T* data_end = Data + Size; while (data < data_end) if (*data++ == v) return true; return false; }
+    inline T*           find(const T& v)                     IM_NOEXCEPT { T* data = Data;  const T* data_end = Data + Size; while (data < data_end) if (*data == v) break; else ++data; return data; }
+    inline const T*     find(const T& v) const               IM_NOEXCEPT { const T* data = Data;  const T* data_end = Data + Size; while (data < data_end) if (*data == v) break; else ++data; return data; }
+    inline bool         find_erase(const T& v)               IM_NOEXCEPT { const T* it = find(v); if (it < Data + Size) { erase(it); return true; } return false; }
+    inline bool         find_erase_unsorted(const T& v)      IM_NOEXCEPT { const T* it = find(v); if (it < Data + Size) { erase_unsorted(it); return true; } return false; }
+    inline int          index_from_ptr(const T* it) const    IM_NOEXCEPT { IM_ASSERT(it >= Data && it < Data + Size); const ptrdiff_t off = it - Data; return (int)off; }
 };
 IM_MSVC_RUNTIME_CHECKS_RESTORE
 
@@ -1772,8 +1771,8 @@ struct ImGuiStyle
     float       CircleTessellationMaxError; // Maximum error (in pixels) allowed when using AddCircle()/AddCircleFilled() or drawing rounded corner rectangles with no explicit segment count specified. Decrease for higher quality but more geometry.
     ImVec4      Colors[ImGuiCol_COUNT];
 
-    IMGUI_API ImGuiStyle() IMGUI_NOEXCEPT;
-    IMGUI_API void ScaleAllSizes(float scale_factor) IMGUI_NOEXCEPT;
+    IMGUI_API ImGuiStyle() IM_NOEXCEPT;
+    IMGUI_API void ScaleAllSizes(float scale_factor) IM_NOEXCEPT;
 };
 
 //-----------------------------------------------------------------------------
@@ -1858,10 +1857,10 @@ struct ImGuiIO
     float       NavInputs[ImGuiNavInput_COUNT]; // Gamepad inputs. Cleared back to zero by EndFrame(). Keyboard keys will be auto-mapped and be written here by NewFrame().
 
     // Functions
-    IMGUI_API void  AddInputCharacter(unsigned int c)       IMGUI_NOEXCEPT;  // Queue new character input
-    IMGUI_API void  AddInputCharacterUTF16(ImWchar16 c)     IMGUI_NOEXCEPT;  // Queue new character input from an UTF-16 character, it can be a surrogate
-    IMGUI_API void  AddInputCharactersUTF8(const char* str) IMGUI_NOEXCEPT;  // Queue new characters input from an UTF-8 string
-    IMGUI_API void  ClearInputCharacters()                  IMGUI_NOEXCEPT;  // Clear the text input buffer manually
+    IMGUI_API void  AddInputCharacter(unsigned int c)       IM_NOEXCEPT;  // Queue new character input
+    IMGUI_API void  AddInputCharacterUTF16(ImWchar16 c)     IM_NOEXCEPT;  // Queue new character input from an UTF-16 character, it can be a surrogate
+    IMGUI_API void  AddInputCharactersUTF8(const char* str) IM_NOEXCEPT;  // Queue new characters input from an UTF-8 string
+    IMGUI_API void  ClearInputCharacters()                  IM_NOEXCEPT;  // Clear the text input buffer manually
 
     //------------------------------------------------------------------
     // Output - Updated by NewFrame() or EndFrame()/Render()
@@ -1909,7 +1908,7 @@ struct ImGuiIO
     ImWchar16   InputQueueSurrogate;            // For AddInputCharacterUTF16
     ImVector<ImWchar> InputQueueCharacters;     // Queue of _characters_ input (obtained by platform backend). Fill using AddInputCharacter() helper.
 
-    IMGUI_API   ImGuiIO() IMGUI_NOEXCEPT;
+    IMGUI_API   ImGuiIO() IM_NOEXCEPT;
 };
 
 //-----------------------------------------------------------------------------
@@ -1946,12 +1945,12 @@ struct ImGuiInputTextCallbackData
 
     // Helper functions for text manipulation.
     // Use those function to benefit from the CallbackResize behaviors. Calling those function reset the selection.
-    IMGUI_API ImGuiInputTextCallbackData() IMGUI_NOEXCEPT;
-    IMGUI_API void      DeleteChars(int pos, int bytes_count) IMGUI_NOEXCEPT;
-    IMGUI_API void      InsertChars(int pos, const char* text, const char* text_end = NULL) IMGUI_NOEXCEPT;
-    void                SelectAll()            IMGUI_NOEXCEPT  { SelectionStart = 0; SelectionEnd = BufTextLen; }
-    void                ClearSelection()       IMGUI_NOEXCEPT  { SelectionStart = SelectionEnd = BufTextLen; }
-    bool                HasSelection() const   IMGUI_NOEXCEPT  { return SelectionStart != SelectionEnd; }
+    IMGUI_API ImGuiInputTextCallbackData() IM_NOEXCEPT;
+    IMGUI_API void      DeleteChars(int pos, int bytes_count) IM_NOEXCEPT;
+    IMGUI_API void      InsertChars(int pos, const char* text, const char* text_end = NULL) IM_NOEXCEPT;
+    void                SelectAll()            IM_NOEXCEPT  { SelectionStart = 0; SelectionEnd = BufTextLen; }
+    void                ClearSelection()       IM_NOEXCEPT  { SelectionStart = SelectionEnd = BufTextLen; }
+    bool                HasSelection() const   IM_NOEXCEPT  { return SelectionStart != SelectionEnd; }
 };
 
 // Resizing callback data to apply custom constraint. As enabled by SetNextWindowSizeConstraints(). Callback is called during the next Begin().
@@ -1979,11 +1978,11 @@ struct ImGuiPayload
     bool            Preview;            // Set when AcceptDragDropPayload() was called and mouse has been hovering the target item (nb: handle overlapping drag targets)
     bool            Delivery;           // Set when AcceptDragDropPayload() was called and mouse button is released over the target item.
 
-    ImGuiPayload() IMGUI_NOEXCEPT  { Clear(); }
-    void Clear()   IMGUI_NOEXCEPT  { SourceId = SourceParentId = 0; Data = NULL; DataSize = 0; memset(DataType, 0, sizeof(DataType)); DataFrameCount = -1; Preview = Delivery = false; }
-    bool IsDataType(const char* type) const IMGUI_NOEXCEPT { return DataFrameCount != -1 && strcmp(type, DataType) == 0; }
-    bool IsPreview() const                  IMGUI_NOEXCEPT { return Preview; }
-    bool IsDelivery() const                 IMGUI_NOEXCEPT { return Delivery; }
+    ImGuiPayload() IM_NOEXCEPT  { Clear(); }
+    void Clear()   IM_NOEXCEPT  { SourceId = SourceParentId = 0; Data = NULL; DataSize = 0; memset(DataType, 0, sizeof(DataType)); DataFrameCount = -1; Preview = Delivery = false; }
+    bool IsDataType(const char* type) const IM_NOEXCEPT { return DataFrameCount != -1 && strcmp(type, DataType) == 0; }
+    bool IsPreview() const                  IM_NOEXCEPT { return Preview; }
+    bool IsDelivery() const                 IM_NOEXCEPT { return Delivery; }
 };
 
 // Sorting specification for one column of a table (sizeof == 12 bytes)
@@ -1994,7 +1993,7 @@ struct ImGuiTableColumnSortSpecs
     ImS16                       SortOrder;          // Index within parent ImGuiTableSortSpecs (always stored in order starting from 0, tables sorted on a single criteria will always have a 0 here)
     ImGuiSortDirection          SortDirection : 8;  // ImGuiSortDirection_Ascending or ImGuiSortDirection_Descending (you can use this or SortSign, whichever is more convenient for your sort function)
 
-    ImGuiTableColumnSortSpecs() IMGUI_NOEXCEPT { memset(this, 0, sizeof(*this)); }
+    ImGuiTableColumnSortSpecs() IM_NOEXCEPT { memset(this, 0, sizeof(*this)); }
 };
 
 // Sorting specifications for a table (often handling sort specs for a single column, occasionally more)
@@ -2007,7 +2006,7 @@ struct ImGuiTableSortSpecs
     int                         SpecsCount;     // Sort spec count. Most often 1. May be > 1 when ImGuiTableFlags_SortMulti is enabled. May be == 0 when ImGuiTableFlags_SortTristate is enabled.
     bool                        SpecsDirty;     // Set to true when specs have changed since last time! Use this to sort again, then clear the flag.
 
-    ImGuiTableSortSpecs() IMGUI_NOEXCEPT { memset(this, 0, sizeof(*this)); }
+    ImGuiTableSortSpecs() IM_NOEXCEPT { memset(this, 0, sizeof(*this)); }
 };
 
 //-----------------------------------------------------------------------------
@@ -2026,20 +2025,20 @@ struct ImGuiTableSortSpecs
 // Usage: static ImGuiOnceUponAFrame oaf; if (oaf) ImGui::Text("This will be called only once per frame");
 struct ImGuiOnceUponAFrame
 {
-    ImGuiOnceUponAFrame() IMGUI_NOEXCEPT : RefFrame(-1) {}
+    ImGuiOnceUponAFrame() IM_NOEXCEPT : RefFrame(-1) {}
     mutable int RefFrame;
-    operator bool() const IMGUI_NOEXCEPT { int current_frame = ImGui::GetFrameCount(); if (RefFrame == current_frame) return false; RefFrame = current_frame; return true; }
+    operator bool() const IM_NOEXCEPT { int current_frame = ImGui::GetFrameCount(); if (RefFrame == current_frame) return false; RefFrame = current_frame; return true; }
 };
 
 // Helper: Parse and apply text filters. In format "aaaaa[,bbbb][,ccccc]"
 struct ImGuiTextFilter
 {
-    IMGUI_API           ImGuiTextFilter(const char* default_filter = "") IMGUI_NOEXCEPT;
-    IMGUI_API bool      Draw(const char* label = "Filter (inc,-exc)", float width = 0.0f) IMGUI_NOEXCEPT;  // Helper calling InputText+Build
-    IMGUI_API bool      PassFilter(const char* text, const char* text_end = NULL) const IMGUI_NOEXCEPT;
-    IMGUI_API void      Build() IMGUI_NOEXCEPT;
-    void                Clear()          IMGUI_NOEXCEPT { InputBuf[0] = 0; Build(); }
-    bool                IsActive() const IMGUI_NOEXCEPT { return !Filters.empty(); }
+    IMGUI_API           ImGuiTextFilter(const char* default_filter = "") IM_NOEXCEPT;
+    IMGUI_API bool      Draw(const char* label = "Filter (inc,-exc)", float width = 0.0f) IM_NOEXCEPT;  // Helper calling InputText+Build
+    IMGUI_API bool      PassFilter(const char* text, const char* text_end = NULL) const IM_NOEXCEPT;
+    IMGUI_API void      Build() IM_NOEXCEPT;
+    void                Clear()          IM_NOEXCEPT { InputBuf[0] = 0; Build(); }
+    bool                IsActive() const IM_NOEXCEPT { return !Filters.empty(); }
 
     // [Internal]
     struct ImGuiTextRange
@@ -2047,10 +2046,10 @@ struct ImGuiTextFilter
         const char*     b;
         const char*     e;
 
-        ImGuiTextRange()                               IMGUI_NOEXCEPT  { b = e = NULL; }
-        ImGuiTextRange(const char* _b, const char* _e) IMGUI_NOEXCEPT  { b = _b; e = _e; }
-        bool            empty() const                  IMGUI_NOEXCEPT  { return b == e; }
-        IMGUI_API void  split(char separator, ImVector<ImGuiTextRange>* out) const IMGUI_NOEXCEPT;
+        ImGuiTextRange()                               IM_NOEXCEPT  { b = e = NULL; }
+        ImGuiTextRange(const char* _b, const char* _e) IM_NOEXCEPT  { b = _b; e = _e; }
+        bool            empty() const                  IM_NOEXCEPT  { return b == e; }
+        IMGUI_API void  split(char separator, ImVector<ImGuiTextRange>* out) const IM_NOEXCEPT;
     };
     char                    InputBuf[256];
     ImVector<ImGuiTextRange>Filters;
@@ -2064,18 +2063,18 @@ struct ImGuiTextBuffer
     ImVector<char>      Buf;
     IMGUI_API static char EmptyString[1];
 
-    ImGuiTextBuffer()                           IMGUI_NOEXCEPT { }
-    inline char         operator[](int i) const IMGUI_NOEXCEPT { IM_ASSERT(Buf.Data != NULL); return Buf.Data[i]; }
-    const char*         begin() const           IMGUI_NOEXCEPT { return Buf.Data ? &Buf.front() : EmptyString; }
-    const char*         end() const             IMGUI_NOEXCEPT { return Buf.Data ? &Buf.back() : EmptyString; }   // Buf is zero-terminated, so end() will point on the zero-terminator
-    int                 size() const            IMGUI_NOEXCEPT { return Buf.Size ? Buf.Size - 1 : 0; }
-    bool                empty() const           IMGUI_NOEXCEPT { return Buf.Size <= 1; }
-    void                clear()                 IMGUI_NOEXCEPT { Buf.clear(); }
-    void                reserve(int capacity)   IMGUI_NOEXCEPT { Buf.reserve(capacity); }
-    const char*         c_str() const           IMGUI_NOEXCEPT { return Buf.Data ? Buf.Data : EmptyString; }
-    IMGUI_API void      append(const char* str, const char* str_end = NULL) IMGUI_NOEXCEPT;
-    IMGUI_API void      appendf(const char* fmt, ...) IMGUI_NOEXCEPT IM_FMTARGS(2);
-    IMGUI_API void      appendfv(const char* fmt, va_list args) IMGUI_NOEXCEPT IM_FMTLIST(2);
+    ImGuiTextBuffer()                           IM_NOEXCEPT { }
+    inline char         operator[](int i) const IM_NOEXCEPT { IM_ASSERT(Buf.Data != NULL); return Buf.Data[i]; }
+    const char*         begin() const           IM_NOEXCEPT { return Buf.Data ? &Buf.front() : EmptyString; }
+    const char*         end() const             IM_NOEXCEPT { return Buf.Data ? &Buf.back() : EmptyString; }   // Buf is zero-terminated, so end() will point on the zero-terminator
+    int                 size() const            IM_NOEXCEPT { return Buf.Size ? Buf.Size - 1 : 0; }
+    bool                empty() const           IM_NOEXCEPT { return Buf.Size <= 1; }
+    void                clear()                 IM_NOEXCEPT { Buf.clear(); }
+    void                reserve(int capacity)   IM_NOEXCEPT { Buf.reserve(capacity); }
+    const char*         c_str() const           IM_NOEXCEPT { return Buf.Data ? Buf.Data : EmptyString; }
+    IMGUI_API void      append(const char* str, const char* str_end = NULL) IM_NOEXCEPT;
+    IMGUI_API void      appendf(const char* fmt, ...) IM_NOEXCEPT IM_FMTARGS(2);
+    IMGUI_API void      appendfv(const char* fmt, va_list args) IM_NOEXCEPT IM_FMTLIST(2);
 };
 
 // Helper: Key->Value storage
@@ -2093,9 +2092,9 @@ struct ImGuiStorage
     {
         ImGuiID key;
         union { int val_i; float val_f; void* val_p; };
-        ImGuiStoragePair(ImGuiID _key, int _val_i)   IMGUI_NOEXCEPT    { key = _key; val_i = _val_i; }
-        ImGuiStoragePair(ImGuiID _key, float _val_f) IMGUI_NOEXCEPT    { key = _key; val_f = _val_f; }
-        ImGuiStoragePair(ImGuiID _key, void* _val_p) IMGUI_NOEXCEPT    { key = _key; val_p = _val_p; }
+        ImGuiStoragePair(ImGuiID _key, int _val_i)   IM_NOEXCEPT    { key = _key; val_i = _val_i; }
+        ImGuiStoragePair(ImGuiID _key, float _val_f) IM_NOEXCEPT    { key = _key; val_f = _val_f; }
+        ImGuiStoragePair(ImGuiID _key, void* _val_p) IM_NOEXCEPT    { key = _key; val_p = _val_p; }
     };
 
     ImVector<ImGuiStoragePair>      Data;
@@ -2103,30 +2102,30 @@ struct ImGuiStorage
     // - Get***() functions find pair, never add/allocate. Pairs are sorted so a query is O(log N)
     // - Set***() functions find pair, insertion on demand if missing.
     // - Sorted insertion is costly, paid once. A typical frame shouldn't need to insert any new pair.
-    void                Clear() IMGUI_NOEXCEPT { Data.clear(); }
-    IMGUI_API int       GetInt(ImGuiID key, int default_val = 0) const IMGUI_NOEXCEPT;
-    IMGUI_API void      SetInt(ImGuiID key, int val) IMGUI_NOEXCEPT;
-    IMGUI_API bool      GetBool(ImGuiID key, bool default_val = false) const IMGUI_NOEXCEPT;
-    IMGUI_API void      SetBool(ImGuiID key, bool val) IMGUI_NOEXCEPT;
-    IMGUI_API float     GetFloat(ImGuiID key, float default_val = 0.0f) const IMGUI_NOEXCEPT;
-    IMGUI_API void      SetFloat(ImGuiID key, float val) IMGUI_NOEXCEPT;
-    IMGUI_API void*     GetVoidPtr(ImGuiID key) const IMGUI_NOEXCEPT; // default_val is NULL
-    IMGUI_API void      SetVoidPtr(ImGuiID key, void* val) IMGUI_NOEXCEPT;
+    void                Clear() IM_NOEXCEPT { Data.clear(); }
+    IMGUI_API int       GetInt(ImGuiID key, int default_val = 0) const IM_NOEXCEPT;
+    IMGUI_API void      SetInt(ImGuiID key, int val) IM_NOEXCEPT;
+    IMGUI_API bool      GetBool(ImGuiID key, bool default_val = false) const IM_NOEXCEPT;
+    IMGUI_API void      SetBool(ImGuiID key, bool val) IM_NOEXCEPT;
+    IMGUI_API float     GetFloat(ImGuiID key, float default_val = 0.0f) const IM_NOEXCEPT;
+    IMGUI_API void      SetFloat(ImGuiID key, float val) IM_NOEXCEPT;
+    IMGUI_API void*     GetVoidPtr(ImGuiID key) const IM_NOEXCEPT; // default_val is NULL
+    IMGUI_API void      SetVoidPtr(ImGuiID key, void* val) IM_NOEXCEPT;
 
     // - Get***Ref() functions finds pair, insert on demand if missing, return pointer. Useful if you intend to do Get+Set.
     // - References are only valid until a new value is added to the storage. Calling a Set***() function or a Get***Ref() function invalidates the pointer.
     // - A typical use case where this is convenient for quick hacking (e.g. add storage during a live Edit&Continue session if you can't modify existing struct)
     //      float* pvar = ImGui::GetFloatRef(key); ImGui::SliderFloat("var", pvar, 0, 100.0f); some_var += *pvar;
-    IMGUI_API int*      GetIntRef(ImGuiID key, int default_val = 0) IMGUI_NOEXCEPT;
-    IMGUI_API bool*     GetBoolRef(ImGuiID key, bool default_val = false) IMGUI_NOEXCEPT;
-    IMGUI_API float*    GetFloatRef(ImGuiID key, float default_val = 0.0f) IMGUI_NOEXCEPT;
-    IMGUI_API void**    GetVoidPtrRef(ImGuiID key, void* default_val = NULL) IMGUI_NOEXCEPT;
+    IMGUI_API int*      GetIntRef(ImGuiID key, int default_val = 0) IM_NOEXCEPT;
+    IMGUI_API bool*     GetBoolRef(ImGuiID key, bool default_val = false) IM_NOEXCEPT;
+    IMGUI_API float*    GetFloatRef(ImGuiID key, float default_val = 0.0f) IM_NOEXCEPT;
+    IMGUI_API void**    GetVoidPtrRef(ImGuiID key, void* default_val = NULL) IM_NOEXCEPT;
 
     // Use on your own storage if you know only integer are being stored (open/close all tree nodes)
-    IMGUI_API void      SetAllInt(int val) IMGUI_NOEXCEPT;
+    IMGUI_API void      SetAllInt(int val) IM_NOEXCEPT;
 
     // For quicker full rebuild of a storage (instead of an incremental one), you may add all your contents and then sort once.
-    IMGUI_API void      BuildSortByKey() IMGUI_NOEXCEPT;
+    IMGUI_API void      BuildSortByKey() IM_NOEXCEPT;
 };
 
 // Helper: Manually clip large list of items.
@@ -2158,17 +2157,17 @@ struct ImGuiListClipper
     float   ItemsHeight;
     float   StartPosY;
 
-    IMGUI_API ImGuiListClipper() IMGUI_NOEXCEPT;
-    IMGUI_API ~ImGuiListClipper() IMGUI_NOEXCEPT;
+    IMGUI_API ImGuiListClipper() IM_NOEXCEPT;
+    IMGUI_API ~ImGuiListClipper() IM_NOEXCEPT;
 
     // items_count: Use INT_MAX if you don't know how many items you have (in which case the cursor won't be advanced in the final step)
     // items_height: Use -1.0f to be calculated automatically on first step. Otherwise pass in the distance between your items, typically GetTextLineHeightWithSpacing() or GetFrameHeightWithSpacing().
-    IMGUI_API void Begin(int items_count, float items_height = -1.0f) IMGUI_NOEXCEPT;  // Automatically called by constructor if you passed 'items_count' or by Step() in Step 1.
-    IMGUI_API void End() IMGUI_NOEXCEPT;                                // Automatically called on the last call of Step() that returns false.
-    IMGUI_API bool Step() IMGUI_NOEXCEPT;                                              // Call until it returns false. The DisplayStart/DisplayEnd fields will be set and you can process/draw those items.
+    IMGUI_API void Begin(int items_count, float items_height = -1.0f) IM_NOEXCEPT;  // Automatically called by constructor if you passed 'items_count' or by Step() in Step 1.
+    IMGUI_API void End() IM_NOEXCEPT;                                // Automatically called on the last call of Step() that returns false.
+    IMGUI_API bool Step() IM_NOEXCEPT;                                              // Call until it returns false. The DisplayStart/DisplayEnd fields will be set and you can process/draw those items.
 
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
-    inline ImGuiListClipper(int items_count, float items_height = -1.0f) IMGUI_NOEXCEPT { memset(this, 0, sizeof(*this)); ItemsCount = -1; Begin(items_count, items_height); } // [removed in 1.79]
+    inline ImGuiListClipper(int items_count, float items_height = -1.0f) IM_NOEXCEPT { memset(this, 0, sizeof(*this)); ItemsCount = -1; Begin(items_count, items_height); } // [removed in 1.79]
 #endif
 };
 
@@ -2199,17 +2198,17 @@ struct ImColor
 {
     ImVec4              Value;
 
-    ImColor()                                                        IMGUI_NOEXCEPT { Value.x = Value.y = Value.z = Value.w = 0.0f; }
-    ImColor(int r, int g, int b, int a = 255)                        IMGUI_NOEXCEPT { float sc = 1.0f / 255.0f; Value.x = (float)r * sc; Value.y = (float)g * sc; Value.z = (float)b * sc; Value.w = (float)a * sc; }
-    ImColor(ImU32 rgba)                                              IMGUI_NOEXCEPT { float sc = 1.0f / 255.0f; Value.x = (float)((rgba >> IM_COL32_R_SHIFT) & 0xFF) * sc; Value.y = (float)((rgba >> IM_COL32_G_SHIFT) & 0xFF) * sc; Value.z = (float)((rgba >> IM_COL32_B_SHIFT) & 0xFF) * sc; Value.w = (float)((rgba >> IM_COL32_A_SHIFT) & 0xFF) * sc; }
-    ImColor(float r, float g, float b, float a = 1.0f)               IMGUI_NOEXCEPT { Value.x = r; Value.y = g; Value.z = b; Value.w = a; }
-    ImColor(const ImVec4& col)                                       IMGUI_NOEXCEPT { Value = col; }
-    inline operator ImU32() const                                    IMGUI_NOEXCEPT { return ImGui::ColorConvertFloat4ToU32(Value); }
-    inline operator ImVec4() const                                   IMGUI_NOEXCEPT { return Value; }
+    ImColor()                                                        IM_NOEXCEPT { Value.x = Value.y = Value.z = Value.w = 0.0f; }
+    ImColor(int r, int g, int b, int a = 255)                        IM_NOEXCEPT { float sc = 1.0f / 255.0f; Value.x = (float)r * sc; Value.y = (float)g * sc; Value.z = (float)b * sc; Value.w = (float)a * sc; }
+    ImColor(ImU32 rgba)                                              IM_NOEXCEPT { float sc = 1.0f / 255.0f; Value.x = (float)((rgba >> IM_COL32_R_SHIFT) & 0xFF) * sc; Value.y = (float)((rgba >> IM_COL32_G_SHIFT) & 0xFF) * sc; Value.z = (float)((rgba >> IM_COL32_B_SHIFT) & 0xFF) * sc; Value.w = (float)((rgba >> IM_COL32_A_SHIFT) & 0xFF) * sc; }
+    ImColor(float r, float g, float b, float a = 1.0f)               IM_NOEXCEPT { Value.x = r; Value.y = g; Value.z = b; Value.w = a; }
+    ImColor(const ImVec4& col)                                       IM_NOEXCEPT { Value = col; }
+    inline operator ImU32() const                                    IM_NOEXCEPT { return ImGui::ColorConvertFloat4ToU32(Value); }
+    inline operator ImVec4() const                                   IM_NOEXCEPT { return Value; }
 
     // FIXME-OBSOLETE: May need to obsolete/cleanup those helpers.
-    inline void    SetHSV(float h, float s, float v, float a = 1.0f) IMGUI_NOEXCEPT { ImGui::ColorConvertHSVtoRGB(h, s, v, Value.x, Value.y, Value.z); Value.w = a; }
-    static ImColor HSV(float h, float s, float v, float a = 1.0f)    IMGUI_NOEXCEPT { float r, g, b; ImGui::ColorConvertHSVtoRGB(h, s, v, r, g, b); return ImColor(r, g, b, a); }
+    inline void    SetHSV(float h, float s, float v, float a = 1.0f) IM_NOEXCEPT { ImGui::ColorConvertHSVtoRGB(h, s, v, Value.x, Value.y, Value.z); Value.w = a; }
+    static ImColor HSV(float h, float s, float v, float a = 1.0f)    IM_NOEXCEPT { float r, g, b; ImGui::ColorConvertHSVtoRGB(h, s, v, r, g, b); return ImColor(r, g, b, a); }
 };
 
 //-----------------------------------------------------------------------------
@@ -2257,7 +2256,7 @@ struct ImDrawCmd
     ImDrawCmd() { memset(this, 0, sizeof(*this)); } // Also ensure our padding fields are zeroed
 
     // Since 1.83: returns ImTextureID associated with this draw call. Warning: DO NOT assume this is always same as 'TextureId' (we will change this function for an upcoming feature)
-    inline ImTextureID GetTexID() const IMGUI_NOEXCEPT { return TextureId; }
+    inline ImTextureID GetTexID() const IM_NOEXCEPT { return TextureId; }
 };
 
 // Vertex index, default to 16-bit
@@ -2307,13 +2306,13 @@ struct ImDrawListSplitter
     int                         _Count;      // Number of active channels (1+)
     ImVector<ImDrawChannel>     _Channels;   // Draw channels (not resized down so _Count might be < Channels.Size)
 
-    inline ImDrawListSplitter() IMGUI_NOEXCEPT  { memset(this, 0, sizeof(*this)); }
-    inline ~ImDrawListSplitter() IMGUI_NOEXCEPT { ClearFreeMemory(); }
-    inline void                 Clear() IMGUI_NOEXCEPT { _Current = 0; _Count = 1; } // Do not clear Channels[] so our allocations are reused next frame
-    IMGUI_API void              ClearFreeMemory() IMGUI_NOEXCEPT;
-    IMGUI_API void              Split(ImDrawList* draw_list, int count) IMGUI_NOEXCEPT;
-    IMGUI_API void              Merge(ImDrawList* draw_list) IMGUI_NOEXCEPT;
-    IMGUI_API void              SetCurrentChannel(ImDrawList* draw_list, int channel_idx) IMGUI_NOEXCEPT;
+    inline ImDrawListSplitter() IM_NOEXCEPT  { memset(this, 0, sizeof(*this)); }
+    inline ~ImDrawListSplitter() IM_NOEXCEPT { ClearFreeMemory(); }
+    inline void                 Clear() IM_NOEXCEPT { _Current = 0; _Count = 1; } // Do not clear Channels[] so our allocations are reused next frame
+    IMGUI_API void              ClearFreeMemory() IM_NOEXCEPT;
+    IMGUI_API void              Split(ImDrawList* draw_list, int count) IM_NOEXCEPT;
+    IMGUI_API void              Merge(ImDrawList* draw_list) IM_NOEXCEPT;
+    IMGUI_API void              SetCurrentChannel(ImDrawList* draw_list, int channel_idx) IM_NOEXCEPT;
 };
 
 // Flags for ImDrawList functions
@@ -2378,16 +2377,16 @@ struct ImDrawList
     float                   _FringeScale;       // [Internal] anti-alias fringe is scaled by this value, this helps to keep things sharp while zooming at vertex buffer content
 
     // If you want to create ImDrawList instances, pass them ImGui::GetDrawListSharedData() or create and use your own ImDrawListSharedData (so you can use ImDrawList without ImGui)
-    ImDrawList(const ImDrawListSharedData* shared_data) IMGUI_NOEXCEPT { memset(this, 0, sizeof(*this)); _Data = shared_data; }
+    ImDrawList(const ImDrawListSharedData* shared_data) IM_NOEXCEPT { memset(this, 0, sizeof(*this)); _Data = shared_data; }
 
-    ~ImDrawList() IMGUI_NOEXCEPT { _ClearFreeMemory(); }
-    IMGUI_API void  PushClipRect(ImVec2 clip_rect_min, ImVec2 clip_rect_max, bool intersect_with_current_clip_rect = false) IMGUI_NOEXCEPT;  // Render-level scissoring. This is passed down to your render function but not used for CPU-side coarse clipping. Prefer using higher-level ImGui::PushClipRect() to affect logic (hit-testing and widget culling)
-    IMGUI_API void  PushClipRectFullScreen() IMGUI_NOEXCEPT;
-    IMGUI_API void  PopClipRect() IMGUI_NOEXCEPT;
-    IMGUI_API void  PushTextureID(ImTextureID texture_id) IMGUI_NOEXCEPT;
-    IMGUI_API void  PopTextureID() IMGUI_NOEXCEPT;
-    inline ImVec2   GetClipRectMin() const IMGUI_NOEXCEPT { const ImVec4& cr = _ClipRectStack.back(); return ImVec2(cr.x, cr.y); }
-    inline ImVec2   GetClipRectMax() const IMGUI_NOEXCEPT { const ImVec4& cr = _ClipRectStack.back(); return ImVec2(cr.z, cr.w); }
+    ~ImDrawList() IM_NOEXCEPT { _ClearFreeMemory(); }
+    IMGUI_API void  PushClipRect(ImVec2 clip_rect_min, ImVec2 clip_rect_max, bool intersect_with_current_clip_rect = false) IM_NOEXCEPT;  // Render-level scissoring. This is passed down to your render function but not used for CPU-side coarse clipping. Prefer using higher-level ImGui::PushClipRect() to affect logic (hit-testing and widget culling)
+    IMGUI_API void  PushClipRectFullScreen() IM_NOEXCEPT;
+    IMGUI_API void  PopClipRect() IM_NOEXCEPT;
+    IMGUI_API void  PushTextureID(ImTextureID texture_id) IM_NOEXCEPT;
+    IMGUI_API void  PopTextureID() IM_NOEXCEPT;
+    inline ImVec2   GetClipRectMin() const IM_NOEXCEPT { const ImVec4& cr = _ClipRectStack.back(); return ImVec2(cr.x, cr.y); }
+    inline ImVec2   GetClipRectMax() const IM_NOEXCEPT { const ImVec4& cr = _ClipRectStack.back(); return ImVec2(cr.z, cr.w); }
 
     // Primitives
     // - For rectangular primitives, "p_min" and "p_max" represent the upper-left and lower-right corners.
@@ -2395,49 +2394,49 @@ struct ImDrawList
     //   In older versions (until Dear ImGui 1.77) the AddCircle functions defaulted to num_segments == 12.
     //   In future versions we will use textures to provide cheaper and higher-quality circles.
     //   Use AddNgon() and AddNgonFilled() functions if you need to guaranteed a specific number of sides.
-    IMGUI_API void  AddLine(const ImVec2& p1, const ImVec2& p2, ImU32 col, float thickness = 1.0f) IMGUI_NOEXCEPT;
-    IMGUI_API void  AddRect(const ImVec2& p_min, const ImVec2& p_max, ImU32 col, float rounding = 0.0f, ImDrawFlags flags = 0, float thickness = 1.0f) IMGUI_NOEXCEPT;   // a: upper-left, b: lower-right (== upper-left + size)
-    IMGUI_API void  AddRectFilled(const ImVec2& p_min, const ImVec2& p_max, ImU32 col, float rounding = 0.0f, ImDrawFlags flags = 0) IMGUI_NOEXCEPT;                     // a: upper-left, b: lower-right (== upper-left + size)
-    IMGUI_API void  AddRectFilledMultiColor(const ImVec2& p_min, const ImVec2& p_max, ImU32 col_upr_left, ImU32 col_upr_right, ImU32 col_bot_right, ImU32 col_bot_left) IMGUI_NOEXCEPT;
-    IMGUI_API void  AddQuad(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, ImU32 col, float thickness = 1.0f) IMGUI_NOEXCEPT;
-    IMGUI_API void  AddQuadFilled(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, ImU32 col) IMGUI_NOEXCEPT;
-    IMGUI_API void  AddTriangle(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, ImU32 col, float thickness = 1.0f) IMGUI_NOEXCEPT;
-    IMGUI_API void  AddTriangleFilled(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, ImU32 col) IMGUI_NOEXCEPT;
-    IMGUI_API void  AddCircle(const ImVec2& center, float radius, ImU32 col, int num_segments = 0, float thickness = 1.0f) IMGUI_NOEXCEPT;
-    IMGUI_API void  AddCircleFilled(const ImVec2& center, float radius, ImU32 col, int num_segments = 0) IMGUI_NOEXCEPT;
-    IMGUI_API void  AddNgon(const ImVec2& center, float radius, ImU32 col, int num_segments, float thickness = 1.0f) IMGUI_NOEXCEPT;
-    IMGUI_API void  AddNgonFilled(const ImVec2& center, float radius, ImU32 col, int num_segments) IMGUI_NOEXCEPT;
-    IMGUI_API void  AddText(const ImVec2& pos, ImU32 col, const char* text_begin, const char* text_end = NULL) IMGUI_NOEXCEPT;
-    IMGUI_API void  AddText(const ImFont* font, float font_size, const ImVec2& pos, ImU32 col, const char* text_begin, const char* text_end = NULL, float wrap_width = 0.0f, const ImVec4* cpu_fine_clip_rect = NULL) IMGUI_NOEXCEPT;
-    IMGUI_API void  AddPolyline(const ImVec2* points, int num_points, ImU32 col, ImDrawFlags flags, float thickness) IMGUI_NOEXCEPT;
-    IMGUI_API void  AddConvexPolyFilled(const ImVec2* points, int num_points, ImU32 col) IMGUI_NOEXCEPT; // Note: Anti-aliased filling requires points to be in clockwise order.
-    IMGUI_API void  AddBezierCubic(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, ImU32 col, float thickness, int num_segments = 0) IMGUI_NOEXCEPT; // Cubic Bezier (4 control points)
-    IMGUI_API void  AddBezierQuadratic(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, ImU32 col, float thickness, int num_segments = 0) IMGUI_NOEXCEPT;               // Quadratic Bezier (3 control points)
+    IMGUI_API void  AddLine(const ImVec2& p1, const ImVec2& p2, ImU32 col, float thickness = 1.0f) IM_NOEXCEPT;
+    IMGUI_API void  AddRect(const ImVec2& p_min, const ImVec2& p_max, ImU32 col, float rounding = 0.0f, ImDrawFlags flags = 0, float thickness = 1.0f) IM_NOEXCEPT;   // a: upper-left, b: lower-right (== upper-left + size)
+    IMGUI_API void  AddRectFilled(const ImVec2& p_min, const ImVec2& p_max, ImU32 col, float rounding = 0.0f, ImDrawFlags flags = 0) IM_NOEXCEPT;                     // a: upper-left, b: lower-right (== upper-left + size)
+    IMGUI_API void  AddRectFilledMultiColor(const ImVec2& p_min, const ImVec2& p_max, ImU32 col_upr_left, ImU32 col_upr_right, ImU32 col_bot_right, ImU32 col_bot_left) IM_NOEXCEPT;
+    IMGUI_API void  AddQuad(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, ImU32 col, float thickness = 1.0f) IM_NOEXCEPT;
+    IMGUI_API void  AddQuadFilled(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, ImU32 col) IM_NOEXCEPT;
+    IMGUI_API void  AddTriangle(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, ImU32 col, float thickness = 1.0f) IM_NOEXCEPT;
+    IMGUI_API void  AddTriangleFilled(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, ImU32 col) IM_NOEXCEPT;
+    IMGUI_API void  AddCircle(const ImVec2& center, float radius, ImU32 col, int num_segments = 0, float thickness = 1.0f) IM_NOEXCEPT;
+    IMGUI_API void  AddCircleFilled(const ImVec2& center, float radius, ImU32 col, int num_segments = 0) IM_NOEXCEPT;
+    IMGUI_API void  AddNgon(const ImVec2& center, float radius, ImU32 col, int num_segments, float thickness = 1.0f) IM_NOEXCEPT;
+    IMGUI_API void  AddNgonFilled(const ImVec2& center, float radius, ImU32 col, int num_segments) IM_NOEXCEPT;
+    IMGUI_API void  AddText(const ImVec2& pos, ImU32 col, const char* text_begin, const char* text_end = NULL) IM_NOEXCEPT;
+    IMGUI_API void  AddText(const ImFont* font, float font_size, const ImVec2& pos, ImU32 col, const char* text_begin, const char* text_end = NULL, float wrap_width = 0.0f, const ImVec4* cpu_fine_clip_rect = NULL) IM_NOEXCEPT;
+    IMGUI_API void  AddPolyline(const ImVec2* points, int num_points, ImU32 col, ImDrawFlags flags, float thickness) IM_NOEXCEPT;
+    IMGUI_API void  AddConvexPolyFilled(const ImVec2* points, int num_points, ImU32 col) IM_NOEXCEPT; // Note: Anti-aliased filling requires points to be in clockwise order.
+    IMGUI_API void  AddBezierCubic(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, ImU32 col, float thickness, int num_segments = 0) IM_NOEXCEPT; // Cubic Bezier (4 control points)
+    IMGUI_API void  AddBezierQuadratic(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, ImU32 col, float thickness, int num_segments = 0) IM_NOEXCEPT;               // Quadratic Bezier (3 control points)
 
     // Image primitives
     // - Read FAQ to understand what ImTextureID is.
     // - "p_min" and "p_max" represent the upper-left and lower-right corners of the rectangle.
     // - "uv_min" and "uv_max" represent the normalized texture coordinates to use for those corners. Using (0,0)->(1,1) texture coordinates will generally display the entire texture.
-    IMGUI_API void  AddImage(ImTextureID user_texture_id, const ImVec2& p_min, const ImVec2& p_max, const ImVec2& uv_min = ImVec2(0, 0), const ImVec2& uv_max = ImVec2(1, 1), ImU32 col = IM_COL32_WHITE) IMGUI_NOEXCEPT;
-    IMGUI_API void  AddImageQuad(ImTextureID user_texture_id, const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, const ImVec2& uv1 = ImVec2(0, 0), const ImVec2& uv2 = ImVec2(1, 0), const ImVec2& uv3 = ImVec2(1, 1), const ImVec2& uv4 = ImVec2(0, 1), ImU32 col = IM_COL32_WHITE) IMGUI_NOEXCEPT;
-    IMGUI_API void  AddImageRounded(ImTextureID user_texture_id, const ImVec2& p_min, const ImVec2& p_max, const ImVec2& uv_min, const ImVec2& uv_max, ImU32 col, float rounding, ImDrawFlags flags = 0) IMGUI_NOEXCEPT;
+    IMGUI_API void  AddImage(ImTextureID user_texture_id, const ImVec2& p_min, const ImVec2& p_max, const ImVec2& uv_min = ImVec2(0, 0), const ImVec2& uv_max = ImVec2(1, 1), ImU32 col = IM_COL32_WHITE) IM_NOEXCEPT;
+    IMGUI_API void  AddImageQuad(ImTextureID user_texture_id, const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, const ImVec2& uv1 = ImVec2(0, 0), const ImVec2& uv2 = ImVec2(1, 0), const ImVec2& uv3 = ImVec2(1, 1), const ImVec2& uv4 = ImVec2(0, 1), ImU32 col = IM_COL32_WHITE) IM_NOEXCEPT;
+    IMGUI_API void  AddImageRounded(ImTextureID user_texture_id, const ImVec2& p_min, const ImVec2& p_max, const ImVec2& uv_min, const ImVec2& uv_max, ImU32 col, float rounding, ImDrawFlags flags = 0) IM_NOEXCEPT;
 
     // Stateful path API, add points then finish with PathFillConvex() or PathStroke()
-    inline    void  PathClear()                                 IMGUI_NOEXCEPT   { _Path.Size = 0; }
-    inline    void  PathLineTo(const ImVec2& pos)               IMGUI_NOEXCEPT   { _Path.push_back(pos); }
-    inline    void  PathLineToMergeDuplicate(const ImVec2& pos) IMGUI_NOEXCEPT   { if (_Path.Size == 0 || memcmp(&_Path.Data[_Path.Size - 1], &pos, 8) != 0) _Path.push_back(pos); }
-    inline    void  PathFillConvex(ImU32 col)                   IMGUI_NOEXCEPT   { AddConvexPolyFilled(_Path.Data, _Path.Size, col); _Path.Size = 0; }  // Note: Anti-aliased filling requires points to be in clockwise order.
-    inline    void  PathStroke(ImU32 col, ImDrawFlags flags = 0, float thickness = 1.0f) IMGUI_NOEXCEPT { AddPolyline(_Path.Data, _Path.Size, col, flags, thickness); _Path.Size = 0; }
-    IMGUI_API void  PathArcTo(const ImVec2& center, float radius, float a_min, float a_max, int num_segments = 0) IMGUI_NOEXCEPT;
-    IMGUI_API void  PathArcToFast(const ImVec2& center, float radius, int a_min_of_12, int a_max_of_12) IMGUI_NOEXCEPT;                // Use precomputed angles for a 12 steps circle
-    IMGUI_API void  PathBezierCubicCurveTo(const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, int num_segments = 0) IMGUI_NOEXCEPT; // Cubic Bezier (4 control points)
-    IMGUI_API void  PathBezierQuadraticCurveTo(const ImVec2& p2, const ImVec2& p3, int num_segments = 0) IMGUI_NOEXCEPT;               // Quadratic Bezier (3 control points)
-    IMGUI_API void  PathRect(const ImVec2& rect_min, const ImVec2& rect_max, float rounding = 0.0f, ImDrawFlags flags = 0) IMGUI_NOEXCEPT;
+    inline    void  PathClear()                                 IM_NOEXCEPT   { _Path.Size = 0; }
+    inline    void  PathLineTo(const ImVec2& pos)               IM_NOEXCEPT   { _Path.push_back(pos); }
+    inline    void  PathLineToMergeDuplicate(const ImVec2& pos) IM_NOEXCEPT   { if (_Path.Size == 0 || memcmp(&_Path.Data[_Path.Size - 1], &pos, 8) != 0) _Path.push_back(pos); }
+    inline    void  PathFillConvex(ImU32 col)                   IM_NOEXCEPT   { AddConvexPolyFilled(_Path.Data, _Path.Size, col); _Path.Size = 0; }  // Note: Anti-aliased filling requires points to be in clockwise order.
+    inline    void  PathStroke(ImU32 col, ImDrawFlags flags = 0, float thickness = 1.0f) IM_NOEXCEPT { AddPolyline(_Path.Data, _Path.Size, col, flags, thickness); _Path.Size = 0; }
+    IMGUI_API void  PathArcTo(const ImVec2& center, float radius, float a_min, float a_max, int num_segments = 0) IM_NOEXCEPT;
+    IMGUI_API void  PathArcToFast(const ImVec2& center, float radius, int a_min_of_12, int a_max_of_12) IM_NOEXCEPT;                // Use precomputed angles for a 12 steps circle
+    IMGUI_API void  PathBezierCubicCurveTo(const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, int num_segments = 0) IM_NOEXCEPT; // Cubic Bezier (4 control points)
+    IMGUI_API void  PathBezierQuadraticCurveTo(const ImVec2& p2, const ImVec2& p3, int num_segments = 0) IM_NOEXCEPT;               // Quadratic Bezier (3 control points)
+    IMGUI_API void  PathRect(const ImVec2& rect_min, const ImVec2& rect_max, float rounding = 0.0f, ImDrawFlags flags = 0) IM_NOEXCEPT;
 
     // Advanced
-    IMGUI_API void  AddCallback(ImDrawCallback callback, void* callback_data) IMGUI_NOEXCEPT;  // Your rendering function must check for 'UserCallback' in ImDrawCmd and call the function instead of rendering triangles.
-    IMGUI_API void  AddDrawCmd() IMGUI_NOEXCEPT;                                               // This is useful if you need to forcefully create a new draw call (to allow for dependent rendering / blending). Otherwise primitives are merged into the same draw-call as much as possible
-    IMGUI_API ImDrawList* CloneOutput() const IMGUI_NOEXCEPT;                                  // Create a clone of the CmdBuffer/IdxBuffer/VtxBuffer.
+    IMGUI_API void  AddCallback(ImDrawCallback callback, void* callback_data) IM_NOEXCEPT;  // Your rendering function must check for 'UserCallback' in ImDrawCmd and call the function instead of rendering triangles.
+    IMGUI_API void  AddDrawCmd() IM_NOEXCEPT;                                               // This is useful if you need to forcefully create a new draw call (to allow for dependent rendering / blending). Otherwise primitives are merged into the same draw-call as much as possible
+    IMGUI_API ImDrawList* CloneOutput() const IM_NOEXCEPT;                                  // Create a clone of the CmdBuffer/IdxBuffer/VtxBuffer.
 
     // Advanced: Channels
     // - Use to split render into layers. By switching channels to can render out-of-order (e.g. submit FG primitives before BG primitives)
@@ -2445,37 +2444,37 @@ struct ImDrawList
     // - FIXME-OBSOLETE: This API shouldn't have been in ImDrawList in the first place!
     //   Prefer using your own persistent instance of ImDrawListSplitter as you can stack them.
     //   Using the ImDrawList::ChannelsXXXX you cannot stack a split over another.
-    inline void     ChannelsSplit(int count)  IMGUI_NOEXCEPT   { _Splitter.Split(this, count); }
-    inline void     ChannelsMerge()           IMGUI_NOEXCEPT   { _Splitter.Merge(this); }
-    inline void     ChannelsSetCurrent(int n) IMGUI_NOEXCEPT   { _Splitter.SetCurrentChannel(this, n); }
+    inline void     ChannelsSplit(int count)  IM_NOEXCEPT   { _Splitter.Split(this, count); }
+    inline void     ChannelsMerge()           IM_NOEXCEPT   { _Splitter.Merge(this); }
+    inline void     ChannelsSetCurrent(int n) IM_NOEXCEPT   { _Splitter.SetCurrentChannel(this, n); }
 
     // Advanced: Primitives allocations
     // - We render triangles (three vertices)
     // - All primitives needs to be reserved via PrimReserve() beforehand.
-    IMGUI_API void  PrimReserve(int idx_count, int vtx_count) IMGUI_NOEXCEPT;
-    IMGUI_API void  PrimUnreserve(int idx_count, int vtx_count) IMGUI_NOEXCEPT;
-    IMGUI_API void  PrimRect(const ImVec2& a, const ImVec2& b, ImU32 col) IMGUI_NOEXCEPT;      // Axis aligned rectangle (composed of two triangles)
-    IMGUI_API void  PrimRectUV(const ImVec2& a, const ImVec2& b, const ImVec2& uv_a, const ImVec2& uv_b, ImU32 col) IMGUI_NOEXCEPT;
-    IMGUI_API void  PrimQuadUV(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& d, const ImVec2& uv_a, const ImVec2& uv_b, const ImVec2& uv_c, const ImVec2& uv_d, ImU32 col) IMGUI_NOEXCEPT;
-    inline    void  PrimWriteVtx(const ImVec2& pos, const ImVec2& uv, ImU32 col) IMGUI_NOEXCEPT    { _VtxWritePtr->pos = pos; _VtxWritePtr->uv = uv; _VtxWritePtr->col = col; _VtxWritePtr++; _VtxCurrentIdx++; }
-    inline    void  PrimWriteIdx(ImDrawIdx idx)                                  IMGUI_NOEXCEPT    { *_IdxWritePtr = idx; _IdxWritePtr++; }
-    inline    void  PrimVtx(const ImVec2& pos, const ImVec2& uv, ImU32 col)      IMGUI_NOEXCEPT    { PrimWriteIdx((ImDrawIdx)_VtxCurrentIdx); PrimWriteVtx(pos, uv, col); } // Write vertex with unique index
+    IMGUI_API void  PrimReserve(int idx_count, int vtx_count) IM_NOEXCEPT;
+    IMGUI_API void  PrimUnreserve(int idx_count, int vtx_count) IM_NOEXCEPT;
+    IMGUI_API void  PrimRect(const ImVec2& a, const ImVec2& b, ImU32 col) IM_NOEXCEPT;      // Axis aligned rectangle (composed of two triangles)
+    IMGUI_API void  PrimRectUV(const ImVec2& a, const ImVec2& b, const ImVec2& uv_a, const ImVec2& uv_b, ImU32 col) IM_NOEXCEPT;
+    IMGUI_API void  PrimQuadUV(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& d, const ImVec2& uv_a, const ImVec2& uv_b, const ImVec2& uv_c, const ImVec2& uv_d, ImU32 col) IM_NOEXCEPT;
+    inline    void  PrimWriteVtx(const ImVec2& pos, const ImVec2& uv, ImU32 col) IM_NOEXCEPT    { _VtxWritePtr->pos = pos; _VtxWritePtr->uv = uv; _VtxWritePtr->col = col; _VtxWritePtr++; _VtxCurrentIdx++; }
+    inline    void  PrimWriteIdx(ImDrawIdx idx)                                  IM_NOEXCEPT    { *_IdxWritePtr = idx; _IdxWritePtr++; }
+    inline    void  PrimVtx(const ImVec2& pos, const ImVec2& uv, ImU32 col)      IM_NOEXCEPT    { PrimWriteIdx((ImDrawIdx)_VtxCurrentIdx); PrimWriteVtx(pos, uv, col); } // Write vertex with unique index
 
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
-    inline    void  AddBezierCurve(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, ImU32 col, float thickness, int num_segments = 0) IMGUI_NOEXCEPT { AddBezierCubic(p1, p2, p3, p4, col, thickness, num_segments); }
-    inline    void  PathBezierCurveTo(const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, int num_segments = 0) IMGUI_NOEXCEPT { PathBezierCubicCurveTo(p2, p3, p4, num_segments); }
+    inline    void  AddBezierCurve(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, ImU32 col, float thickness, int num_segments = 0) IM_NOEXCEPT { AddBezierCubic(p1, p2, p3, p4, col, thickness, num_segments); }
+    inline    void  PathBezierCurveTo(const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, int num_segments = 0) IM_NOEXCEPT { PathBezierCubicCurveTo(p2, p3, p4, num_segments); }
 #endif
 
     // [Internal helpers]
-    IMGUI_API void  _ResetForNewFrame() IMGUI_NOEXCEPT;
-    IMGUI_API void  _ClearFreeMemory() IMGUI_NOEXCEPT;
-    IMGUI_API void  _PopUnusedDrawCmd() IMGUI_NOEXCEPT;
-    IMGUI_API void  _OnChangedClipRect() IMGUI_NOEXCEPT;
-    IMGUI_API void  _OnChangedTextureID() IMGUI_NOEXCEPT;
-    IMGUI_API void  _OnChangedVtxOffset() IMGUI_NOEXCEPT;
-    IMGUI_API int   _CalcCircleAutoSegmentCount(float radius) const IMGUI_NOEXCEPT;
-    IMGUI_API void  _PathArcToFastEx(const ImVec2& center, float radius, int a_min_sample, int a_max_sample, int a_step) IMGUI_NOEXCEPT;
-    IMGUI_API void  _PathArcToN(const ImVec2& center, float radius, float a_min, float a_max, int num_segments) IMGUI_NOEXCEPT;
+    IMGUI_API void  _ResetForNewFrame() IM_NOEXCEPT;
+    IMGUI_API void  _ClearFreeMemory() IM_NOEXCEPT;
+    IMGUI_API void  _PopUnusedDrawCmd() IM_NOEXCEPT;
+    IMGUI_API void  _OnChangedClipRect() IM_NOEXCEPT;
+    IMGUI_API void  _OnChangedTextureID() IM_NOEXCEPT;
+    IMGUI_API void  _OnChangedVtxOffset() IM_NOEXCEPT;
+    IMGUI_API int   _CalcCircleAutoSegmentCount(float radius) const IM_NOEXCEPT;
+    IMGUI_API void  _PathArcToFastEx(const ImVec2& center, float radius, int a_min_sample, int a_max_sample, int a_step) IM_NOEXCEPT;
+    IMGUI_API void  _PathArcToN(const ImVec2& center, float radius, float a_min, float a_max, int num_segments) IM_NOEXCEPT;
 };
 
 // All draw data to render a Dear ImGui frame
@@ -2493,10 +2492,10 @@ struct ImDrawData
     ImVec2          FramebufferScale;       // Amount of pixels for each unit of DisplaySize. Based on io.DisplayFramebufferScale. Generally (1,1) on normal display, (2,2) on OSX with Retina display.
 
     // Functions
-    ImDrawData() IMGUI_NOEXCEPT { Clear(); }
-    void Clear() IMGUI_NOEXCEPT { memset(this, 0, sizeof(*this)); }         // The ImDrawList are owned by ImGuiContext!
-    IMGUI_API void  DeIndexAllBuffers()                    IMGUI_NOEXCEPT;  // Helper to convert all buffers from indexed to non-indexed, in case you cannot render indexed. Note: this is slow and most likely a waste of resources. Always prefer indexed rendering!
-    IMGUI_API void  ScaleClipRects(const ImVec2& fb_scale) IMGUI_NOEXCEPT;  // Helper to scale the ClipRect field of each ImDrawCmd. Use if your final output buffer is at a different scale than Dear ImGui expects, or if there is a difference between your window resolution and framebuffer resolution.
+    ImDrawData() IM_NOEXCEPT { Clear(); }
+    void Clear() IM_NOEXCEPT { memset(this, 0, sizeof(*this)); }         // The ImDrawList are owned by ImGuiContext!
+    IMGUI_API void  DeIndexAllBuffers()                    IM_NOEXCEPT;  // Helper to convert all buffers from indexed to non-indexed, in case you cannot render indexed. Note: this is slow and most likely a waste of resources. Always prefer indexed rendering!
+    IMGUI_API void  ScaleClipRects(const ImVec2& fb_scale) IM_NOEXCEPT;  // Helper to scale the ClipRect field of each ImDrawCmd. Use if your final output buffer is at a different scale than Dear ImGui expects, or if there is a difference between your window resolution and framebuffer resolution.
 };
 
 //-----------------------------------------------------------------------------
@@ -2527,7 +2526,7 @@ struct ImFontConfig
     char            Name[40];               // Name (strictly to ease debugging)
     ImFont*         DstFont;
 
-    IMGUI_API ImFontConfig() IMGUI_NOEXCEPT;
+    IMGUI_API ImFontConfig() IM_NOEXCEPT;
 };
 
 // Hold rendering data for one glyph.
@@ -2548,14 +2547,14 @@ struct ImFontGlyphRangesBuilder
 {
     ImVector<ImU32> UsedChars;            // Store 1-bit per Unicode code point (0=unused, 1=used)
 
-    ImFontGlyphRangesBuilder()             IMGUI_NOEXCEPT { Clear(); }
-    inline void     Clear()                IMGUI_NOEXCEPT { int size_in_bytes = (IM_UNICODE_CODEPOINT_MAX + 1) / 8; UsedChars.resize(size_in_bytes / (int)sizeof(ImU32)); memset(UsedChars.Data, 0, (size_t)size_in_bytes); }
-    inline bool     GetBit(size_t n) const IMGUI_NOEXCEPT { int off = (int)(n >> 5); ImU32 mask = 1u << (n & 31); return (UsedChars[off] & mask) != 0; }  // Get bit n in the array
-    inline void     SetBit(size_t n)       IMGUI_NOEXCEPT { int off = (int)(n >> 5); ImU32 mask = 1u << (n & 31); UsedChars[off] |= mask; }               // Set bit n in the array
-    inline void     AddChar(ImWchar c)     IMGUI_NOEXCEPT { SetBit(c); }                    // Add character
-    IMGUI_API void  AddText(const char* text, const char* text_end = NULL) IMGUI_NOEXCEPT;  // Add string (each character of the UTF-8 string are added)
-    IMGUI_API void  AddRanges(const ImWchar* ranges)                       IMGUI_NOEXCEPT;  // Add ranges, e.g. builder.AddRanges(ImFontAtlas::GetGlyphRangesDefault()) to force add all of ASCII/Latin+Ext
-    IMGUI_API void  BuildRanges(ImVector<ImWchar>* out_ranges)             IMGUI_NOEXCEPT;  // Output new ranges
+    ImFontGlyphRangesBuilder()             IM_NOEXCEPT { Clear(); }
+    inline void     Clear()                IM_NOEXCEPT { int size_in_bytes = (IM_UNICODE_CODEPOINT_MAX + 1) / 8; UsedChars.resize(size_in_bytes / (int)sizeof(ImU32)); memset(UsedChars.Data, 0, (size_t)size_in_bytes); }
+    inline bool     GetBit(size_t n) const IM_NOEXCEPT { int off = (int)(n >> 5); ImU32 mask = 1u << (n & 31); return (UsedChars[off] & mask) != 0; }  // Get bit n in the array
+    inline void     SetBit(size_t n)       IM_NOEXCEPT { int off = (int)(n >> 5); ImU32 mask = 1u << (n & 31); UsedChars[off] |= mask; }               // Set bit n in the array
+    inline void     AddChar(ImWchar c)     IM_NOEXCEPT { SetBit(c); }                    // Add character
+    IMGUI_API void  AddText(const char* text, const char* text_end = NULL) IM_NOEXCEPT;  // Add string (each character of the UTF-8 string are added)
+    IMGUI_API void  AddRanges(const ImWchar* ranges)                       IM_NOEXCEPT;  // Add ranges, e.g. builder.AddRanges(ImFontAtlas::GetGlyphRangesDefault()) to force add all of ASCII/Latin+Ext
+    IMGUI_API void  BuildRanges(ImVector<ImWchar>* out_ranges)             IM_NOEXCEPT;  // Output new ranges
 };
 
 // See ImFontAtlas::AddCustomRectXXX functions.
@@ -2567,8 +2566,8 @@ struct ImFontAtlasCustomRect
     float           GlyphAdvanceX;  // Input    // For custom font glyphs only: glyph xadvance
     ImVec2          GlyphOffset;    // Input    // For custom font glyphs only: glyph display offset
     ImFont*         Font;           // Input    // For custom font glyphs only: target font
-    ImFontAtlasCustomRect() IMGUI_NOEXCEPT { Width = Height = 0; X = Y = 0xFFFF; GlyphID = 0; GlyphAdvanceX = 0.0f; GlyphOffset = ImVec2(0, 0); Font = NULL; }
-    bool IsPacked() const   IMGUI_NOEXCEPT { return X != 0xFFFF; }
+    ImFontAtlasCustomRect() IM_NOEXCEPT { Width = Height = 0; X = Y = 0xFFFF; GlyphID = 0; GlyphAdvanceX = 0.0f; GlyphOffset = ImVec2(0, 0); Font = NULL; }
+    bool IsPacked() const   IM_NOEXCEPT { return X != 0xFFFF; }
 };
 
 // Flags for ImFontAtlas build
@@ -2599,29 +2598,29 @@ enum ImFontAtlasFlags_
 // - This is an old API and it is currently awkward for those and and various other reasons! We will address them in the future!
 struct ImFontAtlas
 {
-    IMGUI_API ImFontAtlas() IMGUI_NOEXCEPT;
-    IMGUI_API ~ImFontAtlas() IMGUI_NOEXCEPT;
-    IMGUI_API ImFont*           AddFont(const ImFontConfig* font_cfg) IMGUI_NOEXCEPT;
-    IMGUI_API ImFont*           AddFontDefault(const ImFontConfig* font_cfg = NULL) IMGUI_NOEXCEPT;
-    IMGUI_API ImFont*           AddFontFromFileTTF(const char* filename, float size_pixels, const ImFontConfig* font_cfg = NULL, const ImWchar* glyph_ranges = NULL) IMGUI_NOEXCEPT;
-    IMGUI_API ImFont*           AddFontFromMemoryTTF(void* font_data, int font_size, float size_pixels, const ImFontConfig* font_cfg = NULL, const ImWchar* glyph_ranges = NULL) IMGUI_NOEXCEPT; // Note: Transfer ownership of 'ttf_data' to ImFontAtlas! Will be deleted after destruction of the atlas. Set font_cfg->FontDataOwnedByAtlas=false to keep ownership of your data and it won't be freed.
-    IMGUI_API ImFont*           AddFontFromMemoryCompressedTTF(const void* compressed_font_data, int compressed_font_size, float size_pixels, const ImFontConfig* font_cfg = NULL, const ImWchar* glyph_ranges = NULL) IMGUI_NOEXCEPT; // 'compressed_font_data' still owned by caller. Compress with binary_to_compressed_c.cpp.
-    IMGUI_API ImFont*           AddFontFromMemoryCompressedBase85TTF(const char* compressed_font_data_base85, float size_pixels, const ImFontConfig* font_cfg = NULL, const ImWchar* glyph_ranges = NULL) IMGUI_NOEXCEPT;              // 'compressed_font_data_base85' still owned by caller. Compress with binary_to_compressed_c.cpp with -base85 parameter.
-    IMGUI_API void              ClearInputData() IMGUI_NOEXCEPT;  // Clear input data (all ImFontConfig structures including sizes, TTF data, glyph ranges, etc.) = all the data used to build the texture and fonts.
-    IMGUI_API void              ClearTexData()   IMGUI_NOEXCEPT;  // Clear output texture data (CPU side). Saves RAM once the texture has been copied to graphics memory.
-    IMGUI_API void              ClearFonts()     IMGUI_NOEXCEPT;  // Clear output font data (glyphs storage, UV coordinates).
-    IMGUI_API void              Clear()          IMGUI_NOEXCEPT;  // Clear all input and output.
+    IMGUI_API ImFontAtlas() IM_NOEXCEPT;
+    IMGUI_API ~ImFontAtlas() IM_NOEXCEPT;
+    IMGUI_API ImFont*           AddFont(const ImFontConfig* font_cfg) IM_NOEXCEPT;
+    IMGUI_API ImFont*           AddFontDefault(const ImFontConfig* font_cfg = NULL) IM_NOEXCEPT;
+    IMGUI_API ImFont*           AddFontFromFileTTF(const char* filename, float size_pixels, const ImFontConfig* font_cfg = NULL, const ImWchar* glyph_ranges = NULL) IM_NOEXCEPT;
+    IMGUI_API ImFont*           AddFontFromMemoryTTF(void* font_data, int font_size, float size_pixels, const ImFontConfig* font_cfg = NULL, const ImWchar* glyph_ranges = NULL) IM_NOEXCEPT; // Note: Transfer ownership of 'ttf_data' to ImFontAtlas! Will be deleted after destruction of the atlas. Set font_cfg->FontDataOwnedByAtlas=false to keep ownership of your data and it won't be freed.
+    IMGUI_API ImFont*           AddFontFromMemoryCompressedTTF(const void* compressed_font_data, int compressed_font_size, float size_pixels, const ImFontConfig* font_cfg = NULL, const ImWchar* glyph_ranges = NULL) IM_NOEXCEPT; // 'compressed_font_data' still owned by caller. Compress with binary_to_compressed_c.cpp.
+    IMGUI_API ImFont*           AddFontFromMemoryCompressedBase85TTF(const char* compressed_font_data_base85, float size_pixels, const ImFontConfig* font_cfg = NULL, const ImWchar* glyph_ranges = NULL) IM_NOEXCEPT;              // 'compressed_font_data_base85' still owned by caller. Compress with binary_to_compressed_c.cpp with -base85 parameter.
+    IMGUI_API void              ClearInputData() IM_NOEXCEPT;  // Clear input data (all ImFontConfig structures including sizes, TTF data, glyph ranges, etc.) = all the data used to build the texture and fonts.
+    IMGUI_API void              ClearTexData()   IM_NOEXCEPT;  // Clear output texture data (CPU side). Saves RAM once the texture has been copied to graphics memory.
+    IMGUI_API void              ClearFonts()     IM_NOEXCEPT;  // Clear output font data (glyphs storage, UV coordinates).
+    IMGUI_API void              Clear()          IM_NOEXCEPT;  // Clear all input and output.
 
     // Build atlas, retrieve pixel data.
     // User is in charge of copying the pixels into graphics memory (e.g. create a texture with your engine). Then store your texture handle with SetTexID().
     // The pitch is always = Width * BytesPerPixels (1 or 4)
     // Building in RGBA32 format is provided for convenience and compatibility, but note that unless you manually manipulate or copy color data into
     // the texture (e.g. when using the AddCustomRect*** api), then the RGB pixels emitted will always be white (~75% of memory/bandwidth waste.
-    IMGUI_API bool              Build() IMGUI_NOEXCEPT;     // Build pixels data. This is called automatically for you by the GetTexData*** functions.
-    IMGUI_API void              GetTexDataAsAlpha8(unsigned char** out_pixels, int* out_width, int* out_height, int* out_bytes_per_pixel = NULL) IMGUI_NOEXCEPT;  // 1 byte per-pixel
-    IMGUI_API void              GetTexDataAsRGBA32(unsigned char** out_pixels, int* out_width, int* out_height, int* out_bytes_per_pixel = NULL) IMGUI_NOEXCEPT;  // 4 bytes-per-pixel
-    bool                        IsBuilt() const IMGUI_NOEXCEPT          { return Fonts.Size > 0 && (TexPixelsAlpha8 != NULL || TexPixelsRGBA32 != NULL); }
-    void                        SetTexID(ImTextureID id) IMGUI_NOEXCEPT { TexID = id; }
+    IMGUI_API bool              Build() IM_NOEXCEPT;     // Build pixels data. This is called automatically for you by the GetTexData*** functions.
+    IMGUI_API void              GetTexDataAsAlpha8(unsigned char** out_pixels, int* out_width, int* out_height, int* out_bytes_per_pixel = NULL) IM_NOEXCEPT;  // 1 byte per-pixel
+    IMGUI_API void              GetTexDataAsRGBA32(unsigned char** out_pixels, int* out_width, int* out_height, int* out_bytes_per_pixel = NULL) IM_NOEXCEPT;  // 4 bytes-per-pixel
+    bool                        IsBuilt() const IM_NOEXCEPT          { return Fonts.Size > 0 && (TexPixelsAlpha8 != NULL || TexPixelsRGBA32 != NULL); }
+    void                        SetTexID(ImTextureID id) IM_NOEXCEPT { TexID = id; }
 
     //-------------------------------------------
     // Glyph Ranges
@@ -2630,14 +2629,14 @@ struct ImFontAtlas
     // Helpers to retrieve list of common Unicode ranges (2 value per range, values are inclusive, zero-terminated list)
     // NB: Make sure that your string are UTF-8 and NOT in your local code page. In C++11, you can create UTF-8 string literal using the u8"Hello world" syntax. See FAQ for details.
     // NB: Consider using ImFontGlyphRangesBuilder to build glyph ranges from textual data.
-    IMGUI_API const ImWchar*    GetGlyphRangesDefault()                 IMGUI_NOEXCEPT;  // Basic Latin, Extended Latin
-    IMGUI_API const ImWchar*    GetGlyphRangesKorean()                  IMGUI_NOEXCEPT;  // Default + Korean characters
-    IMGUI_API const ImWchar*    GetGlyphRangesJapanese()                IMGUI_NOEXCEPT;  // Default + Hiragana, Katakana, Half-Width, Selection of 2999 Ideographs
-    IMGUI_API const ImWchar*    GetGlyphRangesChineseFull()             IMGUI_NOEXCEPT;  // Default + Half-Width + Japanese Hiragana/Katakana + full set of about 21000 CJK Unified Ideographs
-    IMGUI_API const ImWchar*    GetGlyphRangesChineseSimplifiedCommon() IMGUI_NOEXCEPT;  // Default + Half-Width + Japanese Hiragana/Katakana + set of 2500 CJK Unified Ideographs for common simplified Chinese
-    IMGUI_API const ImWchar*    GetGlyphRangesCyrillic()                IMGUI_NOEXCEPT;  // Default + about 400 Cyrillic characters
-    IMGUI_API const ImWchar*    GetGlyphRangesThai()                    IMGUI_NOEXCEPT;  // Default + Thai characters
-    IMGUI_API const ImWchar*    GetGlyphRangesVietnamese()              IMGUI_NOEXCEPT;  // Default + Vietnamese characters
+    IMGUI_API const ImWchar*    GetGlyphRangesDefault()                 IM_NOEXCEPT;  // Basic Latin, Extended Latin
+    IMGUI_API const ImWchar*    GetGlyphRangesKorean()                  IM_NOEXCEPT;  // Default + Korean characters
+    IMGUI_API const ImWchar*    GetGlyphRangesJapanese()                IM_NOEXCEPT;  // Default + Hiragana, Katakana, Half-Width, Selection of 2999 Ideographs
+    IMGUI_API const ImWchar*    GetGlyphRangesChineseFull()             IM_NOEXCEPT;  // Default + Half-Width + Japanese Hiragana/Katakana + full set of about 21000 CJK Unified Ideographs
+    IMGUI_API const ImWchar*    GetGlyphRangesChineseSimplifiedCommon() IM_NOEXCEPT;  // Default + Half-Width + Japanese Hiragana/Katakana + set of 2500 CJK Unified Ideographs for common simplified Chinese
+    IMGUI_API const ImWchar*    GetGlyphRangesCyrillic()                IM_NOEXCEPT;  // Default + about 400 Cyrillic characters
+    IMGUI_API const ImWchar*    GetGlyphRangesThai()                    IM_NOEXCEPT;  // Default + Thai characters
+    IMGUI_API const ImWchar*    GetGlyphRangesVietnamese()              IM_NOEXCEPT;  // Default + Vietnamese characters
 
     //-------------------------------------------
     // [BETA] Custom Rectangles/Glyphs API
@@ -2650,13 +2649,13 @@ struct ImFontAtlas
     //   so you can render e.g. custom colorful icons and use them as regular glyphs.
     // - Read docs/FONTS.md for more details about using colorful icons.
     // - Note: this API may be redesigned later in order to support multi-monitor varying DPI settings.
-    IMGUI_API int               AddCustomRectRegular(int width, int height) IMGUI_NOEXCEPT;
-    IMGUI_API int               AddCustomRectFontGlyph(ImFont* font, ImWchar id, int width, int height, float advance_x, const ImVec2& offset = ImVec2(0, 0)) IMGUI_NOEXCEPT;
-    ImFontAtlasCustomRect*      GetCustomRectByIndex(int index) IMGUI_NOEXCEPT { IM_ASSERT(index >= 0); return &CustomRects[index]; }
+    IMGUI_API int               AddCustomRectRegular(int width, int height) IM_NOEXCEPT;
+    IMGUI_API int               AddCustomRectFontGlyph(ImFont* font, ImWchar id, int width, int height, float advance_x, const ImVec2& offset = ImVec2(0, 0)) IM_NOEXCEPT;
+    ImFontAtlasCustomRect*      GetCustomRectByIndex(int index) IM_NOEXCEPT { IM_ASSERT(index >= 0); return &CustomRects[index]; }
 
     // [Internal]
-    IMGUI_API void              CalcCustomRectUV(const ImFontAtlasCustomRect* rect, ImVec2* out_uv_min, ImVec2* out_uv_max) const IMGUI_NOEXCEPT;
-    IMGUI_API bool              GetMouseCursorTexData(ImGuiMouseCursor cursor, ImVec2* out_offset, ImVec2* out_size, ImVec2 out_uv_border[2], ImVec2 out_uv_fill[2]) IMGUI_NOEXCEPT;
+    IMGUI_API void              CalcCustomRectUV(const ImFontAtlasCustomRect* rect, ImVec2* out_uv_min, ImVec2* out_uv_max) const IM_NOEXCEPT;
+    IMGUI_API bool              GetMouseCursorTexData(ImGuiMouseCursor cursor, ImVec2* out_offset, ImVec2* out_size, ImVec2 out_uv_border[2], ImVec2 out_uv_fill[2]) IM_NOEXCEPT;
 
     //-------------------------------------------
     // Members
@@ -2723,30 +2722,30 @@ struct ImFont
     ImU8                        Used4kPagesMap[(IM_UNICODE_CODEPOINT_MAX+1)/4096/8]; // 2 bytes if ImWchar=ImWchar16, 34 bytes if ImWchar==ImWchar32. Store 1-bit for each block of 4K codepoints that has one active glyph. This is mainly used to facilitate iterations across all used codepoints.
 
     // Methods
-    IMGUI_API ImFont()  IMGUI_NOEXCEPT;
-    IMGUI_API ~ImFont() IMGUI_NOEXCEPT;
-    IMGUI_API const ImFontGlyph*FindGlyph(ImWchar c) const           IMGUI_NOEXCEPT;
-    IMGUI_API const ImFontGlyph*FindGlyphNoFallback(ImWchar c) const IMGUI_NOEXCEPT;
-    float                       GetCharAdvance(ImWchar c) const      IMGUI_NOEXCEPT { return ((int)c < IndexAdvanceX.Size) ? IndexAdvanceX[(int)c] : FallbackAdvanceX; }
-    bool                        IsLoaded() const                     IMGUI_NOEXCEPT { return ContainerAtlas != NULL; }
-    const char*                 GetDebugName() const                 IMGUI_NOEXCEPT { return ConfigData ? ConfigData->Name : "<unknown>"; }
+    IMGUI_API ImFont()  IM_NOEXCEPT;
+    IMGUI_API ~ImFont() IM_NOEXCEPT;
+    IMGUI_API const ImFontGlyph*FindGlyph(ImWchar c) const           IM_NOEXCEPT;
+    IMGUI_API const ImFontGlyph*FindGlyphNoFallback(ImWchar c) const IM_NOEXCEPT;
+    float                       GetCharAdvance(ImWchar c) const      IM_NOEXCEPT { return ((int)c < IndexAdvanceX.Size) ? IndexAdvanceX[(int)c] : FallbackAdvanceX; }
+    bool                        IsLoaded() const                     IM_NOEXCEPT { return ContainerAtlas != NULL; }
+    const char*                 GetDebugName() const                 IM_NOEXCEPT { return ConfigData ? ConfigData->Name : "<unknown>"; }
 
     // 'max_width' stops rendering after a certain width (could be turned into a 2d size). FLT_MAX to disable.
     // 'wrap_width' enable automatic word-wrapping across multiple lines to fit into given width. 0.0f to disable.
-    IMGUI_API ImVec2            CalcTextSizeA(float size, float max_width, float wrap_width, const char* text_begin, const char* text_end = NULL, const char** remaining = NULL) const IMGUI_NOEXCEPT; // utf8
-    IMGUI_API const char*       CalcWordWrapPositionA(float scale, const char* text, const char* text_end, float wrap_width) const IMGUI_NOEXCEPT;
-    IMGUI_API void              RenderChar(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col, ImWchar c) const IMGUI_NOEXCEPT;
-    IMGUI_API void              RenderText(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col, const ImVec4& clip_rect, const char* text_begin, const char* text_end, float wrap_width = 0.0f, bool cpu_fine_clip = false) const IMGUI_NOEXCEPT;
+    IMGUI_API ImVec2            CalcTextSizeA(float size, float max_width, float wrap_width, const char* text_begin, const char* text_end = NULL, const char** remaining = NULL) const IM_NOEXCEPT; // utf8
+    IMGUI_API const char*       CalcWordWrapPositionA(float scale, const char* text, const char* text_end, float wrap_width) const IM_NOEXCEPT;
+    IMGUI_API void              RenderChar(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col, ImWchar c) const IM_NOEXCEPT;
+    IMGUI_API void              RenderText(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col, const ImVec4& clip_rect, const char* text_begin, const char* text_end, float wrap_width = 0.0f, bool cpu_fine_clip = false) const IM_NOEXCEPT;
 
     // [Internal] Don't use!
-    IMGUI_API void              BuildLookupTable() IMGUI_NOEXCEPT;
-    IMGUI_API void              ClearOutputData() IMGUI_NOEXCEPT;
-    IMGUI_API void              GrowIndex(int new_size) IMGUI_NOEXCEPT;
-    IMGUI_API void              AddGlyph(const ImFontConfig* src_cfg, ImWchar c, float x0, float y0, float x1, float y1, float u0, float v0, float u1, float v1, float advance_x) IMGUI_NOEXCEPT;
-    IMGUI_API void              AddRemapChar(ImWchar dst, ImWchar src, bool overwrite_dst = true) IMGUI_NOEXCEPT; // Makes 'dst' character/glyph points to 'src' character/glyph. Currently needs to be called AFTER fonts have been built.
-    IMGUI_API void              SetGlyphVisible(ImWchar c, bool visible) IMGUI_NOEXCEPT;
-    IMGUI_API void              SetFallbackChar(ImWchar c) IMGUI_NOEXCEPT;
-    IMGUI_API bool              IsGlyphRangeUnused(unsigned int c_begin, unsigned int c_last) IMGUI_NOEXCEPT;
+    IMGUI_API void              BuildLookupTable() IM_NOEXCEPT;
+    IMGUI_API void              ClearOutputData() IM_NOEXCEPT;
+    IMGUI_API void              GrowIndex(int new_size) IM_NOEXCEPT;
+    IMGUI_API void              AddGlyph(const ImFontConfig* src_cfg, ImWchar c, float x0, float y0, float x1, float y1, float u0, float v0, float u1, float v1, float advance_x) IM_NOEXCEPT;
+    IMGUI_API void              AddRemapChar(ImWchar dst, ImWchar src, bool overwrite_dst = true) IM_NOEXCEPT; // Makes 'dst' character/glyph points to 'src' character/glyph. Currently needs to be called AFTER fonts have been built.
+    IMGUI_API void              SetGlyphVisible(ImWchar c, bool visible) IM_NOEXCEPT;
+    IMGUI_API void              SetFallbackChar(ImWchar c) IM_NOEXCEPT;
+    IMGUI_API bool              IsGlyphRangeUnused(unsigned int c_begin, unsigned int c_last) IM_NOEXCEPT;
 };
 
 //-----------------------------------------------------------------------------
@@ -2777,11 +2776,11 @@ struct ImGuiViewport
     ImVec2              WorkPos;                // Work Area: Position of the viewport minus task bars, menus bars, status bars (>= Pos)
     ImVec2              WorkSize;               // Work Area: Size of the viewport minus task bars, menu bars, status bars (<= Size)
 
-    ImGuiViewport() IMGUI_NOEXCEPT { memset(this, 0, sizeof(*this)); }
+    ImGuiViewport() IM_NOEXCEPT { memset(this, 0, sizeof(*this)); }
 
     // Helpers
-    ImVec2              GetCenter() const     IMGUI_NOEXCEPT   { return ImVec2(Pos.x + Size.x * 0.5f, Pos.y + Size.y * 0.5f); }
-    ImVec2              GetWorkCenter() const IMGUI_NOEXCEPT   { return ImVec2(WorkPos.x + WorkSize.x * 0.5f, WorkPos.y + WorkSize.y * 0.5f); }
+    ImVec2              GetCenter() const     IM_NOEXCEPT   { return ImVec2(Pos.x + Size.x * 0.5f, Pos.y + Size.y * 0.5f); }
+    ImVec2              GetWorkCenter() const IM_NOEXCEPT   { return ImVec2(WorkPos.x + WorkSize.x * 0.5f, WorkPos.y + WorkSize.y * 0.5f); }
 };
 
 //-----------------------------------------------------------------------------
@@ -2794,36 +2793,36 @@ struct ImGuiViewport
 namespace ImGui
 {
     // OBSOLETED in 1.81 (from February 2021)
-    IMGUI_API bool      ListBoxHeader(const char* label, int items_count, int height_in_items = -1) IMGUI_NOEXCEPT; // Helper to calculate size from items_count and height_in_items
-    static inline bool  ListBoxHeader(const char* label, const ImVec2& size = ImVec2(0, 0)) IMGUI_NOEXCEPT { return BeginListBox(label, size); }
-    static inline void  ListBoxFooter() IMGUI_NOEXCEPT { EndListBox(); }
+    IMGUI_API bool      ListBoxHeader(const char* label, int items_count, int height_in_items = -1) IM_NOEXCEPT; // Helper to calculate size from items_count and height_in_items
+    static inline bool  ListBoxHeader(const char* label, const ImVec2& size = ImVec2(0, 0)) IM_NOEXCEPT { return BeginListBox(label, size); }
+    static inline void  ListBoxFooter() IM_NOEXCEPT { EndListBox(); }
     // OBSOLETED in 1.79 (from August 2020)
-    static inline void  OpenPopupContextItem(const char* str_id = NULL, ImGuiMouseButton mb = 1) IMGUI_NOEXCEPT { OpenPopupOnItemClick(str_id, mb); } // Bool return value removed. Use IsWindowAppearing() in BeginPopup() instead. Renamed in 1.77, renamed back in 1.79. Sorry!
+    static inline void  OpenPopupContextItem(const char* str_id = NULL, ImGuiMouseButton mb = 1) IM_NOEXCEPT { OpenPopupOnItemClick(str_id, mb); } // Bool return value removed. Use IsWindowAppearing() in BeginPopup() instead. Renamed in 1.77, renamed back in 1.79. Sorry!
     // OBSOLETED in 1.78 (from June 2020)
     // Old drag/sliders functions that took a 'float power = 1.0' argument instead of flags.
     // For shared code, you can version check at compile-time with `#if IMGUI_VERSION_NUM >= 17704`.
-    IMGUI_API bool      DragScalar(const char* label, ImGuiDataType data_type, void* p_data, float v_speed, const void* p_min, const void* p_max, const char* format, float power) IMGUI_NOEXCEPT;
-    IMGUI_API bool      DragScalarN(const char* label, ImGuiDataType data_type, void* p_data, int components, float v_speed, const void* p_min, const void* p_max, const char* format, float power) IMGUI_NOEXCEPT;
-    static inline bool  DragFloat(const char* label, float* v, float v_speed, float v_min, float v_max, const char* format, float power)    IMGUI_NOEXCEPT { return DragScalar(label, ImGuiDataType_Float, v, v_speed, &v_min, &v_max, format, power); }
-    static inline bool  DragFloat2(const char* label, float v[2], float v_speed, float v_min, float v_max, const char* format, float power) IMGUI_NOEXCEPT { return DragScalarN(label, ImGuiDataType_Float, v, 2, v_speed, &v_min, &v_max, format, power); }
-    static inline bool  DragFloat3(const char* label, float v[3], float v_speed, float v_min, float v_max, const char* format, float power) IMGUI_NOEXCEPT { return DragScalarN(label, ImGuiDataType_Float, v, 3, v_speed, &v_min, &v_max, format, power); }
-    static inline bool  DragFloat4(const char* label, float v[4], float v_speed, float v_min, float v_max, const char* format, float power) IMGUI_NOEXCEPT { return DragScalarN(label, ImGuiDataType_Float, v, 4, v_speed, &v_min, &v_max, format, power); }
-    IMGUI_API bool      SliderScalar(const char* label, ImGuiDataType data_type, void* p_data, const void* p_min, const void* p_max, const char* format, float power) IMGUI_NOEXCEPT;
-    IMGUI_API bool      SliderScalarN(const char* label, ImGuiDataType data_type, void* p_data, int components, const void* p_min, const void* p_max, const char* format, float power) IMGUI_NOEXCEPT;
-    static inline bool  SliderFloat(const char* label, float* v, float v_min, float v_max, const char* format, float power)                 IMGUI_NOEXCEPT  { return SliderScalar(label, ImGuiDataType_Float, v, &v_min, &v_max, format, power); }
-    static inline bool  SliderFloat2(const char* label, float v[2], float v_min, float v_max, const char* format, float power)              IMGUI_NOEXCEPT  { return SliderScalarN(label, ImGuiDataType_Float, v, 2, &v_min, &v_max, format, power); }
-    static inline bool  SliderFloat3(const char* label, float v[3], float v_min, float v_max, const char* format, float power)              IMGUI_NOEXCEPT  { return SliderScalarN(label, ImGuiDataType_Float, v, 3, &v_min, &v_max, format, power); }
-    static inline bool  SliderFloat4(const char* label, float v[4], float v_min, float v_max, const char* format, float power)              IMGUI_NOEXCEPT  { return SliderScalarN(label, ImGuiDataType_Float, v, 4, &v_min, &v_max, format, power); }
+    IMGUI_API bool      DragScalar(const char* label, ImGuiDataType data_type, void* p_data, float v_speed, const void* p_min, const void* p_max, const char* format, float power) IM_NOEXCEPT;
+    IMGUI_API bool      DragScalarN(const char* label, ImGuiDataType data_type, void* p_data, int components, float v_speed, const void* p_min, const void* p_max, const char* format, float power) IM_NOEXCEPT;
+    static inline bool  DragFloat(const char* label, float* v, float v_speed, float v_min, float v_max, const char* format, float power)    IM_NOEXCEPT { return DragScalar(label, ImGuiDataType_Float, v, v_speed, &v_min, &v_max, format, power); }
+    static inline bool  DragFloat2(const char* label, float v[2], float v_speed, float v_min, float v_max, const char* format, float power) IM_NOEXCEPT { return DragScalarN(label, ImGuiDataType_Float, v, 2, v_speed, &v_min, &v_max, format, power); }
+    static inline bool  DragFloat3(const char* label, float v[3], float v_speed, float v_min, float v_max, const char* format, float power) IM_NOEXCEPT { return DragScalarN(label, ImGuiDataType_Float, v, 3, v_speed, &v_min, &v_max, format, power); }
+    static inline bool  DragFloat4(const char* label, float v[4], float v_speed, float v_min, float v_max, const char* format, float power) IM_NOEXCEPT { return DragScalarN(label, ImGuiDataType_Float, v, 4, v_speed, &v_min, &v_max, format, power); }
+    IMGUI_API bool      SliderScalar(const char* label, ImGuiDataType data_type, void* p_data, const void* p_min, const void* p_max, const char* format, float power) IM_NOEXCEPT;
+    IMGUI_API bool      SliderScalarN(const char* label, ImGuiDataType data_type, void* p_data, int components, const void* p_min, const void* p_max, const char* format, float power) IM_NOEXCEPT;
+    static inline bool  SliderFloat(const char* label, float* v, float v_min, float v_max, const char* format, float power)                 IM_NOEXCEPT  { return SliderScalar(label, ImGuiDataType_Float, v, &v_min, &v_max, format, power); }
+    static inline bool  SliderFloat2(const char* label, float v[2], float v_min, float v_max, const char* format, float power)              IM_NOEXCEPT  { return SliderScalarN(label, ImGuiDataType_Float, v, 2, &v_min, &v_max, format, power); }
+    static inline bool  SliderFloat3(const char* label, float v[3], float v_min, float v_max, const char* format, float power)              IM_NOEXCEPT  { return SliderScalarN(label, ImGuiDataType_Float, v, 3, &v_min, &v_max, format, power); }
+    static inline bool  SliderFloat4(const char* label, float v[4], float v_min, float v_max, const char* format, float power)              IM_NOEXCEPT  { return SliderScalarN(label, ImGuiDataType_Float, v, 4, &v_min, &v_max, format, power); }
     // OBSOLETED in 1.77 (from June 2020)
-    static inline bool  BeginPopupContextWindow(const char* str_id, ImGuiMouseButton mb, bool over_items) IMGUI_NOEXCEPT { return BeginPopupContextWindow(str_id, mb | (over_items ? 0 : ImGuiPopupFlags_NoOpenOverItems)); }
+    static inline bool  BeginPopupContextWindow(const char* str_id, ImGuiMouseButton mb, bool over_items) IM_NOEXCEPT { return BeginPopupContextWindow(str_id, mb | (over_items ? 0 : ImGuiPopupFlags_NoOpenOverItems)); }
     // OBSOLETED in 1.72 (from April 2019)
-    static inline void  TreeAdvanceToLabelPos() IMGUI_NOEXCEPT { SetCursorPosX(GetCursorPosX() + GetTreeNodeToLabelSpacing()); }
+    static inline void  TreeAdvanceToLabelPos() IM_NOEXCEPT { SetCursorPosX(GetCursorPosX() + GetTreeNodeToLabelSpacing()); }
     // OBSOLETED in 1.71 (from June 2019)
-    static inline void  SetNextTreeNodeOpen(bool open, ImGuiCond cond = 0) IMGUI_NOEXCEPT { SetNextItemOpen(open, cond); }
+    static inline void  SetNextTreeNodeOpen(bool open, ImGuiCond cond = 0) IM_NOEXCEPT { SetNextItemOpen(open, cond); }
     // OBSOLETED in 1.70 (from May 2019)
-    static inline float GetContentRegionAvailWidth() IMGUI_NOEXCEPT{ return GetContentRegionAvail().x; }
+    static inline float GetContentRegionAvailWidth() IM_NOEXCEPT{ return GetContentRegionAvail().x; }
     // OBSOLETED in 1.69 (from Mar 2019)
-    static inline ImDrawList* GetOverlayDrawList() IMGUI_NOEXCEPT{ return GetForegroundDrawList(); }
+    static inline ImDrawList* GetOverlayDrawList() IM_NOEXCEPT{ return GetForegroundDrawList(); }
 }
 
 // OBSOLETED in 1.82 (from Mars 2021): flags for AddRect(), AddRectFilled(), AddImageRounded(), PathRect()

--- a/imgui.h
+++ b/imgui.h
@@ -212,8 +212,15 @@ typedef void* ImTextureID;          // User data for rendering backend to identi
 typedef unsigned int ImGuiID;       // A unique ID used by widgets, typically hashed from a stack of string.
 typedef int (*ImGuiInputTextCallback)(ImGuiInputTextCallbackData* data);    // Callback function for ImGui::InputText()
 typedef void (*ImGuiSizeCallback)(ImGuiSizeCallbackData* data);             // Callback function for ImGui::SetNextWindowSizeConstraints()
+
+// C++11 doesn't allow typedef-noexcept, requiring you to use 'using' or typedef decltype(samplefunction) ImGuiMemAllocFunc;
+#if __cplusplus < 201103L
 typedef void* (*ImGuiMemAllocFunc)(size_t sz, void* user_data);             // Function signature for ImGui::SetAllocatorFunctions()
 typedef void (*ImGuiMemFreeFunc)(void* ptr, void* user_data);               // Function signature for ImGui::SetAllocatorFunctions()
+#else
+using ImGuiMemAllocFunc = void(*)(size_t sz, void* user_data) IMGUI_NOEXCEPT;
+using ImGuiMemFreeFunc = void(*)(void* ptr, void* user_data) IMGUI_NOEXCEPT;
+#endif
 
 // Character types
 // (we generally use UTF-8 encoded string in the API. This is storage specifically for a decoded character used for keyboard input and display)
@@ -249,10 +256,10 @@ IM_MSVC_RUNTIME_CHECKS_OFF
 struct ImVec2
 {
     float                                   x, y;
-    ImVec2()                                { x = y = 0.0f; }
-    ImVec2(float _x, float _y)              { x = _x; y = _y; }
-    float  operator[] (size_t idx) const    { IM_ASSERT(idx <= 1); return (&x)[idx]; }    // We very rarely use this [] operator, the assert overhead is fine.
-    float& operator[] (size_t idx)          { IM_ASSERT(idx <= 1); return (&x)[idx]; }    // We very rarely use this [] operator, the assert overhead is fine.
+    ImVec2() IMGUI_NOEXCEPT                             { x = y = 0.0f; }
+    ImVec2(float _x, float _y) IMGUI_NOEXCEPT           { x = _x; y = _y; }
+    float  operator[] (size_t idx) const IMGUI_NOEXCEPT { IM_ASSERT(idx <= 1); return (&x)[idx]; }    // We very rarely use this [] operator, the assert overhead is fine.
+    float& operator[] (size_t idx) IMGUI_NOEXCEPT       { IM_ASSERT(idx <= 1); return (&x)[idx]; }    // We very rarely use this [] operator, the assert overhead is fine.
 #ifdef IM_VEC2_CLASS_EXTRA
     IM_VEC2_CLASS_EXTRA     // Define additional constructors and implicit cast operators in imconfig.h to convert back and forth between your math types and ImVec2.
 #endif
@@ -262,8 +269,8 @@ struct ImVec2
 struct ImVec4
 {
     float                                           x, y, z, w;
-    ImVec4()                                        { x = y = z = w = 0.0f; }
-    ImVec4(float _x, float _y, float _z, float _w)  { x = _x; y = _y; z = _z; w = _w; }
+    ImVec4() IMGUI_NOEXCEPT                                       { x = y = z = w = 0.0f; }
+    ImVec4(float _x, float _y, float _z, float _w) IMGUI_NOEXCEPT { x = _x; y = _y; z = _z; w = _w; }
 #ifdef IM_VEC4_CLASS_EXTRA
     IM_VEC4_CLASS_EXTRA     // Define additional constructors and implicit cast operators in imconfig.h to convert back and forth between your math types and ImVec4.
 #endif
@@ -281,33 +288,33 @@ namespace ImGui
     // - Each context create its own ImFontAtlas by default. You may instance one yourself and pass it to CreateContext() to share a font atlas between contexts.
     // - DLL users: heaps and globals are not shared across DLL boundaries! You will need to call SetCurrentContext() + SetAllocatorFunctions()
     //   for each static/DLL boundary you are calling from. Read "Context and Memory Allocators" section of imgui.cpp for details.
-    IMGUI_API ImGuiContext* CreateContext(ImFontAtlas* shared_font_atlas = NULL);
-    IMGUI_API void          DestroyContext(ImGuiContext* ctx = NULL);   // NULL = destroy current context
-    IMGUI_API ImGuiContext* GetCurrentContext();
-    IMGUI_API void          SetCurrentContext(ImGuiContext* ctx);
+    IMGUI_API ImGuiContext* CreateContext(ImFontAtlas* shared_font_atlas = NULL) IMGUI_NOEXCEPT;
+    IMGUI_API void          DestroyContext(ImGuiContext* ctx = NULL)             IMGUI_NOEXCEPT;   // NULL = destroy current context
+    IMGUI_API ImGuiContext* GetCurrentContext()                                  IMGUI_NOEXCEPT;
+    IMGUI_API void          SetCurrentContext(ImGuiContext* ctx)                 IMGUI_NOEXCEPT;
 
     // Main
-    IMGUI_API ImGuiIO&      GetIO();                                    // access the IO structure (mouse/keyboard/gamepad inputs, time, various configuration options/flags)
-    IMGUI_API ImGuiStyle&   GetStyle();                                 // access the Style structure (colors, sizes). Always use PushStyleCol(), PushStyleVar() to modify style mid-frame!
-    IMGUI_API void          NewFrame();                                 // start a new Dear ImGui frame, you can submit any command from this point until Render()/EndFrame().
-    IMGUI_API void          EndFrame();                                 // ends the Dear ImGui frame. automatically called by Render(). If you don't need to render data (skipping rendering) you may call EndFrame() without Render()... but you'll have wasted CPU already! If you don't need to render, better to not create any windows and not call NewFrame() at all!
-    IMGUI_API void          Render();                                   // ends the Dear ImGui frame, finalize the draw data. You can then get call GetDrawData().
-    IMGUI_API ImDrawData*   GetDrawData();                              // valid after Render() and until the next call to NewFrame(). this is what you have to render.
+    IMGUI_API ImGuiIO&      GetIO()         IMGUI_NOEXCEPT;  // access the IO structure (mouse/keyboard/gamepad inputs, time, various configuration options/flags)
+    IMGUI_API ImGuiStyle&   GetStyle()      IMGUI_NOEXCEPT;  // access the Style structure (colors, sizes). Always use PushStyleCol(), PushStyleVar() to modify style mid-frame!
+    IMGUI_API void          NewFrame()      IMGUI_NOEXCEPT;  // start a new Dear ImGui frame, you can submit any command from this point until Render()/EndFrame().
+    IMGUI_API void          EndFrame()      IMGUI_NOEXCEPT;  // ends the Dear ImGui frame. automatically called by Render(). If you don't need to render data (skipping rendering) you may call EndFrame() without Render()... but you'll have wasted CPU already! If you don't need to render, better to not create any windows and not call NewFrame() at all!
+    IMGUI_API void          Render()        IMGUI_NOEXCEPT;  // ends the Dear ImGui frame, finalize the draw data. You can then get call GetDrawData().
+    IMGUI_API ImDrawData*   GetDrawData()   IMGUI_NOEXCEPT;  // valid after Render() and until the next call to NewFrame(). this is what you have to render.
 
     // Demo, Debug, Information
-    IMGUI_API void          ShowDemoWindow(bool* p_open = NULL);        // create Demo window. demonstrate most ImGui features. call this to learn about the library! try to make it always available in your application!
-    IMGUI_API void          ShowMetricsWindow(bool* p_open = NULL);     // create Metrics/Debugger window. display Dear ImGui internals: windows, draw commands, various internal state, etc.
-    IMGUI_API void          ShowAboutWindow(bool* p_open = NULL);       // create About window. display Dear ImGui version, credits and build/system information.
-    IMGUI_API void          ShowStyleEditor(ImGuiStyle* ref = NULL);    // add style editor block (not a window). you can pass in a reference ImGuiStyle structure to compare to, revert to and save to (else it uses the default style)
-    IMGUI_API bool          ShowStyleSelector(const char* label);       // add style selector block (not a window), essentially a combo listing the default styles.
-    IMGUI_API void          ShowFontSelector(const char* label);        // add font selector block (not a window), essentially a combo listing the loaded fonts.
-    IMGUI_API void          ShowUserGuide();                            // add basic help/info block (not a window): how to manipulate ImGui as a end-user (mouse/keyboard controls).
-    IMGUI_API const char*   GetVersion();                               // get the compiled version string e.g. "1.80 WIP" (essentially the value for IMGUI_VERSION from the compiled version of imgui.cpp)
+    IMGUI_API void          ShowDemoWindow(bool* p_open = NULL)        IMGUI_NOEXCEPT;  // create Demo window. demonstrate most ImGui features. call this to learn about the library! try to make it always available in your application!
+    IMGUI_API void          ShowMetricsWindow(bool* p_open = NULL)     IMGUI_NOEXCEPT;  // create Metrics/Debugger window. display Dear ImGui internals: windows, draw commands, various internal state, etc.
+    IMGUI_API void          ShowAboutWindow(bool* p_open = NULL)       IMGUI_NOEXCEPT;  // create About window. display Dear ImGui version, credits and build/system information.
+    IMGUI_API void          ShowStyleEditor(ImGuiStyle* ref = NULL)    IMGUI_NOEXCEPT;  // add style editor block (not a window). you can pass in a reference ImGuiStyle structure to compare to, revert to and save to (else it uses the default style)
+    IMGUI_API bool          ShowStyleSelector(const char* label)       IMGUI_NOEXCEPT;  // add style selector block (not a window), essentially a combo listing the default styles.
+    IMGUI_API void          ShowFontSelector(const char* label)        IMGUI_NOEXCEPT;  // add font selector block (not a window), essentially a combo listing the loaded fonts.
+    IMGUI_API void          ShowUserGuide()                            IMGUI_NOEXCEPT;  // add basic help/info block (not a window): how to manipulate ImGui as a end-user (mouse/keyboard controls).
+    IMGUI_API const char*   GetVersion()                               IMGUI_NOEXCEPT;  // get the compiled version string e.g. "1.80 WIP" (essentially the value for IMGUI_VERSION from the compiled version of imgui.cpp)
 
     // Styles
-    IMGUI_API void          StyleColorsDark(ImGuiStyle* dst = NULL);    // new, recommended style (default)
-    IMGUI_API void          StyleColorsLight(ImGuiStyle* dst = NULL);   // best used with borders and a custom, thicker font
-    IMGUI_API void          StyleColorsClassic(ImGuiStyle* dst = NULL); // classic imgui style
+    IMGUI_API void          StyleColorsDark(ImGuiStyle* dst = NULL)    IMGUI_NOEXCEPT;  // new, recommended style (default)
+    IMGUI_API void          StyleColorsLight(ImGuiStyle* dst = NULL)   IMGUI_NOEXCEPT;  // best used with borders and a custom, thicker font
+    IMGUI_API void          StyleColorsClassic(ImGuiStyle* dst = NULL) IMGUI_NOEXCEPT;  // classic imgui style
 
     // Windows
     // - Begin() = push window to the stack and start appending to it. End() = pop window from the stack.
@@ -338,85 +345,85 @@ namespace ImGui
 
     // Windows Utilities
     // - 'current window' = the window we are appending into while inside a Begin()/End() block. 'next window' = next window we will Begin() into.
-    IMGUI_API bool          IsWindowAppearing();
-    IMGUI_API bool          IsWindowCollapsed();
-    IMGUI_API bool          IsWindowFocused(ImGuiFocusedFlags flags=0); // is current window focused? or its root/child, depending on flags. see flags for options.
-    IMGUI_API bool          IsWindowHovered(ImGuiHoveredFlags flags=0); // is current window hovered (and typically: not blocked by a popup/modal)? see flags for options. NB: If you are trying to check whether your mouse should be dispatched to imgui or to your app, you should use the 'io.WantCaptureMouse' boolean for that! Please read the FAQ!
-    IMGUI_API ImDrawList*   GetWindowDrawList();                        // get draw list associated to the current window, to append your own drawing primitives
-    IMGUI_API ImVec2        GetWindowPos();                             // get current window position in screen space (useful if you want to do your own drawing via the DrawList API)
-    IMGUI_API ImVec2        GetWindowSize();                            // get current window size
-    IMGUI_API float         GetWindowWidth();                           // get current window width (shortcut for GetWindowSize().x)
-    IMGUI_API float         GetWindowHeight();                          // get current window height (shortcut for GetWindowSize().y)
+    IMGUI_API bool          IsWindowAppearing()                        IMGUI_NOEXCEPT;
+    IMGUI_API bool          IsWindowCollapsed()                        IMGUI_NOEXCEPT;
+    IMGUI_API bool          IsWindowFocused(ImGuiFocusedFlags flags=0) IMGUI_NOEXCEPT;  // is current window focused? or its root/child, depending on flags. see flags for options.
+    IMGUI_API bool          IsWindowHovered(ImGuiHoveredFlags flags=0) IMGUI_NOEXCEPT;  // is current window hovered (and typically: not blocked by a popup/modal)? see flags for options. NB: If you are trying to check whether your mouse should be dispatched to imgui or to your app, you should use the 'io.WantCaptureMouse' boolean for that! Please read the FAQ!
+    IMGUI_API ImDrawList*   GetWindowDrawList()                        IMGUI_NOEXCEPT;  // get draw list associated to the current window, to append your own drawing primitives
+    IMGUI_API ImVec2        GetWindowPos()                             IMGUI_NOEXCEPT;  // get current window position in screen space (useful if you want to do your own drawing via the DrawList API)
+    IMGUI_API ImVec2        GetWindowSize()                            IMGUI_NOEXCEPT;  // get current window size
+    IMGUI_API float         GetWindowWidth()                           IMGUI_NOEXCEPT;  // get current window width (shortcut for GetWindowSize().x)
+    IMGUI_API float         GetWindowHeight()                          IMGUI_NOEXCEPT;  // get current window height (shortcut for GetWindowSize().y)
 
     // Prefer using SetNextXXX functions (before Begin) rather that SetXXX functions (after Begin).
-    IMGUI_API void          SetNextWindowPos(const ImVec2& pos, ImGuiCond cond = 0, const ImVec2& pivot = ImVec2(0, 0)); // set next window position. call before Begin(). use pivot=(0.5f,0.5f) to center on given point, etc.
-    IMGUI_API void          SetNextWindowSize(const ImVec2& size, ImGuiCond cond = 0);                  // set next window size. set axis to 0.0f to force an auto-fit on this axis. call before Begin()
-    IMGUI_API void          SetNextWindowSizeConstraints(const ImVec2& size_min, const ImVec2& size_max, ImGuiSizeCallback custom_callback = NULL, void* custom_callback_data = NULL); // set next window size limits. use -1,-1 on either X/Y axis to preserve the current size. Sizes will be rounded down. Use callback to apply non-trivial programmatic constraints.
-    IMGUI_API void          SetNextWindowContentSize(const ImVec2& size);                               // set next window content size (~ scrollable client area, which enforce the range of scrollbars). Not including window decorations (title bar, menu bar, etc.) nor WindowPadding. set an axis to 0.0f to leave it automatic. call before Begin()
-    IMGUI_API void          SetNextWindowCollapsed(bool collapsed, ImGuiCond cond = 0);                 // set next window collapsed state. call before Begin()
-    IMGUI_API void          SetNextWindowFocus();                                                       // set next window to be focused / top-most. call before Begin()
-    IMGUI_API void          SetNextWindowBgAlpha(float alpha);                                          // set next window background color alpha. helper to easily override the Alpha component of ImGuiCol_WindowBg/ChildBg/PopupBg. you may also use ImGuiWindowFlags_NoBackground.
-    IMGUI_API void          SetWindowPos(const ImVec2& pos, ImGuiCond cond = 0);                        // (not recommended) set current window position - call within Begin()/End(). prefer using SetNextWindowPos(), as this may incur tearing and side-effects.
-    IMGUI_API void          SetWindowSize(const ImVec2& size, ImGuiCond cond = 0);                      // (not recommended) set current window size - call within Begin()/End(). set to ImVec2(0, 0) to force an auto-fit. prefer using SetNextWindowSize(), as this may incur tearing and minor side-effects.
-    IMGUI_API void          SetWindowCollapsed(bool collapsed, ImGuiCond cond = 0);                     // (not recommended) set current window collapsed state. prefer using SetNextWindowCollapsed().
-    IMGUI_API void          SetWindowFocus();                                                           // (not recommended) set current window to be focused / top-most. prefer using SetNextWindowFocus().
-    IMGUI_API void          SetWindowFontScale(float scale);                                            // set font scale. Adjust IO.FontGlobalScale if you want to scale all windows. This is an old API! For correct scaling, prefer to reload font + rebuild ImFontAtlas + call style.ScaleAllSizes().
-    IMGUI_API void          SetWindowPos(const char* name, const ImVec2& pos, ImGuiCond cond = 0);      // set named window position.
-    IMGUI_API void          SetWindowSize(const char* name, const ImVec2& size, ImGuiCond cond = 0);    // set named window size. set axis to 0.0f to force an auto-fit on this axis.
-    IMGUI_API void          SetWindowCollapsed(const char* name, bool collapsed, ImGuiCond cond = 0);   // set named window collapsed state
-    IMGUI_API void          SetWindowFocus(const char* name);                                           // set named window to be focused / top-most. use NULL to remove focus.
+    IMGUI_API void          SetNextWindowPos(const ImVec2& pos, ImGuiCond cond = 0, const ImVec2& pivot = ImVec2(0, 0)) IMGUI_NOEXCEPT; // set next window position. call before Begin(). use pivot=(0.5f,0.5f) to center on given point, etc.
+    IMGUI_API void          SetNextWindowSize(const ImVec2& size, ImGuiCond cond = 0)                IMGUI_NOEXCEPT;                  // set next window size. set axis to 0.0f to force an auto-fit on this axis. call before Begin()
+    IMGUI_API void          SetNextWindowSizeConstraints(const ImVec2& size_min, const ImVec2& size_max, ImGuiSizeCallback custom_callback = NULL, void* custom_callback_data = NULL) IMGUI_NOEXCEPT; // set next window size limits. use -1,-1 on either X/Y axis to preserve the current size. Sizes will be rounded down. Use callback to apply non-trivial programmatic constraints.
+    IMGUI_API void          SetNextWindowContentSize(const ImVec2& size)                             IMGUI_NOEXCEPT;  // set next window content size (~ scrollable client area, which enforce the range of scrollbars). Not including window decorations (title bar, menu bar, etc.) nor WindowPadding. set an axis to 0.0f to leave it automatic. call before Begin()
+    IMGUI_API void          SetNextWindowCollapsed(bool collapsed, ImGuiCond cond = 0)               IMGUI_NOEXCEPT;  // set next window collapsed state. call before Begin()
+    IMGUI_API void          SetNextWindowFocus()                                                     IMGUI_NOEXCEPT;  // set next window to be focused / top-most. call before Begin()
+    IMGUI_API void          SetNextWindowBgAlpha(float alpha)                                        IMGUI_NOEXCEPT;  // set next window background color alpha. helper to easily override the Alpha component of ImGuiCol_WindowBg/ChildBg/PopupBg. you may also use ImGuiWindowFlags_NoBackground.
+    IMGUI_API void          SetWindowPos(const ImVec2& pos, ImGuiCond cond = 0)                      IMGUI_NOEXCEPT;  // (not recommended) set current window position - call within Begin()/End(). prefer using SetNextWindowPos(), as this may incur tearing and side-effects.
+    IMGUI_API void          SetWindowSize(const ImVec2& size, ImGuiCond cond = 0)                    IMGUI_NOEXCEPT;  // (not recommended) set current window size - call within Begin()/End(). set to ImVec2(0, 0) to force an auto-fit. prefer using SetNextWindowSize(), as this may incur tearing and minor side-effects.
+    IMGUI_API void          SetWindowCollapsed(bool collapsed, ImGuiCond cond = 0)                   IMGUI_NOEXCEPT;  // (not recommended) set current window collapsed state. prefer using SetNextWindowCollapsed().
+    IMGUI_API void          SetWindowFocus()                                                         IMGUI_NOEXCEPT;  // (not recommended) set current window to be focused / top-most. prefer using SetNextWindowFocus().
+    IMGUI_API void          SetWindowFontScale(float scale) IMGUI_NOEXCEPT;                                           // set font scale. Adjust IO.FontGlobalScale if you want to scale all windows. This is an old API! For correct scaling, prefer to reload font + rebuild ImFontAtlas + call style.ScaleAllSizes().
+    IMGUI_API void          SetWindowPos(const char* name, const ImVec2& pos, ImGuiCond cond = 0)    IMGUI_NOEXCEPT;  // set named window position.
+    IMGUI_API void          SetWindowSize(const char* name, const ImVec2& size, ImGuiCond cond = 0)  IMGUI_NOEXCEPT;  // set named window size. set axis to 0.0f to force an auto-fit on this axis.
+    IMGUI_API void          SetWindowCollapsed(const char* name, bool collapsed, ImGuiCond cond = 0) IMGUI_NOEXCEPT;  // set named window collapsed state
+    IMGUI_API void          SetWindowFocus(const char* name)                                         IMGUI_NOEXCEPT;  // set named window to be focused / top-most. use NULL to remove focus.
 
     // Content region
     // - Retrieve available space from a given point. GetContentRegionAvail() is frequently useful.
     // - Those functions are bound to be redesigned (they are confusing, incomplete and the Min/Max return values are in local window coordinates which increases confusion)
-    IMGUI_API ImVec2        GetContentRegionAvail();                                        // == GetContentRegionMax() - GetCursorPos()
-    IMGUI_API ImVec2        GetContentRegionMax();                                          // current content boundaries (typically window boundaries including scrolling, or current column boundaries), in windows coordinates
-    IMGUI_API ImVec2        GetWindowContentRegionMin();                                    // content boundaries min (roughly (0,0)-Scroll), in window coordinates
-    IMGUI_API ImVec2        GetWindowContentRegionMax();                                    // content boundaries max (roughly (0,0)+Size-Scroll) where Size can be override with SetNextWindowContentSize(), in window coordinates
-    IMGUI_API float         GetWindowContentRegionWidth();                                  //
+    IMGUI_API ImVec2        GetContentRegionAvail()       IMGUI_NOEXCEPT;                   // == GetContentRegionMax() - GetCursorPos()
+    IMGUI_API ImVec2        GetContentRegionMax()         IMGUI_NOEXCEPT;                   // current content boundaries (typically window boundaries including scrolling, or current column boundaries), in windows coordinates
+    IMGUI_API ImVec2        GetWindowContentRegionMin()   IMGUI_NOEXCEPT;                   // content boundaries min (roughly (0,0)-Scroll), in window coordinates
+    IMGUI_API ImVec2        GetWindowContentRegionMax()   IMGUI_NOEXCEPT;                   // content boundaries max (roughly (0,0)+Size-Scroll) where Size can be override with SetNextWindowContentSize(), in window coordinates
+    IMGUI_API float         GetWindowContentRegionWidth() IMGUI_NOEXCEPT;
 
     // Windows Scrolling
-    IMGUI_API float         GetScrollX();                                                   // get scrolling amount [0 .. GetScrollMaxX()]
-    IMGUI_API float         GetScrollY();                                                   // get scrolling amount [0 .. GetScrollMaxY()]
-    IMGUI_API void          SetScrollX(float scroll_x);                                     // set scrolling amount [0 .. GetScrollMaxX()]
-    IMGUI_API void          SetScrollY(float scroll_y);                                     // set scrolling amount [0 .. GetScrollMaxY()]
-    IMGUI_API float         GetScrollMaxX();                                                // get maximum scrolling amount ~~ ContentSize.x - WindowSize.x - DecorationsSize.x
-    IMGUI_API float         GetScrollMaxY();                                                // get maximum scrolling amount ~~ ContentSize.y - WindowSize.y - DecorationsSize.y
-    IMGUI_API void          SetScrollHereX(float center_x_ratio = 0.5f);                    // adjust scrolling amount to make current cursor position visible. center_x_ratio=0.0: left, 0.5: center, 1.0: right. When using to make a "default/current item" visible, consider using SetItemDefaultFocus() instead.
-    IMGUI_API void          SetScrollHereY(float center_y_ratio = 0.5f);                    // adjust scrolling amount to make current cursor position visible. center_y_ratio=0.0: top, 0.5: center, 1.0: bottom. When using to make a "default/current item" visible, consider using SetItemDefaultFocus() instead.
-    IMGUI_API void          SetScrollFromPosX(float local_x, float center_x_ratio = 0.5f);  // adjust scrolling amount to make given position visible. Generally GetCursorStartPos() + offset to compute a valid position.
-    IMGUI_API void          SetScrollFromPosY(float local_y, float center_y_ratio = 0.5f);  // adjust scrolling amount to make given position visible. Generally GetCursorStartPos() + offset to compute a valid position.
+    IMGUI_API float         GetScrollX()                                IMGUI_NOEXCEPT;     // get scrolling amount [0 .. GetScrollMaxX()]
+    IMGUI_API float         GetScrollY()                                IMGUI_NOEXCEPT;     // get scrolling amount [0 .. GetScrollMaxY()]
+    IMGUI_API void          SetScrollX(float scroll_x)                  IMGUI_NOEXCEPT;     // set scrolling amount [0 .. GetScrollMaxX()]
+    IMGUI_API void          SetScrollY(float scroll_y)                  IMGUI_NOEXCEPT;     // set scrolling amount [0 .. GetScrollMaxY()]
+    IMGUI_API float         GetScrollMaxX()                             IMGUI_NOEXCEPT;     // get maximum scrolling amount ~~ ContentSize.x - WindowSize.x - DecorationsSize.x
+    IMGUI_API float         GetScrollMaxY()                             IMGUI_NOEXCEPT;     // get maximum scrolling amount ~~ ContentSize.y - WindowSize.y - DecorationsSize.y
+    IMGUI_API void          SetScrollHereX(float center_x_ratio = 0.5f) IMGUI_NOEXCEPT;     // adjust scrolling amount to make current cursor position visible. center_x_ratio=0.0: left, 0.5: center, 1.0: right. When using to make a "default/current item" visible, consider using SetItemDefaultFocus() instead.
+    IMGUI_API void          SetScrollHereY(float center_y_ratio = 0.5f) IMGUI_NOEXCEPT;     // adjust scrolling amount to make current cursor position visible. center_y_ratio=0.0: top, 0.5: center, 1.0: bottom. When using to make a "default/current item" visible, consider using SetItemDefaultFocus() instead.
+    IMGUI_API void          SetScrollFromPosX(float local_x, float center_x_ratio = 0.5f) IMGUI_NOEXCEPT;  // adjust scrolling amount to make given position visible. Generally GetCursorStartPos() + offset to compute a valid position.
+    IMGUI_API void          SetScrollFromPosY(float local_y, float center_y_ratio = 0.5f) IMGUI_NOEXCEPT;  // adjust scrolling amount to make given position visible. Generally GetCursorStartPos() + offset to compute a valid position.
 
     // Parameters stacks (shared)
-    IMGUI_API void          PushFont(ImFont* font);                                         // use NULL as a shortcut to push default font
-    IMGUI_API void          PopFont();
-    IMGUI_API void          PushStyleColor(ImGuiCol idx, ImU32 col);                        // modify a style color. always use this if you modify the style after NewFrame().
-    IMGUI_API void          PushStyleColor(ImGuiCol idx, const ImVec4& col);
-    IMGUI_API void          PopStyleColor(int count = 1);
-    IMGUI_API void          PushStyleVar(ImGuiStyleVar idx, float val);                     // modify a style float variable. always use this if you modify the style after NewFrame().
-    IMGUI_API void          PushStyleVar(ImGuiStyleVar idx, const ImVec2& val);             // modify a style ImVec2 variable. always use this if you modify the style after NewFrame().
-    IMGUI_API void          PopStyleVar(int count = 1);
-    IMGUI_API void          PushAllowKeyboardFocus(bool allow_keyboard_focus);              // == tab stop enable. Allow focusing using TAB/Shift-TAB, enabled by default but you can disable it for certain widgets
-    IMGUI_API void          PopAllowKeyboardFocus();
-    IMGUI_API void          PushButtonRepeat(bool repeat);                                  // in 'repeat' mode, Button*() functions return repeated true in a typematic manner (using io.KeyRepeatDelay/io.KeyRepeatRate setting). Note that you can call IsItemActive() after any Button() to tell if the button is held in the current frame.
-    IMGUI_API void          PopButtonRepeat();
+    IMGUI_API void          PushFont(ImFont* font)                             IMGUI_NOEXCEPT;  // use NULL as a shortcut to push default font
+    IMGUI_API void          PopFont()                                          IMGUI_NOEXCEPT;
+    IMGUI_API void          PushStyleColor(ImGuiCol idx, ImU32 col)            IMGUI_NOEXCEPT;  // modify a style color. always use this if you modify the style after NewFrame().
+    IMGUI_API void          PushStyleColor(ImGuiCol idx, const ImVec4& col)    IMGUI_NOEXCEPT;
+    IMGUI_API void          PopStyleColor(int count = 1)                       IMGUI_NOEXCEPT;
+    IMGUI_API void          PushStyleVar(ImGuiStyleVar idx, float val)         IMGUI_NOEXCEPT;  // modify a style float variable. always use this if you modify the style after NewFrame().
+    IMGUI_API void          PushStyleVar(ImGuiStyleVar idx, const ImVec2& val) IMGUI_NOEXCEPT;  // modify a style ImVec2 variable. always use this if you modify the style after NewFrame().
+    IMGUI_API void          PopStyleVar(int count = 1)                         IMGUI_NOEXCEPT;
+    IMGUI_API void          PushAllowKeyboardFocus(bool allow_keyboard_focus)  IMGUI_NOEXCEPT;  // == tab stop enable. Allow focusing using TAB/Shift-TAB, enabled by default but you can disable it for certain widgets
+    IMGUI_API void          PopAllowKeyboardFocus()                            IMGUI_NOEXCEPT;
+    IMGUI_API void          PushButtonRepeat(bool repeat)                      IMGUI_NOEXCEPT;  // in 'repeat' mode, Button*() functions return repeated true in a typematic manner (using io.KeyRepeatDelay/io.KeyRepeatRate setting). Note that you can call IsItemActive() after any Button() to tell if the button is held in the current frame.
+    IMGUI_API void          PopButtonRepeat()                                  IMGUI_NOEXCEPT;
 
     // Parameters stacks (current window)
-    IMGUI_API void          PushItemWidth(float item_width);                                // push width of items for common large "item+label" widgets. >0.0f: width in pixels, <0.0f align xx pixels to the right of window (so -FLT_MIN always align width to the right side).
-    IMGUI_API void          PopItemWidth();
-    IMGUI_API void          SetNextItemWidth(float item_width);                             // set width of the _next_ common large "item+label" widget. >0.0f: width in pixels, <0.0f align xx pixels to the right of window (so -FLT_MIN always align width to the right side)
-    IMGUI_API float         CalcItemWidth();                                                // width of item given pushed settings and current cursor position. NOT necessarily the width of last item unlike most 'Item' functions.
-    IMGUI_API void          PushTextWrapPos(float wrap_local_pos_x = 0.0f);                 // push word-wrapping position for Text*() commands. < 0.0f: no wrapping; 0.0f: wrap to end of window (or column); > 0.0f: wrap at 'wrap_pos_x' position in window local space
-    IMGUI_API void          PopTextWrapPos();
+    IMGUI_API void          PushItemWidth(float item_width)                    IMGUI_NOEXCEPT;  // push width of items for common large "item+label" widgets. >0.0f: width in pixels, <0.0f align xx pixels to the right of window (so -FLT_MIN always align width to the right side).
+    IMGUI_API void          PopItemWidth()                                     IMGUI_NOEXCEPT;
+    IMGUI_API void          SetNextItemWidth(float item_width)                 IMGUI_NOEXCEPT;  // set width of the _next_ common large "item+label" widget. >0.0f: width in pixels, <0.0f align xx pixels to the right of window (so -FLT_MIN always align width to the right side)
+    IMGUI_API float         CalcItemWidth()                                    IMGUI_NOEXCEPT;  // width of item given pushed settings and current cursor position. NOT necessarily the width of last item unlike most 'Item' functions.
+    IMGUI_API void          PushTextWrapPos(float wrap_local_pos_x = 0.0f)     IMGUI_NOEXCEPT;  // push word-wrapping position for Text*() commands. < 0.0f: no wrapping; 0.0f: wrap to end of window (or column); > 0.0f: wrap at 'wrap_pos_x' position in window local space
+    IMGUI_API void          PopTextWrapPos()                                   IMGUI_NOEXCEPT;
 
     // Style read access
-    IMGUI_API ImFont*       GetFont();                                                      // get current font
-    IMGUI_API float         GetFontSize();                                                  // get current font size (= height in pixels) of current font with current scale applied
-    IMGUI_API ImVec2        GetFontTexUvWhitePixel();                                       // get UV coordinate for a while pixel, useful to draw custom shapes via the ImDrawList API
-    IMGUI_API ImU32         GetColorU32(ImGuiCol idx, float alpha_mul = 1.0f);              // retrieve given style color with style alpha applied and optional extra alpha multiplier, packed as a 32-bit value suitable for ImDrawList
-    IMGUI_API ImU32         GetColorU32(const ImVec4& col);                                 // retrieve given color with style alpha applied, packed as a 32-bit value suitable for ImDrawList
-    IMGUI_API ImU32         GetColorU32(ImU32 col);                                         // retrieve given color with style alpha applied, packed as a 32-bit value suitable for ImDrawList
-    IMGUI_API const ImVec4& GetStyleColorVec4(ImGuiCol idx);                                // retrieve style color as stored in ImGuiStyle structure. use to feed back into PushStyleColor(), otherwise use GetColorU32() to get style color with style alpha baked in.
+    IMGUI_API ImFont*       GetFont()                                          IMGUI_NOEXCEPT;  // get current font
+    IMGUI_API float         GetFontSize()                                      IMGUI_NOEXCEPT;  // get current font size (= height in pixels) of current font with current scale applied
+    IMGUI_API ImVec2        GetFontTexUvWhitePixel()                           IMGUI_NOEXCEPT;  // get UV coordinate for a while pixel, useful to draw custom shapes via the ImDrawList API
+    IMGUI_API ImU32         GetColorU32(ImGuiCol idx, float alpha_mul = 1.0f)  IMGUI_NOEXCEPT;  // retrieve given style color with style alpha applied and optional extra alpha multiplier, packed as a 32-bit value suitable for ImDrawList
+    IMGUI_API ImU32         GetColorU32(const ImVec4& col)                     IMGUI_NOEXCEPT;  // retrieve given color with style alpha applied, packed as a 32-bit value suitable for ImDrawList
+    IMGUI_API ImU32         GetColorU32(ImU32 col)                             IMGUI_NOEXCEPT;  // retrieve given color with style alpha applied, packed as a 32-bit value suitable for ImDrawList
+    IMGUI_API const ImVec4& GetStyleColorVec4(ImGuiCol idx)                    IMGUI_NOEXCEPT;  // retrieve style color as stored in ImGuiStyle structure. use to feed back into PushStyleColor(), otherwise use GetColorU32() to get style color with style alpha baked in.
 
     // Cursor / Layout
     // - By "cursor" we mean the current output position.
@@ -425,29 +432,29 @@ namespace ImGui
     // - Attention! We currently have inconsistencies between window-local and absolute positions we will aim to fix with future API:
     //    Window-local coordinates:   SameLine(), GetCursorPos(), SetCursorPos(), GetCursorStartPos(), GetContentRegionMax(), GetWindowContentRegion*(), PushTextWrapPos()
     //    Absolute coordinate:        GetCursorScreenPos(), SetCursorScreenPos(), all ImDrawList:: functions.
-    IMGUI_API void          Separator();                                                    // separator, generally horizontal. inside a menu bar or in horizontal layout mode, this becomes a vertical separator.
-    IMGUI_API void          SameLine(float offset_from_start_x=0.0f, float spacing=-1.0f);  // call between widgets or groups to layout them horizontally. X position given in window coordinates.
-    IMGUI_API void          NewLine();                                                      // undo a SameLine() or force a new line when in an horizontal-layout context.
-    IMGUI_API void          Spacing();                                                      // add vertical spacing.
-    IMGUI_API void          Dummy(const ImVec2& size);                                      // add a dummy item of given size. unlike InvisibleButton(), Dummy() won't take the mouse click or be navigable into.
-    IMGUI_API void          Indent(float indent_w = 0.0f);                                  // move content position toward the right, by indent_w, or style.IndentSpacing if indent_w <= 0
-    IMGUI_API void          Unindent(float indent_w = 0.0f);                                // move content position back to the left, by indent_w, or style.IndentSpacing if indent_w <= 0
+    IMGUI_API void          Separator()                                        IMGUI_NOEXCEPT;  // separator, generally horizontal. inside a menu bar or in horizontal layout mode, this becomes a vertical separator.
+    IMGUI_API void          SameLine(float offset_from_start_x=0.0f, float spacing=-1.0f) IMGUI_NOEXCEPT;  // call between widgets or groups to layout them horizontally. X position given in window coordinates.
+    IMGUI_API void          NewLine()                                          IMGUI_NOEXCEPT;  // undo a SameLine() or force a new line when in an horizontal-layout context.
+    IMGUI_API void          Spacing()                                          IMGUI_NOEXCEPT;  // add vertical spacing.
+    IMGUI_API void          Dummy(const ImVec2& size)                          IMGUI_NOEXCEPT;  // add a dummy item of given size. unlike InvisibleButton(), Dummy() won't take the mouse click or be navigable into.
+    IMGUI_API void          Indent(float indent_w = 0.0f)                      IMGUI_NOEXCEPT;  // move content position toward the right, by indent_w, or style.IndentSpacing if indent_w <= 0
+    IMGUI_API void          Unindent(float indent_w = 0.0f)                    IMGUI_NOEXCEPT;  // move content position back to the left, by indent_w, or style.IndentSpacing if indent_w <= 0
     IMGUI_API void          BeginGroup() IMGUI_NOEXCEPT;                                    // lock horizontal starting position
     IMGUI_API void          EndGroup() IMGUI_NOEXCEPT;                                      // unlock horizontal starting position + capture the whole group bounding box into one "item" (so you can use IsItemHovered() or layout primitives such as SameLine() on whole group, etc.)
-    IMGUI_API ImVec2        GetCursorPos();                                                 // cursor position in window coordinates (relative to window position)
-    IMGUI_API float         GetCursorPosX();                                                //   (some functions are using window-relative coordinates, such as: GetCursorPos, GetCursorStartPos, GetContentRegionMax, GetWindowContentRegion* etc.
-    IMGUI_API float         GetCursorPosY();                                                //    other functions such as GetCursorScreenPos or everything in ImDrawList::
-    IMGUI_API void          SetCursorPos(const ImVec2& local_pos);                          //    are using the main, absolute coordinate system.
-    IMGUI_API void          SetCursorPosX(float local_x);                                   //    GetWindowPos() + GetCursorPos() == GetCursorScreenPos() etc.)
-    IMGUI_API void          SetCursorPosY(float local_y);                                   //
-    IMGUI_API ImVec2        GetCursorStartPos();                                            // initial cursor position in window coordinates
-    IMGUI_API ImVec2        GetCursorScreenPos();                                           // cursor position in absolute coordinates (useful to work with ImDrawList API). generally top-left == GetMainViewport()->Pos == (0,0) in single viewport mode, and bottom-right == GetMainViewport()->Pos+Size == io.DisplaySize in single-viewport mode.
-    IMGUI_API void          SetCursorScreenPos(const ImVec2& pos);                          // cursor position in absolute coordinates
-    IMGUI_API void          AlignTextToFramePadding();                                      // vertically align upcoming text baseline to FramePadding.y so that it will align properly to regularly framed items (call if you have text on a line before a framed item)
-    IMGUI_API float         GetTextLineHeight();                                            // ~ FontSize
-    IMGUI_API float         GetTextLineHeightWithSpacing();                                 // ~ FontSize + style.ItemSpacing.y (distance in pixels between 2 consecutive lines of text)
-    IMGUI_API float         GetFrameHeight();                                               // ~ FontSize + style.FramePadding.y * 2
-    IMGUI_API float         GetFrameHeightWithSpacing();                                    // ~ FontSize + style.FramePadding.y * 2 + style.ItemSpacing.y (distance in pixels between 2 consecutive lines of framed widgets)
+    IMGUI_API ImVec2        GetCursorPos()                                     IMGUI_NOEXCEPT;  // cursor position in window coordinates (relative to window position)
+    IMGUI_API float         GetCursorPosX()                                    IMGUI_NOEXCEPT;  //   (some functions are using window-relative coordinates, such as: GetCursorPos, GetCursorStartPos, GetContentRegionMax, GetWindowContentRegion* etc.
+    IMGUI_API float         GetCursorPosY()                                    IMGUI_NOEXCEPT;  //    other functions such as GetCursorScreenPos or everything in ImDrawList::
+    IMGUI_API void          SetCursorPos(const ImVec2& local_pos)              IMGUI_NOEXCEPT;  //    are using the main, absolute coordinate system.
+    IMGUI_API void          SetCursorPosX(float local_x)                       IMGUI_NOEXCEPT;  //    GetWindowPos() + GetCursorPos() == GetCursorScreenPos() etc.)
+    IMGUI_API void          SetCursorPosY(float local_y)                       IMGUI_NOEXCEPT;  //
+    IMGUI_API ImVec2        GetCursorStartPos()                                IMGUI_NOEXCEPT;  // initial cursor position in window coordinates
+    IMGUI_API ImVec2        GetCursorScreenPos()                               IMGUI_NOEXCEPT;  // cursor position in absolute coordinates (useful to work with ImDrawList API). generally top-left == GetMainViewport()->Pos == (0,0) in single viewport mode, and bottom-right == GetMainViewport()->Pos+Size == io.DisplaySize in single-viewport mode.
+    IMGUI_API void          SetCursorScreenPos(const ImVec2& pos)              IMGUI_NOEXCEPT;  // cursor position in absolute coordinates
+    IMGUI_API void          AlignTextToFramePadding()                          IMGUI_NOEXCEPT;  // vertically align upcoming text baseline to FramePadding.y so that it will align properly to regularly framed items (call if you have text on a line before a framed item)
+    IMGUI_API float         GetTextLineHeight()                                IMGUI_NOEXCEPT;  // ~ FontSize
+    IMGUI_API float         GetTextLineHeightWithSpacing()                     IMGUI_NOEXCEPT;  // ~ FontSize + style.ItemSpacing.y (distance in pixels between 2 consecutive lines of text)
+    IMGUI_API float         GetFrameHeight()                                   IMGUI_NOEXCEPT;  // ~ FontSize + style.FramePadding.y * 2
+    IMGUI_API float         GetFrameHeightWithSpacing()                        IMGUI_NOEXCEPT;  // ~ FontSize + style.FramePadding.y * 2 + style.ItemSpacing.y (distance in pixels between 2 consecutive lines of framed widgets)
 
     // ID stack/scopes
     // - Read the FAQ for more details about how ID are handled in dear imgui. If you are creating widgets in a loop you most
@@ -456,55 +463,55 @@ namespace ImGui
     // - You can also use the "Label##foobar" syntax within widget label to distinguish them from each others.
     // - In this header file we use the "label"/"name" terminology to denote a string that will be displayed and used as an ID,
     //   whereas "str_id" denote a string that is only used as an ID and not normally displayed.
-    IMGUI_API void          PushID(const char* str_id);                                     // push string into the ID stack (will hash string).
-    IMGUI_API void          PushID(const char* str_id_begin, const char* str_id_end);       // push string into the ID stack (will hash string).
-    IMGUI_API void          PushID(const void* ptr_id);                                     // push pointer into the ID stack (will hash pointer).
-    IMGUI_API void          PushID(int int_id);                                             // push integer into the ID stack (will hash integer).
-    IMGUI_API void          PopID();                                                        // pop from the ID stack.
-    IMGUI_API ImGuiID       GetID(const char* str_id);                                      // calculate unique ID (hash of whole ID stack + given parameter). e.g. if you want to query into ImGuiStorage yourself
-    IMGUI_API ImGuiID       GetID(const char* str_id_begin, const char* str_id_end);
-    IMGUI_API ImGuiID       GetID(const void* ptr_id);
+    IMGUI_API void          PushID(const char* str_id)                                      IMGUI_NOEXCEPT;  // push string into the ID stack (will hash string).
+    IMGUI_API void          PushID(const char* str_id_begin, const char* str_id_end)        IMGUI_NOEXCEPT;  // push string into the ID stack (will hash string).
+    IMGUI_API void          PushID(const void* ptr_id)                                      IMGUI_NOEXCEPT;  // push pointer into the ID stack (will hash pointer).
+    IMGUI_API void          PushID(int int_id)                                              IMGUI_NOEXCEPT;  // push integer into the ID stack (will hash integer).
+    IMGUI_API void          PopID()                                                         IMGUI_NOEXCEPT;  // pop from the ID stack.
+    IMGUI_API ImGuiID       GetID(const char* str_id)                                       IMGUI_NOEXCEPT;  // calculate unique ID (hash of whole ID stack + given parameter). e.g. if you want to query into ImGuiStorage yourself
+    IMGUI_API ImGuiID       GetID(const char* str_id_begin, const char* str_id_end)         IMGUI_NOEXCEPT;
+    IMGUI_API ImGuiID       GetID(const void* ptr_id)                                       IMGUI_NOEXCEPT;
 
     // Widgets: Text
-    IMGUI_API void          TextUnformatted(const char* text, const char* text_end = NULL); // raw text without formatting. Roughly equivalent to Text("%s", text) but: A) doesn't require null terminated string if 'text_end' is specified, B) it's faster, no memory copy is done, no buffer size limits, recommended for long chunks of text.
-    IMGUI_API void          Text(const char* fmt, ...)                                      IM_FMTARGS(1); // formatted text
-    IMGUI_API void          TextV(const char* fmt, va_list args)                            IM_FMTLIST(1);
-    IMGUI_API void          TextColored(const ImVec4& col, const char* fmt, ...)            IM_FMTARGS(2); // shortcut for PushStyleColor(ImGuiCol_Text, col); Text(fmt, ...); PopStyleColor();
-    IMGUI_API void          TextColoredV(const ImVec4& col, const char* fmt, va_list args)  IM_FMTLIST(2);
-    IMGUI_API void          TextDisabled(const char* fmt, ...)                              IM_FMTARGS(1); // shortcut for PushStyleColor(ImGuiCol_Text, style.Colors[ImGuiCol_TextDisabled]); Text(fmt, ...); PopStyleColor();
-    IMGUI_API void          TextDisabledV(const char* fmt, va_list args)                    IM_FMTLIST(1);
-    IMGUI_API void          TextWrapped(const char* fmt, ...)                               IM_FMTARGS(1); // shortcut for PushTextWrapPos(0.0f); Text(fmt, ...); PopTextWrapPos();. Note that this won't work on an auto-resizing window if there's no other widgets to extend the window width, yoy may need to set a size using SetNextWindowSize().
-    IMGUI_API void          TextWrappedV(const char* fmt, va_list args)                     IM_FMTLIST(1);
-    IMGUI_API void          LabelText(const char* label, const char* fmt, ...)              IM_FMTARGS(2); // display text+label aligned the same way as value+label widgets
-    IMGUI_API void          LabelTextV(const char* label, const char* fmt, va_list args)    IM_FMTLIST(2);
-    IMGUI_API void          BulletText(const char* fmt, ...)                                IM_FMTARGS(1); // shortcut for Bullet()+Text()
-    IMGUI_API void          BulletTextV(const char* fmt, va_list args)                      IM_FMTLIST(1);
+    IMGUI_API void          TextUnformatted(const char* text, const char* text_end = NULL)  IMGUI_NOEXCEPT;  // raw text without formatting. Roughly equivalent to Text("%s", text) but: A) doesn't require null terminated string if 'text_end' is specified, B) it's faster, no memory copy is done, no buffer size limits, recommended for long chunks of text.
+    IMGUI_API void          Text(const char* fmt, ...)                                      IMGUI_NOEXCEPT  IM_FMTARGS(1); // formatted text
+    IMGUI_API void          TextV(const char* fmt, va_list args)                            IMGUI_NOEXCEPT  IM_FMTLIST(1);
+    IMGUI_API void          TextColored(const ImVec4& col, const char* fmt, ...)            IMGUI_NOEXCEPT  IM_FMTARGS(2); // shortcut for PushStyleColor(ImGuiCol_Text, col); Text(fmt, ...); PopStyleColor();
+    IMGUI_API void          TextColoredV(const ImVec4& col, const char* fmt, va_list args)  IMGUI_NOEXCEPT  IM_FMTLIST(2);
+    IMGUI_API void          TextDisabled(const char* fmt, ...)                              IMGUI_NOEXCEPT  IM_FMTARGS(1); // shortcut for PushStyleColor(ImGuiCol_Text, style.Colors[ImGuiCol_TextDisabled]); Text(fmt, ...); PopStyleColor();
+    IMGUI_API void          TextDisabledV(const char* fmt, va_list args)                    IMGUI_NOEXCEPT  IM_FMTLIST(1);
+    IMGUI_API void          TextWrapped(const char* fmt, ...)                               IMGUI_NOEXCEPT  IM_FMTARGS(1); // shortcut for PushTextWrapPos(0.0f); Text(fmt, ...); PopTextWrapPos();. Note that this won't work on an auto-resizing window if there's no other widgets to extend the window width, yoy may need to set a size using SetNextWindowSize().
+    IMGUI_API void          TextWrappedV(const char* fmt, va_list args)                     IMGUI_NOEXCEPT  IM_FMTLIST(1);
+    IMGUI_API void          LabelText(const char* label, const char* fmt, ...)              IMGUI_NOEXCEPT  IM_FMTARGS(2); // display text+label aligned the same way as value+label widgets
+    IMGUI_API void          LabelTextV(const char* label, const char* fmt, va_list args)    IMGUI_NOEXCEPT  IM_FMTLIST(2);
+    IMGUI_API void          BulletText(const char* fmt, ...)                                IMGUI_NOEXCEPT  IM_FMTARGS(1); // shortcut for Bullet()+Text()
+    IMGUI_API void          BulletTextV(const char* fmt, va_list args)                      IMGUI_NOEXCEPT  IM_FMTLIST(1);
 
     // Widgets: Main
     // - Most widgets return true when the value has been changed or when pressed/selected
     // - You may also use one of the many IsItemXXX functions (e.g. IsItemActive, IsItemHovered, etc.) to query widget state.
-    IMGUI_API bool          Button(const char* label, const ImVec2& size = ImVec2(0, 0));   // button
-    IMGUI_API bool          SmallButton(const char* label);                                 // button with FramePadding=(0,0) to easily embed within text
-    IMGUI_API bool          InvisibleButton(const char* str_id, const ImVec2& size, ImGuiButtonFlags flags = 0); // flexible button behavior without the visuals, frequently useful to build custom behaviors using the public api (along with IsItemActive, IsItemHovered, etc.)
-    IMGUI_API bool          ArrowButton(const char* str_id, ImGuiDir dir);                  // square button with an arrow shape
-    IMGUI_API void          Image(ImTextureID user_texture_id, const ImVec2& size, const ImVec2& uv0 = ImVec2(0, 0), const ImVec2& uv1 = ImVec2(1,1), const ImVec4& tint_col = ImVec4(1,1,1,1), const ImVec4& border_col = ImVec4(0,0,0,0));
-    IMGUI_API bool          ImageButton(ImTextureID user_texture_id, const ImVec2& size, const ImVec2& uv0 = ImVec2(0, 0),  const ImVec2& uv1 = ImVec2(1,1), int frame_padding = -1, const ImVec4& bg_col = ImVec4(0,0,0,0), const ImVec4& tint_col = ImVec4(1,1,1,1));    // <0 frame_padding uses default frame padding settings. 0 for no padding
-    IMGUI_API bool          Checkbox(const char* label, bool* v);
-    IMGUI_API bool          CheckboxFlags(const char* label, int* flags, int flags_value);
-    IMGUI_API bool          CheckboxFlags(const char* label, unsigned int* flags, unsigned int flags_value);
-    IMGUI_API bool          RadioButton(const char* label, bool active);                    // use with e.g. if (RadioButton("one", my_value==1)) { my_value = 1; }
-    IMGUI_API bool          RadioButton(const char* label, int* v, int v_button);           // shortcut to handle the above pattern when value is an integer
-    IMGUI_API void          ProgressBar(float fraction, const ImVec2& size_arg = ImVec2(-FLT_MIN, 0), const char* overlay = NULL);
-    IMGUI_API void          Bullet();                                                       // draw a small circle + keep the cursor on the same line. advance cursor x position by GetTreeNodeToLabelSpacing(), same distance that TreeNode() uses
+    IMGUI_API bool          Button(const char* label, const ImVec2& size = ImVec2(0, 0))    IMGUI_NOEXCEPT;  // button
+    IMGUI_API bool          SmallButton(const char* label)                                  IMGUI_NOEXCEPT;  // button with FramePadding=(0,0) to easily embed within text
+    IMGUI_API bool          InvisibleButton(const char* str_id, const ImVec2& size, ImGuiButtonFlags flags = 0) IMGUI_NOEXCEPT;  // flexible button behavior without the visuals, frequently useful to build custom behaviors using the public api (along with IsItemActive, IsItemHovered, etc.)
+    IMGUI_API bool          ArrowButton(const char* str_id, ImGuiDir dir)                   IMGUI_NOEXCEPT;  // square button with an arrow shape
+    IMGUI_API void          Image(ImTextureID user_texture_id, const ImVec2& size, const ImVec2& uv0 = ImVec2(0, 0), const ImVec2& uv1 = ImVec2(1,1), const ImVec4& tint_col = ImVec4(1,1,1,1), const ImVec4& border_col = ImVec4(0,0,0,0)) IMGUI_NOEXCEPT;
+    IMGUI_API bool          ImageButton(ImTextureID user_texture_id, const ImVec2& size, const ImVec2& uv0 = ImVec2(0, 0),  const ImVec2& uv1 = ImVec2(1,1), int frame_padding = -1, const ImVec4& bg_col = ImVec4(0,0,0,0), const ImVec4& tint_col = ImVec4(1,1,1,1)) IMGUI_NOEXCEPT;  // <0 frame_padding uses default frame padding settings. 0 for no padding
+    IMGUI_API bool          Checkbox(const char* label, bool* v)                            IMGUI_NOEXCEPT;
+    IMGUI_API bool          CheckboxFlags(const char* label, int* flags, int flags_value)   IMGUI_NOEXCEPT;
+    IMGUI_API bool          CheckboxFlags(const char* label, unsigned int* flags, unsigned int flags_value) IMGUI_NOEXCEPT;
+    IMGUI_API bool          RadioButton(const char* label, bool active)                     IMGUI_NOEXCEPT;  // use with e.g. if (RadioButton("one", my_value==1)) { my_value = 1; }
+    IMGUI_API bool          RadioButton(const char* label, int* v, int v_button)            IMGUI_NOEXCEPT;  // shortcut to handle the above pattern when value is an integer
+    IMGUI_API void          ProgressBar(float fraction, const ImVec2& size_arg = ImVec2(-FLT_MIN, 0), const char* overlay = NULL) IMGUI_NOEXCEPT;
+    IMGUI_API void          Bullet()                                                        IMGUI_NOEXCEPT;  // draw a small circle + keep the cursor on the same line. advance cursor x position by GetTreeNodeToLabelSpacing(), same distance that TreeNode() uses
 
     // Widgets: Combo Box
     // - The BeginCombo()/EndCombo() api allows you to manage your contents and selection state however you want it, by creating e.g. Selectable() items.
     // - The old Combo() api are helpers over BeginCombo()/EndCombo() which are kept available for convenience purpose. This is analogous to how ListBox are created.
     IMGUI_API bool          BeginCombo(const char* label, const char* preview_value, ImGuiComboFlags flags = 0) IMGUI_NOEXCEPT;
     IMGUI_API void          EndCombo() IMGUI_NOEXCEPT; // only call EndCombo() if BeginCombo() returns true!
-    IMGUI_API bool          Combo(const char* label, int* current_item, const char* const items[], int items_count, int popup_max_height_in_items = -1);
-    IMGUI_API bool          Combo(const char* label, int* current_item, const char* items_separated_by_zeros, int popup_max_height_in_items = -1);      // Separate items with \0 within a string, end item-list with \0\0. e.g. "One\0Two\0Three\0"
-    IMGUI_API bool          Combo(const char* label, int* current_item, bool(*items_getter)(void* data, int idx, const char** out_text), void* data, int items_count, int popup_max_height_in_items = -1);
+    IMGUI_API bool          Combo(const char* label, int* current_item, const char* const items[], int items_count, int popup_max_height_in_items = -1) IMGUI_NOEXCEPT;
+    IMGUI_API bool          Combo(const char* label, int* current_item, const char* items_separated_by_zeros, int popup_max_height_in_items = -1) IMGUI_NOEXCEPT;      // Separate items with \0 within a string, end item-list with \0\0. e.g. "One\0Two\0Three\0"
+    IMGUI_API bool          Combo(const char* label, int* current_item, bool(*items_getter)(void* data, int idx, const char** out_text), void* data, int items_count, int popup_max_height_in_items = -1) IMGUI_NOEXCEPT;
 
     // Widgets: Drag Sliders
     // - CTRL+Click on any drag box to turn them into an input box. Manually input values aren't clamped and can go off-bounds.
@@ -517,18 +524,18 @@ namespace ImGui
     // - We use the same sets of flags for DragXXX() and SliderXXX() functions as the features are the same and it makes it easier to swap them.
     // - Legacy: Pre-1.78 there are DragXXX() function signatures that takes a final `float power=1.0f' argument instead of the `ImGuiSliderFlags flags=0' argument.
     //   If you get a warning converting a float to ImGuiSliderFlags, read https://github.com/ocornut/imgui/issues/3361
-    IMGUI_API bool          DragFloat(const char* label, float* v, float v_speed = 1.0f, float v_min = 0.0f, float v_max = 0.0f, const char* format = "%.3f", ImGuiSliderFlags flags = 0);     // If v_min >= v_max we have no bound
-    IMGUI_API bool          DragFloat2(const char* label, float v[2], float v_speed = 1.0f, float v_min = 0.0f, float v_max = 0.0f, const char* format = "%.3f", ImGuiSliderFlags flags = 0);
-    IMGUI_API bool          DragFloat3(const char* label, float v[3], float v_speed = 1.0f, float v_min = 0.0f, float v_max = 0.0f, const char* format = "%.3f", ImGuiSliderFlags flags = 0);
-    IMGUI_API bool          DragFloat4(const char* label, float v[4], float v_speed = 1.0f, float v_min = 0.0f, float v_max = 0.0f, const char* format = "%.3f", ImGuiSliderFlags flags = 0);
-    IMGUI_API bool          DragFloatRange2(const char* label, float* v_current_min, float* v_current_max, float v_speed = 1.0f, float v_min = 0.0f, float v_max = 0.0f, const char* format = "%.3f", const char* format_max = NULL, ImGuiSliderFlags flags = 0);
-    IMGUI_API bool          DragInt(const char* label, int* v, float v_speed = 1.0f, int v_min = 0, int v_max = 0, const char* format = "%d", ImGuiSliderFlags flags = 0);  // If v_min >= v_max we have no bound
-    IMGUI_API bool          DragInt2(const char* label, int v[2], float v_speed = 1.0f, int v_min = 0, int v_max = 0, const char* format = "%d", ImGuiSliderFlags flags = 0);
-    IMGUI_API bool          DragInt3(const char* label, int v[3], float v_speed = 1.0f, int v_min = 0, int v_max = 0, const char* format = "%d", ImGuiSliderFlags flags = 0);
-    IMGUI_API bool          DragInt4(const char* label, int v[4], float v_speed = 1.0f, int v_min = 0, int v_max = 0, const char* format = "%d", ImGuiSliderFlags flags = 0);
-    IMGUI_API bool          DragIntRange2(const char* label, int* v_current_min, int* v_current_max, float v_speed = 1.0f, int v_min = 0, int v_max = 0, const char* format = "%d", const char* format_max = NULL, ImGuiSliderFlags flags = 0);
-    IMGUI_API bool          DragScalar(const char* label, ImGuiDataType data_type, void* p_data, float v_speed = 1.0f, const void* p_min = NULL, const void* p_max = NULL, const char* format = NULL, ImGuiSliderFlags flags = 0);
-    IMGUI_API bool          DragScalarN(const char* label, ImGuiDataType data_type, void* p_data, int components, float v_speed = 1.0f, const void* p_min = NULL, const void* p_max = NULL, const char* format = NULL, ImGuiSliderFlags flags = 0);
+    IMGUI_API bool          DragFloat(const char* label, float* v, float v_speed = 1.0f, float v_min = 0.0f, float v_max = 0.0f, const char* format = "%.3f", ImGuiSliderFlags flags = 0)    IMGUI_NOEXCEPT;     // If v_min >= v_max we have no bound
+    IMGUI_API bool          DragFloat2(const char* label, float v[2], float v_speed = 1.0f, float v_min = 0.0f, float v_max = 0.0f, const char* format = "%.3f", ImGuiSliderFlags flags = 0) IMGUI_NOEXCEPT;
+    IMGUI_API bool          DragFloat3(const char* label, float v[3], float v_speed = 1.0f, float v_min = 0.0f, float v_max = 0.0f, const char* format = "%.3f", ImGuiSliderFlags flags = 0) IMGUI_NOEXCEPT;
+    IMGUI_API bool          DragFloat4(const char* label, float v[4], float v_speed = 1.0f, float v_min = 0.0f, float v_max = 0.0f, const char* format = "%.3f", ImGuiSliderFlags flags = 0) IMGUI_NOEXCEPT;
+    IMGUI_API bool          DragFloatRange2(const char* label, float* v_current_min, float* v_current_max, float v_speed = 1.0f, float v_min = 0.0f, float v_max = 0.0f, const char* format = "%.3f", const char* format_max = NULL, ImGuiSliderFlags flags = 0) IMGUI_NOEXCEPT;
+    IMGUI_API bool          DragInt(const char* label, int* v, float v_speed = 1.0f, int v_min = 0, int v_max = 0, const char* format = "%d", ImGuiSliderFlags flags = 0) IMGUI_NOEXCEPT;  // If v_min >= v_max we have no bound
+    IMGUI_API bool          DragInt2(const char* label, int v[2], float v_speed = 1.0f, int v_min = 0, int v_max = 0, const char* format = "%d", ImGuiSliderFlags flags = 0) IMGUI_NOEXCEPT;
+    IMGUI_API bool          DragInt3(const char* label, int v[3], float v_speed = 1.0f, int v_min = 0, int v_max = 0, const char* format = "%d", ImGuiSliderFlags flags = 0) IMGUI_NOEXCEPT;
+    IMGUI_API bool          DragInt4(const char* label, int v[4], float v_speed = 1.0f, int v_min = 0, int v_max = 0, const char* format = "%d", ImGuiSliderFlags flags = 0) IMGUI_NOEXCEPT;
+    IMGUI_API bool          DragIntRange2(const char* label, int* v_current_min, int* v_current_max, float v_speed = 1.0f, int v_min = 0, int v_max = 0, const char* format = "%d", const char* format_max = NULL, ImGuiSliderFlags flags = 0) IMGUI_NOEXCEPT;
+    IMGUI_API bool          DragScalar(const char* label, ImGuiDataType data_type, void* p_data, float v_speed = 1.0f, const void* p_min = NULL, const void* p_max = NULL, const char* format = NULL, ImGuiSliderFlags flags = 0) IMGUI_NOEXCEPT;
+    IMGUI_API bool          DragScalarN(const char* label, ImGuiDataType data_type, void* p_data, int components, float v_speed = 1.0f, const void* p_min = NULL, const void* p_max = NULL, const char* format = NULL, ImGuiSliderFlags flags = 0) IMGUI_NOEXCEPT;
 
     // Widgets: Regular Sliders
     // - CTRL+Click on any slider to turn them into an input box. Manually input values aren't clamped and can go off-bounds.
@@ -536,74 +543,74 @@ namespace ImGui
     // - Format string may also be set to NULL or use the default format ("%f" or "%d").
     // - Legacy: Pre-1.78 there are SliderXXX() function signatures that takes a final `float power=1.0f' argument instead of the `ImGuiSliderFlags flags=0' argument.
     //   If you get a warning converting a float to ImGuiSliderFlags, read https://github.com/ocornut/imgui/issues/3361
-    IMGUI_API bool          SliderFloat(const char* label, float* v, float v_min, float v_max, const char* format = "%.3f", ImGuiSliderFlags flags = 0);     // adjust format to decorate the value with a prefix or a suffix for in-slider labels or unit display.
-    IMGUI_API bool          SliderFloat2(const char* label, float v[2], float v_min, float v_max, const char* format = "%.3f", ImGuiSliderFlags flags = 0);
-    IMGUI_API bool          SliderFloat3(const char* label, float v[3], float v_min, float v_max, const char* format = "%.3f", ImGuiSliderFlags flags = 0);
-    IMGUI_API bool          SliderFloat4(const char* label, float v[4], float v_min, float v_max, const char* format = "%.3f", ImGuiSliderFlags flags = 0);
-    IMGUI_API bool          SliderAngle(const char* label, float* v_rad, float v_degrees_min = -360.0f, float v_degrees_max = +360.0f, const char* format = "%.0f deg", ImGuiSliderFlags flags = 0);
-    IMGUI_API bool          SliderInt(const char* label, int* v, int v_min, int v_max, const char* format = "%d", ImGuiSliderFlags flags = 0);
-    IMGUI_API bool          SliderInt2(const char* label, int v[2], int v_min, int v_max, const char* format = "%d", ImGuiSliderFlags flags = 0);
-    IMGUI_API bool          SliderInt3(const char* label, int v[3], int v_min, int v_max, const char* format = "%d", ImGuiSliderFlags flags = 0);
-    IMGUI_API bool          SliderInt4(const char* label, int v[4], int v_min, int v_max, const char* format = "%d", ImGuiSliderFlags flags = 0);
-    IMGUI_API bool          SliderScalar(const char* label, ImGuiDataType data_type, void* p_data, const void* p_min, const void* p_max, const char* format = NULL, ImGuiSliderFlags flags = 0);
-    IMGUI_API bool          SliderScalarN(const char* label, ImGuiDataType data_type, void* p_data, int components, const void* p_min, const void* p_max, const char* format = NULL, ImGuiSliderFlags flags = 0);
-    IMGUI_API bool          VSliderFloat(const char* label, const ImVec2& size, float* v, float v_min, float v_max, const char* format = "%.3f", ImGuiSliderFlags flags = 0);
-    IMGUI_API bool          VSliderInt(const char* label, const ImVec2& size, int* v, int v_min, int v_max, const char* format = "%d", ImGuiSliderFlags flags = 0);
-    IMGUI_API bool          VSliderScalar(const char* label, const ImVec2& size, ImGuiDataType data_type, void* p_data, const void* p_min, const void* p_max, const char* format = NULL, ImGuiSliderFlags flags = 0);
+    IMGUI_API bool          SliderFloat(const char* label, float* v, float v_min, float v_max, const char* format = "%.3f", ImGuiSliderFlags flags = 0)    IMGUI_NOEXCEPT;  // adjust format to decorate the value with a prefix or a suffix for in-slider labels or unit display.
+    IMGUI_API bool          SliderFloat2(const char* label, float v[2], float v_min, float v_max, const char* format = "%.3f", ImGuiSliderFlags flags = 0) IMGUI_NOEXCEPT;
+    IMGUI_API bool          SliderFloat3(const char* label, float v[3], float v_min, float v_max, const char* format = "%.3f", ImGuiSliderFlags flags = 0) IMGUI_NOEXCEPT;
+    IMGUI_API bool          SliderFloat4(const char* label, float v[4], float v_min, float v_max, const char* format = "%.3f", ImGuiSliderFlags flags = 0) IMGUI_NOEXCEPT;
+    IMGUI_API bool          SliderAngle(const char* label, float* v_rad, float v_degrees_min = -360.0f, float v_degrees_max = +360.0f, const char* format = "%.0f deg", ImGuiSliderFlags flags = 0)                  IMGUI_NOEXCEPT;
+    IMGUI_API bool          SliderInt(const char* label, int* v, int v_min, int v_max, const char* format = "%d", ImGuiSliderFlags flags = 0)              IMGUI_NOEXCEPT;
+    IMGUI_API bool          SliderInt2(const char* label, int v[2], int v_min, int v_max, const char* format = "%d", ImGuiSliderFlags flags = 0)           IMGUI_NOEXCEPT;
+    IMGUI_API bool          SliderInt3(const char* label, int v[3], int v_min, int v_max, const char* format = "%d", ImGuiSliderFlags flags = 0)           IMGUI_NOEXCEPT;
+    IMGUI_API bool          SliderInt4(const char* label, int v[4], int v_min, int v_max, const char* format = "%d", ImGuiSliderFlags flags = 0)           IMGUI_NOEXCEPT;
+    IMGUI_API bool          SliderScalar(const char* label, ImGuiDataType data_type, void* p_data, const void* p_min, const void* p_max, const char* format = NULL, ImGuiSliderFlags flags = 0)                      IMGUI_NOEXCEPT;
+    IMGUI_API bool          SliderScalarN(const char* label, ImGuiDataType data_type, void* p_data, int components, const void* p_min, const void* p_max, const char* format = NULL, ImGuiSliderFlags flags = 0)     IMGUI_NOEXCEPT;
+    IMGUI_API bool          VSliderFloat(const char* label, const ImVec2& size, float* v, float v_min, float v_max, const char* format = "%.3f", ImGuiSliderFlags flags = 0) IMGUI_NOEXCEPT;
+    IMGUI_API bool          VSliderInt(const char* label, const ImVec2& size, int* v, int v_min, int v_max, const char* format = "%d", ImGuiSliderFlags flags = 0)           IMGUI_NOEXCEPT;
+    IMGUI_API bool          VSliderScalar(const char* label, const ImVec2& size, ImGuiDataType data_type, void* p_data, const void* p_min, const void* p_max, const char* format = NULL, ImGuiSliderFlags flags = 0) IMGUI_NOEXCEPT;
 
     // Widgets: Input with Keyboard
     // - If you want to use InputText() with std::string or any custom dynamic string type, see misc/cpp/imgui_stdlib.h and comments in imgui_demo.cpp.
     // - Most of the ImGuiInputTextFlags flags are only useful for InputText() and not for InputFloatX, InputIntX, InputDouble etc.
-    IMGUI_API bool          InputText(const char* label, char* buf, size_t buf_size, ImGuiInputTextFlags flags = 0, ImGuiInputTextCallback callback = NULL, void* user_data = NULL);
-    IMGUI_API bool          InputTextMultiline(const char* label, char* buf, size_t buf_size, const ImVec2& size = ImVec2(0, 0), ImGuiInputTextFlags flags = 0, ImGuiInputTextCallback callback = NULL, void* user_data = NULL);
-    IMGUI_API bool          InputTextWithHint(const char* label, const char* hint, char* buf, size_t buf_size, ImGuiInputTextFlags flags = 0, ImGuiInputTextCallback callback = NULL, void* user_data = NULL);
-    IMGUI_API bool          InputFloat(const char* label, float* v, float step = 0.0f, float step_fast = 0.0f, const char* format = "%.3f", ImGuiInputTextFlags flags = 0);
-    IMGUI_API bool          InputFloat2(const char* label, float v[2], const char* format = "%.3f", ImGuiInputTextFlags flags = 0);
-    IMGUI_API bool          InputFloat3(const char* label, float v[3], const char* format = "%.3f", ImGuiInputTextFlags flags = 0);
-    IMGUI_API bool          InputFloat4(const char* label, float v[4], const char* format = "%.3f", ImGuiInputTextFlags flags = 0);
-    IMGUI_API bool          InputInt(const char* label, int* v, int step = 1, int step_fast = 100, ImGuiInputTextFlags flags = 0);
-    IMGUI_API bool          InputInt2(const char* label, int v[2], ImGuiInputTextFlags flags = 0);
-    IMGUI_API bool          InputInt3(const char* label, int v[3], ImGuiInputTextFlags flags = 0);
-    IMGUI_API bool          InputInt4(const char* label, int v[4], ImGuiInputTextFlags flags = 0);
-    IMGUI_API bool          InputDouble(const char* label, double* v, double step = 0.0, double step_fast = 0.0, const char* format = "%.6f", ImGuiInputTextFlags flags = 0);
-    IMGUI_API bool          InputScalar(const char* label, ImGuiDataType data_type, void* p_data, const void* p_step = NULL, const void* p_step_fast = NULL, const char* format = NULL, ImGuiInputTextFlags flags = 0);
-    IMGUI_API bool          InputScalarN(const char* label, ImGuiDataType data_type, void* p_data, int components, const void* p_step = NULL, const void* p_step_fast = NULL, const char* format = NULL, ImGuiInputTextFlags flags = 0);
+    IMGUI_API bool          InputText(const char* label, char* buf, size_t buf_size, ImGuiInputTextFlags flags = 0, ImGuiInputTextCallback callback = NULL, void* user_data = NULL)                                                    IMGUI_NOEXCEPT;
+    IMGUI_API bool          InputTextMultiline(const char* label, char* buf, size_t buf_size, const ImVec2& size = ImVec2(0, 0), ImGuiInputTextFlags flags = 0, ImGuiInputTextCallback callback = NULL, void* user_data = NULL)        IMGUI_NOEXCEPT;
+    IMGUI_API bool          InputTextWithHint(const char* label, const char* hint, char* buf, size_t buf_size, ImGuiInputTextFlags flags = 0, ImGuiInputTextCallback callback = NULL, void* user_data = NULL)                          IMGUI_NOEXCEPT;
+    IMGUI_API bool          InputFloat(const char* label, float* v, float step = 0.0f, float step_fast = 0.0f, const char* format = "%.3f", ImGuiInputTextFlags flags = 0)                                                             IMGUI_NOEXCEPT;
+    IMGUI_API bool          InputFloat2(const char* label, float v[2], const char* format = "%.3f", ImGuiInputTextFlags flags = 0) IMGUI_NOEXCEPT;
+    IMGUI_API bool          InputFloat3(const char* label, float v[3], const char* format = "%.3f", ImGuiInputTextFlags flags = 0) IMGUI_NOEXCEPT;
+    IMGUI_API bool          InputFloat4(const char* label, float v[4], const char* format = "%.3f", ImGuiInputTextFlags flags = 0) IMGUI_NOEXCEPT;
+    IMGUI_API bool          InputInt(const char* label, int* v, int step = 1, int step_fast = 100, ImGuiInputTextFlags flags = 0)  IMGUI_NOEXCEPT;
+    IMGUI_API bool          InputInt2(const char* label, int v[2], ImGuiInputTextFlags flags = 0)                                  IMGUI_NOEXCEPT;
+    IMGUI_API bool          InputInt3(const char* label, int v[3], ImGuiInputTextFlags flags = 0)                                  IMGUI_NOEXCEPT;
+    IMGUI_API bool          InputInt4(const char* label, int v[4], ImGuiInputTextFlags flags = 0)                                  IMGUI_NOEXCEPT;
+    IMGUI_API bool          InputDouble(const char* label, double* v, double step = 0.0, double step_fast = 0.0, const char* format = "%.6f", ImGuiInputTextFlags flags = 0)                                                            IMGUI_NOEXCEPT;
+    IMGUI_API bool          InputScalar(const char* label, ImGuiDataType data_type, void* p_data, const void* p_step = NULL, const void* p_step_fast = NULL, const char* format = NULL, ImGuiInputTextFlags flags = 0)                  IMGUI_NOEXCEPT;
+    IMGUI_API bool          InputScalarN(const char* label, ImGuiDataType data_type, void* p_data, int components, const void* p_step = NULL, const void* p_step_fast = NULL, const char* format = NULL, ImGuiInputTextFlags flags = 0) IMGUI_NOEXCEPT;
 
     // Widgets: Color Editor/Picker (tip: the ColorEdit* functions have a little color square that can be left-clicked to open a picker, and right-clicked to open an option menu.)
     // - Note that in C++ a 'float v[X]' function argument is the _same_ as 'float* v', the array syntax is just a way to document the number of elements that are expected to be accessible.
     // - You can pass the address of a first float element out of a contiguous structure, e.g. &myvector.x
-    IMGUI_API bool          ColorEdit3(const char* label, float col[3], ImGuiColorEditFlags flags = 0);
-    IMGUI_API bool          ColorEdit4(const char* label, float col[4], ImGuiColorEditFlags flags = 0);
-    IMGUI_API bool          ColorPicker3(const char* label, float col[3], ImGuiColorEditFlags flags = 0);
-    IMGUI_API bool          ColorPicker4(const char* label, float col[4], ImGuiColorEditFlags flags = 0, const float* ref_col = NULL);
-    IMGUI_API bool          ColorButton(const char* desc_id, const ImVec4& col, ImGuiColorEditFlags flags = 0, ImVec2 size = ImVec2(0, 0)); // display a color square/button, hover for details, return true when pressed.
-    IMGUI_API void          SetColorEditOptions(ImGuiColorEditFlags flags);                     // initialize current options (generally on application startup) if you want to select a default format, picker type, etc. User will be able to change many settings, unless you pass the _NoOptions flag to your calls.
+    IMGUI_API bool          ColorEdit3(const char* label, float col[3], ImGuiColorEditFlags flags = 0)   IMGUI_NOEXCEPT;
+    IMGUI_API bool          ColorEdit4(const char* label, float col[4], ImGuiColorEditFlags flags = 0)   IMGUI_NOEXCEPT;
+    IMGUI_API bool          ColorPicker3(const char* label, float col[3], ImGuiColorEditFlags flags = 0) IMGUI_NOEXCEPT;
+    IMGUI_API bool          ColorPicker4(const char* label, float col[4], ImGuiColorEditFlags flags = 0, const float* ref_col = NULL) IMGUI_NOEXCEPT;
+    IMGUI_API bool          ColorButton(const char* desc_id, const ImVec4& col, ImGuiColorEditFlags flags = 0, ImVec2 size = ImVec2(0, 0)) IMGUI_NOEXCEPT;  // display a color square/button, hover for details, return true when pressed.
+    IMGUI_API void          SetColorEditOptions(ImGuiColorEditFlags flags)                               IMGUI_NOEXCEPT;  // initialize current options (generally on application startup) if you want to select a default format, picker type, etc. User will be able to change many settings, unless you pass the _NoOptions flag to your calls.
 
     // Widgets: Trees
     // - TreeNode functions return true when the node is open, in which case you need to also call TreePop() when you are finished displaying the tree node contents.
-    IMGUI_API bool          TreeNode(const char* label);
-    IMGUI_API bool          TreeNode(const char* str_id, const char* fmt, ...) IM_FMTARGS(2);   // helper variation to easily decorelate the id from the displayed string. Read the FAQ about why and how to use ID. to align arbitrary text at the same level as a TreeNode() you can use Bullet().
-    IMGUI_API bool          TreeNode(const void* ptr_id, const char* fmt, ...) IM_FMTARGS(2);   // "
-    IMGUI_API bool          TreeNodeV(const char* str_id, const char* fmt, va_list args) IM_FMTLIST(2);
-    IMGUI_API bool          TreeNodeV(const void* ptr_id, const char* fmt, va_list args) IM_FMTLIST(2);
-    IMGUI_API bool          TreeNodeEx(const char* label, ImGuiTreeNodeFlags flags = 0);
-    IMGUI_API bool          TreeNodeEx(const char* str_id, ImGuiTreeNodeFlags flags, const char* fmt, ...) IM_FMTARGS(3);
-    IMGUI_API bool          TreeNodeEx(const void* ptr_id, ImGuiTreeNodeFlags flags, const char* fmt, ...) IM_FMTARGS(3);
-    IMGUI_API bool          TreeNodeExV(const char* str_id, ImGuiTreeNodeFlags flags, const char* fmt, va_list args) IM_FMTLIST(3);
-    IMGUI_API bool          TreeNodeExV(const void* ptr_id, ImGuiTreeNodeFlags flags, const char* fmt, va_list args) IM_FMTLIST(3);
-    IMGUI_API void          TreePush(const char* str_id);                                       // ~ Indent()+PushId(). Already called by TreeNode() when returning true, but you can call TreePush/TreePop yourself if desired.
-    IMGUI_API void          TreePush(const void* ptr_id = NULL);                                // "
-    IMGUI_API void          TreePop();                                                          // ~ Unindent()+PopId()
-    IMGUI_API float         GetTreeNodeToLabelSpacing();                                        // horizontal distance preceding label when using TreeNode*() or Bullet() == (g.FontSize + style.FramePadding.x*2) for a regular unframed TreeNode
-    IMGUI_API bool          CollapsingHeader(const char* label, ImGuiTreeNodeFlags flags = 0);  // if returning 'true' the header is open. doesn't indent nor push on ID stack. user doesn't have to call TreePop().
-    IMGUI_API bool          CollapsingHeader(const char* label, bool* p_visible, ImGuiTreeNodeFlags flags = 0); // when 'p_visible != NULL': if '*p_visible==true' display an additional small close button on upper right of the header which will set the bool to false when clicked, if '*p_visible==false' don't display the header.
-    IMGUI_API void          SetNextItemOpen(bool is_open, ImGuiCond cond = 0);                  // set next TreeNode/CollapsingHeader open state.
+    IMGUI_API bool          TreeNode(const char* label)                                                              IMGUI_NOEXCEPT;
+    IMGUI_API bool          TreeNode(const char* str_id, const char* fmt, ...)                                       IMGUI_NOEXCEPT IM_FMTARGS(2);   // helper variation to easily decorelate the id from the displayed string. Read the FAQ about why and how to use ID. to align arbitrary text at the same level as a TreeNode() you can use Bullet().
+    IMGUI_API bool          TreeNode(const void* ptr_id, const char* fmt, ...)                                       IMGUI_NOEXCEPT IM_FMTARGS(2);   // "
+    IMGUI_API bool          TreeNodeV(const char* str_id, const char* fmt, va_list args)                             IMGUI_NOEXCEPT IM_FMTLIST(2);
+    IMGUI_API bool          TreeNodeV(const void* ptr_id, const char* fmt, va_list args)                             IMGUI_NOEXCEPT IM_FMTLIST(2);
+    IMGUI_API bool          TreeNodeEx(const char* label, ImGuiTreeNodeFlags flags = 0)                              IMGUI_NOEXCEPT;
+    IMGUI_API bool          TreeNodeEx(const char* str_id, ImGuiTreeNodeFlags flags, const char* fmt, ...)           IMGUI_NOEXCEPT IM_FMTARGS(3);
+    IMGUI_API bool          TreeNodeEx(const void* ptr_id, ImGuiTreeNodeFlags flags, const char* fmt, ...)           IMGUI_NOEXCEPT IM_FMTARGS(3);
+    IMGUI_API bool          TreeNodeExV(const char* str_id, ImGuiTreeNodeFlags flags, const char* fmt, va_list args) IMGUI_NOEXCEPT IM_FMTLIST(3);
+    IMGUI_API bool          TreeNodeExV(const void* ptr_id, ImGuiTreeNodeFlags flags, const char* fmt, va_list args) IMGUI_NOEXCEPT IM_FMTLIST(3);
+    IMGUI_API void          TreePush(const char* str_id)                                      IMGUI_NOEXCEPT;  // ~ Indent()+PushId(). Already called by TreeNode() when returning true, but you can call TreePush/TreePop yourself if desired.
+    IMGUI_API void          TreePush(const void* ptr_id = NULL)                               IMGUI_NOEXCEPT;  // "
+    IMGUI_API void          TreePop()                                                         IMGUI_NOEXCEPT;  // ~ Unindent()+PopId()
+    IMGUI_API float         GetTreeNodeToLabelSpacing()                                       IMGUI_NOEXCEPT;  // horizontal distance preceding label when using TreeNode*() or Bullet() == (g.FontSize + style.FramePadding.x*2) for a regular unframed TreeNode
+    IMGUI_API bool          CollapsingHeader(const char* label, ImGuiTreeNodeFlags flags = 0) IMGUI_NOEXCEPT;  // if returning 'true' the header is open. doesn't indent nor push on ID stack. user doesn't have to call TreePop().
+    IMGUI_API bool          CollapsingHeader(const char* label, bool* p_visible, ImGuiTreeNodeFlags flags = 0) IMGUI_NOEXCEPT; // when 'p_visible != NULL': if '*p_visible==true' display an additional small close button on upper right of the header which will set the bool to false when clicked, if '*p_visible==false' don't display the header.
+    IMGUI_API void          SetNextItemOpen(bool is_open, ImGuiCond cond = 0)                 IMGUI_NOEXCEPT;  // set next TreeNode/CollapsingHeader open state.
 
     // Widgets: Selectables
     // - A selectable highlights when hovered, and can display another color when selected.
     // - Neighbors selectable extend their highlight bounds in order to leave no gap between them. This is so a series of selected Selectable appear contiguous.
-    IMGUI_API bool          Selectable(const char* label, bool selected = false, ImGuiSelectableFlags flags = 0, const ImVec2& size = ImVec2(0, 0)); // "bool selected" carry the selection state (read-only). Selectable() is clicked is returns true so you can modify your selection state. size.x==0.0: use remaining width, size.x>0.0: specify width. size.y==0.0: use label height, size.y>0.0: specify height
-    IMGUI_API bool          Selectable(const char* label, bool* p_selected, ImGuiSelectableFlags flags = 0, const ImVec2& size = ImVec2(0, 0));      // "bool* p_selected" point to the selection state (read-write), as a convenient helper.
+    IMGUI_API bool          Selectable(const char* label, bool selected = false, ImGuiSelectableFlags flags = 0, const ImVec2& size = ImVec2(0, 0)) IMGUI_NOEXCEPT;  // "bool selected" carry the selection state (read-only). Selectable() is clicked is returns true so you can modify your selection state. size.x==0.0: use remaining width, size.x>0.0: specify width. size.y==0.0: use label height, size.y>0.0: specify height
+    IMGUI_API bool          Selectable(const char* label, bool* p_selected, ImGuiSelectableFlags flags = 0, const ImVec2& size = ImVec2(0, 0))      IMGUI_NOEXCEPT;  // "bool* p_selected" point to the selection state (read-write), as a convenient helper.
 
     // Widgets: List Boxes
     // - This is essentially a thin wrapper to using BeginChild/EndChild with some stylistic changes.
@@ -613,22 +620,22 @@ namespace ImGui
     // - Choose frame height:  size.y > 0.0f: custom  /  size.y < 0.0f or -FLT_MIN: bottom-align  /  size.y = 0.0f (default): arbitrary default height which can fit ~7 items
     IMGUI_API bool          BeginListBox(const char* label, const ImVec2& size = ImVec2(0, 0)) IMGUI_NOEXCEPT; // open a framed scrolling region
     IMGUI_API void          EndListBox() IMGUI_NOEXCEPT;                                                       // only call EndListBox() if BeginListBox() returned true!
-    IMGUI_API bool          ListBox(const char* label, int* current_item, const char* const items[], int items_count, int height_in_items = -1);
-    IMGUI_API bool          ListBox(const char* label, int* current_item, bool (*items_getter)(void* data, int idx, const char** out_text), void* data, int items_count, int height_in_items = -1);
+    IMGUI_API bool          ListBox(const char* label, int* current_item, const char* const items[], int items_count, int height_in_items = -1) IMGUI_NOEXCEPT;
+    IMGUI_API bool          ListBox(const char* label, int* current_item, bool (*items_getter)(void* data, int idx, const char** out_text), void* data, int items_count, int height_in_items = -1) IMGUI_NOEXCEPT;
 
     // Widgets: Data Plotting
     // - Consider using ImPlot (https://github.com/epezent/implot)
-    IMGUI_API void          PlotLines(const char* label, const float* values, int values_count, int values_offset = 0, const char* overlay_text = NULL, float scale_min = FLT_MAX, float scale_max = FLT_MAX, ImVec2 graph_size = ImVec2(0, 0), int stride = sizeof(float));
-    IMGUI_API void          PlotLines(const char* label, float(*values_getter)(void* data, int idx), void* data, int values_count, int values_offset = 0, const char* overlay_text = NULL, float scale_min = FLT_MAX, float scale_max = FLT_MAX, ImVec2 graph_size = ImVec2(0, 0));
-    IMGUI_API void          PlotHistogram(const char* label, const float* values, int values_count, int values_offset = 0, const char* overlay_text = NULL, float scale_min = FLT_MAX, float scale_max = FLT_MAX, ImVec2 graph_size = ImVec2(0, 0), int stride = sizeof(float));
-    IMGUI_API void          PlotHistogram(const char* label, float(*values_getter)(void* data, int idx), void* data, int values_count, int values_offset = 0, const char* overlay_text = NULL, float scale_min = FLT_MAX, float scale_max = FLT_MAX, ImVec2 graph_size = ImVec2(0, 0));
+    IMGUI_API void          PlotLines(const char* label, const float* values, int values_count, int values_offset = 0, const char* overlay_text = NULL, float scale_min = FLT_MAX, float scale_max = FLT_MAX, ImVec2 graph_size = ImVec2(0, 0), int stride = sizeof(float))            IMGUI_NOEXCEPT;
+    IMGUI_API void          PlotLines(const char* label, float(*values_getter)(void* data, int idx), void* data, int values_count, int values_offset = 0, const char* overlay_text = NULL, float scale_min = FLT_MAX, float scale_max = FLT_MAX, ImVec2 graph_size = ImVec2(0, 0))     IMGUI_NOEXCEPT;
+    IMGUI_API void          PlotHistogram(const char* label, const float* values, int values_count, int values_offset = 0, const char* overlay_text = NULL, float scale_min = FLT_MAX, float scale_max = FLT_MAX, ImVec2 graph_size = ImVec2(0, 0), int stride = sizeof(float))        IMGUI_NOEXCEPT;
+    IMGUI_API void          PlotHistogram(const char* label, float(*values_getter)(void* data, int idx), void* data, int values_count, int values_offset = 0, const char* overlay_text = NULL, float scale_min = FLT_MAX, float scale_max = FLT_MAX, ImVec2 graph_size = ImVec2(0, 0)) IMGUI_NOEXCEPT;
 
     // Widgets: Value() Helpers.
     // - Those are merely shortcut to calling Text() with a format string. Output single value in "name: value" format (tip: freely declare more in your code to handle your types. you can add functions to the ImGui namespace)
-    IMGUI_API void          Value(const char* prefix, bool b);
-    IMGUI_API void          Value(const char* prefix, int v);
-    IMGUI_API void          Value(const char* prefix, unsigned int v);
-    IMGUI_API void          Value(const char* prefix, float v, const char* float_format = NULL);
+    IMGUI_API void          Value(const char* prefix, bool b)                                   IMGUI_NOEXCEPT;
+    IMGUI_API void          Value(const char* prefix, int v)                                    IMGUI_NOEXCEPT;
+    IMGUI_API void          Value(const char* prefix, unsigned int v)                           IMGUI_NOEXCEPT;
+    IMGUI_API void          Value(const char* prefix, float v, const char* float_format = NULL) IMGUI_NOEXCEPT;
 
     // Widgets: Menus
     // - Use BeginMenuBar() on a window ImGuiWindowFlags_MenuBar to append to its menu bar.
@@ -641,15 +648,15 @@ namespace ImGui
     IMGUI_API void          EndMainMenuBar() IMGUI_NOEXCEPT;                                                                       // only call EndMainMenuBar() if BeginMainMenuBar() returns true!
     IMGUI_API bool          BeginMenu(const char* label, bool enabled = true) IMGUI_NOEXCEPT;                                      // create a sub-menu entry. only call EndMenu() if this returns true!
     IMGUI_API void          EndMenu() IMGUI_NOEXCEPT;                                                          					   // only call EndMenu() if BeginMenu() returns true!
-    IMGUI_API bool          MenuItem(const char* label, const char* shortcut = NULL, bool selected = false, bool enabled = true);  // return true when activated.
-    IMGUI_API bool          MenuItem(const char* label, const char* shortcut, bool* p_selected, bool enabled = true);              // return true when activated + toggle (*p_selected) if p_selected != NULL
+    IMGUI_API bool          MenuItem(const char* label, const char* shortcut = NULL, bool selected = false, bool enabled = true) IMGUI_NOEXCEPT;  // return true when activated.
+    IMGUI_API bool          MenuItem(const char* label, const char* shortcut, bool* p_selected, bool enabled = true)             IMGUI_NOEXCEPT;  // return true when activated + toggle (*p_selected) if p_selected != NULL
 
     // Tooltips
     // - Tooltip are windows following the mouse. They do not take focus away.
     IMGUI_API void          BeginTooltip() IMGUI_NOEXCEPT;                                      // begin/append a tooltip window. to create full-featured tooltip (with any kind of items).
     IMGUI_API void          EndTooltip() IMGUI_NOEXCEPT;
-    IMGUI_API void          SetTooltip(const char* fmt, ...) IM_FMTARGS(1);                     // set a text-only tooltip, typically use with ImGui::IsItemHovered(). override any previous call to SetTooltip().
-    IMGUI_API void          SetTooltipV(const char* fmt, va_list args) IM_FMTLIST(1);
+    IMGUI_API void          SetTooltip(const char* fmt, ...)           IMGUI_NOEXCEPT IM_FMTARGS(1);       // set a text-only tooltip, typically use with ImGui::IsItemHovered(). override any previous call to SetTooltip().
+    IMGUI_API void          SetTooltipV(const char* fmt, va_list args) IMGUI_NOEXCEPT IM_FMTLIST(1);
 
     // Popups, Modals
     //  - They block normal mouse hovering detection (and therefore most mouse interactions) behind them.
@@ -672,23 +679,23 @@ namespace ImGui
     //  - CloseCurrentPopup() is called by default by Selectable()/MenuItem() when activated (FIXME: need some options).
     //  - Use ImGuiPopupFlags_NoOpenOverExistingPopup to avoid opening a popup if there's already one at the same level. This is equivalent to e.g. testing for !IsAnyPopupOpen() prior to OpenPopup().
     //  - Use IsWindowAppearing() after BeginPopup() to tell if a window just opened.
-    IMGUI_API void          OpenPopup(const char* str_id, ImGuiPopupFlags popup_flags = 0);                     // call to mark popup as open (don't call every frame!).
-    IMGUI_API void          OpenPopup(ImGuiID id, ImGuiPopupFlags popup_flags = 0);                             // id overload to facilitate calling from nested stacks
-    IMGUI_API void          OpenPopupOnItemClick(const char* str_id = NULL, ImGuiPopupFlags popup_flags = 1);   // helper to open popup when clicked on last item. Default to ImGuiPopupFlags_MouseButtonRight == 1. (note: actually triggers on the mouse _released_ event to be consistent with popup behaviors)
-    IMGUI_API void          CloseCurrentPopup();                                                                // manually close the popup we have begin-ed into.
+    IMGUI_API void          OpenPopup(const char* str_id, ImGuiPopupFlags popup_flags = 0)                      IMGUI_NOEXCEPT;  // call to mark popup as open (don't call every frame!).
+    IMGUI_API void          OpenPopup(ImGuiID id, ImGuiPopupFlags popup_flags = 0)                              IMGUI_NOEXCEPT;  // id overload to facilitate calling from nested stacks
+    IMGUI_API void          OpenPopupOnItemClick(const char* str_id = NULL, ImGuiPopupFlags popup_flags = 1)    IMGUI_NOEXCEPT;  // helper to open popup when clicked on last item. Default to ImGuiPopupFlags_MouseButtonRight == 1. (note: actually triggers on the mouse _released_ event to be consistent with popup behaviors)
+    IMGUI_API void          CloseCurrentPopup()                                                                 IMGUI_NOEXCEPT;  // manually close the popup we have begin-ed into.
     // Popups: open+begin combined functions helpers
     //  - Helpers to do OpenPopup+BeginPopup where the Open action is triggered by e.g. hovering an item and right-clicking.
     //  - They are convenient to easily create context menus, hence the name.
     //  - IMPORTANT: Notice that BeginPopupContextXXX takes ImGuiPopupFlags just like OpenPopup() and unlike BeginPopup(). For full consistency, we may add ImGuiWindowFlags to the BeginPopupContextXXX functions in the future.
     //  - IMPORTANT: we exceptionally default their flags to 1 (== ImGuiPopupFlags_MouseButtonRight) for backward compatibility with older API taking 'int mouse_button = 1' parameter, so if you add other flags remember to re-add the ImGuiPopupFlags_MouseButtonRight.
     IMGUI_API bool          BeginPopupContextItem(const char* str_id = NULL, ImGuiPopupFlags popup_flags = 1) IMGUI_NOEXCEPT;  // open+begin popup when clicked on last item. Use str_id==NULL to associate the popup to previous item. If you want to use that on a non-interactive item such as Text() you need to pass in an explicit ID here. read comments in .cpp!
-    IMGUI_API bool          BeginPopupContextWindow(const char* str_id = NULL, ImGuiPopupFlags popup_flags = 1) IMGUI_NOEXCEPT;// open+begin popup when clicked on current window.
+    IMGUI_API bool          BeginPopupContextWindow(const char* str_id = NULL, ImGuiPopupFlags popup_flags = 1) IMGUI_NOEXCEPT;  // open+begin popup when clicked on current window.
     IMGUI_API bool          BeginPopupContextVoid(const char* str_id = NULL, ImGuiPopupFlags popup_flags = 1) IMGUI_NOEXCEPT;  // open+begin popup when clicked in void (where there are no windows).
     // Popups: query functions
     //  - IsPopupOpen(): return true if the popup is open at the current BeginPopup() level of the popup stack.
     //  - IsPopupOpen() with ImGuiPopupFlags_AnyPopupId: return true if any popup is open at the current BeginPopup() level of the popup stack.
     //  - IsPopupOpen() with ImGuiPopupFlags_AnyPopupId + ImGuiPopupFlags_AnyPopupLevel: return true if any popup is open.
-    IMGUI_API bool          IsPopupOpen(const char* str_id, ImGuiPopupFlags flags = 0);                         // return true if the popup is open.
+    IMGUI_API bool          IsPopupOpen(const char* str_id, ImGuiPopupFlags flags = 0)                           IMGUI_NOEXCEPT;  // return true if the popup is open.
 
     // Tables
     // [BETA API] API may evolve slightly! If you use this, please update to the next version when it comes out!
@@ -717,9 +724,9 @@ namespace ImGui
     // - 5. Call EndTable()
     IMGUI_API bool          BeginTable(const char* str_id, int column, ImGuiTableFlags flags = 0, const ImVec2& outer_size = ImVec2(0.0f, 0.0f), float inner_width = 0.0f) IMGUI_NOEXCEPT;
     IMGUI_API void          EndTable() IMGUI_NOEXCEPT;                                 // only call EndTable() if BeginTable() returns true!
-    IMGUI_API void          TableNextRow(ImGuiTableRowFlags row_flags = 0, float min_row_height = 0.0f); // append into the first cell of a new row.
-    IMGUI_API bool          TableNextColumn();                          // append into the next column (or first column of next row if currently in last column). Return true when column is visible.
-    IMGUI_API bool          TableSetColumnIndex(int column_n);          // append into the specified column. Return true when column is visible.
+    IMGUI_API void          TableNextRow(ImGuiTableRowFlags row_flags = 0, float min_row_height = 0.0f) IMGUI_NOEXCEPT;  // append into the first cell of a new row.
+    IMGUI_API bool          TableNextColumn()                                                           IMGUI_NOEXCEPT;  // append into the next column (or first column of next row if currently in last column). Return true when column is visible.
+    IMGUI_API bool          TableSetColumnIndex(int column_n)                                           IMGUI_NOEXCEPT;  // append into the specified column. Return true when column is visible.
     // Tables: Headers & Columns declaration
     // - Use TableSetupColumn() to specify label, resizing policy, default width/weight, id, various other flags etc.
     // - Use TableHeadersRow() to create a header row and automatically submit a TableHeader() for each column.
@@ -728,55 +735,55 @@ namespace ImGui
     // - You may manually submit headers using TableNextRow() + TableHeader() calls, but this is only useful in
     //   some advanced use cases (e.g. adding custom widgets in header row).
     // - Use TableSetupScrollFreeze() to lock columns/rows so they stay visible when scrolled.
-    IMGUI_API void          TableSetupColumn(const char* label, ImGuiTableColumnFlags flags = 0, float init_width_or_weight = 0.0f, ImGuiID user_id = 0);
-    IMGUI_API void          TableSetupScrollFreeze(int cols, int rows); // lock columns/rows so they stay visible when scrolled.
-    IMGUI_API void          TableHeadersRow();                          // submit all headers cells based on data provided to TableSetupColumn() + submit context menu
-    IMGUI_API void          TableHeader(const char* label);             // submit one header cell manually (rarely used)
+    IMGUI_API void          TableSetupColumn(const char* label, ImGuiTableColumnFlags flags = 0, float init_width_or_weight = 0.0f, ImGuiID user_id = 0) IMGUI_NOEXCEPT;
+    IMGUI_API void          TableSetupScrollFreeze(int cols, int rows)                                  IMGUI_NOEXCEPT;  // lock columns/rows so they stay visible when scrolled.
+    IMGUI_API void          TableHeadersRow()                                                           IMGUI_NOEXCEPT;  // submit all headers cells based on data provided to TableSetupColumn() + submit context menu
+    IMGUI_API void          TableHeader(const char* label)                                              IMGUI_NOEXCEPT;  // submit one header cell manually (rarely used)
     // Tables: Sorting
     // - Call TableGetSortSpecs() to retrieve latest sort specs for the table. NULL when not sorting.
     // - When 'SpecsDirty == true' you should sort your data. It will be true when sorting specs have changed
     //   since last call, or the first time. Make sure to set 'SpecsDirty = false' after sorting, else you may
     //   wastefully sort your data every frame!
     // - Lifetime: don't hold on this pointer over multiple frames or past any subsequent call to BeginTable().
-    IMGUI_API ImGuiTableSortSpecs*  TableGetSortSpecs();                        // get latest sort specs for the table (NULL if not sorting).
+    IMGUI_API ImGuiTableSortSpecs*  TableGetSortSpecs()                                                 IMGUI_NOEXCEPT;  // get latest sort specs for the table (NULL if not sorting).
     // Tables: Miscellaneous functions
     // - Functions args 'int column_n' treat the default value of -1 as the same as passing the current column index.
-    IMGUI_API int                   TableGetColumnCount();                      // return number of columns (value passed to BeginTable)
-    IMGUI_API int                   TableGetColumnIndex();                      // return current column index.
-    IMGUI_API int                   TableGetRowIndex();                         // return current row index.
-    IMGUI_API const char*           TableGetColumnName(int column_n = -1);      // return "" if column didn't have a name declared by TableSetupColumn(). Pass -1 to use current column.
-    IMGUI_API ImGuiTableColumnFlags TableGetColumnFlags(int column_n = -1);     // return column flags so you can query their Enabled/Visible/Sorted/Hovered status flags. Pass -1 to use current column.
-    IMGUI_API void                  TableSetColumnEnabled(int column_n, bool v);// change enabled/disabled state of a column, set to false to hide the column. Note that end-user can use the context menu to change this themselves (right-click in headers, or right-click in columns body with ImGuiTableFlags_ContextMenuInBody)
-    IMGUI_API void                  TableSetBgColor(ImGuiTableBgTarget target, ImU32 color, int column_n = -1);  // change the color of a cell, row, or column. See ImGuiTableBgTarget_ flags for details.
+    IMGUI_API int                   TableGetColumnCount()                                               IMGUI_NOEXCEPT;  // return number of columns (value passed to BeginTable)
+    IMGUI_API int                   TableGetColumnIndex()                                               IMGUI_NOEXCEPT;  // return current column index.
+    IMGUI_API int                   TableGetRowIndex()                                                  IMGUI_NOEXCEPT;  // return current row index.
+    IMGUI_API const char*           TableGetColumnName(int column_n = -1)                               IMGUI_NOEXCEPT;  // return "" if column didn't have a name declared by TableSetupColumn(). Pass -1 to use current column.
+    IMGUI_API ImGuiTableColumnFlags TableGetColumnFlags(int column_n = -1)                              IMGUI_NOEXCEPT;  // return column flags so you can query their Enabled/Visible/Sorted/Hovered status flags. Pass -1 to use current column.
+    IMGUI_API void                  TableSetColumnEnabled(int column_n, bool v)                         IMGUI_NOEXCEPT;  // change enabled/disabled state of a column, set to false to hide the column. Note that end-user can use the context menu to change this themselves (right-click in headers, or right-click in columns body with ImGuiTableFlags_ContextMenuInBody)
+    IMGUI_API void                  TableSetBgColor(ImGuiTableBgTarget target, ImU32 color, int column_n = -1) IMGUI_NOEXCEPT;  // change the color of a cell, row, or column. See ImGuiTableBgTarget_ flags for details.
 
     // Legacy Columns API (2020: prefer using Tables!)
     // - You can also use SameLine(pos_x) to mimic simplified columns.
-    IMGUI_API void          Columns(int count = 1, const char* id = NULL, bool border = true);
-    IMGUI_API void          NextColumn();                                                       // next column, defaults to current row or next row if the current row is finished
-    IMGUI_API int           GetColumnIndex();                                                   // get current column index
-    IMGUI_API float         GetColumnWidth(int column_index = -1);                              // get column width (in pixels). pass -1 to use current column
-    IMGUI_API void          SetColumnWidth(int column_index, float width);                      // set column width (in pixels). pass -1 to use current column
-    IMGUI_API float         GetColumnOffset(int column_index = -1);                             // get position of column line (in pixels, from the left side of the contents region). pass -1 to use current column, otherwise 0..GetColumnsCount() inclusive. column 0 is typically 0.0f
-    IMGUI_API void          SetColumnOffset(int column_index, float offset_x);                  // set position of column line (in pixels, from the left side of the contents region). pass -1 to use current column
-    IMGUI_API int           GetColumnsCount();
+    IMGUI_API void          Columns(int count = 1, const char* id = NULL, bool border = true)           IMGUI_NOEXCEPT;
+    IMGUI_API void          NextColumn()                                                                IMGUI_NOEXCEPT;  // next column, defaults to current row or next row if the current row is finished
+    IMGUI_API int           GetColumnIndex()                                                            IMGUI_NOEXCEPT;  // get current column index
+    IMGUI_API float         GetColumnWidth(int column_index = -1)                                       IMGUI_NOEXCEPT;  // get column width (in pixels). pass -1 to use current column
+    IMGUI_API void          SetColumnWidth(int column_index, float width)                               IMGUI_NOEXCEPT;  // set column width (in pixels). pass -1 to use current column
+    IMGUI_API float         GetColumnOffset(int column_index = -1)                                      IMGUI_NOEXCEPT;  // get position of column line (in pixels, from the left side of the contents region). pass -1 to use current column, otherwise 0..GetColumnsCount() inclusive. column 0 is typically 0.0f
+    IMGUI_API void          SetColumnOffset(int column_index, float offset_x)                           IMGUI_NOEXCEPT;  // set position of column line (in pixels, from the left side of the contents region). pass -1 to use current column
+    IMGUI_API int           GetColumnsCount()                                                           IMGUI_NOEXCEPT;
 
     // Tab Bars, Tabs
     IMGUI_API bool          BeginTabBar(const char* str_id, ImGuiTabBarFlags flags = 0) IMGUI_NOEXCEPT;        // create and append into a TabBar
     IMGUI_API void          EndTabBar() IMGUI_NOEXCEPT;                                                        // only call EndTabBar() if BeginTabBar() returns true!
     IMGUI_API bool          BeginTabItem(const char* label, bool* p_open = NULL, ImGuiTabItemFlags flags = 0) IMGUI_NOEXCEPT;  // create a Tab. Returns true if the Tab is selected.
     IMGUI_API void          EndTabItem() IMGUI_NOEXCEPT;                                                       // only call EndTabItem() if BeginTabItem() returns true!
-    IMGUI_API bool          TabItemButton(const char* label, ImGuiTabItemFlags flags = 0);                     // create a Tab behaving like a button. return true when clicked. cannot be selected in the tab bar.
-    IMGUI_API void          SetTabItemClosed(const char* tab_or_docked_window_label);                          // notify TabBar or Docking system of a closed tab/window ahead (useful to reduce visual flicker on reorderable tab bars). For tab-bar: call after BeginTabBar() and before Tab submissions. Otherwise call with a window name.
+    IMGUI_API bool          TabItemButton(const char* label, ImGuiTabItemFlags flags = 0)                 IMGUI_NOEXCEPT;  // create a Tab behaving like a button. return true when clicked. cannot be selected in the tab bar.
+    IMGUI_API void          SetTabItemClosed(const char* tab_or_docked_window_label)                      IMGUI_NOEXCEPT;  // notify TabBar or Docking system of a closed tab/window ahead (useful to reduce visual flicker on reorderable tab bars). For tab-bar: call after BeginTabBar() and before Tab submissions. Otherwise call with a window name.
 
     // Logging/Capture
     // - All text output from the interface can be captured into tty/file/clipboard. By default, tree nodes are automatically opened during logging.
-    IMGUI_API void          LogToTTY(int auto_open_depth = -1);                                 // start logging to tty (stdout)
-    IMGUI_API void          LogToFile(int auto_open_depth = -1, const char* filename = NULL);   // start logging to file
-    IMGUI_API void          LogToClipboard(int auto_open_depth = -1);                           // start logging to OS clipboard
-    IMGUI_API void          LogFinish();                                                        // stop logging (close file, etc.)
-    IMGUI_API void          LogButtons();                                                       // helper to display buttons for logging to tty/file/clipboard
-    IMGUI_API void          LogText(const char* fmt, ...) IM_FMTARGS(1);                        // pass text data straight to log (without being displayed)
-    IMGUI_API void          LogTextV(const char* fmt, va_list args) IM_FMTLIST(1);
+    IMGUI_API void          LogToTTY(int auto_open_depth = -1)                                            IMGUI_NOEXCEPT;  // start logging to tty (stdout)
+    IMGUI_API void          LogToFile(int auto_open_depth = -1, const char* filename = NULL)              IMGUI_NOEXCEPT;  // start logging to file
+    IMGUI_API void          LogToClipboard(int auto_open_depth = -1)                                      IMGUI_NOEXCEPT;  // start logging to OS clipboard
+    IMGUI_API void          LogFinish()                                                                   IMGUI_NOEXCEPT;  // stop logging (close file, etc.)
+    IMGUI_API void          LogButtons()                                                                  IMGUI_NOEXCEPT;  // helper to display buttons for logging to tty/file/clipboard
+    IMGUI_API void          LogText(const char* fmt, ...)                                                 IMGUI_NOEXCEPT IM_FMTARGS(1);  // pass text data straight to log (without being displayed)
+    IMGUI_API void          LogTextV(const char* fmt, va_list args)                                       IMGUI_NOEXCEPT IM_FMTLIST(1);
 
     // Drag and Drop
     // - On source items, call BeginDragDropSource(), if it returns true also call SetDragDropPayload() + EndDragDropSource().
@@ -784,127 +791,127 @@ namespace ImGui
     // - If you stop calling BeginDragDropSource() the payload is preserved however it won't have a preview tooltip (we currently display a fallback "..." tooltip, see #1725)
     // - An item can be both drag source and drop target.
     IMGUI_API bool          BeginDragDropSource(ImGuiDragDropFlags flags = 0) IMGUI_NOEXCEPT;                       // call after submitting an item which may be dragged. when this return true, you can call SetDragDropPayload() + EndDragDropSource()
-    IMGUI_API bool          SetDragDropPayload(const char* type, const void* data, size_t sz, ImGuiCond cond = 0);  // type is a user defined string of maximum 32 characters. Strings starting with '_' are reserved for dear imgui internal types. Data is copied and held by imgui.
+    IMGUI_API bool          SetDragDropPayload(const char* type, const void* data, size_t sz, ImGuiCond cond = 0) IMGUI_NOEXCEPT;  // type is a user defined string of maximum 32 characters. Strings starting with '_' are reserved for dear imgui internal types. Data is copied and held by imgui.
     IMGUI_API void          EndDragDropSource() IMGUI_NOEXCEPT;                                                     // only call EndDragDropSource() if BeginDragDropSource() returns true!
     IMGUI_API bool                  BeginDragDropTarget() IMGUI_NOEXCEPT;                                           // call after submitting an item that may receive a payload. If this returns true, you can call AcceptDragDropPayload() + EndDragDropTarget()
-    IMGUI_API const ImGuiPayload*   AcceptDragDropPayload(const char* type, ImGuiDragDropFlags flags = 0);          // accept contents of a given type. If ImGuiDragDropFlags_AcceptBeforeDelivery is set you can peek into the payload before the mouse button is released.
+    IMGUI_API const ImGuiPayload*   AcceptDragDropPayload(const char* type, ImGuiDragDropFlags flags = 0) IMGUI_NOEXCEPT;   // accept contents of a given type. If ImGuiDragDropFlags_AcceptBeforeDelivery is set you can peek into the payload before the mouse button is released.
     IMGUI_API void                  EndDragDropTarget() IMGUI_NOEXCEPT;                                             // only call EndDragDropTarget() if BeginDragDropTarget() returns true!
-    IMGUI_API const ImGuiPayload*   GetDragDropPayload();                                                           // peek directly into the current payload from anywhere. may return NULL. use ImGuiPayload::IsDataType() to test for the payload type.
+    IMGUI_API const ImGuiPayload*   GetDragDropPayload()                                                  IMGUI_NOEXCEPT;   // peek directly into the current payload from anywhere. may return NULL. use ImGuiPayload::IsDataType() to test for the payload type.
 
     // Clipping
     // - Mouse hovering is affected by ImGui::PushClipRect() calls, unlike direct calls to ImDrawList::PushClipRect() which are render only.
-    IMGUI_API void          PushClipRect(const ImVec2& clip_rect_min, const ImVec2& clip_rect_max, bool intersect_with_current_clip_rect);
-    IMGUI_API void          PopClipRect();
+    IMGUI_API void          PushClipRect(const ImVec2& clip_rect_min, const ImVec2& clip_rect_max, bool intersect_with_current_clip_rect) IMGUI_NOEXCEPT;
+    IMGUI_API void          PopClipRect() IMGUI_NOEXCEPT;
 
     // Focus, Activation
     // - Prefer using "SetItemDefaultFocus()" over "if (IsWindowAppearing()) SetScrollHereY()" when applicable to signify "this is the default item"
-    IMGUI_API void          SetItemDefaultFocus();                                              // make last item the default focused item of a window.
-    IMGUI_API void          SetKeyboardFocusHere(int offset = 0);                               // focus keyboard on the next widget. Use positive 'offset' to access sub components of a multiple component widget. Use -1 to access previous widget.
+    IMGUI_API void          SetItemDefaultFocus() IMGUI_NOEXCEPT;                                              // make last item the default focused item of a window.
+    IMGUI_API void          SetKeyboardFocusHere(int offset = 0) IMGUI_NOEXCEPT;                               // focus keyboard on the next widget. Use positive 'offset' to access sub components of a multiple component widget. Use -1 to access previous widget.
 
     // Item/Widgets Utilities and Query Functions
     // - Most of the functions are referring to the previous Item that has been submitted.
     // - See Demo Window under "Widgets->Querying Status" for an interactive visualization of most of those functions.
-    IMGUI_API bool          IsItemHovered(ImGuiHoveredFlags flags = 0);                         // is the last item hovered? (and usable, aka not blocked by a popup, etc.). See ImGuiHoveredFlags for more options.
-    IMGUI_API bool          IsItemActive();                                                     // is the last item active? (e.g. button being held, text field being edited. This will continuously return true while holding mouse button on an item. Items that don't interact will always return false)
-    IMGUI_API bool          IsItemFocused();                                                    // is the last item focused for keyboard/gamepad navigation?
-    IMGUI_API bool          IsItemClicked(ImGuiMouseButton mouse_button = 0);                   // is the last item hovered and mouse clicked on? (**)  == IsMouseClicked(mouse_button) && IsItemHovered()Important. (**) this it NOT equivalent to the behavior of e.g. Button(). Read comments in function definition.
-    IMGUI_API bool          IsItemVisible();                                                    // is the last item visible? (items may be out of sight because of clipping/scrolling)
-    IMGUI_API bool          IsItemEdited();                                                     // did the last item modify its underlying value this frame? or was pressed? This is generally the same as the "bool" return value of many widgets.
-    IMGUI_API bool          IsItemActivated();                                                  // was the last item just made active (item was previously inactive).
-    IMGUI_API bool          IsItemDeactivated();                                                // was the last item just made inactive (item was previously active). Useful for Undo/Redo patterns with widgets that requires continuous editing.
-    IMGUI_API bool          IsItemDeactivatedAfterEdit();                                       // was the last item just made inactive and made a value change when it was active? (e.g. Slider/Drag moved). Useful for Undo/Redo patterns with widgets that requires continuous editing. Note that you may get false positives (some widgets such as Combo()/ListBox()/Selectable() will return true even when clicking an already selected item).
-    IMGUI_API bool          IsItemToggledOpen();                                                // was the last item open state toggled? set by TreeNode().
-    IMGUI_API bool          IsAnyItemHovered();                                                 // is any item hovered?
-    IMGUI_API bool          IsAnyItemActive();                                                  // is any item active?
-    IMGUI_API bool          IsAnyItemFocused();                                                 // is any item focused?
-    IMGUI_API ImVec2        GetItemRectMin();                                                   // get upper-left bounding rectangle of the last item (screen space)
-    IMGUI_API ImVec2        GetItemRectMax();                                                   // get lower-right bounding rectangle of the last item (screen space)
-    IMGUI_API ImVec2        GetItemRectSize();                                                  // get size of last item
-    IMGUI_API void          SetItemAllowOverlap();                                              // allow last item to be overlapped by a subsequent item. sometimes useful with invisible buttons, selectables, etc. to catch unused area.
+    IMGUI_API bool          IsItemHovered(ImGuiHoveredFlags flags = 0)                                    IMGUI_NOEXCEPT;  // is the last item hovered? (and usable, aka not blocked by a popup, etc.). See ImGuiHoveredFlags for more options.
+    IMGUI_API bool          IsItemActive()                                                                IMGUI_NOEXCEPT;  // is the last item active? (e.g. button being held, text field being edited. This will continuously return true while holding mouse button on an item. Items that don't interact will always return false)
+    IMGUI_API bool          IsItemFocused()                                                               IMGUI_NOEXCEPT;  // is the last item focused for keyboard/gamepad navigation?
+    IMGUI_API bool          IsItemClicked(ImGuiMouseButton mouse_button = 0)                              IMGUI_NOEXCEPT;  // is the last item hovered and mouse clicked on? (**)  == IsMouseClicked(mouse_button) && IsItemHovered()Important. (**) this it NOT equivalent to the behavior of e.g. Button(). Read comments in function definition.
+    IMGUI_API bool          IsItemVisible()                                                               IMGUI_NOEXCEPT;  // is the last item visible? (items may be out of sight because of clipping/scrolling)
+    IMGUI_API bool          IsItemEdited()                                                                IMGUI_NOEXCEPT;  // did the last item modify its underlying value this frame? or was pressed? This is generally the same as the "bool" return value of many widgets.
+    IMGUI_API bool          IsItemActivated()                                                             IMGUI_NOEXCEPT;  // was the last item just made active (item was previously inactive).
+    IMGUI_API bool          IsItemDeactivated()                                                           IMGUI_NOEXCEPT;  // was the last item just made inactive (item was previously active). Useful for Undo/Redo patterns with widgets that requires continuous editing.
+    IMGUI_API bool          IsItemDeactivatedAfterEdit()                                                  IMGUI_NOEXCEPT;  // was the last item just made inactive and made a value change when it was active? (e.g. Slider/Drag moved). Useful for Undo/Redo patterns with widgets that requires continuous editing. Note that you may get false positives (some widgets such as Combo()/ListBox()/Selectable() will return true even when clicking an already selected item).
+    IMGUI_API bool          IsItemToggledOpen()                                                           IMGUI_NOEXCEPT;  // was the last item open state toggled? set by TreeNode().
+    IMGUI_API bool          IsAnyItemHovered()                                                            IMGUI_NOEXCEPT;  // is any item hovered?
+    IMGUI_API bool          IsAnyItemActive()                                                             IMGUI_NOEXCEPT;  // is any item active?
+    IMGUI_API bool          IsAnyItemFocused()                                                            IMGUI_NOEXCEPT;  // is any item focused?
+    IMGUI_API ImVec2        GetItemRectMin()                                                              IMGUI_NOEXCEPT;  // get upper-left bounding rectangle of the last item (screen space)
+    IMGUI_API ImVec2        GetItemRectMax()                                                              IMGUI_NOEXCEPT;  // get lower-right bounding rectangle of the last item (screen space)
+    IMGUI_API ImVec2        GetItemRectSize()                                                             IMGUI_NOEXCEPT;  // get size of last item
+    IMGUI_API void          SetItemAllowOverlap()                                                         IMGUI_NOEXCEPT;  // allow last item to be overlapped by a subsequent item. sometimes useful with invisible buttons, selectables, etc. to catch unused area.
 
     // Viewports
     // - Currently represents the Platform Window created by the application which is hosting our Dear ImGui windows.
     // - In 'docking' branch with multi-viewport enabled, we extend this concept to have multiple active viewports.
     // - In the future we will extend this concept further to also represent Platform Monitor and support a "no main platform window" operation mode.
-    IMGUI_API ImGuiViewport* GetMainViewport();                                                 // return primary/default viewport. This can never be NULL.
+    IMGUI_API ImGuiViewport* GetMainViewport() IMGUI_NOEXCEPT;                                                 // return primary/default viewport. This can never be NULL.
 
     // Miscellaneous Utilities
-    IMGUI_API bool          IsRectVisible(const ImVec2& size);                                  // test if rectangle (of given size, starting from cursor position) is visible / not clipped.
-    IMGUI_API bool          IsRectVisible(const ImVec2& rect_min, const ImVec2& rect_max);      // test if rectangle (in screen space) is visible / not clipped. to perform coarse clipping on user's side.
-    IMGUI_API double        GetTime();                                                          // get global imgui time. incremented by io.DeltaTime every frame.
-    IMGUI_API int           GetFrameCount();                                                    // get global imgui frame count. incremented by 1 every frame.
-    IMGUI_API ImDrawList*   GetBackgroundDrawList();                                            // this draw list will be the first rendering one. Useful to quickly draw shapes/text behind dear imgui contents.
-    IMGUI_API ImDrawList*   GetForegroundDrawList();                                            // this draw list will be the last rendered one. Useful to quickly draw shapes/text over dear imgui contents.
-    IMGUI_API ImDrawListSharedData* GetDrawListSharedData();                                    // you may use this when creating your own ImDrawList instances.
-    IMGUI_API const char*   GetStyleColorName(ImGuiCol idx);                                    // get a string corresponding to the enum value (for display, saving, etc.).
-    IMGUI_API void          SetStateStorage(ImGuiStorage* storage);                             // replace current window storage with our own (if you want to manipulate it yourself, typically clear subsection of it)
-    IMGUI_API ImGuiStorage* GetStateStorage();
-    IMGUI_API void          CalcListClipping(int items_count, float items_height, int* out_items_display_start, int* out_items_display_end);    // calculate coarse clipping for large list of evenly sized items. Prefer using the ImGuiListClipper higher-level helper if you can.
+    IMGUI_API bool          IsRectVisible(const ImVec2& size)                                             IMGUI_NOEXCEPT;  // test if rectangle (of given size, starting from cursor position) is visible / not clipped.
+    IMGUI_API bool          IsRectVisible(const ImVec2& rect_min, const ImVec2& rect_max)                 IMGUI_NOEXCEPT;  // test if rectangle (in screen space) is visible / not clipped. to perform coarse clipping on user's side.
+    IMGUI_API double        GetTime()                                                                     IMGUI_NOEXCEPT;  // get global imgui time. incremented by io.DeltaTime every frame.
+    IMGUI_API int           GetFrameCount()                                                               IMGUI_NOEXCEPT;  // get global imgui frame count. incremented by 1 every frame.
+    IMGUI_API ImDrawList*   GetBackgroundDrawList()                                                       IMGUI_NOEXCEPT;  // this draw list will be the first rendering one. Useful to quickly draw shapes/text behind dear imgui contents.
+    IMGUI_API ImDrawList*   GetForegroundDrawList()                                                       IMGUI_NOEXCEPT;  // this draw list will be the last rendered one. Useful to quickly draw shapes/text over dear imgui contents.
+    IMGUI_API ImDrawListSharedData* GetDrawListSharedData()                                               IMGUI_NOEXCEPT;  // you may use this when creating your own ImDrawList instances.
+    IMGUI_API const char*   GetStyleColorName(ImGuiCol idx)                                               IMGUI_NOEXCEPT;  // get a string corresponding to the enum value (for display, saving, etc.).
+    IMGUI_API void          SetStateStorage(ImGuiStorage* storage)                                        IMGUI_NOEXCEPT;  // replace current window storage with our own (if you want to manipulate it yourself, typically clear subsection of it)
+    IMGUI_API ImGuiStorage* GetStateStorage()                                                             IMGUI_NOEXCEPT;
+    IMGUI_API void          CalcListClipping(int items_count, float items_height, int* out_items_display_start, int* out_items_display_end) IMGUI_NOEXCEPT;  // calculate coarse clipping for large list of evenly sized items. Prefer using the ImGuiListClipper higher-level helper if you can.
     IMGUI_API bool          BeginChildFrame(ImGuiID id, const ImVec2& size, ImGuiWindowFlags flags = 0) IMGUI_NOEXCEPT;  // helper to create a child window / scrolling region that looks like a normal widget frame
     IMGUI_API void          EndChildFrame() IMGUI_NOEXCEPT;                                     // always call EndChildFrame() regardless of BeginChildFrame() return values (which indicates a collapsed/clipped window)
 
     // Text Utilities
-    IMGUI_API ImVec2        CalcTextSize(const char* text, const char* text_end = NULL, bool hide_text_after_double_hash = false, float wrap_width = -1.0f);
+    IMGUI_API ImVec2        CalcTextSize(const char* text, const char* text_end = NULL, bool hide_text_after_double_hash = false, float wrap_width = -1.0f) IMGUI_NOEXCEPT;
 
     // Color Utilities
-    IMGUI_API ImVec4        ColorConvertU32ToFloat4(ImU32 in);
-    IMGUI_API ImU32         ColorConvertFloat4ToU32(const ImVec4& in);
-    IMGUI_API void          ColorConvertRGBtoHSV(float r, float g, float b, float& out_h, float& out_s, float& out_v);
-    IMGUI_API void          ColorConvertHSVtoRGB(float h, float s, float v, float& out_r, float& out_g, float& out_b);
+    IMGUI_API ImVec4        ColorConvertU32ToFloat4(ImU32 in)                                                         IMGUI_NOEXCEPT;
+    IMGUI_API ImU32         ColorConvertFloat4ToU32(const ImVec4& in)                                                 IMGUI_NOEXCEPT;
+    IMGUI_API void          ColorConvertRGBtoHSV(float r, float g, float b, float& out_h, float& out_s, float& out_v) IMGUI_NOEXCEPT;
+    IMGUI_API void          ColorConvertHSVtoRGB(float h, float s, float v, float& out_r, float& out_g, float& out_b) IMGUI_NOEXCEPT;
 
     // Inputs Utilities: Keyboard
     // - For 'int user_key_index' you can use your own indices/enums according to how your backend/engine stored them in io.KeysDown[].
     // - We don't know the meaning of those value. You can use GetKeyIndex() to map a ImGuiKey_ value into the user index.
-    IMGUI_API int           GetKeyIndex(ImGuiKey imgui_key);                                    // map ImGuiKey_* values into user's key index. == io.KeyMap[key]
-    IMGUI_API bool          IsKeyDown(int user_key_index);                                      // is key being held. == io.KeysDown[user_key_index].
-    IMGUI_API bool          IsKeyPressed(int user_key_index, bool repeat = true);               // was key pressed (went from !Down to Down)? if repeat=true, uses io.KeyRepeatDelay / KeyRepeatRate
-    IMGUI_API bool          IsKeyReleased(int user_key_index);                                  // was key released (went from Down to !Down)?
-    IMGUI_API int           GetKeyPressedAmount(int key_index, float repeat_delay, float rate); // uses provided repeat rate/delay. return a count, most often 0 or 1 but might be >1 if RepeatRate is small enough that DeltaTime > RepeatRate
-    IMGUI_API void          CaptureKeyboardFromApp(bool want_capture_keyboard_value = true);    // attention: misleading name! manually override io.WantCaptureKeyboard flag next frame (said flag is entirely left for your application to handle). e.g. force capture keyboard when your widget is being hovered. This is equivalent to setting "io.WantCaptureKeyboard = want_capture_keyboard_value"; after the next NewFrame() call.
+    IMGUI_API int           GetKeyIndex(ImGuiKey imgui_key)                                    IMGUI_NOEXCEPT;  // map ImGuiKey_* values into user's key index. == io.KeyMap[key]
+    IMGUI_API bool          IsKeyDown(int user_key_index)                                      IMGUI_NOEXCEPT;  // is key being held. == io.KeysDown[user_key_index].
+    IMGUI_API bool          IsKeyPressed(int user_key_index, bool repeat = true)               IMGUI_NOEXCEPT;  // was key pressed (went from !Down to Down)? if repeat=true, uses io.KeyRepeatDelay / KeyRepeatRate
+    IMGUI_API bool          IsKeyReleased(int user_key_index)                                  IMGUI_NOEXCEPT;  // was key released (went from Down to !Down)?
+    IMGUI_API int           GetKeyPressedAmount(int key_index, float repeat_delay, float rate) IMGUI_NOEXCEPT;  // uses provided repeat rate/delay. return a count, most often 0 or 1 but might be >1 if RepeatRate is small enough that DeltaTime > RepeatRate
+    IMGUI_API void          CaptureKeyboardFromApp(bool want_capture_keyboard_value = true)    IMGUI_NOEXCEPT;  // attention: misleading name! manually override io.WantCaptureKeyboard flag next frame (said flag is entirely left for your application to handle). e.g. force capture keyboard when your widget is being hovered. This is equivalent to setting "io.WantCaptureKeyboard = want_capture_keyboard_value"; after the next NewFrame() call.
 
     // Inputs Utilities: Mouse
     // - To refer to a mouse button, you may use named enums in your code e.g. ImGuiMouseButton_Left, ImGuiMouseButton_Right.
     // - You can also use regular integer: it is forever guaranteed that 0=Left, 1=Right, 2=Middle.
     // - Dragging operations are only reported after mouse has moved a certain distance away from the initial clicking position (see 'lock_threshold' and 'io.MouseDraggingThreshold')
-    IMGUI_API bool          IsMouseDown(ImGuiMouseButton button);                               // is mouse button held?
-    IMGUI_API bool          IsMouseClicked(ImGuiMouseButton button, bool repeat = false);       // did mouse button clicked? (went from !Down to Down)
-    IMGUI_API bool          IsMouseReleased(ImGuiMouseButton button);                           // did mouse button released? (went from Down to !Down)
-    IMGUI_API bool          IsMouseDoubleClicked(ImGuiMouseButton button);                      // did mouse button double-clicked? (note that a double-click will also report IsMouseClicked() == true)
-    IMGUI_API bool          IsMouseHoveringRect(const ImVec2& r_min, const ImVec2& r_max, bool clip = true);// is mouse hovering given bounding rect (in screen space). clipped by current clipping settings, but disregarding of other consideration of focus/window ordering/popup-block.
-    IMGUI_API bool          IsMousePosValid(const ImVec2* mouse_pos = NULL);                    // by convention we use (-FLT_MAX,-FLT_MAX) to denote that there is no mouse available
-    IMGUI_API bool          IsAnyMouseDown();                                                   // is any mouse button held?
-    IMGUI_API ImVec2        GetMousePos();                                                      // shortcut to ImGui::GetIO().MousePos provided by user, to be consistent with other calls
-    IMGUI_API ImVec2        GetMousePosOnOpeningCurrentPopup();                                 // retrieve mouse position at the time of opening popup we have BeginPopup() into (helper to avoid user backing that value themselves)
-    IMGUI_API bool          IsMouseDragging(ImGuiMouseButton button, float lock_threshold = -1.0f);         // is mouse dragging? (if lock_threshold < -1.0f, uses io.MouseDraggingThreshold)
-    IMGUI_API ImVec2        GetMouseDragDelta(ImGuiMouseButton button = 0, float lock_threshold = -1.0f);   // return the delta from the initial clicking position while the mouse button is pressed or was just released. This is locked and return 0.0f until the mouse moves past a distance threshold at least once (if lock_threshold < -1.0f, uses io.MouseDraggingThreshold)
-    IMGUI_API void          ResetMouseDragDelta(ImGuiMouseButton button = 0);                   //
-    IMGUI_API ImGuiMouseCursor GetMouseCursor();                                                // get desired cursor type, reset in ImGui::NewFrame(), this is updated during the frame. valid before Render(). If you use software rendering by setting io.MouseDrawCursor ImGui will render those for you
-    IMGUI_API void          SetMouseCursor(ImGuiMouseCursor cursor_type);                       // set desired cursor type
-    IMGUI_API void          CaptureMouseFromApp(bool want_capture_mouse_value = true);          // attention: misleading name! manually override io.WantCaptureMouse flag next frame (said flag is entirely left for your application to handle). This is equivalent to setting "io.WantCaptureMouse = want_capture_mouse_value;" after the next NewFrame() call.
+    IMGUI_API bool          IsMouseDown(ImGuiMouseButton button) IMGUI_NOEXCEPT;                               // is mouse button held?
+    IMGUI_API bool          IsMouseClicked(ImGuiMouseButton button, bool repeat = false) IMGUI_NOEXCEPT;       // did mouse button clicked? (went from !Down to Down)
+    IMGUI_API bool          IsMouseReleased(ImGuiMouseButton button) IMGUI_NOEXCEPT;                           // did mouse button released? (went from Down to !Down)
+    IMGUI_API bool          IsMouseDoubleClicked(ImGuiMouseButton button) IMGUI_NOEXCEPT;                      // did mouse button double-clicked? (note that a double-click will also report IsMouseClicked() == true)
+    IMGUI_API bool          IsMouseHoveringRect(const ImVec2& r_min, const ImVec2& r_max, bool clip = true) IMGUI_NOEXCEPT;// is mouse hovering given bounding rect (in screen space). clipped by current clipping settings, but disregarding of other consideration of focus/window ordering/popup-block.
+    IMGUI_API bool          IsMousePosValid(const ImVec2* mouse_pos = NULL) IMGUI_NOEXCEPT;                    // by convention we use (-FLT_MAX,-FLT_MAX) to denote that there is no mouse available
+    IMGUI_API bool          IsAnyMouseDown() IMGUI_NOEXCEPT;                                                   // is any mouse button held?
+    IMGUI_API ImVec2        GetMousePos() IMGUI_NOEXCEPT;                                                      // shortcut to ImGui::GetIO().MousePos provided by user, to be consistent with other calls
+    IMGUI_API ImVec2        GetMousePosOnOpeningCurrentPopup() IMGUI_NOEXCEPT;                                 // retrieve mouse position at the time of opening popup we have BeginPopup() into (helper to avoid user backing that value themselves)
+    IMGUI_API bool          IsMouseDragging(ImGuiMouseButton button, float lock_threshold = -1.0f) IMGUI_NOEXCEPT;         // is mouse dragging? (if lock_threshold < -1.0f, uses io.MouseDraggingThreshold)
+    IMGUI_API ImVec2        GetMouseDragDelta(ImGuiMouseButton button = 0, float lock_threshold = -1.0f) IMGUI_NOEXCEPT;   // return the delta from the initial clicking position while the mouse button is pressed or was just released. This is locked and return 0.0f until the mouse moves past a distance threshold at least once (if lock_threshold < -1.0f, uses io.MouseDraggingThreshold)
+    IMGUI_API void          ResetMouseDragDelta(ImGuiMouseButton button = 0) IMGUI_NOEXCEPT;                   //
+    IMGUI_API ImGuiMouseCursor GetMouseCursor() IMGUI_NOEXCEPT;                                                // get desired cursor type, reset in ImGui::NewFrame(), this is updated during the frame. valid before Render(). If you use software rendering by setting io.MouseDrawCursor ImGui will render those for you
+    IMGUI_API void          SetMouseCursor(ImGuiMouseCursor cursor_type) IMGUI_NOEXCEPT;                       // set desired cursor type
+    IMGUI_API void          CaptureMouseFromApp(bool want_capture_mouse_value = true) IMGUI_NOEXCEPT;          // attention: misleading name! manually override io.WantCaptureMouse flag next frame (said flag is entirely left for your application to handle). This is equivalent to setting "io.WantCaptureMouse = want_capture_mouse_value;" after the next NewFrame() call.
 
     // Clipboard Utilities
     // - Also see the LogToClipboard() function to capture GUI into clipboard, or easily output text data to the clipboard.
-    IMGUI_API const char*   GetClipboardText();
-    IMGUI_API void          SetClipboardText(const char* text);
+    IMGUI_API const char*   GetClipboardText() IMGUI_NOEXCEPT;
+    IMGUI_API void          SetClipboardText(const char* text) IMGUI_NOEXCEPT;
 
     // Settings/.Ini Utilities
     // - The disk functions are automatically called if io.IniFilename != NULL (default is "imgui.ini").
     // - Set io.IniFilename to NULL to load/save manually. Read io.WantSaveIniSettings description about handling .ini saving manually.
-    IMGUI_API void          LoadIniSettingsFromDisk(const char* ini_filename);                  // call after CreateContext() and before the first call to NewFrame(). NewFrame() automatically calls LoadIniSettingsFromDisk(io.IniFilename).
-    IMGUI_API void          LoadIniSettingsFromMemory(const char* ini_data, size_t ini_size=0); // call after CreateContext() and before the first call to NewFrame() to provide .ini data from your own data source.
-    IMGUI_API void          SaveIniSettingsToDisk(const char* ini_filename);                    // this is automatically called (if io.IniFilename is not empty) a few seconds after any modification that should be reflected in the .ini file (and also by DestroyContext).
-    IMGUI_API const char*   SaveIniSettingsToMemory(size_t* out_ini_size = NULL);               // return a zero-terminated string with the .ini data which you can save by your own mean. call when io.WantSaveIniSettings is set, then save data by your own mean and clear io.WantSaveIniSettings.
+    IMGUI_API void          LoadIniSettingsFromDisk(const char* ini_filename) IMGUI_NOEXCEPT;                  // call after CreateContext() and before the first call to NewFrame(). NewFrame() automatically calls LoadIniSettingsFromDisk(io.IniFilename).
+    IMGUI_API void          LoadIniSettingsFromMemory(const char* ini_data, size_t ini_size=0) IMGUI_NOEXCEPT; // call after CreateContext() and before the first call to NewFrame() to provide .ini data from your own data source.
+    IMGUI_API void          SaveIniSettingsToDisk(const char* ini_filename) IMGUI_NOEXCEPT;                    // this is automatically called (if io.IniFilename is not empty) a few seconds after any modification that should be reflected in the .ini file (and also by DestroyContext).
+    IMGUI_API const char*   SaveIniSettingsToMemory(size_t* out_ini_size = NULL) IMGUI_NOEXCEPT;               // return a zero-terminated string with the .ini data which you can save by your own mean. call when io.WantSaveIniSettings is set, then save data by your own mean and clear io.WantSaveIniSettings.
 
     // Debug Utilities
     // - This is used by the IMGUI_CHECKVERSION() macro.
-    IMGUI_API bool          DebugCheckVersionAndDataLayout(const char* version_str, size_t sz_io, size_t sz_style, size_t sz_vec2, size_t sz_vec4, size_t sz_drawvert, size_t sz_drawidx); // This is called by IMGUI_CHECKVERSION() macro.
+    IMGUI_API bool          DebugCheckVersionAndDataLayout(const char* version_str, size_t sz_io, size_t sz_style, size_t sz_vec2, size_t sz_vec4, size_t sz_drawvert, size_t sz_drawidx) IMGUI_NOEXCEPT; // This is called by IMGUI_CHECKVERSION() macro.
 
     // Memory Allocators
     // - Those functions are not reliant on the current context.
     // - DLL users: heaps and globals are not shared across DLL boundaries! You will need to call SetCurrentContext() + SetAllocatorFunctions()
     //   for each static/DLL boundary you are calling from. Read "Context and Memory Allocators" section of imgui.cpp for more details.
-    IMGUI_API void          SetAllocatorFunctions(ImGuiMemAllocFunc alloc_func, ImGuiMemFreeFunc free_func, void* user_data = NULL);
-    IMGUI_API void          GetAllocatorFunctions(ImGuiMemAllocFunc* p_alloc_func, ImGuiMemFreeFunc* p_free_func, void** p_user_data);
+    IMGUI_API void          SetAllocatorFunctions(ImGuiMemAllocFunc alloc_func, ImGuiMemFreeFunc free_func, void* user_data = NULL) IMGUI_NOEXCEPT;
+    IMGUI_API void          GetAllocatorFunctions(ImGuiMemAllocFunc* p_alloc_func, ImGuiMemFreeFunc* p_free_func, void** p_user_data) IMGUI_NOEXCEPT;
     IMGUI_API void*         MemAlloc(size_t size) IMGUI_NOEXCEPT;
     IMGUI_API void          MemFree(void* ptr) IMGUI_NOEXCEPT;
 
@@ -1634,8 +1641,8 @@ enum ImGuiCond_
 //-----------------------------------------------------------------------------
 
 struct ImNewWrapper {};
-inline void* operator new(size_t, ImNewWrapper, void* ptr) { return ptr; }
-inline void  operator delete(void*, ImNewWrapper, void*)   {} // This is only required so we can use the symmetrical new()
+inline void* operator new(size_t, ImNewWrapper, void* ptr) IMGUI_NOEXCEPT { return ptr; }
+inline void  operator delete(void*, ImNewWrapper, void*)   IMGUI_NOEXCEPT {} // This is only required so we can use the symmetrical new()
 #define IM_ALLOC(_SIZE)                     ImGui::MemAlloc(_SIZE)
 #define IM_FREE(_PTR)                       ImGui::MemFree(_PTR)
 #define IM_PLACEMENT_NEW(_PTR)              new(ImNewWrapper(), _PTR)
@@ -1667,50 +1674,50 @@ struct ImVector
     typedef const value_type*   const_iterator;
 
     // Constructors, destructor
-    inline ImVector()                                       { Size = Capacity = 0; Data = NULL; }
-    inline ImVector(const ImVector<T>& src)                 { Size = Capacity = 0; Data = NULL; operator=(src); }
-    inline ImVector<T>& operator=(const ImVector<T>& src)   { clear(); resize(src.Size); memcpy(Data, src.Data, (size_t)Size * sizeof(T)); return *this; }
-    inline ~ImVector()                                      { if (Data) IM_FREE(Data); }
+    inline ImVector()                                        IMGUI_NOEXCEPT { Size = Capacity = 0; Data = NULL; }
+    inline ImVector(const ImVector<T>& src)                  IMGUI_NOEXCEPT { Size = Capacity = 0; Data = NULL; operator=(src); }
+    inline ImVector<T>& operator=(const ImVector<T>& src)    IMGUI_NOEXCEPT { clear(); resize(src.Size); memcpy(Data, src.Data, (size_t)Size * sizeof(T)); return *this; }
+    inline ~ImVector()                                       IMGUI_NOEXCEPT { if (Data) IM_FREE(Data); }
 
-    inline bool         empty() const                       { return Size == 0; }
-    inline int          size() const                        { return Size; }
-    inline int          size_in_bytes() const               { return Size * (int)sizeof(T); }
-    inline int          max_size() const                    { return 0x7FFFFFFF / (int)sizeof(T); }
-    inline int          capacity() const                    { return Capacity; }
-    inline T&           operator[](int i)                   { IM_ASSERT(i >= 0 && i < Size); return Data[i]; }
-    inline const T&     operator[](int i) const             { IM_ASSERT(i >= 0 && i < Size); return Data[i]; }
+    inline bool         empty() const                        IMGUI_NOEXCEPT { return Size == 0; }
+    inline int          size() const                         IMGUI_NOEXCEPT { return Size; }
+    inline int          size_in_bytes() const                IMGUI_NOEXCEPT { return Size * (int)sizeof(T); }
+    inline int          max_size() const                     IMGUI_NOEXCEPT { return 0x7FFFFFFF / (int)sizeof(T); }
+    inline int          capacity() const                     IMGUI_NOEXCEPT { return Capacity; }
+    inline T&           operator[](int i)                    IMGUI_NOEXCEPT { IM_ASSERT(i >= 0 && i < Size); return Data[i]; }
+    inline const T&     operator[](int i) const              IMGUI_NOEXCEPT { IM_ASSERT(i >= 0 && i < Size); return Data[i]; }
 
-    inline void         clear()                             { if (Data) { Size = Capacity = 0; IM_FREE(Data); Data = NULL; } }
-    inline T*           begin()                             { return Data; }
-    inline const T*     begin() const                       { return Data; }
-    inline T*           end()                               { return Data + Size; }
-    inline const T*     end() const                         { return Data + Size; }
-    inline T&           front()                             { IM_ASSERT(Size > 0); return Data[0]; }
-    inline const T&     front() const                       { IM_ASSERT(Size > 0); return Data[0]; }
-    inline T&           back()                              { IM_ASSERT(Size > 0); return Data[Size - 1]; }
-    inline const T&     back() const                        { IM_ASSERT(Size > 0); return Data[Size - 1]; }
-    inline void         swap(ImVector<T>& rhs)              { int rhs_size = rhs.Size; rhs.Size = Size; Size = rhs_size; int rhs_cap = rhs.Capacity; rhs.Capacity = Capacity; Capacity = rhs_cap; T* rhs_data = rhs.Data; rhs.Data = Data; Data = rhs_data; }
+    inline void         clear()                              IMGUI_NOEXCEPT { if (Data) { Size = Capacity = 0; IM_FREE(Data); Data = NULL; } }
+    inline T*           begin()                              IMGUI_NOEXCEPT { return Data; }
+    inline const T*     begin() const                        IMGUI_NOEXCEPT { return Data; }
+    inline T*           end()                                IMGUI_NOEXCEPT { return Data + Size; }
+    inline const T*     end() const                          IMGUI_NOEXCEPT { return Data + Size; }
+    inline T&           front()                              IMGUI_NOEXCEPT { IM_ASSERT(Size > 0); return Data[0]; }
+    inline const T&     front() const                        IMGUI_NOEXCEPT { IM_ASSERT(Size > 0); return Data[0]; }
+    inline T&           back()                               IMGUI_NOEXCEPT { IM_ASSERT(Size > 0); return Data[Size - 1]; }
+    inline const T&     back() const                         IMGUI_NOEXCEPT { IM_ASSERT(Size > 0); return Data[Size - 1]; }
+    inline void         swap(ImVector<T>& rhs)               IMGUI_NOEXCEPT { int rhs_size = rhs.Size; rhs.Size = Size; Size = rhs_size; int rhs_cap = rhs.Capacity; rhs.Capacity = Capacity; Capacity = rhs_cap; T* rhs_data = rhs.Data; rhs.Data = Data; Data = rhs_data; }
 
-    inline int          _grow_capacity(int sz) const        { int new_capacity = Capacity ? (Capacity + Capacity / 2) : 8; return new_capacity > sz ? new_capacity : sz; }
-    inline void         resize(int new_size)                { if (new_size > Capacity) reserve(_grow_capacity(new_size)); Size = new_size; }
-    inline void         resize(int new_size, const T& v)    { if (new_size > Capacity) reserve(_grow_capacity(new_size)); if (new_size > Size) for (int n = Size; n < new_size; n++) memcpy(&Data[n], &v, sizeof(v)); Size = new_size; }
-    inline void         shrink(int new_size)                { IM_ASSERT(new_size <= Size); Size = new_size; } // Resize a vector to a smaller size, guaranteed not to cause a reallocation
-    inline void         reserve(int new_capacity)           { if (new_capacity <= Capacity) return; T* new_data = (T*)IM_ALLOC((size_t)new_capacity * sizeof(T)); if (Data) { memcpy(new_data, Data, (size_t)Size * sizeof(T)); IM_FREE(Data); } Data = new_data; Capacity = new_capacity; }
+    inline int          _grow_capacity(int sz) const         IMGUI_NOEXCEPT { int new_capacity = Capacity ? (Capacity + Capacity / 2) : 8; return new_capacity > sz ? new_capacity : sz; }
+    inline void         resize(int new_size)                 IMGUI_NOEXCEPT { if (new_size > Capacity) reserve(_grow_capacity(new_size)); Size = new_size; }
+    inline void         resize(int new_size, const T& v)     IMGUI_NOEXCEPT { if (new_size > Capacity) reserve(_grow_capacity(new_size)); if (new_size > Size) for (int n = Size; n < new_size; n++) memcpy(&Data[n], &v, sizeof(v)); Size = new_size; }
+    inline void         shrink(int new_size)                 IMGUI_NOEXCEPT { IM_ASSERT(new_size <= Size); Size = new_size; } // Resize a vector to a smaller size, guaranteed not to cause a reallocation
+    inline void         reserve(int new_capacity)            IMGUI_NOEXCEPT { if (new_capacity <= Capacity) return; T* new_data = (T*)IM_ALLOC((size_t)new_capacity * sizeof(T)); if (Data) { memcpy(new_data, Data, (size_t)Size * sizeof(T)); IM_FREE(Data); } Data = new_data; Capacity = new_capacity; }
 
     // NB: It is illegal to call push_back/push_front/insert with a reference pointing inside the ImVector data itself! e.g. v.push_back(v[10]) is forbidden.
-    inline void         push_back(const T& v)               { if (Size == Capacity) reserve(_grow_capacity(Size + 1)); memcpy(&Data[Size], &v, sizeof(v)); Size++; }
-    inline void         pop_back()                          { IM_ASSERT(Size > 0); Size--; }
-    inline void         push_front(const T& v)              { if (Size == 0) push_back(v); else insert(Data, v); }
-    inline T*           erase(const T* it)                  { IM_ASSERT(it >= Data && it < Data + Size); const ptrdiff_t off = it - Data; memmove(Data + off, Data + off + 1, ((size_t)Size - (size_t)off - 1) * sizeof(T)); Size--; return Data + off; }
-    inline T*           erase(const T* it, const T* it_last){ IM_ASSERT(it >= Data && it < Data + Size && it_last > it && it_last <= Data + Size); const ptrdiff_t count = it_last - it; const ptrdiff_t off = it - Data; memmove(Data + off, Data + off + count, ((size_t)Size - (size_t)off - count) * sizeof(T)); Size -= (int)count; return Data + off; }
-    inline T*           erase_unsorted(const T* it)         { IM_ASSERT(it >= Data && it < Data + Size);  const ptrdiff_t off = it - Data; if (it < Data + Size - 1) memcpy(Data + off, Data + Size - 1, sizeof(T)); Size--; return Data + off; }
-    inline T*           insert(const T* it, const T& v)     { IM_ASSERT(it >= Data && it <= Data + Size); const ptrdiff_t off = it - Data; if (Size == Capacity) reserve(_grow_capacity(Size + 1)); if (off < (int)Size) memmove(Data + off + 1, Data + off, ((size_t)Size - (size_t)off) * sizeof(T)); memcpy(&Data[off], &v, sizeof(v)); Size++; return Data + off; }
-    inline bool         contains(const T& v) const          { const T* data = Data;  const T* data_end = Data + Size; while (data < data_end) if (*data++ == v) return true; return false; }
-    inline T*           find(const T& v)                    { T* data = Data;  const T* data_end = Data + Size; while (data < data_end) if (*data == v) break; else ++data; return data; }
-    inline const T*     find(const T& v) const              { const T* data = Data;  const T* data_end = Data + Size; while (data < data_end) if (*data == v) break; else ++data; return data; }
-    inline bool         find_erase(const T& v)              { const T* it = find(v); if (it < Data + Size) { erase(it); return true; } return false; }
-    inline bool         find_erase_unsorted(const T& v)     { const T* it = find(v); if (it < Data + Size) { erase_unsorted(it); return true; } return false; }
-    inline int          index_from_ptr(const T* it) const   { IM_ASSERT(it >= Data && it < Data + Size); const ptrdiff_t off = it - Data; return (int)off; }
+    inline void         push_back(const T& v)                IMGUI_NOEXCEPT { if (Size == Capacity) reserve(_grow_capacity(Size + 1)); memcpy(&Data[Size], &v, sizeof(v)); Size++; }
+    inline void         pop_back()                           IMGUI_NOEXCEPT { IM_ASSERT(Size > 0); Size--; }
+    inline void         push_front(const T& v)               IMGUI_NOEXCEPT { if (Size == 0) push_back(v); else insert(Data, v); }
+    inline T*           erase(const T* it)                   IMGUI_NOEXCEPT { IM_ASSERT(it >= Data && it < Data + Size); const ptrdiff_t off = it - Data; memmove(Data + off, Data + off + 1, ((size_t)Size - (size_t)off - 1) * sizeof(T)); Size--; return Data + off; }
+    inline T*           erase(const T* it, const T* it_last) IMGUI_NOEXCEPT { IM_ASSERT(it >= Data && it < Data + Size && it_last > it && it_last <= Data + Size); const ptrdiff_t count = it_last - it; const ptrdiff_t off = it - Data; memmove(Data + off, Data + off + count, ((size_t)Size - (size_t)off - count) * sizeof(T)); Size -= (int)count; return Data + off; }
+    inline T*           erase_unsorted(const T* it)          IMGUI_NOEXCEPT { IM_ASSERT(it >= Data && it < Data + Size);  const ptrdiff_t off = it - Data; if (it < Data + Size - 1) memcpy(Data + off, Data + Size - 1, sizeof(T)); Size--; return Data + off; }
+    inline T*           insert(const T* it, const T& v)      IMGUI_NOEXCEPT { IM_ASSERT(it >= Data && it <= Data + Size); const ptrdiff_t off = it - Data; if (Size == Capacity) reserve(_grow_capacity(Size + 1)); if (off < (int)Size) memmove(Data + off + 1, Data + off, ((size_t)Size - (size_t)off) * sizeof(T)); memcpy(&Data[off], &v, sizeof(v)); Size++; return Data + off; }
+    inline bool         contains(const T& v) const           IMGUI_NOEXCEPT { const T* data = Data;  const T* data_end = Data + Size; while (data < data_end) if (*data++ == v) return true; return false; }
+    inline T*           find(const T& v)                     IMGUI_NOEXCEPT { T* data = Data;  const T* data_end = Data + Size; while (data < data_end) if (*data == v) break; else ++data; return data; }
+    inline const T*     find(const T& v) const               IMGUI_NOEXCEPT { const T* data = Data;  const T* data_end = Data + Size; while (data < data_end) if (*data == v) break; else ++data; return data; }
+    inline bool         find_erase(const T& v)               IMGUI_NOEXCEPT { const T* it = find(v); if (it < Data + Size) { erase(it); return true; } return false; }
+    inline bool         find_erase_unsorted(const T& v)      IMGUI_NOEXCEPT { const T* it = find(v); if (it < Data + Size) { erase_unsorted(it); return true; } return false; }
+    inline int          index_from_ptr(const T* it) const    IMGUI_NOEXCEPT { IM_ASSERT(it >= Data && it < Data + Size); const ptrdiff_t off = it - Data; return (int)off; }
 };
 IM_MSVC_RUNTIME_CHECKS_RESTORE
 
@@ -1765,8 +1772,8 @@ struct ImGuiStyle
     float       CircleTessellationMaxError; // Maximum error (in pixels) allowed when using AddCircle()/AddCircleFilled() or drawing rounded corner rectangles with no explicit segment count specified. Decrease for higher quality but more geometry.
     ImVec4      Colors[ImGuiCol_COUNT];
 
-    IMGUI_API ImGuiStyle();
-    IMGUI_API void ScaleAllSizes(float scale_factor);
+    IMGUI_API ImGuiStyle() IMGUI_NOEXCEPT;
+    IMGUI_API void ScaleAllSizes(float scale_factor) IMGUI_NOEXCEPT;
 };
 
 //-----------------------------------------------------------------------------
@@ -1851,10 +1858,10 @@ struct ImGuiIO
     float       NavInputs[ImGuiNavInput_COUNT]; // Gamepad inputs. Cleared back to zero by EndFrame(). Keyboard keys will be auto-mapped and be written here by NewFrame().
 
     // Functions
-    IMGUI_API void  AddInputCharacter(unsigned int c);          // Queue new character input
-    IMGUI_API void  AddInputCharacterUTF16(ImWchar16 c);        // Queue new character input from an UTF-16 character, it can be a surrogate
-    IMGUI_API void  AddInputCharactersUTF8(const char* str);    // Queue new characters input from an UTF-8 string
-    IMGUI_API void  ClearInputCharacters();                     // Clear the text input buffer manually
+    IMGUI_API void  AddInputCharacter(unsigned int c)       IMGUI_NOEXCEPT;  // Queue new character input
+    IMGUI_API void  AddInputCharacterUTF16(ImWchar16 c)     IMGUI_NOEXCEPT;  // Queue new character input from an UTF-16 character, it can be a surrogate
+    IMGUI_API void  AddInputCharactersUTF8(const char* str) IMGUI_NOEXCEPT;  // Queue new characters input from an UTF-8 string
+    IMGUI_API void  ClearInputCharacters()                  IMGUI_NOEXCEPT;  // Clear the text input buffer manually
 
     //------------------------------------------------------------------
     // Output - Updated by NewFrame() or EndFrame()/Render()
@@ -1902,7 +1909,7 @@ struct ImGuiIO
     ImWchar16   InputQueueSurrogate;            // For AddInputCharacterUTF16
     ImVector<ImWchar> InputQueueCharacters;     // Queue of _characters_ input (obtained by platform backend). Fill using AddInputCharacter() helper.
 
-    IMGUI_API   ImGuiIO();
+    IMGUI_API   ImGuiIO() IMGUI_NOEXCEPT;
 };
 
 //-----------------------------------------------------------------------------
@@ -1939,12 +1946,12 @@ struct ImGuiInputTextCallbackData
 
     // Helper functions for text manipulation.
     // Use those function to benefit from the CallbackResize behaviors. Calling those function reset the selection.
-    IMGUI_API ImGuiInputTextCallbackData();
-    IMGUI_API void      DeleteChars(int pos, int bytes_count);
-    IMGUI_API void      InsertChars(int pos, const char* text, const char* text_end = NULL);
-    void                SelectAll()             { SelectionStart = 0; SelectionEnd = BufTextLen; }
-    void                ClearSelection()        { SelectionStart = SelectionEnd = BufTextLen; }
-    bool                HasSelection() const    { return SelectionStart != SelectionEnd; }
+    IMGUI_API ImGuiInputTextCallbackData() IMGUI_NOEXCEPT;
+    IMGUI_API void      DeleteChars(int pos, int bytes_count) IMGUI_NOEXCEPT;
+    IMGUI_API void      InsertChars(int pos, const char* text, const char* text_end = NULL) IMGUI_NOEXCEPT;
+    void                SelectAll()            IMGUI_NOEXCEPT  { SelectionStart = 0; SelectionEnd = BufTextLen; }
+    void                ClearSelection()       IMGUI_NOEXCEPT  { SelectionStart = SelectionEnd = BufTextLen; }
+    bool                HasSelection() const   IMGUI_NOEXCEPT  { return SelectionStart != SelectionEnd; }
 };
 
 // Resizing callback data to apply custom constraint. As enabled by SetNextWindowSizeConstraints(). Callback is called during the next Begin().
@@ -1972,11 +1979,11 @@ struct ImGuiPayload
     bool            Preview;            // Set when AcceptDragDropPayload() was called and mouse has been hovering the target item (nb: handle overlapping drag targets)
     bool            Delivery;           // Set when AcceptDragDropPayload() was called and mouse button is released over the target item.
 
-    ImGuiPayload()  { Clear(); }
-    void Clear()    { SourceId = SourceParentId = 0; Data = NULL; DataSize = 0; memset(DataType, 0, sizeof(DataType)); DataFrameCount = -1; Preview = Delivery = false; }
-    bool IsDataType(const char* type) const { return DataFrameCount != -1 && strcmp(type, DataType) == 0; }
-    bool IsPreview() const                  { return Preview; }
-    bool IsDelivery() const                 { return Delivery; }
+    ImGuiPayload() IMGUI_NOEXCEPT  { Clear(); }
+    void Clear()   IMGUI_NOEXCEPT  { SourceId = SourceParentId = 0; Data = NULL; DataSize = 0; memset(DataType, 0, sizeof(DataType)); DataFrameCount = -1; Preview = Delivery = false; }
+    bool IsDataType(const char* type) const IMGUI_NOEXCEPT { return DataFrameCount != -1 && strcmp(type, DataType) == 0; }
+    bool IsPreview() const                  IMGUI_NOEXCEPT { return Preview; }
+    bool IsDelivery() const                 IMGUI_NOEXCEPT { return Delivery; }
 };
 
 // Sorting specification for one column of a table (sizeof == 12 bytes)
@@ -1987,7 +1994,7 @@ struct ImGuiTableColumnSortSpecs
     ImS16                       SortOrder;          // Index within parent ImGuiTableSortSpecs (always stored in order starting from 0, tables sorted on a single criteria will always have a 0 here)
     ImGuiSortDirection          SortDirection : 8;  // ImGuiSortDirection_Ascending or ImGuiSortDirection_Descending (you can use this or SortSign, whichever is more convenient for your sort function)
 
-    ImGuiTableColumnSortSpecs() { memset(this, 0, sizeof(*this)); }
+    ImGuiTableColumnSortSpecs() IMGUI_NOEXCEPT { memset(this, 0, sizeof(*this)); }
 };
 
 // Sorting specifications for a table (often handling sort specs for a single column, occasionally more)
@@ -2000,7 +2007,7 @@ struct ImGuiTableSortSpecs
     int                         SpecsCount;     // Sort spec count. Most often 1. May be > 1 when ImGuiTableFlags_SortMulti is enabled. May be == 0 when ImGuiTableFlags_SortTristate is enabled.
     bool                        SpecsDirty;     // Set to true when specs have changed since last time! Use this to sort again, then clear the flag.
 
-    ImGuiTableSortSpecs()       { memset(this, 0, sizeof(*this)); }
+    ImGuiTableSortSpecs() IMGUI_NOEXCEPT { memset(this, 0, sizeof(*this)); }
 };
 
 //-----------------------------------------------------------------------------
@@ -2019,20 +2026,20 @@ struct ImGuiTableSortSpecs
 // Usage: static ImGuiOnceUponAFrame oaf; if (oaf) ImGui::Text("This will be called only once per frame");
 struct ImGuiOnceUponAFrame
 {
-    ImGuiOnceUponAFrame() { RefFrame = -1; }
+    ImGuiOnceUponAFrame() IMGUI_NOEXCEPT : RefFrame(-1) {}
     mutable int RefFrame;
-    operator bool() const { int current_frame = ImGui::GetFrameCount(); if (RefFrame == current_frame) return false; RefFrame = current_frame; return true; }
+    operator bool() const IMGUI_NOEXCEPT { int current_frame = ImGui::GetFrameCount(); if (RefFrame == current_frame) return false; RefFrame = current_frame; return true; }
 };
 
 // Helper: Parse and apply text filters. In format "aaaaa[,bbbb][,ccccc]"
 struct ImGuiTextFilter
 {
-    IMGUI_API           ImGuiTextFilter(const char* default_filter = "");
-    IMGUI_API bool      Draw(const char* label = "Filter (inc,-exc)", float width = 0.0f);  // Helper calling InputText+Build
-    IMGUI_API bool      PassFilter(const char* text, const char* text_end = NULL) const;
-    IMGUI_API void      Build();
-    void                Clear()          { InputBuf[0] = 0; Build(); }
-    bool                IsActive() const { return !Filters.empty(); }
+    IMGUI_API           ImGuiTextFilter(const char* default_filter = "") IMGUI_NOEXCEPT;
+    IMGUI_API bool      Draw(const char* label = "Filter (inc,-exc)", float width = 0.0f) IMGUI_NOEXCEPT;  // Helper calling InputText+Build
+    IMGUI_API bool      PassFilter(const char* text, const char* text_end = NULL) const IMGUI_NOEXCEPT;
+    IMGUI_API void      Build() IMGUI_NOEXCEPT;
+    void                Clear()          IMGUI_NOEXCEPT { InputBuf[0] = 0; Build(); }
+    bool                IsActive() const IMGUI_NOEXCEPT { return !Filters.empty(); }
 
     // [Internal]
     struct ImGuiTextRange
@@ -2040,10 +2047,10 @@ struct ImGuiTextFilter
         const char*     b;
         const char*     e;
 
-        ImGuiTextRange()                                { b = e = NULL; }
-        ImGuiTextRange(const char* _b, const char* _e)  { b = _b; e = _e; }
-        bool            empty() const                   { return b == e; }
-        IMGUI_API void  split(char separator, ImVector<ImGuiTextRange>* out) const;
+        ImGuiTextRange()                               IMGUI_NOEXCEPT  { b = e = NULL; }
+        ImGuiTextRange(const char* _b, const char* _e) IMGUI_NOEXCEPT  { b = _b; e = _e; }
+        bool            empty() const                  IMGUI_NOEXCEPT  { return b == e; }
+        IMGUI_API void  split(char separator, ImVector<ImGuiTextRange>* out) const IMGUI_NOEXCEPT;
     };
     char                    InputBuf[256];
     ImVector<ImGuiTextRange>Filters;
@@ -2057,18 +2064,18 @@ struct ImGuiTextBuffer
     ImVector<char>      Buf;
     IMGUI_API static char EmptyString[1];
 
-    ImGuiTextBuffer()   { }
-    inline char         operator[](int i) const { IM_ASSERT(Buf.Data != NULL); return Buf.Data[i]; }
-    const char*         begin() const           { return Buf.Data ? &Buf.front() : EmptyString; }
-    const char*         end() const             { return Buf.Data ? &Buf.back() : EmptyString; }   // Buf is zero-terminated, so end() will point on the zero-terminator
-    int                 size() const            { return Buf.Size ? Buf.Size - 1 : 0; }
-    bool                empty() const           { return Buf.Size <= 1; }
-    void                clear()                 { Buf.clear(); }
-    void                reserve(int capacity)   { Buf.reserve(capacity); }
-    const char*         c_str() const           { return Buf.Data ? Buf.Data : EmptyString; }
-    IMGUI_API void      append(const char* str, const char* str_end = NULL);
-    IMGUI_API void      appendf(const char* fmt, ...) IM_FMTARGS(2);
-    IMGUI_API void      appendfv(const char* fmt, va_list args) IM_FMTLIST(2);
+    ImGuiTextBuffer()                           IMGUI_NOEXCEPT { }
+    inline char         operator[](int i) const IMGUI_NOEXCEPT { IM_ASSERT(Buf.Data != NULL); return Buf.Data[i]; }
+    const char*         begin() const           IMGUI_NOEXCEPT { return Buf.Data ? &Buf.front() : EmptyString; }
+    const char*         end() const             IMGUI_NOEXCEPT { return Buf.Data ? &Buf.back() : EmptyString; }   // Buf is zero-terminated, so end() will point on the zero-terminator
+    int                 size() const            IMGUI_NOEXCEPT { return Buf.Size ? Buf.Size - 1 : 0; }
+    bool                empty() const           IMGUI_NOEXCEPT { return Buf.Size <= 1; }
+    void                clear()                 IMGUI_NOEXCEPT { Buf.clear(); }
+    void                reserve(int capacity)   IMGUI_NOEXCEPT { Buf.reserve(capacity); }
+    const char*         c_str() const           IMGUI_NOEXCEPT { return Buf.Data ? Buf.Data : EmptyString; }
+    IMGUI_API void      append(const char* str, const char* str_end = NULL) IMGUI_NOEXCEPT;
+    IMGUI_API void      appendf(const char* fmt, ...) IMGUI_NOEXCEPT IM_FMTARGS(2);
+    IMGUI_API void      appendfv(const char* fmt, va_list args) IMGUI_NOEXCEPT IM_FMTLIST(2);
 };
 
 // Helper: Key->Value storage
@@ -2086,9 +2093,9 @@ struct ImGuiStorage
     {
         ImGuiID key;
         union { int val_i; float val_f; void* val_p; };
-        ImGuiStoragePair(ImGuiID _key, int _val_i)      { key = _key; val_i = _val_i; }
-        ImGuiStoragePair(ImGuiID _key, float _val_f)    { key = _key; val_f = _val_f; }
-        ImGuiStoragePair(ImGuiID _key, void* _val_p)    { key = _key; val_p = _val_p; }
+        ImGuiStoragePair(ImGuiID _key, int _val_i)   IMGUI_NOEXCEPT    { key = _key; val_i = _val_i; }
+        ImGuiStoragePair(ImGuiID _key, float _val_f) IMGUI_NOEXCEPT    { key = _key; val_f = _val_f; }
+        ImGuiStoragePair(ImGuiID _key, void* _val_p) IMGUI_NOEXCEPT    { key = _key; val_p = _val_p; }
     };
 
     ImVector<ImGuiStoragePair>      Data;
@@ -2096,30 +2103,30 @@ struct ImGuiStorage
     // - Get***() functions find pair, never add/allocate. Pairs are sorted so a query is O(log N)
     // - Set***() functions find pair, insertion on demand if missing.
     // - Sorted insertion is costly, paid once. A typical frame shouldn't need to insert any new pair.
-    void                Clear() { Data.clear(); }
-    IMGUI_API int       GetInt(ImGuiID key, int default_val = 0) const;
-    IMGUI_API void      SetInt(ImGuiID key, int val);
-    IMGUI_API bool      GetBool(ImGuiID key, bool default_val = false) const;
-    IMGUI_API void      SetBool(ImGuiID key, bool val);
-    IMGUI_API float     GetFloat(ImGuiID key, float default_val = 0.0f) const;
-    IMGUI_API void      SetFloat(ImGuiID key, float val);
-    IMGUI_API void*     GetVoidPtr(ImGuiID key) const; // default_val is NULL
-    IMGUI_API void      SetVoidPtr(ImGuiID key, void* val);
+    void                Clear() IMGUI_NOEXCEPT { Data.clear(); }
+    IMGUI_API int       GetInt(ImGuiID key, int default_val = 0) const IMGUI_NOEXCEPT;
+    IMGUI_API void      SetInt(ImGuiID key, int val) IMGUI_NOEXCEPT;
+    IMGUI_API bool      GetBool(ImGuiID key, bool default_val = false) const IMGUI_NOEXCEPT;
+    IMGUI_API void      SetBool(ImGuiID key, bool val) IMGUI_NOEXCEPT;
+    IMGUI_API float     GetFloat(ImGuiID key, float default_val = 0.0f) const IMGUI_NOEXCEPT;
+    IMGUI_API void      SetFloat(ImGuiID key, float val) IMGUI_NOEXCEPT;
+    IMGUI_API void*     GetVoidPtr(ImGuiID key) const IMGUI_NOEXCEPT; // default_val is NULL
+    IMGUI_API void      SetVoidPtr(ImGuiID key, void* val) IMGUI_NOEXCEPT;
 
     // - Get***Ref() functions finds pair, insert on demand if missing, return pointer. Useful if you intend to do Get+Set.
     // - References are only valid until a new value is added to the storage. Calling a Set***() function or a Get***Ref() function invalidates the pointer.
     // - A typical use case where this is convenient for quick hacking (e.g. add storage during a live Edit&Continue session if you can't modify existing struct)
     //      float* pvar = ImGui::GetFloatRef(key); ImGui::SliderFloat("var", pvar, 0, 100.0f); some_var += *pvar;
-    IMGUI_API int*      GetIntRef(ImGuiID key, int default_val = 0);
-    IMGUI_API bool*     GetBoolRef(ImGuiID key, bool default_val = false);
-    IMGUI_API float*    GetFloatRef(ImGuiID key, float default_val = 0.0f);
-    IMGUI_API void**    GetVoidPtrRef(ImGuiID key, void* default_val = NULL);
+    IMGUI_API int*      GetIntRef(ImGuiID key, int default_val = 0) IMGUI_NOEXCEPT;
+    IMGUI_API bool*     GetBoolRef(ImGuiID key, bool default_val = false) IMGUI_NOEXCEPT;
+    IMGUI_API float*    GetFloatRef(ImGuiID key, float default_val = 0.0f) IMGUI_NOEXCEPT;
+    IMGUI_API void**    GetVoidPtrRef(ImGuiID key, void* default_val = NULL) IMGUI_NOEXCEPT;
 
     // Use on your own storage if you know only integer are being stored (open/close all tree nodes)
-    IMGUI_API void      SetAllInt(int val);
+    IMGUI_API void      SetAllInt(int val) IMGUI_NOEXCEPT;
 
     // For quicker full rebuild of a storage (instead of an incremental one), you may add all your contents and then sort once.
-    IMGUI_API void      BuildSortByKey();
+    IMGUI_API void      BuildSortByKey() IMGUI_NOEXCEPT;
 };
 
 // Helper: Manually clip large list of items.
@@ -2151,17 +2158,17 @@ struct ImGuiListClipper
     float   ItemsHeight;
     float   StartPosY;
 
-    IMGUI_API ImGuiListClipper();
-    IMGUI_API ~ImGuiListClipper();
+    IMGUI_API ImGuiListClipper() IMGUI_NOEXCEPT;
+    IMGUI_API ~ImGuiListClipper() IMGUI_NOEXCEPT;
 
     // items_count: Use INT_MAX if you don't know how many items you have (in which case the cursor won't be advanced in the final step)
     // items_height: Use -1.0f to be calculated automatically on first step. Otherwise pass in the distance between your items, typically GetTextLineHeightWithSpacing() or GetFrameHeightWithSpacing().
     IMGUI_API void Begin(int items_count, float items_height = -1.0f) IMGUI_NOEXCEPT;  // Automatically called by constructor if you passed 'items_count' or by Step() in Step 1.
     IMGUI_API void End() IMGUI_NOEXCEPT;                                // Automatically called on the last call of Step() that returns false.
-    IMGUI_API bool Step();                                              // Call until it returns false. The DisplayStart/DisplayEnd fields will be set and you can process/draw those items.
+    IMGUI_API bool Step() IMGUI_NOEXCEPT;                                              // Call until it returns false. The DisplayStart/DisplayEnd fields will be set and you can process/draw those items.
 
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
-    inline ImGuiListClipper(int items_count, float items_height = -1.0f) { memset(this, 0, sizeof(*this)); ItemsCount = -1; Begin(items_count, items_height); } // [removed in 1.79]
+    inline ImGuiListClipper(int items_count, float items_height = -1.0f) IMGUI_NOEXCEPT { memset(this, 0, sizeof(*this)); ItemsCount = -1; Begin(items_count, items_height); } // [removed in 1.79]
 #endif
 };
 
@@ -2192,17 +2199,17 @@ struct ImColor
 {
     ImVec4              Value;
 
-    ImColor()                                                       { Value.x = Value.y = Value.z = Value.w = 0.0f; }
-    ImColor(int r, int g, int b, int a = 255)                       { float sc = 1.0f / 255.0f; Value.x = (float)r * sc; Value.y = (float)g * sc; Value.z = (float)b * sc; Value.w = (float)a * sc; }
-    ImColor(ImU32 rgba)                                             { float sc = 1.0f / 255.0f; Value.x = (float)((rgba >> IM_COL32_R_SHIFT) & 0xFF) * sc; Value.y = (float)((rgba >> IM_COL32_G_SHIFT) & 0xFF) * sc; Value.z = (float)((rgba >> IM_COL32_B_SHIFT) & 0xFF) * sc; Value.w = (float)((rgba >> IM_COL32_A_SHIFT) & 0xFF) * sc; }
-    ImColor(float r, float g, float b, float a = 1.0f)              { Value.x = r; Value.y = g; Value.z = b; Value.w = a; }
-    ImColor(const ImVec4& col)                                      { Value = col; }
-    inline operator ImU32() const                                   { return ImGui::ColorConvertFloat4ToU32(Value); }
-    inline operator ImVec4() const                                  { return Value; }
+    ImColor()                                                        IMGUI_NOEXCEPT { Value.x = Value.y = Value.z = Value.w = 0.0f; }
+    ImColor(int r, int g, int b, int a = 255)                        IMGUI_NOEXCEPT { float sc = 1.0f / 255.0f; Value.x = (float)r * sc; Value.y = (float)g * sc; Value.z = (float)b * sc; Value.w = (float)a * sc; }
+    ImColor(ImU32 rgba)                                              IMGUI_NOEXCEPT { float sc = 1.0f / 255.0f; Value.x = (float)((rgba >> IM_COL32_R_SHIFT) & 0xFF) * sc; Value.y = (float)((rgba >> IM_COL32_G_SHIFT) & 0xFF) * sc; Value.z = (float)((rgba >> IM_COL32_B_SHIFT) & 0xFF) * sc; Value.w = (float)((rgba >> IM_COL32_A_SHIFT) & 0xFF) * sc; }
+    ImColor(float r, float g, float b, float a = 1.0f)               IMGUI_NOEXCEPT { Value.x = r; Value.y = g; Value.z = b; Value.w = a; }
+    ImColor(const ImVec4& col)                                       IMGUI_NOEXCEPT { Value = col; }
+    inline operator ImU32() const                                    IMGUI_NOEXCEPT { return ImGui::ColorConvertFloat4ToU32(Value); }
+    inline operator ImVec4() const                                   IMGUI_NOEXCEPT { return Value; }
 
     // FIXME-OBSOLETE: May need to obsolete/cleanup those helpers.
-    inline void    SetHSV(float h, float s, float v, float a = 1.0f){ ImGui::ColorConvertHSVtoRGB(h, s, v, Value.x, Value.y, Value.z); Value.w = a; }
-    static ImColor HSV(float h, float s, float v, float a = 1.0f)   { float r, g, b; ImGui::ColorConvertHSVtoRGB(h, s, v, r, g, b); return ImColor(r, g, b, a); }
+    inline void    SetHSV(float h, float s, float v, float a = 1.0f) IMGUI_NOEXCEPT { ImGui::ColorConvertHSVtoRGB(h, s, v, Value.x, Value.y, Value.z); Value.w = a; }
+    static ImColor HSV(float h, float s, float v, float a = 1.0f)    IMGUI_NOEXCEPT { float r, g, b; ImGui::ColorConvertHSVtoRGB(h, s, v, r, g, b); return ImColor(r, g, b, a); }
 };
 
 //-----------------------------------------------------------------------------
@@ -2250,7 +2257,7 @@ struct ImDrawCmd
     ImDrawCmd() { memset(this, 0, sizeof(*this)); } // Also ensure our padding fields are zeroed
 
     // Since 1.83: returns ImTextureID associated with this draw call. Warning: DO NOT assume this is always same as 'TextureId' (we will change this function for an upcoming feature)
-    inline ImTextureID GetTexID() const { return TextureId; }
+    inline ImTextureID GetTexID() const IMGUI_NOEXCEPT { return TextureId; }
 };
 
 // Vertex index, default to 16-bit
@@ -2300,13 +2307,13 @@ struct ImDrawListSplitter
     int                         _Count;      // Number of active channels (1+)
     ImVector<ImDrawChannel>     _Channels;   // Draw channels (not resized down so _Count might be < Channels.Size)
 
-    inline ImDrawListSplitter()  { memset(this, 0, sizeof(*this)); }
-    inline ~ImDrawListSplitter() { ClearFreeMemory(); }
-    inline void                 Clear() { _Current = 0; _Count = 1; } // Do not clear Channels[] so our allocations are reused next frame
-    IMGUI_API void              ClearFreeMemory();
-    IMGUI_API void              Split(ImDrawList* draw_list, int count);
-    IMGUI_API void              Merge(ImDrawList* draw_list);
-    IMGUI_API void              SetCurrentChannel(ImDrawList* draw_list, int channel_idx);
+    inline ImDrawListSplitter() IMGUI_NOEXCEPT  { memset(this, 0, sizeof(*this)); }
+    inline ~ImDrawListSplitter() IMGUI_NOEXCEPT { ClearFreeMemory(); }
+    inline void                 Clear() IMGUI_NOEXCEPT { _Current = 0; _Count = 1; } // Do not clear Channels[] so our allocations are reused next frame
+    IMGUI_API void              ClearFreeMemory() IMGUI_NOEXCEPT;
+    IMGUI_API void              Split(ImDrawList* draw_list, int count) IMGUI_NOEXCEPT;
+    IMGUI_API void              Merge(ImDrawList* draw_list) IMGUI_NOEXCEPT;
+    IMGUI_API void              SetCurrentChannel(ImDrawList* draw_list, int channel_idx) IMGUI_NOEXCEPT;
 };
 
 // Flags for ImDrawList functions
@@ -2371,16 +2378,16 @@ struct ImDrawList
     float                   _FringeScale;       // [Internal] anti-alias fringe is scaled by this value, this helps to keep things sharp while zooming at vertex buffer content
 
     // If you want to create ImDrawList instances, pass them ImGui::GetDrawListSharedData() or create and use your own ImDrawListSharedData (so you can use ImDrawList without ImGui)
-    ImDrawList(const ImDrawListSharedData* shared_data) { memset(this, 0, sizeof(*this)); _Data = shared_data; }
+    ImDrawList(const ImDrawListSharedData* shared_data) IMGUI_NOEXCEPT { memset(this, 0, sizeof(*this)); _Data = shared_data; }
 
-    ~ImDrawList() { _ClearFreeMemory(); }
-    IMGUI_API void  PushClipRect(ImVec2 clip_rect_min, ImVec2 clip_rect_max, bool intersect_with_current_clip_rect = false);  // Render-level scissoring. This is passed down to your render function but not used for CPU-side coarse clipping. Prefer using higher-level ImGui::PushClipRect() to affect logic (hit-testing and widget culling)
-    IMGUI_API void  PushClipRectFullScreen();
-    IMGUI_API void  PopClipRect();
-    IMGUI_API void  PushTextureID(ImTextureID texture_id);
-    IMGUI_API void  PopTextureID();
-    inline ImVec2   GetClipRectMin() const { const ImVec4& cr = _ClipRectStack.back(); return ImVec2(cr.x, cr.y); }
-    inline ImVec2   GetClipRectMax() const { const ImVec4& cr = _ClipRectStack.back(); return ImVec2(cr.z, cr.w); }
+    ~ImDrawList() IMGUI_NOEXCEPT { _ClearFreeMemory(); }
+    IMGUI_API void  PushClipRect(ImVec2 clip_rect_min, ImVec2 clip_rect_max, bool intersect_with_current_clip_rect = false) IMGUI_NOEXCEPT;  // Render-level scissoring. This is passed down to your render function but not used for CPU-side coarse clipping. Prefer using higher-level ImGui::PushClipRect() to affect logic (hit-testing and widget culling)
+    IMGUI_API void  PushClipRectFullScreen() IMGUI_NOEXCEPT;
+    IMGUI_API void  PopClipRect() IMGUI_NOEXCEPT;
+    IMGUI_API void  PushTextureID(ImTextureID texture_id) IMGUI_NOEXCEPT;
+    IMGUI_API void  PopTextureID() IMGUI_NOEXCEPT;
+    inline ImVec2   GetClipRectMin() const IMGUI_NOEXCEPT { const ImVec4& cr = _ClipRectStack.back(); return ImVec2(cr.x, cr.y); }
+    inline ImVec2   GetClipRectMax() const IMGUI_NOEXCEPT { const ImVec4& cr = _ClipRectStack.back(); return ImVec2(cr.z, cr.w); }
 
     // Primitives
     // - For rectangular primitives, "p_min" and "p_max" represent the upper-left and lower-right corners.
@@ -2388,49 +2395,49 @@ struct ImDrawList
     //   In older versions (until Dear ImGui 1.77) the AddCircle functions defaulted to num_segments == 12.
     //   In future versions we will use textures to provide cheaper and higher-quality circles.
     //   Use AddNgon() and AddNgonFilled() functions if you need to guaranteed a specific number of sides.
-    IMGUI_API void  AddLine(const ImVec2& p1, const ImVec2& p2, ImU32 col, float thickness = 1.0f);
-    IMGUI_API void  AddRect(const ImVec2& p_min, const ImVec2& p_max, ImU32 col, float rounding = 0.0f, ImDrawFlags flags = 0, float thickness = 1.0f);   // a: upper-left, b: lower-right (== upper-left + size)
-    IMGUI_API void  AddRectFilled(const ImVec2& p_min, const ImVec2& p_max, ImU32 col, float rounding = 0.0f, ImDrawFlags flags = 0);                     // a: upper-left, b: lower-right (== upper-left + size)
-    IMGUI_API void  AddRectFilledMultiColor(const ImVec2& p_min, const ImVec2& p_max, ImU32 col_upr_left, ImU32 col_upr_right, ImU32 col_bot_right, ImU32 col_bot_left);
-    IMGUI_API void  AddQuad(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, ImU32 col, float thickness = 1.0f);
-    IMGUI_API void  AddQuadFilled(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, ImU32 col);
-    IMGUI_API void  AddTriangle(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, ImU32 col, float thickness = 1.0f);
-    IMGUI_API void  AddTriangleFilled(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, ImU32 col);
-    IMGUI_API void  AddCircle(const ImVec2& center, float radius, ImU32 col, int num_segments = 0, float thickness = 1.0f);
-    IMGUI_API void  AddCircleFilled(const ImVec2& center, float radius, ImU32 col, int num_segments = 0);
-    IMGUI_API void  AddNgon(const ImVec2& center, float radius, ImU32 col, int num_segments, float thickness = 1.0f);
-    IMGUI_API void  AddNgonFilled(const ImVec2& center, float radius, ImU32 col, int num_segments);
-    IMGUI_API void  AddText(const ImVec2& pos, ImU32 col, const char* text_begin, const char* text_end = NULL);
-    IMGUI_API void  AddText(const ImFont* font, float font_size, const ImVec2& pos, ImU32 col, const char* text_begin, const char* text_end = NULL, float wrap_width = 0.0f, const ImVec4* cpu_fine_clip_rect = NULL);
-    IMGUI_API void  AddPolyline(const ImVec2* points, int num_points, ImU32 col, ImDrawFlags flags, float thickness);
-    IMGUI_API void  AddConvexPolyFilled(const ImVec2* points, int num_points, ImU32 col); // Note: Anti-aliased filling requires points to be in clockwise order.
-    IMGUI_API void  AddBezierCubic(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, ImU32 col, float thickness, int num_segments = 0); // Cubic Bezier (4 control points)
-    IMGUI_API void  AddBezierQuadratic(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, ImU32 col, float thickness, int num_segments = 0);               // Quadratic Bezier (3 control points)
+    IMGUI_API void  AddLine(const ImVec2& p1, const ImVec2& p2, ImU32 col, float thickness = 1.0f) IMGUI_NOEXCEPT;
+    IMGUI_API void  AddRect(const ImVec2& p_min, const ImVec2& p_max, ImU32 col, float rounding = 0.0f, ImDrawFlags flags = 0, float thickness = 1.0f) IMGUI_NOEXCEPT;   // a: upper-left, b: lower-right (== upper-left + size)
+    IMGUI_API void  AddRectFilled(const ImVec2& p_min, const ImVec2& p_max, ImU32 col, float rounding = 0.0f, ImDrawFlags flags = 0) IMGUI_NOEXCEPT;                     // a: upper-left, b: lower-right (== upper-left + size)
+    IMGUI_API void  AddRectFilledMultiColor(const ImVec2& p_min, const ImVec2& p_max, ImU32 col_upr_left, ImU32 col_upr_right, ImU32 col_bot_right, ImU32 col_bot_left) IMGUI_NOEXCEPT;
+    IMGUI_API void  AddQuad(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, ImU32 col, float thickness = 1.0f) IMGUI_NOEXCEPT;
+    IMGUI_API void  AddQuadFilled(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, ImU32 col) IMGUI_NOEXCEPT;
+    IMGUI_API void  AddTriangle(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, ImU32 col, float thickness = 1.0f) IMGUI_NOEXCEPT;
+    IMGUI_API void  AddTriangleFilled(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, ImU32 col) IMGUI_NOEXCEPT;
+    IMGUI_API void  AddCircle(const ImVec2& center, float radius, ImU32 col, int num_segments = 0, float thickness = 1.0f) IMGUI_NOEXCEPT;
+    IMGUI_API void  AddCircleFilled(const ImVec2& center, float radius, ImU32 col, int num_segments = 0) IMGUI_NOEXCEPT;
+    IMGUI_API void  AddNgon(const ImVec2& center, float radius, ImU32 col, int num_segments, float thickness = 1.0f) IMGUI_NOEXCEPT;
+    IMGUI_API void  AddNgonFilled(const ImVec2& center, float radius, ImU32 col, int num_segments) IMGUI_NOEXCEPT;
+    IMGUI_API void  AddText(const ImVec2& pos, ImU32 col, const char* text_begin, const char* text_end = NULL) IMGUI_NOEXCEPT;
+    IMGUI_API void  AddText(const ImFont* font, float font_size, const ImVec2& pos, ImU32 col, const char* text_begin, const char* text_end = NULL, float wrap_width = 0.0f, const ImVec4* cpu_fine_clip_rect = NULL) IMGUI_NOEXCEPT;
+    IMGUI_API void  AddPolyline(const ImVec2* points, int num_points, ImU32 col, ImDrawFlags flags, float thickness) IMGUI_NOEXCEPT;
+    IMGUI_API void  AddConvexPolyFilled(const ImVec2* points, int num_points, ImU32 col) IMGUI_NOEXCEPT; // Note: Anti-aliased filling requires points to be in clockwise order.
+    IMGUI_API void  AddBezierCubic(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, ImU32 col, float thickness, int num_segments = 0) IMGUI_NOEXCEPT; // Cubic Bezier (4 control points)
+    IMGUI_API void  AddBezierQuadratic(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, ImU32 col, float thickness, int num_segments = 0) IMGUI_NOEXCEPT;               // Quadratic Bezier (3 control points)
 
     // Image primitives
     // - Read FAQ to understand what ImTextureID is.
     // - "p_min" and "p_max" represent the upper-left and lower-right corners of the rectangle.
     // - "uv_min" and "uv_max" represent the normalized texture coordinates to use for those corners. Using (0,0)->(1,1) texture coordinates will generally display the entire texture.
-    IMGUI_API void  AddImage(ImTextureID user_texture_id, const ImVec2& p_min, const ImVec2& p_max, const ImVec2& uv_min = ImVec2(0, 0), const ImVec2& uv_max = ImVec2(1, 1), ImU32 col = IM_COL32_WHITE);
-    IMGUI_API void  AddImageQuad(ImTextureID user_texture_id, const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, const ImVec2& uv1 = ImVec2(0, 0), const ImVec2& uv2 = ImVec2(1, 0), const ImVec2& uv3 = ImVec2(1, 1), const ImVec2& uv4 = ImVec2(0, 1), ImU32 col = IM_COL32_WHITE);
-    IMGUI_API void  AddImageRounded(ImTextureID user_texture_id, const ImVec2& p_min, const ImVec2& p_max, const ImVec2& uv_min, const ImVec2& uv_max, ImU32 col, float rounding, ImDrawFlags flags = 0);
+    IMGUI_API void  AddImage(ImTextureID user_texture_id, const ImVec2& p_min, const ImVec2& p_max, const ImVec2& uv_min = ImVec2(0, 0), const ImVec2& uv_max = ImVec2(1, 1), ImU32 col = IM_COL32_WHITE) IMGUI_NOEXCEPT;
+    IMGUI_API void  AddImageQuad(ImTextureID user_texture_id, const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, const ImVec2& uv1 = ImVec2(0, 0), const ImVec2& uv2 = ImVec2(1, 0), const ImVec2& uv3 = ImVec2(1, 1), const ImVec2& uv4 = ImVec2(0, 1), ImU32 col = IM_COL32_WHITE) IMGUI_NOEXCEPT;
+    IMGUI_API void  AddImageRounded(ImTextureID user_texture_id, const ImVec2& p_min, const ImVec2& p_max, const ImVec2& uv_min, const ImVec2& uv_max, ImU32 col, float rounding, ImDrawFlags flags = 0) IMGUI_NOEXCEPT;
 
     // Stateful path API, add points then finish with PathFillConvex() or PathStroke()
-    inline    void  PathClear()                                                 { _Path.Size = 0; }
-    inline    void  PathLineTo(const ImVec2& pos)                               { _Path.push_back(pos); }
-    inline    void  PathLineToMergeDuplicate(const ImVec2& pos)                 { if (_Path.Size == 0 || memcmp(&_Path.Data[_Path.Size - 1], &pos, 8) != 0) _Path.push_back(pos); }
-    inline    void  PathFillConvex(ImU32 col)                                   { AddConvexPolyFilled(_Path.Data, _Path.Size, col); _Path.Size = 0; }  // Note: Anti-aliased filling requires points to be in clockwise order.
-    inline    void  PathStroke(ImU32 col, ImDrawFlags flags = 0, float thickness = 1.0f) { AddPolyline(_Path.Data, _Path.Size, col, flags, thickness); _Path.Size = 0; }
-    IMGUI_API void  PathArcTo(const ImVec2& center, float radius, float a_min, float a_max, int num_segments = 0);
-    IMGUI_API void  PathArcToFast(const ImVec2& center, float radius, int a_min_of_12, int a_max_of_12);                // Use precomputed angles for a 12 steps circle
-    IMGUI_API void  PathBezierCubicCurveTo(const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, int num_segments = 0); // Cubic Bezier (4 control points)
-    IMGUI_API void  PathBezierQuadraticCurveTo(const ImVec2& p2, const ImVec2& p3, int num_segments = 0);               // Quadratic Bezier (3 control points)
-    IMGUI_API void  PathRect(const ImVec2& rect_min, const ImVec2& rect_max, float rounding = 0.0f, ImDrawFlags flags = 0);
+    inline    void  PathClear()                                 IMGUI_NOEXCEPT   { _Path.Size = 0; }
+    inline    void  PathLineTo(const ImVec2& pos)               IMGUI_NOEXCEPT   { _Path.push_back(pos); }
+    inline    void  PathLineToMergeDuplicate(const ImVec2& pos) IMGUI_NOEXCEPT   { if (_Path.Size == 0 || memcmp(&_Path.Data[_Path.Size - 1], &pos, 8) != 0) _Path.push_back(pos); }
+    inline    void  PathFillConvex(ImU32 col)                   IMGUI_NOEXCEPT   { AddConvexPolyFilled(_Path.Data, _Path.Size, col); _Path.Size = 0; }  // Note: Anti-aliased filling requires points to be in clockwise order.
+    inline    void  PathStroke(ImU32 col, ImDrawFlags flags = 0, float thickness = 1.0f) IMGUI_NOEXCEPT { AddPolyline(_Path.Data, _Path.Size, col, flags, thickness); _Path.Size = 0; }
+    IMGUI_API void  PathArcTo(const ImVec2& center, float radius, float a_min, float a_max, int num_segments = 0) IMGUI_NOEXCEPT;
+    IMGUI_API void  PathArcToFast(const ImVec2& center, float radius, int a_min_of_12, int a_max_of_12) IMGUI_NOEXCEPT;                // Use precomputed angles for a 12 steps circle
+    IMGUI_API void  PathBezierCubicCurveTo(const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, int num_segments = 0) IMGUI_NOEXCEPT; // Cubic Bezier (4 control points)
+    IMGUI_API void  PathBezierQuadraticCurveTo(const ImVec2& p2, const ImVec2& p3, int num_segments = 0) IMGUI_NOEXCEPT;               // Quadratic Bezier (3 control points)
+    IMGUI_API void  PathRect(const ImVec2& rect_min, const ImVec2& rect_max, float rounding = 0.0f, ImDrawFlags flags = 0) IMGUI_NOEXCEPT;
 
     // Advanced
-    IMGUI_API void  AddCallback(ImDrawCallback callback, void* callback_data);  // Your rendering function must check for 'UserCallback' in ImDrawCmd and call the function instead of rendering triangles.
-    IMGUI_API void  AddDrawCmd();                                               // This is useful if you need to forcefully create a new draw call (to allow for dependent rendering / blending). Otherwise primitives are merged into the same draw-call as much as possible
-    IMGUI_API ImDrawList* CloneOutput() const;                                  // Create a clone of the CmdBuffer/IdxBuffer/VtxBuffer.
+    IMGUI_API void  AddCallback(ImDrawCallback callback, void* callback_data) IMGUI_NOEXCEPT;  // Your rendering function must check for 'UserCallback' in ImDrawCmd and call the function instead of rendering triangles.
+    IMGUI_API void  AddDrawCmd() IMGUI_NOEXCEPT;                                               // This is useful if you need to forcefully create a new draw call (to allow for dependent rendering / blending). Otherwise primitives are merged into the same draw-call as much as possible
+    IMGUI_API ImDrawList* CloneOutput() const IMGUI_NOEXCEPT;                                  // Create a clone of the CmdBuffer/IdxBuffer/VtxBuffer.
 
     // Advanced: Channels
     // - Use to split render into layers. By switching channels to can render out-of-order (e.g. submit FG primitives before BG primitives)
@@ -2438,37 +2445,37 @@ struct ImDrawList
     // - FIXME-OBSOLETE: This API shouldn't have been in ImDrawList in the first place!
     //   Prefer using your own persistent instance of ImDrawListSplitter as you can stack them.
     //   Using the ImDrawList::ChannelsXXXX you cannot stack a split over another.
-    inline void     ChannelsSplit(int count)    { _Splitter.Split(this, count); }
-    inline void     ChannelsMerge()             { _Splitter.Merge(this); }
-    inline void     ChannelsSetCurrent(int n)   { _Splitter.SetCurrentChannel(this, n); }
+    inline void     ChannelsSplit(int count)  IMGUI_NOEXCEPT   { _Splitter.Split(this, count); }
+    inline void     ChannelsMerge()           IMGUI_NOEXCEPT   { _Splitter.Merge(this); }
+    inline void     ChannelsSetCurrent(int n) IMGUI_NOEXCEPT   { _Splitter.SetCurrentChannel(this, n); }
 
     // Advanced: Primitives allocations
     // - We render triangles (three vertices)
     // - All primitives needs to be reserved via PrimReserve() beforehand.
-    IMGUI_API void  PrimReserve(int idx_count, int vtx_count);
-    IMGUI_API void  PrimUnreserve(int idx_count, int vtx_count);
-    IMGUI_API void  PrimRect(const ImVec2& a, const ImVec2& b, ImU32 col);      // Axis aligned rectangle (composed of two triangles)
-    IMGUI_API void  PrimRectUV(const ImVec2& a, const ImVec2& b, const ImVec2& uv_a, const ImVec2& uv_b, ImU32 col);
-    IMGUI_API void  PrimQuadUV(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& d, const ImVec2& uv_a, const ImVec2& uv_b, const ImVec2& uv_c, const ImVec2& uv_d, ImU32 col);
-    inline    void  PrimWriteVtx(const ImVec2& pos, const ImVec2& uv, ImU32 col)    { _VtxWritePtr->pos = pos; _VtxWritePtr->uv = uv; _VtxWritePtr->col = col; _VtxWritePtr++; _VtxCurrentIdx++; }
-    inline    void  PrimWriteIdx(ImDrawIdx idx)                                     { *_IdxWritePtr = idx; _IdxWritePtr++; }
-    inline    void  PrimVtx(const ImVec2& pos, const ImVec2& uv, ImU32 col)         { PrimWriteIdx((ImDrawIdx)_VtxCurrentIdx); PrimWriteVtx(pos, uv, col); } // Write vertex with unique index
+    IMGUI_API void  PrimReserve(int idx_count, int vtx_count) IMGUI_NOEXCEPT;
+    IMGUI_API void  PrimUnreserve(int idx_count, int vtx_count) IMGUI_NOEXCEPT;
+    IMGUI_API void  PrimRect(const ImVec2& a, const ImVec2& b, ImU32 col) IMGUI_NOEXCEPT;      // Axis aligned rectangle (composed of two triangles)
+    IMGUI_API void  PrimRectUV(const ImVec2& a, const ImVec2& b, const ImVec2& uv_a, const ImVec2& uv_b, ImU32 col) IMGUI_NOEXCEPT;
+    IMGUI_API void  PrimQuadUV(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& d, const ImVec2& uv_a, const ImVec2& uv_b, const ImVec2& uv_c, const ImVec2& uv_d, ImU32 col) IMGUI_NOEXCEPT;
+    inline    void  PrimWriteVtx(const ImVec2& pos, const ImVec2& uv, ImU32 col) IMGUI_NOEXCEPT    { _VtxWritePtr->pos = pos; _VtxWritePtr->uv = uv; _VtxWritePtr->col = col; _VtxWritePtr++; _VtxCurrentIdx++; }
+    inline    void  PrimWriteIdx(ImDrawIdx idx)                                  IMGUI_NOEXCEPT    { *_IdxWritePtr = idx; _IdxWritePtr++; }
+    inline    void  PrimVtx(const ImVec2& pos, const ImVec2& uv, ImU32 col)      IMGUI_NOEXCEPT    { PrimWriteIdx((ImDrawIdx)_VtxCurrentIdx); PrimWriteVtx(pos, uv, col); } // Write vertex with unique index
 
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
-    inline    void  AddBezierCurve(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, ImU32 col, float thickness, int num_segments = 0) { AddBezierCubic(p1, p2, p3, p4, col, thickness, num_segments); }
-    inline    void  PathBezierCurveTo(const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, int num_segments = 0) { PathBezierCubicCurveTo(p2, p3, p4, num_segments); }
+    inline    void  AddBezierCurve(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, ImU32 col, float thickness, int num_segments = 0) IMGUI_NOEXCEPT { AddBezierCubic(p1, p2, p3, p4, col, thickness, num_segments); }
+    inline    void  PathBezierCurveTo(const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, int num_segments = 0) IMGUI_NOEXCEPT { PathBezierCubicCurveTo(p2, p3, p4, num_segments); }
 #endif
 
     // [Internal helpers]
-    IMGUI_API void  _ResetForNewFrame();
-    IMGUI_API void  _ClearFreeMemory();
-    IMGUI_API void  _PopUnusedDrawCmd();
-    IMGUI_API void  _OnChangedClipRect();
-    IMGUI_API void  _OnChangedTextureID();
-    IMGUI_API void  _OnChangedVtxOffset();
-    IMGUI_API int   _CalcCircleAutoSegmentCount(float radius) const;
-    IMGUI_API void  _PathArcToFastEx(const ImVec2& center, float radius, int a_min_sample, int a_max_sample, int a_step);
-    IMGUI_API void  _PathArcToN(const ImVec2& center, float radius, float a_min, float a_max, int num_segments);
+    IMGUI_API void  _ResetForNewFrame() IMGUI_NOEXCEPT;
+    IMGUI_API void  _ClearFreeMemory() IMGUI_NOEXCEPT;
+    IMGUI_API void  _PopUnusedDrawCmd() IMGUI_NOEXCEPT;
+    IMGUI_API void  _OnChangedClipRect() IMGUI_NOEXCEPT;
+    IMGUI_API void  _OnChangedTextureID() IMGUI_NOEXCEPT;
+    IMGUI_API void  _OnChangedVtxOffset() IMGUI_NOEXCEPT;
+    IMGUI_API int   _CalcCircleAutoSegmentCount(float radius) const IMGUI_NOEXCEPT;
+    IMGUI_API void  _PathArcToFastEx(const ImVec2& center, float radius, int a_min_sample, int a_max_sample, int a_step) IMGUI_NOEXCEPT;
+    IMGUI_API void  _PathArcToN(const ImVec2& center, float radius, float a_min, float a_max, int num_segments) IMGUI_NOEXCEPT;
 };
 
 // All draw data to render a Dear ImGui frame
@@ -2486,10 +2493,10 @@ struct ImDrawData
     ImVec2          FramebufferScale;       // Amount of pixels for each unit of DisplaySize. Based on io.DisplayFramebufferScale. Generally (1,1) on normal display, (2,2) on OSX with Retina display.
 
     // Functions
-    ImDrawData()    { Clear(); }
-    void Clear()    { memset(this, 0, sizeof(*this)); }     // The ImDrawList are owned by ImGuiContext!
-    IMGUI_API void  DeIndexAllBuffers();                    // Helper to convert all buffers from indexed to non-indexed, in case you cannot render indexed. Note: this is slow and most likely a waste of resources. Always prefer indexed rendering!
-    IMGUI_API void  ScaleClipRects(const ImVec2& fb_scale); // Helper to scale the ClipRect field of each ImDrawCmd. Use if your final output buffer is at a different scale than Dear ImGui expects, or if there is a difference between your window resolution and framebuffer resolution.
+    ImDrawData() IMGUI_NOEXCEPT { Clear(); }
+    void Clear() IMGUI_NOEXCEPT { memset(this, 0, sizeof(*this)); }         // The ImDrawList are owned by ImGuiContext!
+    IMGUI_API void  DeIndexAllBuffers()                    IMGUI_NOEXCEPT;  // Helper to convert all buffers from indexed to non-indexed, in case you cannot render indexed. Note: this is slow and most likely a waste of resources. Always prefer indexed rendering!
+    IMGUI_API void  ScaleClipRects(const ImVec2& fb_scale) IMGUI_NOEXCEPT;  // Helper to scale the ClipRect field of each ImDrawCmd. Use if your final output buffer is at a different scale than Dear ImGui expects, or if there is a difference between your window resolution and framebuffer resolution.
 };
 
 //-----------------------------------------------------------------------------
@@ -2520,7 +2527,7 @@ struct ImFontConfig
     char            Name[40];               // Name (strictly to ease debugging)
     ImFont*         DstFont;
 
-    IMGUI_API ImFontConfig();
+    IMGUI_API ImFontConfig() IMGUI_NOEXCEPT;
 };
 
 // Hold rendering data for one glyph.
@@ -2541,14 +2548,14 @@ struct ImFontGlyphRangesBuilder
 {
     ImVector<ImU32> UsedChars;            // Store 1-bit per Unicode code point (0=unused, 1=used)
 
-    ImFontGlyphRangesBuilder()              { Clear(); }
-    inline void     Clear()                 { int size_in_bytes = (IM_UNICODE_CODEPOINT_MAX + 1) / 8; UsedChars.resize(size_in_bytes / (int)sizeof(ImU32)); memset(UsedChars.Data, 0, (size_t)size_in_bytes); }
-    inline bool     GetBit(size_t n) const  { int off = (int)(n >> 5); ImU32 mask = 1u << (n & 31); return (UsedChars[off] & mask) != 0; }  // Get bit n in the array
-    inline void     SetBit(size_t n)        { int off = (int)(n >> 5); ImU32 mask = 1u << (n & 31); UsedChars[off] |= mask; }               // Set bit n in the array
-    inline void     AddChar(ImWchar c)      { SetBit(c); }                      // Add character
-    IMGUI_API void  AddText(const char* text, const char* text_end = NULL);     // Add string (each character of the UTF-8 string are added)
-    IMGUI_API void  AddRanges(const ImWchar* ranges);                           // Add ranges, e.g. builder.AddRanges(ImFontAtlas::GetGlyphRangesDefault()) to force add all of ASCII/Latin+Ext
-    IMGUI_API void  BuildRanges(ImVector<ImWchar>* out_ranges);                 // Output new ranges
+    ImFontGlyphRangesBuilder()             IMGUI_NOEXCEPT { Clear(); }
+    inline void     Clear()                IMGUI_NOEXCEPT { int size_in_bytes = (IM_UNICODE_CODEPOINT_MAX + 1) / 8; UsedChars.resize(size_in_bytes / (int)sizeof(ImU32)); memset(UsedChars.Data, 0, (size_t)size_in_bytes); }
+    inline bool     GetBit(size_t n) const IMGUI_NOEXCEPT { int off = (int)(n >> 5); ImU32 mask = 1u << (n & 31); return (UsedChars[off] & mask) != 0; }  // Get bit n in the array
+    inline void     SetBit(size_t n)       IMGUI_NOEXCEPT { int off = (int)(n >> 5); ImU32 mask = 1u << (n & 31); UsedChars[off] |= mask; }               // Set bit n in the array
+    inline void     AddChar(ImWchar c)     IMGUI_NOEXCEPT { SetBit(c); }                    // Add character
+    IMGUI_API void  AddText(const char* text, const char* text_end = NULL) IMGUI_NOEXCEPT;  // Add string (each character of the UTF-8 string are added)
+    IMGUI_API void  AddRanges(const ImWchar* ranges)                       IMGUI_NOEXCEPT;  // Add ranges, e.g. builder.AddRanges(ImFontAtlas::GetGlyphRangesDefault()) to force add all of ASCII/Latin+Ext
+    IMGUI_API void  BuildRanges(ImVector<ImWchar>* out_ranges)             IMGUI_NOEXCEPT;  // Output new ranges
 };
 
 // See ImFontAtlas::AddCustomRectXXX functions.
@@ -2560,8 +2567,8 @@ struct ImFontAtlasCustomRect
     float           GlyphAdvanceX;  // Input    // For custom font glyphs only: glyph xadvance
     ImVec2          GlyphOffset;    // Input    // For custom font glyphs only: glyph display offset
     ImFont*         Font;           // Input    // For custom font glyphs only: target font
-    ImFontAtlasCustomRect()         { Width = Height = 0; X = Y = 0xFFFF; GlyphID = 0; GlyphAdvanceX = 0.0f; GlyphOffset = ImVec2(0, 0); Font = NULL; }
-    bool IsPacked() const           { return X != 0xFFFF; }
+    ImFontAtlasCustomRect() IMGUI_NOEXCEPT { Width = Height = 0; X = Y = 0xFFFF; GlyphID = 0; GlyphAdvanceX = 0.0f; GlyphOffset = ImVec2(0, 0); Font = NULL; }
+    bool IsPacked() const   IMGUI_NOEXCEPT { return X != 0xFFFF; }
 };
 
 // Flags for ImFontAtlas build
@@ -2592,29 +2599,29 @@ enum ImFontAtlasFlags_
 // - This is an old API and it is currently awkward for those and and various other reasons! We will address them in the future!
 struct ImFontAtlas
 {
-    IMGUI_API ImFontAtlas();
-    IMGUI_API ~ImFontAtlas();
-    IMGUI_API ImFont*           AddFont(const ImFontConfig* font_cfg);
-    IMGUI_API ImFont*           AddFontDefault(const ImFontConfig* font_cfg = NULL);
-    IMGUI_API ImFont*           AddFontFromFileTTF(const char* filename, float size_pixels, const ImFontConfig* font_cfg = NULL, const ImWchar* glyph_ranges = NULL);
-    IMGUI_API ImFont*           AddFontFromMemoryTTF(void* font_data, int font_size, float size_pixels, const ImFontConfig* font_cfg = NULL, const ImWchar* glyph_ranges = NULL); // Note: Transfer ownership of 'ttf_data' to ImFontAtlas! Will be deleted after destruction of the atlas. Set font_cfg->FontDataOwnedByAtlas=false to keep ownership of your data and it won't be freed.
-    IMGUI_API ImFont*           AddFontFromMemoryCompressedTTF(const void* compressed_font_data, int compressed_font_size, float size_pixels, const ImFontConfig* font_cfg = NULL, const ImWchar* glyph_ranges = NULL); // 'compressed_font_data' still owned by caller. Compress with binary_to_compressed_c.cpp.
-    IMGUI_API ImFont*           AddFontFromMemoryCompressedBase85TTF(const char* compressed_font_data_base85, float size_pixels, const ImFontConfig* font_cfg = NULL, const ImWchar* glyph_ranges = NULL);              // 'compressed_font_data_base85' still owned by caller. Compress with binary_to_compressed_c.cpp with -base85 parameter.
-    IMGUI_API void              ClearInputData();           // Clear input data (all ImFontConfig structures including sizes, TTF data, glyph ranges, etc.) = all the data used to build the texture and fonts.
-    IMGUI_API void              ClearTexData();             // Clear output texture data (CPU side). Saves RAM once the texture has been copied to graphics memory.
-    IMGUI_API void              ClearFonts();               // Clear output font data (glyphs storage, UV coordinates).
-    IMGUI_API void              Clear();                    // Clear all input and output.
+    IMGUI_API ImFontAtlas() IMGUI_NOEXCEPT;
+    IMGUI_API ~ImFontAtlas() IMGUI_NOEXCEPT;
+    IMGUI_API ImFont*           AddFont(const ImFontConfig* font_cfg) IMGUI_NOEXCEPT;
+    IMGUI_API ImFont*           AddFontDefault(const ImFontConfig* font_cfg = NULL) IMGUI_NOEXCEPT;
+    IMGUI_API ImFont*           AddFontFromFileTTF(const char* filename, float size_pixels, const ImFontConfig* font_cfg = NULL, const ImWchar* glyph_ranges = NULL) IMGUI_NOEXCEPT;
+    IMGUI_API ImFont*           AddFontFromMemoryTTF(void* font_data, int font_size, float size_pixels, const ImFontConfig* font_cfg = NULL, const ImWchar* glyph_ranges = NULL) IMGUI_NOEXCEPT; // Note: Transfer ownership of 'ttf_data' to ImFontAtlas! Will be deleted after destruction of the atlas. Set font_cfg->FontDataOwnedByAtlas=false to keep ownership of your data and it won't be freed.
+    IMGUI_API ImFont*           AddFontFromMemoryCompressedTTF(const void* compressed_font_data, int compressed_font_size, float size_pixels, const ImFontConfig* font_cfg = NULL, const ImWchar* glyph_ranges = NULL) IMGUI_NOEXCEPT; // 'compressed_font_data' still owned by caller. Compress with binary_to_compressed_c.cpp.
+    IMGUI_API ImFont*           AddFontFromMemoryCompressedBase85TTF(const char* compressed_font_data_base85, float size_pixels, const ImFontConfig* font_cfg = NULL, const ImWchar* glyph_ranges = NULL) IMGUI_NOEXCEPT;              // 'compressed_font_data_base85' still owned by caller. Compress with binary_to_compressed_c.cpp with -base85 parameter.
+    IMGUI_API void              ClearInputData() IMGUI_NOEXCEPT;  // Clear input data (all ImFontConfig structures including sizes, TTF data, glyph ranges, etc.) = all the data used to build the texture and fonts.
+    IMGUI_API void              ClearTexData()   IMGUI_NOEXCEPT;  // Clear output texture data (CPU side). Saves RAM once the texture has been copied to graphics memory.
+    IMGUI_API void              ClearFonts()     IMGUI_NOEXCEPT;  // Clear output font data (glyphs storage, UV coordinates).
+    IMGUI_API void              Clear()          IMGUI_NOEXCEPT;  // Clear all input and output.
 
     // Build atlas, retrieve pixel data.
     // User is in charge of copying the pixels into graphics memory (e.g. create a texture with your engine). Then store your texture handle with SetTexID().
     // The pitch is always = Width * BytesPerPixels (1 or 4)
     // Building in RGBA32 format is provided for convenience and compatibility, but note that unless you manually manipulate or copy color data into
     // the texture (e.g. when using the AddCustomRect*** api), then the RGB pixels emitted will always be white (~75% of memory/bandwidth waste.
-    IMGUI_API bool              Build();                    // Build pixels data. This is called automatically for you by the GetTexData*** functions.
-    IMGUI_API void              GetTexDataAsAlpha8(unsigned char** out_pixels, int* out_width, int* out_height, int* out_bytes_per_pixel = NULL);  // 1 byte per-pixel
-    IMGUI_API void              GetTexDataAsRGBA32(unsigned char** out_pixels, int* out_width, int* out_height, int* out_bytes_per_pixel = NULL);  // 4 bytes-per-pixel
-    bool                        IsBuilt() const             { return Fonts.Size > 0 && (TexPixelsAlpha8 != NULL || TexPixelsRGBA32 != NULL); }
-    void                        SetTexID(ImTextureID id)    { TexID = id; }
+    IMGUI_API bool              Build() IMGUI_NOEXCEPT;     // Build pixels data. This is called automatically for you by the GetTexData*** functions.
+    IMGUI_API void              GetTexDataAsAlpha8(unsigned char** out_pixels, int* out_width, int* out_height, int* out_bytes_per_pixel = NULL) IMGUI_NOEXCEPT;  // 1 byte per-pixel
+    IMGUI_API void              GetTexDataAsRGBA32(unsigned char** out_pixels, int* out_width, int* out_height, int* out_bytes_per_pixel = NULL) IMGUI_NOEXCEPT;  // 4 bytes-per-pixel
+    bool                        IsBuilt() const IMGUI_NOEXCEPT          { return Fonts.Size > 0 && (TexPixelsAlpha8 != NULL || TexPixelsRGBA32 != NULL); }
+    void                        SetTexID(ImTextureID id) IMGUI_NOEXCEPT { TexID = id; }
 
     //-------------------------------------------
     // Glyph Ranges
@@ -2623,14 +2630,14 @@ struct ImFontAtlas
     // Helpers to retrieve list of common Unicode ranges (2 value per range, values are inclusive, zero-terminated list)
     // NB: Make sure that your string are UTF-8 and NOT in your local code page. In C++11, you can create UTF-8 string literal using the u8"Hello world" syntax. See FAQ for details.
     // NB: Consider using ImFontGlyphRangesBuilder to build glyph ranges from textual data.
-    IMGUI_API const ImWchar*    GetGlyphRangesDefault();                // Basic Latin, Extended Latin
-    IMGUI_API const ImWchar*    GetGlyphRangesKorean();                 // Default + Korean characters
-    IMGUI_API const ImWchar*    GetGlyphRangesJapanese();               // Default + Hiragana, Katakana, Half-Width, Selection of 2999 Ideographs
-    IMGUI_API const ImWchar*    GetGlyphRangesChineseFull();            // Default + Half-Width + Japanese Hiragana/Katakana + full set of about 21000 CJK Unified Ideographs
-    IMGUI_API const ImWchar*    GetGlyphRangesChineseSimplifiedCommon();// Default + Half-Width + Japanese Hiragana/Katakana + set of 2500 CJK Unified Ideographs for common simplified Chinese
-    IMGUI_API const ImWchar*    GetGlyphRangesCyrillic();               // Default + about 400 Cyrillic characters
-    IMGUI_API const ImWchar*    GetGlyphRangesThai();                   // Default + Thai characters
-    IMGUI_API const ImWchar*    GetGlyphRangesVietnamese();             // Default + Vietnamese characters
+    IMGUI_API const ImWchar*    GetGlyphRangesDefault()                 IMGUI_NOEXCEPT;  // Basic Latin, Extended Latin
+    IMGUI_API const ImWchar*    GetGlyphRangesKorean()                  IMGUI_NOEXCEPT;  // Default + Korean characters
+    IMGUI_API const ImWchar*    GetGlyphRangesJapanese()                IMGUI_NOEXCEPT;  // Default + Hiragana, Katakana, Half-Width, Selection of 2999 Ideographs
+    IMGUI_API const ImWchar*    GetGlyphRangesChineseFull()             IMGUI_NOEXCEPT;  // Default + Half-Width + Japanese Hiragana/Katakana + full set of about 21000 CJK Unified Ideographs
+    IMGUI_API const ImWchar*    GetGlyphRangesChineseSimplifiedCommon() IMGUI_NOEXCEPT;  // Default + Half-Width + Japanese Hiragana/Katakana + set of 2500 CJK Unified Ideographs for common simplified Chinese
+    IMGUI_API const ImWchar*    GetGlyphRangesCyrillic()                IMGUI_NOEXCEPT;  // Default + about 400 Cyrillic characters
+    IMGUI_API const ImWchar*    GetGlyphRangesThai()                    IMGUI_NOEXCEPT;  // Default + Thai characters
+    IMGUI_API const ImWchar*    GetGlyphRangesVietnamese()              IMGUI_NOEXCEPT;  // Default + Vietnamese characters
 
     //-------------------------------------------
     // [BETA] Custom Rectangles/Glyphs API
@@ -2643,13 +2650,13 @@ struct ImFontAtlas
     //   so you can render e.g. custom colorful icons and use them as regular glyphs.
     // - Read docs/FONTS.md for more details about using colorful icons.
     // - Note: this API may be redesigned later in order to support multi-monitor varying DPI settings.
-    IMGUI_API int               AddCustomRectRegular(int width, int height);
-    IMGUI_API int               AddCustomRectFontGlyph(ImFont* font, ImWchar id, int width, int height, float advance_x, const ImVec2& offset = ImVec2(0, 0));
-    ImFontAtlasCustomRect*      GetCustomRectByIndex(int index) { IM_ASSERT(index >= 0); return &CustomRects[index]; }
+    IMGUI_API int               AddCustomRectRegular(int width, int height) IMGUI_NOEXCEPT;
+    IMGUI_API int               AddCustomRectFontGlyph(ImFont* font, ImWchar id, int width, int height, float advance_x, const ImVec2& offset = ImVec2(0, 0)) IMGUI_NOEXCEPT;
+    ImFontAtlasCustomRect*      GetCustomRectByIndex(int index) IMGUI_NOEXCEPT { IM_ASSERT(index >= 0); return &CustomRects[index]; }
 
     // [Internal]
-    IMGUI_API void              CalcCustomRectUV(const ImFontAtlasCustomRect* rect, ImVec2* out_uv_min, ImVec2* out_uv_max) const;
-    IMGUI_API bool              GetMouseCursorTexData(ImGuiMouseCursor cursor, ImVec2* out_offset, ImVec2* out_size, ImVec2 out_uv_border[2], ImVec2 out_uv_fill[2]);
+    IMGUI_API void              CalcCustomRectUV(const ImFontAtlasCustomRect* rect, ImVec2* out_uv_min, ImVec2* out_uv_max) const IMGUI_NOEXCEPT;
+    IMGUI_API bool              GetMouseCursorTexData(ImGuiMouseCursor cursor, ImVec2* out_offset, ImVec2* out_size, ImVec2 out_uv_border[2], ImVec2 out_uv_fill[2]) IMGUI_NOEXCEPT;
 
     //-------------------------------------------
     // Members
@@ -2716,30 +2723,30 @@ struct ImFont
     ImU8                        Used4kPagesMap[(IM_UNICODE_CODEPOINT_MAX+1)/4096/8]; // 2 bytes if ImWchar=ImWchar16, 34 bytes if ImWchar==ImWchar32. Store 1-bit for each block of 4K codepoints that has one active glyph. This is mainly used to facilitate iterations across all used codepoints.
 
     // Methods
-    IMGUI_API ImFont();
-    IMGUI_API ~ImFont();
-    IMGUI_API const ImFontGlyph*FindGlyph(ImWchar c) const;
-    IMGUI_API const ImFontGlyph*FindGlyphNoFallback(ImWchar c) const;
-    float                       GetCharAdvance(ImWchar c) const     { return ((int)c < IndexAdvanceX.Size) ? IndexAdvanceX[(int)c] : FallbackAdvanceX; }
-    bool                        IsLoaded() const                    { return ContainerAtlas != NULL; }
-    const char*                 GetDebugName() const                { return ConfigData ? ConfigData->Name : "<unknown>"; }
+    IMGUI_API ImFont()  IMGUI_NOEXCEPT;
+    IMGUI_API ~ImFont() IMGUI_NOEXCEPT;
+    IMGUI_API const ImFontGlyph*FindGlyph(ImWchar c) const           IMGUI_NOEXCEPT;
+    IMGUI_API const ImFontGlyph*FindGlyphNoFallback(ImWchar c) const IMGUI_NOEXCEPT;
+    float                       GetCharAdvance(ImWchar c) const      IMGUI_NOEXCEPT { return ((int)c < IndexAdvanceX.Size) ? IndexAdvanceX[(int)c] : FallbackAdvanceX; }
+    bool                        IsLoaded() const                     IMGUI_NOEXCEPT { return ContainerAtlas != NULL; }
+    const char*                 GetDebugName() const                 IMGUI_NOEXCEPT { return ConfigData ? ConfigData->Name : "<unknown>"; }
 
     // 'max_width' stops rendering after a certain width (could be turned into a 2d size). FLT_MAX to disable.
     // 'wrap_width' enable automatic word-wrapping across multiple lines to fit into given width. 0.0f to disable.
-    IMGUI_API ImVec2            CalcTextSizeA(float size, float max_width, float wrap_width, const char* text_begin, const char* text_end = NULL, const char** remaining = NULL) const; // utf8
-    IMGUI_API const char*       CalcWordWrapPositionA(float scale, const char* text, const char* text_end, float wrap_width) const;
-    IMGUI_API void              RenderChar(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col, ImWchar c) const;
-    IMGUI_API void              RenderText(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col, const ImVec4& clip_rect, const char* text_begin, const char* text_end, float wrap_width = 0.0f, bool cpu_fine_clip = false) const;
+    IMGUI_API ImVec2            CalcTextSizeA(float size, float max_width, float wrap_width, const char* text_begin, const char* text_end = NULL, const char** remaining = NULL) const IMGUI_NOEXCEPT; // utf8
+    IMGUI_API const char*       CalcWordWrapPositionA(float scale, const char* text, const char* text_end, float wrap_width) const IMGUI_NOEXCEPT;
+    IMGUI_API void              RenderChar(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col, ImWchar c) const IMGUI_NOEXCEPT;
+    IMGUI_API void              RenderText(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col, const ImVec4& clip_rect, const char* text_begin, const char* text_end, float wrap_width = 0.0f, bool cpu_fine_clip = false) const IMGUI_NOEXCEPT;
 
     // [Internal] Don't use!
-    IMGUI_API void              BuildLookupTable();
-    IMGUI_API void              ClearOutputData();
-    IMGUI_API void              GrowIndex(int new_size);
-    IMGUI_API void              AddGlyph(const ImFontConfig* src_cfg, ImWchar c, float x0, float y0, float x1, float y1, float u0, float v0, float u1, float v1, float advance_x);
-    IMGUI_API void              AddRemapChar(ImWchar dst, ImWchar src, bool overwrite_dst = true); // Makes 'dst' character/glyph points to 'src' character/glyph. Currently needs to be called AFTER fonts have been built.
-    IMGUI_API void              SetGlyphVisible(ImWchar c, bool visible);
-    IMGUI_API void              SetFallbackChar(ImWchar c);
-    IMGUI_API bool              IsGlyphRangeUnused(unsigned int c_begin, unsigned int c_last);
+    IMGUI_API void              BuildLookupTable() IMGUI_NOEXCEPT;
+    IMGUI_API void              ClearOutputData() IMGUI_NOEXCEPT;
+    IMGUI_API void              GrowIndex(int new_size) IMGUI_NOEXCEPT;
+    IMGUI_API void              AddGlyph(const ImFontConfig* src_cfg, ImWchar c, float x0, float y0, float x1, float y1, float u0, float v0, float u1, float v1, float advance_x) IMGUI_NOEXCEPT;
+    IMGUI_API void              AddRemapChar(ImWchar dst, ImWchar src, bool overwrite_dst = true) IMGUI_NOEXCEPT; // Makes 'dst' character/glyph points to 'src' character/glyph. Currently needs to be called AFTER fonts have been built.
+    IMGUI_API void              SetGlyphVisible(ImWchar c, bool visible) IMGUI_NOEXCEPT;
+    IMGUI_API void              SetFallbackChar(ImWchar c) IMGUI_NOEXCEPT;
+    IMGUI_API bool              IsGlyphRangeUnused(unsigned int c_begin, unsigned int c_last) IMGUI_NOEXCEPT;
 };
 
 //-----------------------------------------------------------------------------
@@ -2770,11 +2777,11 @@ struct ImGuiViewport
     ImVec2              WorkPos;                // Work Area: Position of the viewport minus task bars, menus bars, status bars (>= Pos)
     ImVec2              WorkSize;               // Work Area: Size of the viewport minus task bars, menu bars, status bars (<= Size)
 
-    ImGuiViewport()     { memset(this, 0, sizeof(*this)); }
+    ImGuiViewport() IMGUI_NOEXCEPT { memset(this, 0, sizeof(*this)); }
 
     // Helpers
-    ImVec2              GetCenter() const       { return ImVec2(Pos.x + Size.x * 0.5f, Pos.y + Size.y * 0.5f); }
-    ImVec2              GetWorkCenter() const   { return ImVec2(WorkPos.x + WorkSize.x * 0.5f, WorkPos.y + WorkSize.y * 0.5f); }
+    ImVec2              GetCenter() const     IMGUI_NOEXCEPT   { return ImVec2(Pos.x + Size.x * 0.5f, Pos.y + Size.y * 0.5f); }
+    ImVec2              GetWorkCenter() const IMGUI_NOEXCEPT   { return ImVec2(WorkPos.x + WorkSize.x * 0.5f, WorkPos.y + WorkSize.y * 0.5f); }
 };
 
 //-----------------------------------------------------------------------------
@@ -2787,36 +2794,36 @@ struct ImGuiViewport
 namespace ImGui
 {
     // OBSOLETED in 1.81 (from February 2021)
-    IMGUI_API bool      ListBoxHeader(const char* label, int items_count, int height_in_items = -1); // Helper to calculate size from items_count and height_in_items
-    static inline bool  ListBoxHeader(const char* label, const ImVec2& size = ImVec2(0, 0)) { return BeginListBox(label, size); }
-    static inline void  ListBoxFooter() { EndListBox(); }
+    IMGUI_API bool      ListBoxHeader(const char* label, int items_count, int height_in_items = -1) IMGUI_NOEXCEPT; // Helper to calculate size from items_count and height_in_items
+    static inline bool  ListBoxHeader(const char* label, const ImVec2& size = ImVec2(0, 0)) IMGUI_NOEXCEPT { return BeginListBox(label, size); }
+    static inline void  ListBoxFooter() IMGUI_NOEXCEPT { EndListBox(); }
     // OBSOLETED in 1.79 (from August 2020)
-    static inline void  OpenPopupContextItem(const char* str_id = NULL, ImGuiMouseButton mb = 1) { OpenPopupOnItemClick(str_id, mb); } // Bool return value removed. Use IsWindowAppearing() in BeginPopup() instead. Renamed in 1.77, renamed back in 1.79. Sorry!
+    static inline void  OpenPopupContextItem(const char* str_id = NULL, ImGuiMouseButton mb = 1) IMGUI_NOEXCEPT { OpenPopupOnItemClick(str_id, mb); } // Bool return value removed. Use IsWindowAppearing() in BeginPopup() instead. Renamed in 1.77, renamed back in 1.79. Sorry!
     // OBSOLETED in 1.78 (from June 2020)
     // Old drag/sliders functions that took a 'float power = 1.0' argument instead of flags.
     // For shared code, you can version check at compile-time with `#if IMGUI_VERSION_NUM >= 17704`.
-    IMGUI_API bool      DragScalar(const char* label, ImGuiDataType data_type, void* p_data, float v_speed, const void* p_min, const void* p_max, const char* format, float power);
-    IMGUI_API bool      DragScalarN(const char* label, ImGuiDataType data_type, void* p_data, int components, float v_speed, const void* p_min, const void* p_max, const char* format, float power);
-    static inline bool  DragFloat(const char* label, float* v, float v_speed, float v_min, float v_max, const char* format, float power)    { return DragScalar(label, ImGuiDataType_Float, v, v_speed, &v_min, &v_max, format, power); }
-    static inline bool  DragFloat2(const char* label, float v[2], float v_speed, float v_min, float v_max, const char* format, float power) { return DragScalarN(label, ImGuiDataType_Float, v, 2, v_speed, &v_min, &v_max, format, power); }
-    static inline bool  DragFloat3(const char* label, float v[3], float v_speed, float v_min, float v_max, const char* format, float power) { return DragScalarN(label, ImGuiDataType_Float, v, 3, v_speed, &v_min, &v_max, format, power); }
-    static inline bool  DragFloat4(const char* label, float v[4], float v_speed, float v_min, float v_max, const char* format, float power) { return DragScalarN(label, ImGuiDataType_Float, v, 4, v_speed, &v_min, &v_max, format, power); }
-    IMGUI_API bool      SliderScalar(const char* label, ImGuiDataType data_type, void* p_data, const void* p_min, const void* p_max, const char* format, float power);
-    IMGUI_API bool      SliderScalarN(const char* label, ImGuiDataType data_type, void* p_data, int components, const void* p_min, const void* p_max, const char* format, float power);
-    static inline bool  SliderFloat(const char* label, float* v, float v_min, float v_max, const char* format, float power)                 { return SliderScalar(label, ImGuiDataType_Float, v, &v_min, &v_max, format, power); }
-    static inline bool  SliderFloat2(const char* label, float v[2], float v_min, float v_max, const char* format, float power)              { return SliderScalarN(label, ImGuiDataType_Float, v, 2, &v_min, &v_max, format, power); }
-    static inline bool  SliderFloat3(const char* label, float v[3], float v_min, float v_max, const char* format, float power)              { return SliderScalarN(label, ImGuiDataType_Float, v, 3, &v_min, &v_max, format, power); }
-    static inline bool  SliderFloat4(const char* label, float v[4], float v_min, float v_max, const char* format, float power)              { return SliderScalarN(label, ImGuiDataType_Float, v, 4, &v_min, &v_max, format, power); }
+    IMGUI_API bool      DragScalar(const char* label, ImGuiDataType data_type, void* p_data, float v_speed, const void* p_min, const void* p_max, const char* format, float power) IMGUI_NOEXCEPT;
+    IMGUI_API bool      DragScalarN(const char* label, ImGuiDataType data_type, void* p_data, int components, float v_speed, const void* p_min, const void* p_max, const char* format, float power) IMGUI_NOEXCEPT;
+    static inline bool  DragFloat(const char* label, float* v, float v_speed, float v_min, float v_max, const char* format, float power)    IMGUI_NOEXCEPT { return DragScalar(label, ImGuiDataType_Float, v, v_speed, &v_min, &v_max, format, power); }
+    static inline bool  DragFloat2(const char* label, float v[2], float v_speed, float v_min, float v_max, const char* format, float power) IMGUI_NOEXCEPT { return DragScalarN(label, ImGuiDataType_Float, v, 2, v_speed, &v_min, &v_max, format, power); }
+    static inline bool  DragFloat3(const char* label, float v[3], float v_speed, float v_min, float v_max, const char* format, float power) IMGUI_NOEXCEPT { return DragScalarN(label, ImGuiDataType_Float, v, 3, v_speed, &v_min, &v_max, format, power); }
+    static inline bool  DragFloat4(const char* label, float v[4], float v_speed, float v_min, float v_max, const char* format, float power) IMGUI_NOEXCEPT { return DragScalarN(label, ImGuiDataType_Float, v, 4, v_speed, &v_min, &v_max, format, power); }
+    IMGUI_API bool      SliderScalar(const char* label, ImGuiDataType data_type, void* p_data, const void* p_min, const void* p_max, const char* format, float power) IMGUI_NOEXCEPT;
+    IMGUI_API bool      SliderScalarN(const char* label, ImGuiDataType data_type, void* p_data, int components, const void* p_min, const void* p_max, const char* format, float power) IMGUI_NOEXCEPT;
+    static inline bool  SliderFloat(const char* label, float* v, float v_min, float v_max, const char* format, float power)                 IMGUI_NOEXCEPT  { return SliderScalar(label, ImGuiDataType_Float, v, &v_min, &v_max, format, power); }
+    static inline bool  SliderFloat2(const char* label, float v[2], float v_min, float v_max, const char* format, float power)              IMGUI_NOEXCEPT  { return SliderScalarN(label, ImGuiDataType_Float, v, 2, &v_min, &v_max, format, power); }
+    static inline bool  SliderFloat3(const char* label, float v[3], float v_min, float v_max, const char* format, float power)              IMGUI_NOEXCEPT  { return SliderScalarN(label, ImGuiDataType_Float, v, 3, &v_min, &v_max, format, power); }
+    static inline bool  SliderFloat4(const char* label, float v[4], float v_min, float v_max, const char* format, float power)              IMGUI_NOEXCEPT  { return SliderScalarN(label, ImGuiDataType_Float, v, 4, &v_min, &v_max, format, power); }
     // OBSOLETED in 1.77 (from June 2020)
-    static inline bool  BeginPopupContextWindow(const char* str_id, ImGuiMouseButton mb, bool over_items) { return BeginPopupContextWindow(str_id, mb | (over_items ? 0 : ImGuiPopupFlags_NoOpenOverItems)); }
+    static inline bool  BeginPopupContextWindow(const char* str_id, ImGuiMouseButton mb, bool over_items) IMGUI_NOEXCEPT { return BeginPopupContextWindow(str_id, mb | (over_items ? 0 : ImGuiPopupFlags_NoOpenOverItems)); }
     // OBSOLETED in 1.72 (from April 2019)
-    static inline void  TreeAdvanceToLabelPos()             { SetCursorPosX(GetCursorPosX() + GetTreeNodeToLabelSpacing()); }
+    static inline void  TreeAdvanceToLabelPos() IMGUI_NOEXCEPT { SetCursorPosX(GetCursorPosX() + GetTreeNodeToLabelSpacing()); }
     // OBSOLETED in 1.71 (from June 2019)
-    static inline void  SetNextTreeNodeOpen(bool open, ImGuiCond cond = 0) { SetNextItemOpen(open, cond); }
+    static inline void  SetNextTreeNodeOpen(bool open, ImGuiCond cond = 0) IMGUI_NOEXCEPT { SetNextItemOpen(open, cond); }
     // OBSOLETED in 1.70 (from May 2019)
-    static inline float GetContentRegionAvailWidth()        { return GetContentRegionAvail().x; }
+    static inline float GetContentRegionAvailWidth() IMGUI_NOEXCEPT{ return GetContentRegionAvail().x; }
     // OBSOLETED in 1.69 (from Mar 2019)
-    static inline ImDrawList* GetOverlayDrawList()          { return GetForegroundDrawList(); }
+    static inline ImDrawList* GetOverlayDrawList() IMGUI_NOEXCEPT{ return GetForegroundDrawList(); }
 }
 
 // OBSOLETED in 1.82 (from Mars 2021): flags for AddRect(), AddRectFilled(), AddImageRounded(), PathRect()

--- a/imgui.h
+++ b/imgui.h
@@ -46,6 +46,11 @@ Index of this file:
 #include "imconfig.h"
 #endif
 
+// If you want to use the 'noexcept' specifier, #define IMGUI_NOEX
+#ifndef IMGUI_NOEXCEPT
+# define IMGUI_NOEXCEPT
+#endif
+
 #ifndef IMGUI_DISABLE
 
 //-----------------------------------------------------------------------------
@@ -316,8 +321,8 @@ namespace ImGui
     //    BeginPopup/EndPopup, etc. where the EndXXX call should only be called if the corresponding BeginXXX function
     //    returned true. Begin and BeginChild are the only odd ones out. Will be fixed in a future update.]
     // - Note that the bottom of window stack always contains a window called "Debug".
-    IMGUI_API bool          Begin(const char* name, bool* p_open = NULL, ImGuiWindowFlags flags = 0);
-    IMGUI_API void          End();
+    IMGUI_API bool          Begin(const char* name, bool* p_open = NULL, ImGuiWindowFlags flags = 0) IMGUI_NOEXCEPT;
+    IMGUI_API void          End() IMGUI_NOEXCEPT;
 
     // Child Windows
     // - Use child windows to begin into a self-contained independent scrolling/clipping regions within a host window. Child windows can embed their own child.
@@ -327,9 +332,9 @@ namespace ImGui
     //   [Important: due to legacy reason, this is inconsistent with most other functions such as BeginMenu/EndMenu,
     //    BeginPopup/EndPopup, etc. where the EndXXX call should only be called if the corresponding BeginXXX function
     //    returned true. Begin and BeginChild are the only odd ones out. Will be fixed in a future update.]
-    IMGUI_API bool          BeginChild(const char* str_id, const ImVec2& size = ImVec2(0, 0), bool border = false, ImGuiWindowFlags flags = 0);
-    IMGUI_API bool          BeginChild(ImGuiID id, const ImVec2& size = ImVec2(0, 0), bool border = false, ImGuiWindowFlags flags = 0);
-    IMGUI_API void          EndChild();
+    IMGUI_API bool          BeginChild(const char* str_id, const ImVec2& size = ImVec2(0, 0), bool border = false, ImGuiWindowFlags flags = 0) IMGUI_NOEXCEPT;
+    IMGUI_API bool          BeginChild(ImGuiID id, const ImVec2& size = ImVec2(0, 0), bool border = false, ImGuiWindowFlags flags = 0) IMGUI_NOEXCEPT;
+    IMGUI_API void          EndChild() IMGUI_NOEXCEPT;
 
     // Windows Utilities
     // - 'current window' = the window we are appending into while inside a Begin()/End() block. 'next window' = next window we will Begin() into.
@@ -427,8 +432,8 @@ namespace ImGui
     IMGUI_API void          Dummy(const ImVec2& size);                                      // add a dummy item of given size. unlike InvisibleButton(), Dummy() won't take the mouse click or be navigable into.
     IMGUI_API void          Indent(float indent_w = 0.0f);                                  // move content position toward the right, by indent_w, or style.IndentSpacing if indent_w <= 0
     IMGUI_API void          Unindent(float indent_w = 0.0f);                                // move content position back to the left, by indent_w, or style.IndentSpacing if indent_w <= 0
-    IMGUI_API void          BeginGroup();                                                   // lock horizontal starting position
-    IMGUI_API void          EndGroup();                                                     // unlock horizontal starting position + capture the whole group bounding box into one "item" (so you can use IsItemHovered() or layout primitives such as SameLine() on whole group, etc.)
+    IMGUI_API void          BeginGroup() IMGUI_NOEXCEPT;                                    // lock horizontal starting position
+    IMGUI_API void          EndGroup() IMGUI_NOEXCEPT;                                      // unlock horizontal starting position + capture the whole group bounding box into one "item" (so you can use IsItemHovered() or layout primitives such as SameLine() on whole group, etc.)
     IMGUI_API ImVec2        GetCursorPos();                                                 // cursor position in window coordinates (relative to window position)
     IMGUI_API float         GetCursorPosX();                                                //   (some functions are using window-relative coordinates, such as: GetCursorPos, GetCursorStartPos, GetContentRegionMax, GetWindowContentRegion* etc.
     IMGUI_API float         GetCursorPosY();                                                //    other functions such as GetCursorScreenPos or everything in ImDrawList::
@@ -495,8 +500,8 @@ namespace ImGui
     // Widgets: Combo Box
     // - The BeginCombo()/EndCombo() api allows you to manage your contents and selection state however you want it, by creating e.g. Selectable() items.
     // - The old Combo() api are helpers over BeginCombo()/EndCombo() which are kept available for convenience purpose. This is analogous to how ListBox are created.
-    IMGUI_API bool          BeginCombo(const char* label, const char* preview_value, ImGuiComboFlags flags = 0);
-    IMGUI_API void          EndCombo(); // only call EndCombo() if BeginCombo() returns true!
+    IMGUI_API bool          BeginCombo(const char* label, const char* preview_value, ImGuiComboFlags flags = 0) IMGUI_NOEXCEPT;
+    IMGUI_API void          EndCombo() IMGUI_NOEXCEPT; // only call EndCombo() if BeginCombo() returns true!
     IMGUI_API bool          Combo(const char* label, int* current_item, const char* const items[], int items_count, int popup_max_height_in_items = -1);
     IMGUI_API bool          Combo(const char* label, int* current_item, const char* items_separated_by_zeros, int popup_max_height_in_items = -1);      // Separate items with \0 within a string, end item-list with \0\0. e.g. "One\0Two\0Three\0"
     IMGUI_API bool          Combo(const char* label, int* current_item, bool(*items_getter)(void* data, int idx, const char** out_text), void* data, int items_count, int popup_max_height_in_items = -1);
@@ -606,8 +611,8 @@ namespace ImGui
     // - The simplified/old ListBox() api are helpers over BeginListBox()/EndListBox() which are kept available for convenience purpose. This is analoguous to how Combos are created.
     // - Choose frame width:   size.x > 0.0f: custom  /  size.x < 0.0f or -FLT_MIN: right-align   /  size.x = 0.0f (default): use current ItemWidth
     // - Choose frame height:  size.y > 0.0f: custom  /  size.y < 0.0f or -FLT_MIN: bottom-align  /  size.y = 0.0f (default): arbitrary default height which can fit ~7 items
-    IMGUI_API bool          BeginListBox(const char* label, const ImVec2& size = ImVec2(0, 0)); // open a framed scrolling region
-    IMGUI_API void          EndListBox();                                                       // only call EndListBox() if BeginListBox() returned true!
+    IMGUI_API bool          BeginListBox(const char* label, const ImVec2& size = ImVec2(0, 0)) IMGUI_NOEXCEPT; // open a framed scrolling region
+    IMGUI_API void          EndListBox() IMGUI_NOEXCEPT;                                                       // only call EndListBox() if BeginListBox() returned true!
     IMGUI_API bool          ListBox(const char* label, int* current_item, const char* const items[], int items_count, int height_in_items = -1);
     IMGUI_API bool          ListBox(const char* label, int* current_item, bool (*items_getter)(void* data, int idx, const char** out_text), void* data, int items_count, int height_in_items = -1);
 
@@ -630,19 +635,19 @@ namespace ImGui
     // - Use BeginMainMenuBar() to create a menu bar at the top of the screen and append to it.
     // - Use BeginMenu() to create a menu. You can call BeginMenu() multiple time with the same identifier to append more items to it.
     // - Not that MenuItem() keyboardshortcuts are displayed as a convenience but _not processed_ by Dear ImGui at the moment.
-    IMGUI_API bool          BeginMenuBar();                                                     // append to menu-bar of current window (requires ImGuiWindowFlags_MenuBar flag set on parent window).
-    IMGUI_API void          EndMenuBar();                                                       // only call EndMenuBar() if BeginMenuBar() returns true!
-    IMGUI_API bool          BeginMainMenuBar();                                                 // create and append to a full screen menu-bar.
-    IMGUI_API void          EndMainMenuBar();                                                   // only call EndMainMenuBar() if BeginMainMenuBar() returns true!
-    IMGUI_API bool          BeginMenu(const char* label, bool enabled = true);                  // create a sub-menu entry. only call EndMenu() if this returns true!
-    IMGUI_API void          EndMenu();                                                          // only call EndMenu() if BeginMenu() returns true!
+    IMGUI_API bool          BeginMenuBar() IMGUI_NOEXCEPT;                                                                         // append to menu-bar of current window (requires ImGuiWindowFlags_MenuBar flag set on parent window).
+    IMGUI_API void          EndMenuBar() IMGUI_NOEXCEPT;                                                                           // only call EndMenuBar() if BeginMenuBar() returns true!
+    IMGUI_API bool          BeginMainMenuBar() IMGUI_NOEXCEPT;                                                                     // create and append to a full screen menu-bar.
+    IMGUI_API void          EndMainMenuBar() IMGUI_NOEXCEPT;                                                                       // only call EndMainMenuBar() if BeginMainMenuBar() returns true!
+    IMGUI_API bool          BeginMenu(const char* label, bool enabled = true) IMGUI_NOEXCEPT;                                      // create a sub-menu entry. only call EndMenu() if this returns true!
+    IMGUI_API void          EndMenu() IMGUI_NOEXCEPT;                                                          					   // only call EndMenu() if BeginMenu() returns true!
     IMGUI_API bool          MenuItem(const char* label, const char* shortcut = NULL, bool selected = false, bool enabled = true);  // return true when activated.
     IMGUI_API bool          MenuItem(const char* label, const char* shortcut, bool* p_selected, bool enabled = true);              // return true when activated + toggle (*p_selected) if p_selected != NULL
 
     // Tooltips
     // - Tooltip are windows following the mouse. They do not take focus away.
-    IMGUI_API void          BeginTooltip();                                                     // begin/append a tooltip window. to create full-featured tooltip (with any kind of items).
-    IMGUI_API void          EndTooltip();
+    IMGUI_API void          BeginTooltip() IMGUI_NOEXCEPT;                                      // begin/append a tooltip window. to create full-featured tooltip (with any kind of items).
+    IMGUI_API void          EndTooltip() IMGUI_NOEXCEPT;
     IMGUI_API void          SetTooltip(const char* fmt, ...) IM_FMTARGS(1);                     // set a text-only tooltip, typically use with ImGui::IsItemHovered(). override any previous call to SetTooltip().
     IMGUI_API void          SetTooltipV(const char* fmt, va_list args) IM_FMTLIST(1);
 
@@ -657,9 +662,9 @@ namespace ImGui
     // Popups: begin/end functions
     //  - BeginPopup(): query popup state, if open start appending into the window. Call EndPopup() afterwards. ImGuiWindowFlags are forwarded to the window.
     //  - BeginPopupModal(): block every interactions behind the window, cannot be closed by user, add a dimming background, has a title bar.
-    IMGUI_API bool          BeginPopup(const char* str_id, ImGuiWindowFlags flags = 0);                         // return true if the popup is open, and you can start outputting to it.
-    IMGUI_API bool          BeginPopupModal(const char* name, bool* p_open = NULL, ImGuiWindowFlags flags = 0); // return true if the modal is open, and you can start outputting to it.
-    IMGUI_API void          EndPopup();                                                                         // only call EndPopup() if BeginPopupXXX() returns true!
+    IMGUI_API bool          BeginPopup(const char* str_id, ImGuiWindowFlags flags = 0) IMGUI_NOEXCEPT;                         // return true if the popup is open, and you can start outputting to it.
+    IMGUI_API bool          BeginPopupModal(const char* name, bool* p_open = NULL, ImGuiWindowFlags flags = 0) IMGUI_NOEXCEPT; // return true if the modal is open, and you can start outputting to it.
+    IMGUI_API void          EndPopup() IMGUI_NOEXCEPT;                                                                         // only call EndPopup() if BeginPopupXXX() returns true!
     // Popups: open/close functions
     //  - OpenPopup(): set popup state to open. ImGuiPopupFlags are available for opening options.
     //  - If not modal: they can be closed by clicking anywhere outside them, or by pressing ESCAPE.
@@ -676,9 +681,9 @@ namespace ImGui
     //  - They are convenient to easily create context menus, hence the name.
     //  - IMPORTANT: Notice that BeginPopupContextXXX takes ImGuiPopupFlags just like OpenPopup() and unlike BeginPopup(). For full consistency, we may add ImGuiWindowFlags to the BeginPopupContextXXX functions in the future.
     //  - IMPORTANT: we exceptionally default their flags to 1 (== ImGuiPopupFlags_MouseButtonRight) for backward compatibility with older API taking 'int mouse_button = 1' parameter, so if you add other flags remember to re-add the ImGuiPopupFlags_MouseButtonRight.
-    IMGUI_API bool          BeginPopupContextItem(const char* str_id = NULL, ImGuiPopupFlags popup_flags = 1);  // open+begin popup when clicked on last item. Use str_id==NULL to associate the popup to previous item. If you want to use that on a non-interactive item such as Text() you need to pass in an explicit ID here. read comments in .cpp!
-    IMGUI_API bool          BeginPopupContextWindow(const char* str_id = NULL, ImGuiPopupFlags popup_flags = 1);// open+begin popup when clicked on current window.
-    IMGUI_API bool          BeginPopupContextVoid(const char* str_id = NULL, ImGuiPopupFlags popup_flags = 1);  // open+begin popup when clicked in void (where there are no windows).
+    IMGUI_API bool          BeginPopupContextItem(const char* str_id = NULL, ImGuiPopupFlags popup_flags = 1) IMGUI_NOEXCEPT;  // open+begin popup when clicked on last item. Use str_id==NULL to associate the popup to previous item. If you want to use that on a non-interactive item such as Text() you need to pass in an explicit ID here. read comments in .cpp!
+    IMGUI_API bool          BeginPopupContextWindow(const char* str_id = NULL, ImGuiPopupFlags popup_flags = 1) IMGUI_NOEXCEPT;// open+begin popup when clicked on current window.
+    IMGUI_API bool          BeginPopupContextVoid(const char* str_id = NULL, ImGuiPopupFlags popup_flags = 1) IMGUI_NOEXCEPT;  // open+begin popup when clicked in void (where there are no windows).
     // Popups: query functions
     //  - IsPopupOpen(): return true if the popup is open at the current BeginPopup() level of the popup stack.
     //  - IsPopupOpen() with ImGuiPopupFlags_AnyPopupId: return true if any popup is open at the current BeginPopup() level of the popup stack.
@@ -710,8 +715,8 @@ namespace ImGui
     //        TableNextRow()                           -> Text("Hello 0")                                               // Not OK! Missing TableSetColumnIndex() or TableNextColumn()! Text will not appear!
     //        --------------------------------------------------------------------------------------------------------
     // - 5. Call EndTable()
-    IMGUI_API bool          BeginTable(const char* str_id, int column, ImGuiTableFlags flags = 0, const ImVec2& outer_size = ImVec2(0.0f, 0.0f), float inner_width = 0.0f);
-    IMGUI_API void          EndTable();                                 // only call EndTable() if BeginTable() returns true!
+    IMGUI_API bool          BeginTable(const char* str_id, int column, ImGuiTableFlags flags = 0, const ImVec2& outer_size = ImVec2(0.0f, 0.0f), float inner_width = 0.0f) IMGUI_NOEXCEPT;
+    IMGUI_API void          EndTable() IMGUI_NOEXCEPT;                                 // only call EndTable() if BeginTable() returns true!
     IMGUI_API void          TableNextRow(ImGuiTableRowFlags row_flags = 0, float min_row_height = 0.0f); // append into the first cell of a new row.
     IMGUI_API bool          TableNextColumn();                          // append into the next column (or first column of next row if currently in last column). Return true when column is visible.
     IMGUI_API bool          TableSetColumnIndex(int column_n);          // append into the specified column. Return true when column is visible.
@@ -756,12 +761,12 @@ namespace ImGui
     IMGUI_API int           GetColumnsCount();
 
     // Tab Bars, Tabs
-    IMGUI_API bool          BeginTabBar(const char* str_id, ImGuiTabBarFlags flags = 0);        // create and append into a TabBar
-    IMGUI_API void          EndTabBar();                                                        // only call EndTabBar() if BeginTabBar() returns true!
-    IMGUI_API bool          BeginTabItem(const char* label, bool* p_open = NULL, ImGuiTabItemFlags flags = 0); // create a Tab. Returns true if the Tab is selected.
-    IMGUI_API void          EndTabItem();                                                       // only call EndTabItem() if BeginTabItem() returns true!
-    IMGUI_API bool          TabItemButton(const char* label, ImGuiTabItemFlags flags = 0);      // create a Tab behaving like a button. return true when clicked. cannot be selected in the tab bar.
-    IMGUI_API void          SetTabItemClosed(const char* tab_or_docked_window_label);           // notify TabBar or Docking system of a closed tab/window ahead (useful to reduce visual flicker on reorderable tab bars). For tab-bar: call after BeginTabBar() and before Tab submissions. Otherwise call with a window name.
+    IMGUI_API bool          BeginTabBar(const char* str_id, ImGuiTabBarFlags flags = 0) IMGUI_NOEXCEPT;        // create and append into a TabBar
+    IMGUI_API void          EndTabBar() IMGUI_NOEXCEPT;                                                        // only call EndTabBar() if BeginTabBar() returns true!
+    IMGUI_API bool          BeginTabItem(const char* label, bool* p_open = NULL, ImGuiTabItemFlags flags = 0) IMGUI_NOEXCEPT;  // create a Tab. Returns true if the Tab is selected.
+    IMGUI_API void          EndTabItem() IMGUI_NOEXCEPT;                                                       // only call EndTabItem() if BeginTabItem() returns true!
+    IMGUI_API bool          TabItemButton(const char* label, ImGuiTabItemFlags flags = 0);                     // create a Tab behaving like a button. return true when clicked. cannot be selected in the tab bar.
+    IMGUI_API void          SetTabItemClosed(const char* tab_or_docked_window_label);                          // notify TabBar or Docking system of a closed tab/window ahead (useful to reduce visual flicker on reorderable tab bars). For tab-bar: call after BeginTabBar() and before Tab submissions. Otherwise call with a window name.
 
     // Logging/Capture
     // - All text output from the interface can be captured into tty/file/clipboard. By default, tree nodes are automatically opened during logging.
@@ -778,12 +783,12 @@ namespace ImGui
     // - On target candidates, call BeginDragDropTarget(), if it returns true also call AcceptDragDropPayload() + EndDragDropTarget().
     // - If you stop calling BeginDragDropSource() the payload is preserved however it won't have a preview tooltip (we currently display a fallback "..." tooltip, see #1725)
     // - An item can be both drag source and drop target.
-    IMGUI_API bool          BeginDragDropSource(ImGuiDragDropFlags flags = 0);                                      // call after submitting an item which may be dragged. when this return true, you can call SetDragDropPayload() + EndDragDropSource()
+    IMGUI_API bool          BeginDragDropSource(ImGuiDragDropFlags flags = 0) IMGUI_NOEXCEPT;                       // call after submitting an item which may be dragged. when this return true, you can call SetDragDropPayload() + EndDragDropSource()
     IMGUI_API bool          SetDragDropPayload(const char* type, const void* data, size_t sz, ImGuiCond cond = 0);  // type is a user defined string of maximum 32 characters. Strings starting with '_' are reserved for dear imgui internal types. Data is copied and held by imgui.
-    IMGUI_API void          EndDragDropSource();                                                                    // only call EndDragDropSource() if BeginDragDropSource() returns true!
-    IMGUI_API bool                  BeginDragDropTarget();                                                          // call after submitting an item that may receive a payload. If this returns true, you can call AcceptDragDropPayload() + EndDragDropTarget()
+    IMGUI_API void          EndDragDropSource() IMGUI_NOEXCEPT;                                                     // only call EndDragDropSource() if BeginDragDropSource() returns true!
+    IMGUI_API bool                  BeginDragDropTarget() IMGUI_NOEXCEPT;                                           // call after submitting an item that may receive a payload. If this returns true, you can call AcceptDragDropPayload() + EndDragDropTarget()
     IMGUI_API const ImGuiPayload*   AcceptDragDropPayload(const char* type, ImGuiDragDropFlags flags = 0);          // accept contents of a given type. If ImGuiDragDropFlags_AcceptBeforeDelivery is set you can peek into the payload before the mouse button is released.
-    IMGUI_API void                  EndDragDropTarget();                                                            // only call EndDragDropTarget() if BeginDragDropTarget() returns true!
+    IMGUI_API void                  EndDragDropTarget() IMGUI_NOEXCEPT;                                             // only call EndDragDropTarget() if BeginDragDropTarget() returns true!
     IMGUI_API const ImGuiPayload*   GetDragDropPayload();                                                           // peek directly into the current payload from anywhere. may return NULL. use ImGuiPayload::IsDataType() to test for the payload type.
 
     // Clipping
@@ -835,8 +840,8 @@ namespace ImGui
     IMGUI_API void          SetStateStorage(ImGuiStorage* storage);                             // replace current window storage with our own (if you want to manipulate it yourself, typically clear subsection of it)
     IMGUI_API ImGuiStorage* GetStateStorage();
     IMGUI_API void          CalcListClipping(int items_count, float items_height, int* out_items_display_start, int* out_items_display_end);    // calculate coarse clipping for large list of evenly sized items. Prefer using the ImGuiListClipper higher-level helper if you can.
-    IMGUI_API bool          BeginChildFrame(ImGuiID id, const ImVec2& size, ImGuiWindowFlags flags = 0); // helper to create a child window / scrolling region that looks like a normal widget frame
-    IMGUI_API void          EndChildFrame();                                                    // always call EndChildFrame() regardless of BeginChildFrame() return values (which indicates a collapsed/clipped window)
+    IMGUI_API bool          BeginChildFrame(ImGuiID id, const ImVec2& size, ImGuiWindowFlags flags = 0) IMGUI_NOEXCEPT;  // helper to create a child window / scrolling region that looks like a normal widget frame
+    IMGUI_API void          EndChildFrame() IMGUI_NOEXCEPT;                                     // always call EndChildFrame() regardless of BeginChildFrame() return values (which indicates a collapsed/clipped window)
 
     // Text Utilities
     IMGUI_API ImVec2        CalcTextSize(const char* text, const char* text_end = NULL, bool hide_text_after_double_hash = false, float wrap_width = -1.0f);
@@ -900,8 +905,8 @@ namespace ImGui
     //   for each static/DLL boundary you are calling from. Read "Context and Memory Allocators" section of imgui.cpp for more details.
     IMGUI_API void          SetAllocatorFunctions(ImGuiMemAllocFunc alloc_func, ImGuiMemFreeFunc free_func, void* user_data = NULL);
     IMGUI_API void          GetAllocatorFunctions(ImGuiMemAllocFunc* p_alloc_func, ImGuiMemFreeFunc* p_free_func, void** p_user_data);
-    IMGUI_API void*         MemAlloc(size_t size);
-    IMGUI_API void          MemFree(void* ptr);
+    IMGUI_API void*         MemAlloc(size_t size) IMGUI_NOEXCEPT;
+    IMGUI_API void          MemFree(void* ptr) IMGUI_NOEXCEPT;
 
 } // namespace ImGui
 
@@ -2151,8 +2156,8 @@ struct ImGuiListClipper
 
     // items_count: Use INT_MAX if you don't know how many items you have (in which case the cursor won't be advanced in the final step)
     // items_height: Use -1.0f to be calculated automatically on first step. Otherwise pass in the distance between your items, typically GetTextLineHeightWithSpacing() or GetFrameHeightWithSpacing().
-    IMGUI_API void Begin(int items_count, float items_height = -1.0f);  // Automatically called by constructor if you passed 'items_count' or by Step() in Step 1.
-    IMGUI_API void End();                                               // Automatically called on the last call of Step() that returns false.
+    IMGUI_API void Begin(int items_count, float items_height = -1.0f) IMGUI_NOEXCEPT;  // Automatically called by constructor if you passed 'items_count' or by Step() in Step 1.
+    IMGUI_API void End() IMGUI_NOEXCEPT;                                // Automatically called on the last call of Step() that returns false.
     IMGUI_API bool Step();                                              // Call until it returns false. The DisplayStart/DisplayEnd fields will be set and you can process/draw those items.
 
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -170,24 +170,24 @@ Index of this file:
 #if !defined(IMGUI_DISABLE_DEMO_WINDOWS)
 
 // Forward Declarations
-static void ShowExampleAppDocuments(bool* p_open);
-static void ShowExampleAppMainMenuBar();
-static void ShowExampleAppConsole(bool* p_open);
-static void ShowExampleAppLog(bool* p_open);
-static void ShowExampleAppLayout(bool* p_open);
-static void ShowExampleAppPropertyEditor(bool* p_open);
-static void ShowExampleAppLongText(bool* p_open);
-static void ShowExampleAppAutoResize(bool* p_open);
-static void ShowExampleAppConstrainedResize(bool* p_open);
-static void ShowExampleAppSimpleOverlay(bool* p_open);
-static void ShowExampleAppFullscreen(bool* p_open);
-static void ShowExampleAppWindowTitles(bool* p_open);
-static void ShowExampleAppCustomRendering(bool* p_open);
-static void ShowExampleMenuFile();
+static void ShowExampleAppDocuments(bool* p_open)         IMGUI_NOEXCEPT;
+static void ShowExampleAppMainMenuBar()                   IMGUI_NOEXCEPT;
+static void ShowExampleAppConsole(bool* p_open)           IMGUI_NOEXCEPT;
+static void ShowExampleAppLog(bool* p_open)               IMGUI_NOEXCEPT;
+static void ShowExampleAppLayout(bool* p_open)            IMGUI_NOEXCEPT;
+static void ShowExampleAppPropertyEditor(bool* p_open)    IMGUI_NOEXCEPT;
+static void ShowExampleAppLongText(bool* p_open)          IMGUI_NOEXCEPT;
+static void ShowExampleAppAutoResize(bool* p_open)        IMGUI_NOEXCEPT;
+static void ShowExampleAppConstrainedResize(bool* p_open) IMGUI_NOEXCEPT;
+static void ShowExampleAppSimpleOverlay(bool* p_open)     IMGUI_NOEXCEPT;
+static void ShowExampleAppFullscreen(bool* p_open)        IMGUI_NOEXCEPT;
+static void ShowExampleAppWindowTitles(bool* p_open)      IMGUI_NOEXCEPT;
+static void ShowExampleAppCustomRendering(bool* p_open)   IMGUI_NOEXCEPT;
+static void ShowExampleMenuFile()                         IMGUI_NOEXCEPT;
 
 // Helper to display a little (?) mark which shows a tooltip when hovered.
 // In your own code you may want to display an actual icon if you are using a merged icon fonts (see docs/FONTS.md)
-static void HelpMarker(const char* desc)
+static void HelpMarker(const char* desc) IMGUI_NOEXCEPT
 {
     ImGui::TextDisabled("(?)");
     if (ImGui::IsItemHovered())
@@ -201,7 +201,7 @@ static void HelpMarker(const char* desc)
 }
 
 // Helper to display basic user controls.
-void ImGui::ShowUserGuide()
+void ImGui::ShowUserGuide() IMGUI_NOEXCEPT
 {
     ImGuiIO& io = ImGui::GetIO();
     ImGui::BulletText("Double-click on title bar to collapse window.");
@@ -245,17 +245,17 @@ void ImGui::ShowUserGuide()
 
 // We split the contents of the big ShowDemoWindow() function into smaller functions
 // (because the link time of very large functions grow non-linearly)
-static void ShowDemoWindowWidgets();
-static void ShowDemoWindowLayout();
-static void ShowDemoWindowPopups();
-static void ShowDemoWindowTables();
-static void ShowDemoWindowColumns();
-static void ShowDemoWindowMisc();
+static void ShowDemoWindowWidgets() IMGUI_NOEXCEPT;
+static void ShowDemoWindowLayout()  IMGUI_NOEXCEPT;
+static void ShowDemoWindowPopups()  IMGUI_NOEXCEPT;
+static void ShowDemoWindowTables()  IMGUI_NOEXCEPT;
+static void ShowDemoWindowColumns() IMGUI_NOEXCEPT;
+static void ShowDemoWindowMisc()    IMGUI_NOEXCEPT;
 
 // Demonstrate most Dear ImGui features (this is big function!)
 // You may execute this function to experiment with the UI and understand what it does.
 // You may then search for keywords in the code when you are interested by a specific feature.
-void ImGui::ShowDemoWindow(bool* p_open)
+void ImGui::ShowDemoWindow(bool* p_open) IMGUI_NOEXCEPT
 {
     // Exceptionally add an extra assert here for people confused about initial Dear ImGui setup
     // Most ImGui functions would normally just crash if the context is missing.
@@ -525,7 +525,7 @@ void ImGui::ShowDemoWindow(bool* p_open)
     ImGui::End();
 }
 
-static void ShowDemoWindowWidgets()
+static void ShowDemoWindowWidgets() IMGUI_NOEXCEPT
 {
     if (!ImGui::CollapsingHeader("Widgets"))
         return;
@@ -2323,7 +2323,7 @@ static void ShowDemoWindowWidgets()
     }
 }
 
-static void ShowDemoWindowLayout()
+static void ShowDemoWindowLayout() IMGUI_NOEXCEPT
 {
     if (!ImGui::CollapsingHeader("Layout & Scrolling"))
         return;
@@ -3089,7 +3089,7 @@ static void ShowDemoWindowLayout()
     }
 }
 
-static void ShowDemoWindowPopups()
+static void ShowDemoWindowPopups() IMGUI_NOEXCEPT
 {
     if (!ImGui::CollapsingHeader("Popups & Modal windows"))
         return;
@@ -3439,20 +3439,20 @@ const ImGuiTableSortSpecs* MyItem::s_current_sort_specs = NULL;
 }
 
 // Make the UI compact because there are so many fields
-static void PushStyleCompact()
+static void PushStyleCompact() IMGUI_NOEXCEPT
 {
     ImGuiStyle& style = ImGui::GetStyle();
     ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(style.FramePadding.x, (float)(int)(style.FramePadding.y * 0.60f)));
     ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(style.ItemSpacing.x, (float)(int)(style.ItemSpacing.y * 0.60f)));
 }
 
-static void PopStyleCompact()
+static void PopStyleCompact() IMGUI_NOEXCEPT
 {
     ImGui::PopStyleVar(2);
 }
 
 // Show a combo box with a choice of sizing policies
-static void EditTableSizingFlags(ImGuiTableFlags* p_flags)
+static void EditTableSizingFlags(ImGuiTableFlags* p_flags) IMGUI_NOEXCEPT
 {
     struct EnumDesc { ImGuiTableFlags Value; const char* Name; const char* Tooltip; };
     static const EnumDesc policies[] =
@@ -3494,7 +3494,7 @@ static void EditTableSizingFlags(ImGuiTableFlags* p_flags)
     }
 }
 
-static void EditTableColumnsFlags(ImGuiTableColumnFlags* p_flags)
+static void EditTableColumnsFlags(ImGuiTableColumnFlags* p_flags) IMGUI_NOEXCEPT
 {
     ImGui::CheckboxFlags("_DefaultHide", p_flags, ImGuiTableColumnFlags_DefaultHide);
     ImGui::CheckboxFlags("_DefaultSort", p_flags, ImGuiTableColumnFlags_DefaultSort);
@@ -3516,7 +3516,7 @@ static void EditTableColumnsFlags(ImGuiTableColumnFlags* p_flags)
     ImGui::CheckboxFlags("_IndentDisable", p_flags, ImGuiTableColumnFlags_IndentDisable); ImGui::SameLine(); HelpMarker("Default for column >0");
 }
 
-static void ShowTableColumnsStatusFlags(ImGuiTableColumnFlags flags)
+static void ShowTableColumnsStatusFlags(ImGuiTableColumnFlags flags) IMGUI_NOEXCEPT
 {
     ImGui::CheckboxFlags("_IsEnabled", &flags, ImGuiTableColumnFlags_IsEnabled);
     ImGui::CheckboxFlags("_IsVisible", &flags, ImGuiTableColumnFlags_IsVisible);
@@ -3524,7 +3524,7 @@ static void ShowTableColumnsStatusFlags(ImGuiTableColumnFlags flags)
     ImGui::CheckboxFlags("_IsHovered", &flags, ImGuiTableColumnFlags_IsHovered);
 }
 
-static void ShowDemoWindowTables()
+static void ShowDemoWindowTables() IMGUI_NOEXCEPT
 {
     //ImGui::SetNextItemOpen(true, ImGuiCond_Once);
     if (!ImGui::CollapsingHeader("Tables & Columns"))
@@ -5226,7 +5226,7 @@ static void ShowDemoWindowTables()
 
 // Demonstrate old/legacy Columns API!
 // [2020: Columns are under-featured and not maintained. Prefer using the more flexible and powerful BeginTable() API!]
-static void ShowDemoWindowColumns()
+static void ShowDemoWindowColumns() IMGUI_NOEXCEPT
 {
     bool open = ImGui::TreeNode("Legacy Columns API");
     ImGui::SameLine();
@@ -5423,7 +5423,7 @@ static void ShowDemoWindowColumns()
     ImGui::TreePop();
 }
 
-static void ShowDemoWindowMisc()
+static void ShowDemoWindowMisc() IMGUI_NOEXCEPT
 {
     if (ImGui::CollapsingHeader("Filtering"))
     {
@@ -5606,7 +5606,7 @@ static void ShowDemoWindowMisc()
 // Access from Dear ImGui Demo -> Tools -> About
 //-----------------------------------------------------------------------------
 
-void ImGui::ShowAboutWindow(bool* p_open)
+void ImGui::ShowAboutWindow(bool* p_open) IMGUI_NOEXCEPT
 {
     if (!ImGui::Begin("About Dear ImGui", p_open, ImGuiWindowFlags_AlwaysAutoResize))
     {
@@ -5753,7 +5753,7 @@ void ImGui::ShowAboutWindow(bool* p_open)
 // Demo helper function to select among default colors. See ShowStyleEditor() for more advanced options.
 // Here we use the simplified Combo() api that packs items into a single literal string.
 // Useful for quick combo boxes where the choices are known locally.
-bool ImGui::ShowStyleSelector(const char* label)
+bool ImGui::ShowStyleSelector(const char* label) IMGUI_NOEXCEPT
 {
     static int style_idx = -1;
     if (ImGui::Combo(label, &style_idx, "Dark\0Light\0Classic\0"))
@@ -5771,7 +5771,7 @@ bool ImGui::ShowStyleSelector(const char* label)
 
 // Demo helper function to select among loaded fonts.
 // Here we use the regular BeginCombo()/EndCombo() api which is more the more flexible one.
-void ImGui::ShowFontSelector(const char* label)
+void ImGui::ShowFontSelector(const char* label) IMGUI_NOEXCEPT
 {
     ImGuiIO& io = ImGui::GetIO();
     ImFont* font_current = ImGui::GetFont();
@@ -5796,7 +5796,7 @@ void ImGui::ShowFontSelector(const char* label)
 }
 
 // [Internal] Display details for a single font, called by ShowStyleEditor().
-static void NodeFont(ImFont* font)
+static void NodeFont(ImFont* font) IMGUI_NOEXCEPT
 {
     ImGuiIO& io = ImGui::GetIO();
     ImGuiStyle& style = ImGui::GetStyle();
@@ -5883,7 +5883,7 @@ static void NodeFont(ImFont* font)
     ImGui::TreePop();
 }
 
-void ImGui::ShowStyleEditor(ImGuiStyle* ref)
+void ImGui::ShowStyleEditor(ImGuiStyle* ref) IMGUI_NOEXCEPT
 {
     // You can pass in a reference ImGuiStyle structure to compare to, revert to and save to
     // (without a reference style pointer, we will use one compared locally as a reference)
@@ -6153,7 +6153,7 @@ void ImGui::ShowStyleEditor(ImGuiStyle* ref)
 // Note the difference between BeginMainMenuBar() and BeginMenuBar():
 // - BeginMenuBar() = menu-bar inside current window (which needs the ImGuiWindowFlags_MenuBar flag!)
 // - BeginMainMenuBar() = helper to create menu-bar-sized window at the top of the main viewport + call BeginMenuBar() into it.
-static void ShowExampleAppMainMenuBar()
+static void ShowExampleAppMainMenuBar() IMGUI_NOEXCEPT
 {
     if (ImGui::BeginMainMenuBar())
     {
@@ -6178,7 +6178,7 @@ static void ShowExampleAppMainMenuBar()
 
 // Note that shortcuts are currently provided for display only
 // (future version will add explicit flags to BeginMenu() to request processing shortcuts)
-static void ShowExampleMenuFile()
+static void ShowExampleMenuFile() IMGUI_NOEXCEPT
 {
     ImGui::MenuItem("(demo menu)", NULL, false, false);
     if (ImGui::MenuItem("New")) {}
@@ -6271,7 +6271,7 @@ struct ExampleAppConsole
     bool                  AutoScroll;
     bool                  ScrollToBottom;
 
-    ExampleAppConsole()
+    ExampleAppConsole() IMGUI_NOEXCEPT
     {
         ClearLog();
         memset(InputBuf, 0, sizeof(InputBuf));
@@ -6286,7 +6286,7 @@ struct ExampleAppConsole
         ScrollToBottom = false;
         AddLog("Welcome to Dear ImGui!");
     }
-    ~ExampleAppConsole()
+    ~ExampleAppConsole() IMGUI_NOEXCEPT
     {
         ClearLog();
         for (int i = 0; i < History.Size; i++)
@@ -6294,19 +6294,19 @@ struct ExampleAppConsole
     }
 
     // Portable helpers
-    static int   Stricmp(const char* s1, const char* s2)         { int d; while ((d = toupper(*s2) - toupper(*s1)) == 0 && *s1) { s1++; s2++; } return d; }
-    static int   Strnicmp(const char* s1, const char* s2, int n) { int d = 0; while (n > 0 && (d = toupper(*s2) - toupper(*s1)) == 0 && *s1) { s1++; s2++; n--; } return d; }
-    static char* Strdup(const char* s)                           { IM_ASSERT(s); size_t len = strlen(s) + 1; void* buf = malloc(len); IM_ASSERT(buf); return (char*)memcpy(buf, (const void*)s, len); }
-    static void  Strtrim(char* s)                                { char* str_end = s + strlen(s); while (str_end > s && str_end[-1] == ' ') str_end--; *str_end = 0; }
+    static int   Stricmp(const char* s1, const char* s2)         IMGUI_NOEXCEPT { int d; while ((d = toupper(*s2) - toupper(*s1)) == 0 && *s1) { s1++; s2++; } return d; }
+    static int   Strnicmp(const char* s1, const char* s2, int n) IMGUI_NOEXCEPT { int d = 0; while (n > 0 && (d = toupper(*s2) - toupper(*s1)) == 0 && *s1) { s1++; s2++; n--; } return d; }
+    static char* Strdup(const char* s)                           IMGUI_NOEXCEPT { IM_ASSERT(s); size_t len = strlen(s) + 1; void* buf = malloc(len); IM_ASSERT(buf); return (char*)memcpy(buf, (const void*)s, len); }
+    static void  Strtrim(char* s)                                IMGUI_NOEXCEPT { char* str_end = s + strlen(s); while (str_end > s && str_end[-1] == ' ') str_end--; *str_end = 0; }
 
-    void    ClearLog()
+    void    ClearLog() IMGUI_NOEXCEPT
     {
         for (int i = 0; i < Items.Size; i++)
             free(Items[i]);
         Items.clear();
     }
 
-    void    AddLog(const char* fmt, ...) IM_FMTARGS(2)
+    void    AddLog(const char* fmt, ...) IM_FMTARGS(2) IMGUI_NOEXCEPT
     {
         // FIXME-OPT
         char buf[1024];
@@ -6318,7 +6318,7 @@ struct ExampleAppConsole
         Items.push_back(Strdup(buf));
     }
 
-    void    Draw(const char* title, bool* p_open)
+    void    Draw(const char* title, bool* p_open) IMGUI_NOEXCEPT
     {
         ImGui::SetNextWindowSize(ImVec2(520, 600), ImGuiCond_FirstUseEver);
         if (!ImGui::Begin(title, p_open))
@@ -6455,7 +6455,7 @@ struct ExampleAppConsole
         ImGui::End();
     }
 
-    void    ExecCommand(const char* command_line)
+    void    ExecCommand(const char* command_line) IMGUI_NOEXCEPT
     {
         AddLog("# %s\n", command_line);
 
@@ -6498,13 +6498,13 @@ struct ExampleAppConsole
     }
 
     // In C++11 you'd be better off using lambdas for this sort of forwarding callbacks
-    static int TextEditCallbackStub(ImGuiInputTextCallbackData* data)
+    static int TextEditCallbackStub(ImGuiInputTextCallbackData* data) IMGUI_NOEXCEPT
     {
         ExampleAppConsole* console = (ExampleAppConsole*)data->UserData;
         return console->TextEditCallback(data);
     }
 
-    int     TextEditCallback(ImGuiInputTextCallbackData* data)
+    int     TextEditCallback(ImGuiInputTextCallbackData* data) IMGUI_NOEXCEPT
     {
         //AddLog("cursor: %d, selection: %d-%d", data->CursorPos, data->SelectionStart, data->SelectionEnd);
         switch (data->EventFlag)
@@ -6606,7 +6606,7 @@ struct ExampleAppConsole
     }
 };
 
-static void ShowExampleAppConsole(bool* p_open)
+static void ShowExampleAppConsole(bool* p_open) IMGUI_NOEXCEPT
 {
     static ExampleAppConsole console;
     console.Draw("Example: Console", p_open);
@@ -6627,20 +6627,20 @@ struct ExampleAppLog
     ImVector<int>       LineOffsets; // Index to lines offset. We maintain this with AddLog() calls.
     bool                AutoScroll;  // Keep scrolling if already at the bottom.
 
-    ExampleAppLog()
+    ExampleAppLog() IMGUI_NOEXCEPT
     {
         AutoScroll = true;
         Clear();
     }
 
-    void    Clear()
+    void    Clear() IMGUI_NOEXCEPT
     {
         Buf.clear();
         LineOffsets.clear();
         LineOffsets.push_back(0);
     }
 
-    void    AddLog(const char* fmt, ...) IM_FMTARGS(2)
+    void    AddLog(const char* fmt, ...) IM_FMTARGS(2) IMGUI_NOEXCEPT
     {
         int old_size = Buf.size();
         va_list args;
@@ -6652,7 +6652,7 @@ struct ExampleAppLog
                 LineOffsets.push_back(old_size + 1);
     }
 
-    void    Draw(const char* title, bool* p_open = NULL)
+    void    Draw(const char* title, bool* p_open = NULL) IMGUI_NOEXCEPT
     {
         if (!ImGui::Begin(title, p_open))
         {
@@ -6741,7 +6741,7 @@ struct ExampleAppLog
 };
 
 // Demonstrate creating a simple log window with basic filtering.
-static void ShowExampleAppLog(bool* p_open)
+static void ShowExampleAppLog(bool* p_open) IMGUI_NOEXCEPT
 {
     static ExampleAppLog log;
 
@@ -6775,7 +6775,7 @@ static void ShowExampleAppLog(bool* p_open)
 //-----------------------------------------------------------------------------
 
 // Demonstrate create a window with multiple child windows.
-static void ShowExampleAppLayout(bool* p_open)
+static void ShowExampleAppLayout(bool* p_open) IMGUI_NOEXCEPT
 {
     ImGui::SetNextWindowSize(ImVec2(500, 440), ImGuiCond_FirstUseEver);
     if (ImGui::Begin("Example: Simple layout", p_open, ImGuiWindowFlags_MenuBar))
@@ -6839,7 +6839,7 @@ static void ShowExampleAppLayout(bool* p_open)
 // [SECTION] Example App: Property Editor / ShowExampleAppPropertyEditor()
 //-----------------------------------------------------------------------------
 
-static void ShowPlaceholderObject(const char* prefix, int uid)
+static void ShowPlaceholderObject(const char* prefix, int uid) IMGUI_NOEXCEPT
 {
     // Use object uid as identifier. Most commonly you could also use the object pointer as a base ID.
     ImGui::PushID(uid);
@@ -6887,7 +6887,7 @@ static void ShowPlaceholderObject(const char* prefix, int uid)
 }
 
 // Demonstrate create a simple property editor.
-static void ShowExampleAppPropertyEditor(bool* p_open)
+static void ShowExampleAppPropertyEditor(bool* p_open) IMGUI_NOEXCEPT
 {
     ImGui::SetNextWindowSize(ImVec2(430, 450), ImGuiCond_FirstUseEver);
     if (!ImGui::Begin("Example: Property editor", p_open))
@@ -6922,7 +6922,7 @@ static void ShowExampleAppPropertyEditor(bool* p_open)
 //-----------------------------------------------------------------------------
 
 // Demonstrate/test rendering huge amount of text, and the incidence of clipping.
-static void ShowExampleAppLongText(bool* p_open)
+static void ShowExampleAppLongText(bool* p_open) IMGUI_NOEXCEPT
 {
     ImGui::SetNextWindowSize(ImVec2(520, 600), ImGuiCond_FirstUseEver);
     if (!ImGui::Begin("Example: Long text display", p_open))
@@ -6984,7 +6984,7 @@ static void ShowExampleAppLongText(bool* p_open)
 //-----------------------------------------------------------------------------
 
 // Demonstrate creating a window which gets auto-resized according to its content.
-static void ShowExampleAppAutoResize(bool* p_open)
+static void ShowExampleAppAutoResize(bool* p_open) IMGUI_NOEXCEPT
 {
     if (!ImGui::Begin("Example: Auto-resizing window", p_open, ImGuiWindowFlags_AlwaysAutoResize))
     {
@@ -7008,7 +7008,7 @@ static void ShowExampleAppAutoResize(bool* p_open)
 //-----------------------------------------------------------------------------
 
 // Demonstrate creating a window with custom resize constraints.
-static void ShowExampleAppConstrainedResize(bool* p_open)
+static void ShowExampleAppConstrainedResize(bool* p_open) IMGUI_NOEXCEPT
 {
     struct CustomConstraints
     {
@@ -7062,7 +7062,7 @@ static void ShowExampleAppConstrainedResize(bool* p_open)
 
 // Demonstrate creating a simple static window with no decoration
 // + a context-menu to choose which corner of the screen to use.
-static void ShowExampleAppSimpleOverlay(bool* p_open)
+static void ShowExampleAppSimpleOverlay(bool* p_open) IMGUI_NOEXCEPT
 {
     const float PAD = 10.0f;
     static int corner = 0;
@@ -7109,7 +7109,7 @@ static void ShowExampleAppSimpleOverlay(bool* p_open)
 //-----------------------------------------------------------------------------
 
 // Demonstrate creating a window covering the entire screen/viewport
-static void ShowExampleAppFullscreen(bool* p_open)
+static void ShowExampleAppFullscreen(bool* p_open) IMGUI_NOEXCEPT
 {
     static bool use_work_area = true;
     static ImGuiWindowFlags flags = ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoSavedSettings;
@@ -7147,7 +7147,7 @@ static void ShowExampleAppFullscreen(bool* p_open)
 // Demonstrate using "##" and "###" in identifiers to manipulate ID generation.
 // This apply to all regular items as well.
 // Read FAQ section "How can I have multiple widgets with the same label?" for details.
-static void ShowExampleAppWindowTitles(bool*)
+static void ShowExampleAppWindowTitles(bool*) IMGUI_NOEXCEPT
 {
     const ImGuiViewport* viewport = ImGui::GetMainViewport();
     const ImVec2 base_pos = viewport->Pos;
@@ -7180,7 +7180,7 @@ static void ShowExampleAppWindowTitles(bool*)
 //-----------------------------------------------------------------------------
 
 // Demonstrate using the low-level ImDrawList to draw custom shapes.
-static void ShowExampleAppCustomRendering(bool* p_open)
+static void ShowExampleAppCustomRendering(bool* p_open) IMGUI_NOEXCEPT
 {
     if (!ImGui::Begin("Example: Custom rendering", p_open))
     {
@@ -7430,7 +7430,7 @@ struct MyDocument
     bool        WantClose;  // Set when the document
     ImVec4      Color;      // An arbitrary variable associated to the document
 
-    MyDocument(const char* name, bool open = true, const ImVec4& color = ImVec4(1.0f, 1.0f, 1.0f, 1.0f))
+    MyDocument(const char* name, bool open = true, const ImVec4& color = ImVec4(1.0f, 1.0f, 1.0f, 1.0f)) IMGUI_NOEXCEPT
     {
         Name = name;
         Open = OpenPrev = open;
@@ -7438,13 +7438,13 @@ struct MyDocument
         WantClose = false;
         Color = color;
     }
-    void DoOpen()       { Open = true; }
-    void DoQueueClose() { WantClose = true; }
-    void DoForceClose() { Open = false; Dirty = false; }
-    void DoSave()       { Dirty = false; }
+    void DoOpen()       IMGUI_NOEXCEPT { Open = true; }
+    void DoQueueClose() IMGUI_NOEXCEPT { WantClose = true; }
+    void DoForceClose() IMGUI_NOEXCEPT { Open = false; Dirty = false; }
+    void DoSave()       IMGUI_NOEXCEPT { Dirty = false; }
 
     // Display placeholder contents for the Document
-    static void DisplayContents(MyDocument* doc)
+    static void DisplayContents(MyDocument* doc) IMGUI_NOEXCEPT
     {
         ImGui::PushID(doc);
         ImGui::Text("Document \"%s\"", doc->Name);
@@ -7461,7 +7461,7 @@ struct MyDocument
     }
 
     // Display context menu for the Document
-    static void DisplayContextMenu(MyDocument* doc)
+    static void DisplayContextMenu(MyDocument* doc) IMGUI_NOEXCEPT
     {
         if (!ImGui::BeginPopupContextItem())
             return;
@@ -7480,7 +7480,7 @@ struct ExampleAppDocuments
 {
     ImVector<MyDocument> Documents;
 
-    ExampleAppDocuments()
+    ExampleAppDocuments() IMGUI_NOEXCEPT
     {
         Documents.push_back(MyDocument("Lettuce",             true,  ImVec4(0.4f, 0.8f, 0.4f, 1.0f)));
         Documents.push_back(MyDocument("Eggplant",            true,  ImVec4(0.8f, 0.5f, 1.0f, 1.0f)));
@@ -7499,7 +7499,7 @@ struct ExampleAppDocuments
 // give the impression of a flicker for one frame.
 // We call SetTabItemClosed() to manually notify the Tab Bar or Docking system of removed tabs to avoid this glitch.
 // Note that this completely optional, and only affect tab bars with the ImGuiTabBarFlags_Reorderable flag.
-static void NotifyOfDocumentsClosedElsewhere(ExampleAppDocuments& app)
+static void NotifyOfDocumentsClosedElsewhere(ExampleAppDocuments& app) IMGUI_NOEXCEPT
 {
     for (int doc_n = 0; doc_n < app.Documents.Size; doc_n++)
     {
@@ -7510,7 +7510,7 @@ static void NotifyOfDocumentsClosedElsewhere(ExampleAppDocuments& app)
     }
 }
 
-void ShowExampleAppDocuments(bool* p_open)
+void ShowExampleAppDocuments(bool* p_open) IMGUI_NOEXCEPT
 {
     static ExampleAppDocuments app;
 
@@ -7694,10 +7694,10 @@ void ShowExampleAppDocuments(bool* p_open)
 // End of Demo code
 #else
 
-void ImGui::ShowAboutWindow(bool*) {}
-void ImGui::ShowDemoWindow(bool*) {}
-void ImGui::ShowUserGuide() {}
-void ImGui::ShowStyleEditor(ImGuiStyle*) {}
+void ImGui::ShowAboutWindow(bool*) IMGUI_NOEXCEPT {}
+void ImGui::ShowDemoWindow(bool*) IMGUI_NOEXCEPT {}
+void ImGui::ShowUserGuide() IMGUI_NOEXCEPT {}
+void ImGui::ShowStyleEditor(ImGuiStyle*) IMGUI_NOEXCEPT {}
 
 #endif
 

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -170,24 +170,24 @@ Index of this file:
 #if !defined(IMGUI_DISABLE_DEMO_WINDOWS)
 
 // Forward Declarations
-static void ShowExampleAppDocuments(bool* p_open)         IMGUI_NOEXCEPT;
-static void ShowExampleAppMainMenuBar()                   IMGUI_NOEXCEPT;
-static void ShowExampleAppConsole(bool* p_open)           IMGUI_NOEXCEPT;
-static void ShowExampleAppLog(bool* p_open)               IMGUI_NOEXCEPT;
-static void ShowExampleAppLayout(bool* p_open)            IMGUI_NOEXCEPT;
-static void ShowExampleAppPropertyEditor(bool* p_open)    IMGUI_NOEXCEPT;
-static void ShowExampleAppLongText(bool* p_open)          IMGUI_NOEXCEPT;
-static void ShowExampleAppAutoResize(bool* p_open)        IMGUI_NOEXCEPT;
-static void ShowExampleAppConstrainedResize(bool* p_open) IMGUI_NOEXCEPT;
-static void ShowExampleAppSimpleOverlay(bool* p_open)     IMGUI_NOEXCEPT;
-static void ShowExampleAppFullscreen(bool* p_open)        IMGUI_NOEXCEPT;
-static void ShowExampleAppWindowTitles(bool* p_open)      IMGUI_NOEXCEPT;
-static void ShowExampleAppCustomRendering(bool* p_open)   IMGUI_NOEXCEPT;
-static void ShowExampleMenuFile()                         IMGUI_NOEXCEPT;
+static void ShowExampleAppDocuments(bool* p_open)         IM_NOEXCEPT;
+static void ShowExampleAppMainMenuBar()                   IM_NOEXCEPT;
+static void ShowExampleAppConsole(bool* p_open)           IM_NOEXCEPT;
+static void ShowExampleAppLog(bool* p_open)               IM_NOEXCEPT;
+static void ShowExampleAppLayout(bool* p_open)            IM_NOEXCEPT;
+static void ShowExampleAppPropertyEditor(bool* p_open)    IM_NOEXCEPT;
+static void ShowExampleAppLongText(bool* p_open)          IM_NOEXCEPT;
+static void ShowExampleAppAutoResize(bool* p_open)        IM_NOEXCEPT;
+static void ShowExampleAppConstrainedResize(bool* p_open) IM_NOEXCEPT;
+static void ShowExampleAppSimpleOverlay(bool* p_open)     IM_NOEXCEPT;
+static void ShowExampleAppFullscreen(bool* p_open)        IM_NOEXCEPT;
+static void ShowExampleAppWindowTitles(bool* p_open)      IM_NOEXCEPT;
+static void ShowExampleAppCustomRendering(bool* p_open)   IM_NOEXCEPT;
+static void ShowExampleMenuFile()                         IM_NOEXCEPT;
 
 // Helper to display a little (?) mark which shows a tooltip when hovered.
 // In your own code you may want to display an actual icon if you are using a merged icon fonts (see docs/FONTS.md)
-static void HelpMarker(const char* desc) IMGUI_NOEXCEPT
+static void HelpMarker(const char* desc) IM_NOEXCEPT
 {
     ImGui::TextDisabled("(?)");
     if (ImGui::IsItemHovered())
@@ -201,7 +201,7 @@ static void HelpMarker(const char* desc) IMGUI_NOEXCEPT
 }
 
 // Helper to display basic user controls.
-void ImGui::ShowUserGuide() IMGUI_NOEXCEPT
+void ImGui::ShowUserGuide() IM_NOEXCEPT
 {
     ImGuiIO& io = ImGui::GetIO();
     ImGui::BulletText("Double-click on title bar to collapse window.");
@@ -245,17 +245,17 @@ void ImGui::ShowUserGuide() IMGUI_NOEXCEPT
 
 // We split the contents of the big ShowDemoWindow() function into smaller functions
 // (because the link time of very large functions grow non-linearly)
-static void ShowDemoWindowWidgets() IMGUI_NOEXCEPT;
-static void ShowDemoWindowLayout()  IMGUI_NOEXCEPT;
-static void ShowDemoWindowPopups()  IMGUI_NOEXCEPT;
-static void ShowDemoWindowTables()  IMGUI_NOEXCEPT;
-static void ShowDemoWindowColumns() IMGUI_NOEXCEPT;
-static void ShowDemoWindowMisc()    IMGUI_NOEXCEPT;
+static void ShowDemoWindowWidgets() IM_NOEXCEPT;
+static void ShowDemoWindowLayout()  IM_NOEXCEPT;
+static void ShowDemoWindowPopups()  IM_NOEXCEPT;
+static void ShowDemoWindowTables()  IM_NOEXCEPT;
+static void ShowDemoWindowColumns() IM_NOEXCEPT;
+static void ShowDemoWindowMisc()    IM_NOEXCEPT;
 
 // Demonstrate most Dear ImGui features (this is big function!)
 // You may execute this function to experiment with the UI and understand what it does.
 // You may then search for keywords in the code when you are interested by a specific feature.
-void ImGui::ShowDemoWindow(bool* p_open) IMGUI_NOEXCEPT
+void ImGui::ShowDemoWindow(bool* p_open) IM_NOEXCEPT
 {
     // Exceptionally add an extra assert here for people confused about initial Dear ImGui setup
     // Most ImGui functions would normally just crash if the context is missing.
@@ -525,7 +525,7 @@ void ImGui::ShowDemoWindow(bool* p_open) IMGUI_NOEXCEPT
     ImGui::End();
 }
 
-static void ShowDemoWindowWidgets() IMGUI_NOEXCEPT
+static void ShowDemoWindowWidgets() IM_NOEXCEPT
 {
     if (!ImGui::CollapsingHeader("Widgets"))
         return;
@@ -2323,7 +2323,7 @@ static void ShowDemoWindowWidgets() IMGUI_NOEXCEPT
     }
 }
 
-static void ShowDemoWindowLayout() IMGUI_NOEXCEPT
+static void ShowDemoWindowLayout() IM_NOEXCEPT
 {
     if (!ImGui::CollapsingHeader("Layout & Scrolling"))
         return;
@@ -3089,7 +3089,7 @@ static void ShowDemoWindowLayout() IMGUI_NOEXCEPT
     }
 }
 
-static void ShowDemoWindowPopups() IMGUI_NOEXCEPT
+static void ShowDemoWindowPopups() IM_NOEXCEPT
 {
     if (!ImGui::CollapsingHeader("Popups & Modal windows"))
         return;
@@ -3439,20 +3439,20 @@ const ImGuiTableSortSpecs* MyItem::s_current_sort_specs = NULL;
 }
 
 // Make the UI compact because there are so many fields
-static void PushStyleCompact() IMGUI_NOEXCEPT
+static void PushStyleCompact() IM_NOEXCEPT
 {
     ImGuiStyle& style = ImGui::GetStyle();
     ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(style.FramePadding.x, (float)(int)(style.FramePadding.y * 0.60f)));
     ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(style.ItemSpacing.x, (float)(int)(style.ItemSpacing.y * 0.60f)));
 }
 
-static void PopStyleCompact() IMGUI_NOEXCEPT
+static void PopStyleCompact() IM_NOEXCEPT
 {
     ImGui::PopStyleVar(2);
 }
 
 // Show a combo box with a choice of sizing policies
-static void EditTableSizingFlags(ImGuiTableFlags* p_flags) IMGUI_NOEXCEPT
+static void EditTableSizingFlags(ImGuiTableFlags* p_flags) IM_NOEXCEPT
 {
     struct EnumDesc { ImGuiTableFlags Value; const char* Name; const char* Tooltip; };
     static const EnumDesc policies[] =
@@ -3494,7 +3494,7 @@ static void EditTableSizingFlags(ImGuiTableFlags* p_flags) IMGUI_NOEXCEPT
     }
 }
 
-static void EditTableColumnsFlags(ImGuiTableColumnFlags* p_flags) IMGUI_NOEXCEPT
+static void EditTableColumnsFlags(ImGuiTableColumnFlags* p_flags) IM_NOEXCEPT
 {
     ImGui::CheckboxFlags("_DefaultHide", p_flags, ImGuiTableColumnFlags_DefaultHide);
     ImGui::CheckboxFlags("_DefaultSort", p_flags, ImGuiTableColumnFlags_DefaultSort);
@@ -3516,7 +3516,7 @@ static void EditTableColumnsFlags(ImGuiTableColumnFlags* p_flags) IMGUI_NOEXCEPT
     ImGui::CheckboxFlags("_IndentDisable", p_flags, ImGuiTableColumnFlags_IndentDisable); ImGui::SameLine(); HelpMarker("Default for column >0");
 }
 
-static void ShowTableColumnsStatusFlags(ImGuiTableColumnFlags flags) IMGUI_NOEXCEPT
+static void ShowTableColumnsStatusFlags(ImGuiTableColumnFlags flags) IM_NOEXCEPT
 {
     ImGui::CheckboxFlags("_IsEnabled", &flags, ImGuiTableColumnFlags_IsEnabled);
     ImGui::CheckboxFlags("_IsVisible", &flags, ImGuiTableColumnFlags_IsVisible);
@@ -3524,7 +3524,7 @@ static void ShowTableColumnsStatusFlags(ImGuiTableColumnFlags flags) IMGUI_NOEXC
     ImGui::CheckboxFlags("_IsHovered", &flags, ImGuiTableColumnFlags_IsHovered);
 }
 
-static void ShowDemoWindowTables() IMGUI_NOEXCEPT
+static void ShowDemoWindowTables() IM_NOEXCEPT
 {
     //ImGui::SetNextItemOpen(true, ImGuiCond_Once);
     if (!ImGui::CollapsingHeader("Tables & Columns"))
@@ -5226,7 +5226,7 @@ static void ShowDemoWindowTables() IMGUI_NOEXCEPT
 
 // Demonstrate old/legacy Columns API!
 // [2020: Columns are under-featured and not maintained. Prefer using the more flexible and powerful BeginTable() API!]
-static void ShowDemoWindowColumns() IMGUI_NOEXCEPT
+static void ShowDemoWindowColumns() IM_NOEXCEPT
 {
     bool open = ImGui::TreeNode("Legacy Columns API");
     ImGui::SameLine();
@@ -5423,7 +5423,7 @@ static void ShowDemoWindowColumns() IMGUI_NOEXCEPT
     ImGui::TreePop();
 }
 
-static void ShowDemoWindowMisc() IMGUI_NOEXCEPT
+static void ShowDemoWindowMisc() IM_NOEXCEPT
 {
     if (ImGui::CollapsingHeader("Filtering"))
     {
@@ -5606,7 +5606,7 @@ static void ShowDemoWindowMisc() IMGUI_NOEXCEPT
 // Access from Dear ImGui Demo -> Tools -> About
 //-----------------------------------------------------------------------------
 
-void ImGui::ShowAboutWindow(bool* p_open) IMGUI_NOEXCEPT
+void ImGui::ShowAboutWindow(bool* p_open) IM_NOEXCEPT
 {
     if (!ImGui::Begin("About Dear ImGui", p_open, ImGuiWindowFlags_AlwaysAutoResize))
     {
@@ -5753,7 +5753,7 @@ void ImGui::ShowAboutWindow(bool* p_open) IMGUI_NOEXCEPT
 // Demo helper function to select among default colors. See ShowStyleEditor() for more advanced options.
 // Here we use the simplified Combo() api that packs items into a single literal string.
 // Useful for quick combo boxes where the choices are known locally.
-bool ImGui::ShowStyleSelector(const char* label) IMGUI_NOEXCEPT
+bool ImGui::ShowStyleSelector(const char* label) IM_NOEXCEPT
 {
     static int style_idx = -1;
     if (ImGui::Combo(label, &style_idx, "Dark\0Light\0Classic\0"))
@@ -5771,7 +5771,7 @@ bool ImGui::ShowStyleSelector(const char* label) IMGUI_NOEXCEPT
 
 // Demo helper function to select among loaded fonts.
 // Here we use the regular BeginCombo()/EndCombo() api which is more the more flexible one.
-void ImGui::ShowFontSelector(const char* label) IMGUI_NOEXCEPT
+void ImGui::ShowFontSelector(const char* label) IM_NOEXCEPT
 {
     ImGuiIO& io = ImGui::GetIO();
     ImFont* font_current = ImGui::GetFont();
@@ -5796,7 +5796,7 @@ void ImGui::ShowFontSelector(const char* label) IMGUI_NOEXCEPT
 }
 
 // [Internal] Display details for a single font, called by ShowStyleEditor().
-static void NodeFont(ImFont* font) IMGUI_NOEXCEPT
+static void NodeFont(ImFont* font) IM_NOEXCEPT
 {
     ImGuiIO& io = ImGui::GetIO();
     ImGuiStyle& style = ImGui::GetStyle();
@@ -5883,7 +5883,7 @@ static void NodeFont(ImFont* font) IMGUI_NOEXCEPT
     ImGui::TreePop();
 }
 
-void ImGui::ShowStyleEditor(ImGuiStyle* ref) IMGUI_NOEXCEPT
+void ImGui::ShowStyleEditor(ImGuiStyle* ref) IM_NOEXCEPT
 {
     // You can pass in a reference ImGuiStyle structure to compare to, revert to and save to
     // (without a reference style pointer, we will use one compared locally as a reference)
@@ -6153,7 +6153,7 @@ void ImGui::ShowStyleEditor(ImGuiStyle* ref) IMGUI_NOEXCEPT
 // Note the difference between BeginMainMenuBar() and BeginMenuBar():
 // - BeginMenuBar() = menu-bar inside current window (which needs the ImGuiWindowFlags_MenuBar flag!)
 // - BeginMainMenuBar() = helper to create menu-bar-sized window at the top of the main viewport + call BeginMenuBar() into it.
-static void ShowExampleAppMainMenuBar() IMGUI_NOEXCEPT
+static void ShowExampleAppMainMenuBar() IM_NOEXCEPT
 {
     if (ImGui::BeginMainMenuBar())
     {
@@ -6178,7 +6178,7 @@ static void ShowExampleAppMainMenuBar() IMGUI_NOEXCEPT
 
 // Note that shortcuts are currently provided for display only
 // (future version will add explicit flags to BeginMenu() to request processing shortcuts)
-static void ShowExampleMenuFile() IMGUI_NOEXCEPT
+static void ShowExampleMenuFile() IM_NOEXCEPT
 {
     ImGui::MenuItem("(demo menu)", NULL, false, false);
     if (ImGui::MenuItem("New")) {}
@@ -6271,7 +6271,7 @@ struct ExampleAppConsole
     bool                  AutoScroll;
     bool                  ScrollToBottom;
 
-    ExampleAppConsole() IMGUI_NOEXCEPT
+    ExampleAppConsole() IM_NOEXCEPT
     {
         ClearLog();
         memset(InputBuf, 0, sizeof(InputBuf));
@@ -6286,7 +6286,7 @@ struct ExampleAppConsole
         ScrollToBottom = false;
         AddLog("Welcome to Dear ImGui!");
     }
-    ~ExampleAppConsole() IMGUI_NOEXCEPT
+    ~ExampleAppConsole() IM_NOEXCEPT
     {
         ClearLog();
         for (int i = 0; i < History.Size; i++)
@@ -6294,19 +6294,19 @@ struct ExampleAppConsole
     }
 
     // Portable helpers
-    static int   Stricmp(const char* s1, const char* s2)         IMGUI_NOEXCEPT { int d; while ((d = toupper(*s2) - toupper(*s1)) == 0 && *s1) { s1++; s2++; } return d; }
-    static int   Strnicmp(const char* s1, const char* s2, int n) IMGUI_NOEXCEPT { int d = 0; while (n > 0 && (d = toupper(*s2) - toupper(*s1)) == 0 && *s1) { s1++; s2++; n--; } return d; }
-    static char* Strdup(const char* s)                           IMGUI_NOEXCEPT { IM_ASSERT(s); size_t len = strlen(s) + 1; void* buf = malloc(len); IM_ASSERT(buf); return (char*)memcpy(buf, (const void*)s, len); }
-    static void  Strtrim(char* s)                                IMGUI_NOEXCEPT { char* str_end = s + strlen(s); while (str_end > s && str_end[-1] == ' ') str_end--; *str_end = 0; }
+    static int   Stricmp(const char* s1, const char* s2)         IM_NOEXCEPT { int d; while ((d = toupper(*s2) - toupper(*s1)) == 0 && *s1) { s1++; s2++; } return d; }
+    static int   Strnicmp(const char* s1, const char* s2, int n) IM_NOEXCEPT { int d = 0; while (n > 0 && (d = toupper(*s2) - toupper(*s1)) == 0 && *s1) { s1++; s2++; n--; } return d; }
+    static char* Strdup(const char* s)                           IM_NOEXCEPT { IM_ASSERT(s); size_t len = strlen(s) + 1; void* buf = malloc(len); IM_ASSERT(buf); return (char*)memcpy(buf, (const void*)s, len); }
+    static void  Strtrim(char* s)                                IM_NOEXCEPT { char* str_end = s + strlen(s); while (str_end > s && str_end[-1] == ' ') str_end--; *str_end = 0; }
 
-    void    ClearLog() IMGUI_NOEXCEPT
+    void    ClearLog() IM_NOEXCEPT
     {
         for (int i = 0; i < Items.Size; i++)
             free(Items[i]);
         Items.clear();
     }
 
-    void    AddLog(const char* fmt, ...) IM_FMTARGS(2) IMGUI_NOEXCEPT
+    void    AddLog(const char* fmt, ...) IM_FMTARGS(2) IM_NOEXCEPT
     {
         // FIXME-OPT
         char buf[1024];
@@ -6318,7 +6318,7 @@ struct ExampleAppConsole
         Items.push_back(Strdup(buf));
     }
 
-    void    Draw(const char* title, bool* p_open) IMGUI_NOEXCEPT
+    void    Draw(const char* title, bool* p_open) IM_NOEXCEPT
     {
         ImGui::SetNextWindowSize(ImVec2(520, 600), ImGuiCond_FirstUseEver);
         if (!ImGui::Begin(title, p_open))
@@ -6455,7 +6455,7 @@ struct ExampleAppConsole
         ImGui::End();
     }
 
-    void    ExecCommand(const char* command_line) IMGUI_NOEXCEPT
+    void    ExecCommand(const char* command_line) IM_NOEXCEPT
     {
         AddLog("# %s\n", command_line);
 
@@ -6498,13 +6498,13 @@ struct ExampleAppConsole
     }
 
     // In C++11 you'd be better off using lambdas for this sort of forwarding callbacks
-    static int TextEditCallbackStub(ImGuiInputTextCallbackData* data) IMGUI_NOEXCEPT
+    static int TextEditCallbackStub(ImGuiInputTextCallbackData* data) IM_NOEXCEPT
     {
         ExampleAppConsole* console = (ExampleAppConsole*)data->UserData;
         return console->TextEditCallback(data);
     }
 
-    int     TextEditCallback(ImGuiInputTextCallbackData* data) IMGUI_NOEXCEPT
+    int     TextEditCallback(ImGuiInputTextCallbackData* data) IM_NOEXCEPT
     {
         //AddLog("cursor: %d, selection: %d-%d", data->CursorPos, data->SelectionStart, data->SelectionEnd);
         switch (data->EventFlag)
@@ -6606,7 +6606,7 @@ struct ExampleAppConsole
     }
 };
 
-static void ShowExampleAppConsole(bool* p_open) IMGUI_NOEXCEPT
+static void ShowExampleAppConsole(bool* p_open) IM_NOEXCEPT
 {
     static ExampleAppConsole console;
     console.Draw("Example: Console", p_open);
@@ -6627,20 +6627,20 @@ struct ExampleAppLog
     ImVector<int>       LineOffsets; // Index to lines offset. We maintain this with AddLog() calls.
     bool                AutoScroll;  // Keep scrolling if already at the bottom.
 
-    ExampleAppLog() IMGUI_NOEXCEPT
+    ExampleAppLog() IM_NOEXCEPT
     {
         AutoScroll = true;
         Clear();
     }
 
-    void    Clear() IMGUI_NOEXCEPT
+    void    Clear() IM_NOEXCEPT
     {
         Buf.clear();
         LineOffsets.clear();
         LineOffsets.push_back(0);
     }
 
-    void    AddLog(const char* fmt, ...) IM_FMTARGS(2) IMGUI_NOEXCEPT
+    void    AddLog(const char* fmt, ...) IM_FMTARGS(2) IM_NOEXCEPT
     {
         int old_size = Buf.size();
         va_list args;
@@ -6652,7 +6652,7 @@ struct ExampleAppLog
                 LineOffsets.push_back(old_size + 1);
     }
 
-    void    Draw(const char* title, bool* p_open = NULL) IMGUI_NOEXCEPT
+    void    Draw(const char* title, bool* p_open = NULL) IM_NOEXCEPT
     {
         if (!ImGui::Begin(title, p_open))
         {
@@ -6741,7 +6741,7 @@ struct ExampleAppLog
 };
 
 // Demonstrate creating a simple log window with basic filtering.
-static void ShowExampleAppLog(bool* p_open) IMGUI_NOEXCEPT
+static void ShowExampleAppLog(bool* p_open) IM_NOEXCEPT
 {
     static ExampleAppLog log;
 
@@ -6775,7 +6775,7 @@ static void ShowExampleAppLog(bool* p_open) IMGUI_NOEXCEPT
 //-----------------------------------------------------------------------------
 
 // Demonstrate create a window with multiple child windows.
-static void ShowExampleAppLayout(bool* p_open) IMGUI_NOEXCEPT
+static void ShowExampleAppLayout(bool* p_open) IM_NOEXCEPT
 {
     ImGui::SetNextWindowSize(ImVec2(500, 440), ImGuiCond_FirstUseEver);
     if (ImGui::Begin("Example: Simple layout", p_open, ImGuiWindowFlags_MenuBar))
@@ -6839,7 +6839,7 @@ static void ShowExampleAppLayout(bool* p_open) IMGUI_NOEXCEPT
 // [SECTION] Example App: Property Editor / ShowExampleAppPropertyEditor()
 //-----------------------------------------------------------------------------
 
-static void ShowPlaceholderObject(const char* prefix, int uid) IMGUI_NOEXCEPT
+static void ShowPlaceholderObject(const char* prefix, int uid) IM_NOEXCEPT
 {
     // Use object uid as identifier. Most commonly you could also use the object pointer as a base ID.
     ImGui::PushID(uid);
@@ -6887,7 +6887,7 @@ static void ShowPlaceholderObject(const char* prefix, int uid) IMGUI_NOEXCEPT
 }
 
 // Demonstrate create a simple property editor.
-static void ShowExampleAppPropertyEditor(bool* p_open) IMGUI_NOEXCEPT
+static void ShowExampleAppPropertyEditor(bool* p_open) IM_NOEXCEPT
 {
     ImGui::SetNextWindowSize(ImVec2(430, 450), ImGuiCond_FirstUseEver);
     if (!ImGui::Begin("Example: Property editor", p_open))
@@ -6922,7 +6922,7 @@ static void ShowExampleAppPropertyEditor(bool* p_open) IMGUI_NOEXCEPT
 //-----------------------------------------------------------------------------
 
 // Demonstrate/test rendering huge amount of text, and the incidence of clipping.
-static void ShowExampleAppLongText(bool* p_open) IMGUI_NOEXCEPT
+static void ShowExampleAppLongText(bool* p_open) IM_NOEXCEPT
 {
     ImGui::SetNextWindowSize(ImVec2(520, 600), ImGuiCond_FirstUseEver);
     if (!ImGui::Begin("Example: Long text display", p_open))
@@ -6984,7 +6984,7 @@ static void ShowExampleAppLongText(bool* p_open) IMGUI_NOEXCEPT
 //-----------------------------------------------------------------------------
 
 // Demonstrate creating a window which gets auto-resized according to its content.
-static void ShowExampleAppAutoResize(bool* p_open) IMGUI_NOEXCEPT
+static void ShowExampleAppAutoResize(bool* p_open) IM_NOEXCEPT
 {
     if (!ImGui::Begin("Example: Auto-resizing window", p_open, ImGuiWindowFlags_AlwaysAutoResize))
     {
@@ -7008,7 +7008,7 @@ static void ShowExampleAppAutoResize(bool* p_open) IMGUI_NOEXCEPT
 //-----------------------------------------------------------------------------
 
 // Demonstrate creating a window with custom resize constraints.
-static void ShowExampleAppConstrainedResize(bool* p_open) IMGUI_NOEXCEPT
+static void ShowExampleAppConstrainedResize(bool* p_open) IM_NOEXCEPT
 {
     struct CustomConstraints
     {
@@ -7062,7 +7062,7 @@ static void ShowExampleAppConstrainedResize(bool* p_open) IMGUI_NOEXCEPT
 
 // Demonstrate creating a simple static window with no decoration
 // + a context-menu to choose which corner of the screen to use.
-static void ShowExampleAppSimpleOverlay(bool* p_open) IMGUI_NOEXCEPT
+static void ShowExampleAppSimpleOverlay(bool* p_open) IM_NOEXCEPT
 {
     const float PAD = 10.0f;
     static int corner = 0;
@@ -7109,7 +7109,7 @@ static void ShowExampleAppSimpleOverlay(bool* p_open) IMGUI_NOEXCEPT
 //-----------------------------------------------------------------------------
 
 // Demonstrate creating a window covering the entire screen/viewport
-static void ShowExampleAppFullscreen(bool* p_open) IMGUI_NOEXCEPT
+static void ShowExampleAppFullscreen(bool* p_open) IM_NOEXCEPT
 {
     static bool use_work_area = true;
     static ImGuiWindowFlags flags = ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoSavedSettings;
@@ -7147,7 +7147,7 @@ static void ShowExampleAppFullscreen(bool* p_open) IMGUI_NOEXCEPT
 // Demonstrate using "##" and "###" in identifiers to manipulate ID generation.
 // This apply to all regular items as well.
 // Read FAQ section "How can I have multiple widgets with the same label?" for details.
-static void ShowExampleAppWindowTitles(bool*) IMGUI_NOEXCEPT
+static void ShowExampleAppWindowTitles(bool*) IM_NOEXCEPT
 {
     const ImGuiViewport* viewport = ImGui::GetMainViewport();
     const ImVec2 base_pos = viewport->Pos;
@@ -7180,7 +7180,7 @@ static void ShowExampleAppWindowTitles(bool*) IMGUI_NOEXCEPT
 //-----------------------------------------------------------------------------
 
 // Demonstrate using the low-level ImDrawList to draw custom shapes.
-static void ShowExampleAppCustomRendering(bool* p_open) IMGUI_NOEXCEPT
+static void ShowExampleAppCustomRendering(bool* p_open) IM_NOEXCEPT
 {
     if (!ImGui::Begin("Example: Custom rendering", p_open))
     {
@@ -7430,7 +7430,7 @@ struct MyDocument
     bool        WantClose;  // Set when the document
     ImVec4      Color;      // An arbitrary variable associated to the document
 
-    MyDocument(const char* name, bool open = true, const ImVec4& color = ImVec4(1.0f, 1.0f, 1.0f, 1.0f)) IMGUI_NOEXCEPT
+    MyDocument(const char* name, bool open = true, const ImVec4& color = ImVec4(1.0f, 1.0f, 1.0f, 1.0f)) IM_NOEXCEPT
     {
         Name = name;
         Open = OpenPrev = open;
@@ -7438,13 +7438,13 @@ struct MyDocument
         WantClose = false;
         Color = color;
     }
-    void DoOpen()       IMGUI_NOEXCEPT { Open = true; }
-    void DoQueueClose() IMGUI_NOEXCEPT { WantClose = true; }
-    void DoForceClose() IMGUI_NOEXCEPT { Open = false; Dirty = false; }
-    void DoSave()       IMGUI_NOEXCEPT { Dirty = false; }
+    void DoOpen()       IM_NOEXCEPT { Open = true; }
+    void DoQueueClose() IM_NOEXCEPT { WantClose = true; }
+    void DoForceClose() IM_NOEXCEPT { Open = false; Dirty = false; }
+    void DoSave()       IM_NOEXCEPT { Dirty = false; }
 
     // Display placeholder contents for the Document
-    static void DisplayContents(MyDocument* doc) IMGUI_NOEXCEPT
+    static void DisplayContents(MyDocument* doc) IM_NOEXCEPT
     {
         ImGui::PushID(doc);
         ImGui::Text("Document \"%s\"", doc->Name);
@@ -7461,7 +7461,7 @@ struct MyDocument
     }
 
     // Display context menu for the Document
-    static void DisplayContextMenu(MyDocument* doc) IMGUI_NOEXCEPT
+    static void DisplayContextMenu(MyDocument* doc) IM_NOEXCEPT
     {
         if (!ImGui::BeginPopupContextItem())
             return;
@@ -7480,7 +7480,7 @@ struct ExampleAppDocuments
 {
     ImVector<MyDocument> Documents;
 
-    ExampleAppDocuments() IMGUI_NOEXCEPT
+    ExampleAppDocuments() IM_NOEXCEPT
     {
         Documents.push_back(MyDocument("Lettuce",             true,  ImVec4(0.4f, 0.8f, 0.4f, 1.0f)));
         Documents.push_back(MyDocument("Eggplant",            true,  ImVec4(0.8f, 0.5f, 1.0f, 1.0f)));
@@ -7499,7 +7499,7 @@ struct ExampleAppDocuments
 // give the impression of a flicker for one frame.
 // We call SetTabItemClosed() to manually notify the Tab Bar or Docking system of removed tabs to avoid this glitch.
 // Note that this completely optional, and only affect tab bars with the ImGuiTabBarFlags_Reorderable flag.
-static void NotifyOfDocumentsClosedElsewhere(ExampleAppDocuments& app) IMGUI_NOEXCEPT
+static void NotifyOfDocumentsClosedElsewhere(ExampleAppDocuments& app) IM_NOEXCEPT
 {
     for (int doc_n = 0; doc_n < app.Documents.Size; doc_n++)
     {
@@ -7510,7 +7510,7 @@ static void NotifyOfDocumentsClosedElsewhere(ExampleAppDocuments& app) IMGUI_NOE
     }
 }
 
-void ShowExampleAppDocuments(bool* p_open) IMGUI_NOEXCEPT
+void ShowExampleAppDocuments(bool* p_open) IM_NOEXCEPT
 {
     static ExampleAppDocuments app;
 
@@ -7694,10 +7694,10 @@ void ShowExampleAppDocuments(bool* p_open) IMGUI_NOEXCEPT
 // End of Demo code
 #else
 
-void ImGui::ShowAboutWindow(bool*) IMGUI_NOEXCEPT {}
-void ImGui::ShowDemoWindow(bool*) IMGUI_NOEXCEPT {}
-void ImGui::ShowUserGuide() IMGUI_NOEXCEPT {}
-void ImGui::ShowStyleEditor(ImGuiStyle*) IMGUI_NOEXCEPT {}
+void ImGui::ShowAboutWindow(bool*) IM_NOEXCEPT {}
+void ImGui::ShowDemoWindow(bool*) IM_NOEXCEPT {}
+void ImGui::ShowUserGuide() IM_NOEXCEPT {}
+void ImGui::ShowStyleEditor(ImGuiStyle*) IM_NOEXCEPT {}
 
 #endif
 

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -187,7 +187,7 @@ using namespace IMGUI_STB_NAMESPACE;
 // [SECTION] Style functions
 //-----------------------------------------------------------------------------
 
-void ImGui::StyleColorsDark(ImGuiStyle* dst) IMGUI_NOEXCEPT
+void ImGui::StyleColorsDark(ImGuiStyle* dst) IM_NOEXCEPT
 {
     ImGuiStyle* style = dst ? dst : &ImGui::GetStyle();
     ImVec4* colors = style->Colors;
@@ -247,7 +247,7 @@ void ImGui::StyleColorsDark(ImGuiStyle* dst) IMGUI_NOEXCEPT
     colors[ImGuiCol_ModalWindowDimBg]       = ImVec4(0.80f, 0.80f, 0.80f, 0.35f);
 }
 
-void ImGui::StyleColorsClassic(ImGuiStyle* dst) IMGUI_NOEXCEPT
+void ImGui::StyleColorsClassic(ImGuiStyle* dst) IM_NOEXCEPT
 {
     ImGuiStyle* style = dst ? dst : &ImGui::GetStyle();
     ImVec4* colors = style->Colors;
@@ -308,7 +308,7 @@ void ImGui::StyleColorsClassic(ImGuiStyle* dst) IMGUI_NOEXCEPT
 }
 
 // Those light colors are better suited with a thicker font than the default one + FrameBorder
-void ImGui::StyleColorsLight(ImGuiStyle* dst) IMGUI_NOEXCEPT
+void ImGui::StyleColorsLight(ImGuiStyle* dst) IM_NOEXCEPT
 {
     ImGuiStyle* style = dst ? dst : &ImGui::GetStyle();
     ImVec4* colors = style->Colors;
@@ -372,7 +372,7 @@ void ImGui::StyleColorsLight(ImGuiStyle* dst) IMGUI_NOEXCEPT
 // [SECTION] ImDrawList
 //-----------------------------------------------------------------------------
 
-ImDrawListSharedData::ImDrawListSharedData() IMGUI_NOEXCEPT
+ImDrawListSharedData::ImDrawListSharedData() IM_NOEXCEPT
 {
     memset(this, 0, sizeof(*this));
     for (int i = 0; i < IM_ARRAYSIZE(ArcFastVtx); i++)
@@ -383,7 +383,7 @@ ImDrawListSharedData::ImDrawListSharedData() IMGUI_NOEXCEPT
     ArcFastRadiusCutoff = IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_CALC_R(IM_DRAWLIST_ARCFAST_SAMPLE_MAX, CircleSegmentMaxError);
 }
 
-void ImDrawListSharedData::SetCircleTessellationMaxError(float max_error) IMGUI_NOEXCEPT
+void ImDrawListSharedData::SetCircleTessellationMaxError(float max_error) IM_NOEXCEPT
 {
     if (CircleSegmentMaxError == max_error)
         return;
@@ -399,7 +399,7 @@ void ImDrawListSharedData::SetCircleTessellationMaxError(float max_error) IMGUI_
 }
 
 // Initialize before use in a new frame. We always have a command ready in the buffer.
-void ImDrawList::_ResetForNewFrame() IMGUI_NOEXCEPT
+void ImDrawList::_ResetForNewFrame() IM_NOEXCEPT
 {
     // Verify that the ImDrawCmd fields we want to memcmp() are contiguous in memory.
     // (those should be IM_STATIC_ASSERT() in theory but with our pre C++11 setup the whole check doesn't compile with GCC)
@@ -423,7 +423,7 @@ void ImDrawList::_ResetForNewFrame() IMGUI_NOEXCEPT
     _FringeScale = 1.0f;
 }
 
-void ImDrawList::_ClearFreeMemory() IMGUI_NOEXCEPT
+void ImDrawList::_ClearFreeMemory() IM_NOEXCEPT
 {
     CmdBuffer.clear();
     IdxBuffer.clear();
@@ -438,7 +438,7 @@ void ImDrawList::_ClearFreeMemory() IMGUI_NOEXCEPT
     _Splitter.ClearFreeMemory();
 }
 
-ImDrawList* ImDrawList::CloneOutput() const IMGUI_NOEXCEPT
+ImDrawList* ImDrawList::CloneOutput() const IM_NOEXCEPT
 {
     ImDrawList* dst = IM_NEW(ImDrawList(_Data));
     dst->CmdBuffer = CmdBuffer;
@@ -448,7 +448,7 @@ ImDrawList* ImDrawList::CloneOutput() const IMGUI_NOEXCEPT
     return dst;
 }
 
-void ImDrawList::AddDrawCmd() IMGUI_NOEXCEPT
+void ImDrawList::AddDrawCmd() IM_NOEXCEPT
 {
     ImDrawCmd draw_cmd;
     draw_cmd.ClipRect = _CmdHeader.ClipRect;    // Same as calling ImDrawCmd_HeaderCopy()
@@ -462,7 +462,7 @@ void ImDrawList::AddDrawCmd() IMGUI_NOEXCEPT
 
 // Pop trailing draw command (used before merging or presenting to user)
 // Note that this leaves the ImDrawList in a state unfit for further commands, as most code assume that CmdBuffer.Size > 0 && CmdBuffer.back().UserCallback == NULL
-void ImDrawList::_PopUnusedDrawCmd() IMGUI_NOEXCEPT
+void ImDrawList::_PopUnusedDrawCmd() IM_NOEXCEPT
 {
     if (CmdBuffer.Size == 0)
         return;
@@ -471,7 +471,7 @@ void ImDrawList::_PopUnusedDrawCmd() IMGUI_NOEXCEPT
         CmdBuffer.pop_back();
 }
 
-void ImDrawList::AddCallback(ImDrawCallback callback, void* callback_data) IMGUI_NOEXCEPT
+void ImDrawList::AddCallback(ImDrawCallback callback, void* callback_data) IM_NOEXCEPT
 {
     ImDrawCmd* curr_cmd = &CmdBuffer.Data[CmdBuffer.Size - 1];
     IM_ASSERT(curr_cmd->UserCallback == NULL);
@@ -493,7 +493,7 @@ void ImDrawList::AddCallback(ImDrawCallback callback, void* callback_data) IMGUI
 
 // Our scheme may appears a bit unusual, basically we want the most-common calls AddLine AddRect etc. to not have to perform any check so we always have a command ready in the stack.
 // The cost of figuring out if a new command has to be added or if we can merge is paid in those Update** functions only.
-void ImDrawList::_OnChangedClipRect() IMGUI_NOEXCEPT
+void ImDrawList::_OnChangedClipRect() IM_NOEXCEPT
 {
     // If current command is used with different settings we need to add a new command
     ImDrawCmd* curr_cmd = &CmdBuffer.Data[CmdBuffer.Size - 1];
@@ -515,7 +515,7 @@ void ImDrawList::_OnChangedClipRect() IMGUI_NOEXCEPT
     curr_cmd->ClipRect = _CmdHeader.ClipRect;
 }
 
-void ImDrawList::_OnChangedTextureID() IMGUI_NOEXCEPT
+void ImDrawList::_OnChangedTextureID() IM_NOEXCEPT
 {
     // If current command is used with different settings we need to add a new command
     ImDrawCmd* curr_cmd = &CmdBuffer.Data[CmdBuffer.Size - 1];
@@ -537,7 +537,7 @@ void ImDrawList::_OnChangedTextureID() IMGUI_NOEXCEPT
     curr_cmd->TextureId = _CmdHeader.TextureId;
 }
 
-void ImDrawList::_OnChangedVtxOffset() IMGUI_NOEXCEPT
+void ImDrawList::_OnChangedVtxOffset() IM_NOEXCEPT
 {
     // We don't need to compare curr_cmd->VtxOffset != _CmdHeader.VtxOffset because we know it'll be different at the time we call this.
     _VtxCurrentIdx = 0;
@@ -552,7 +552,7 @@ void ImDrawList::_OnChangedVtxOffset() IMGUI_NOEXCEPT
     curr_cmd->VtxOffset = _CmdHeader.VtxOffset;
 }
 
-int ImDrawList::_CalcCircleAutoSegmentCount(float radius) const IMGUI_NOEXCEPT
+int ImDrawList::_CalcCircleAutoSegmentCount(float radius) const IM_NOEXCEPT
 {
     // Automatic segment count
     const int radius_idx = (int)(radius + 0.999999f); // ceil to never reduce accuracy
@@ -563,7 +563,7 @@ int ImDrawList::_CalcCircleAutoSegmentCount(float radius) const IMGUI_NOEXCEPT
 }
 
 // Render-level scissoring. This is passed down to your render function but not used for CPU-side coarse clipping. Prefer using higher-level ImGui::PushClipRect() to affect logic (hit-testing and widget culling)
-void ImDrawList::PushClipRect(ImVec2 cr_min, ImVec2 cr_max, bool intersect_with_current_clip_rect) IMGUI_NOEXCEPT
+void ImDrawList::PushClipRect(ImVec2 cr_min, ImVec2 cr_max, bool intersect_with_current_clip_rect) IM_NOEXCEPT
 {
     ImVec4 cr(cr_min.x, cr_min.y, cr_max.x, cr_max.y);
     if (intersect_with_current_clip_rect)
@@ -582,26 +582,26 @@ void ImDrawList::PushClipRect(ImVec2 cr_min, ImVec2 cr_max, bool intersect_with_
     _OnChangedClipRect();
 }
 
-void ImDrawList::PushClipRectFullScreen() IMGUI_NOEXCEPT
+void ImDrawList::PushClipRectFullScreen() IM_NOEXCEPT
 {
     PushClipRect(ImVec2(_Data->ClipRectFullscreen.x, _Data->ClipRectFullscreen.y), ImVec2(_Data->ClipRectFullscreen.z, _Data->ClipRectFullscreen.w));
 }
 
-void ImDrawList::PopClipRect() IMGUI_NOEXCEPT
+void ImDrawList::PopClipRect() IM_NOEXCEPT
 {
     _ClipRectStack.pop_back();
     _CmdHeader.ClipRect = (_ClipRectStack.Size == 0) ? _Data->ClipRectFullscreen : _ClipRectStack.Data[_ClipRectStack.Size - 1];
     _OnChangedClipRect();
 }
 
-void ImDrawList::PushTextureID(ImTextureID texture_id) IMGUI_NOEXCEPT
+void ImDrawList::PushTextureID(ImTextureID texture_id) IM_NOEXCEPT
 {
     _TextureIdStack.push_back(texture_id);
     _CmdHeader.TextureId = texture_id;
     _OnChangedTextureID();
 }
 
-void ImDrawList::PopTextureID() IMGUI_NOEXCEPT
+void ImDrawList::PopTextureID() IM_NOEXCEPT
 {
     _TextureIdStack.pop_back();
     _CmdHeader.TextureId = (_TextureIdStack.Size == 0) ? (ImTextureID)NULL : _TextureIdStack.Data[_TextureIdStack.Size - 1];
@@ -611,7 +611,7 @@ void ImDrawList::PopTextureID() IMGUI_NOEXCEPT
 // Reserve space for a number of vertices and indices.
 // You must finish filling your reserved data before calling PrimReserve() again, as it may reallocate or
 // submit the intermediate results. PrimUnreserve() can be used to release unused allocations.
-void ImDrawList::PrimReserve(int idx_count, int vtx_count) IMGUI_NOEXCEPT
+void ImDrawList::PrimReserve(int idx_count, int vtx_count) IM_NOEXCEPT
 {
     // Large mesh support (when enabled)
     IM_ASSERT_PARANOID(idx_count >= 0 && vtx_count >= 0);
@@ -637,7 +637,7 @@ void ImDrawList::PrimReserve(int idx_count, int vtx_count) IMGUI_NOEXCEPT
 }
 
 // Release the a number of reserved vertices/indices from the end of the last reservation made with PrimReserve().
-void ImDrawList::PrimUnreserve(int idx_count, int vtx_count) IMGUI_NOEXCEPT
+void ImDrawList::PrimUnreserve(int idx_count, int vtx_count) IM_NOEXCEPT
 {
     IM_ASSERT_PARANOID(idx_count >= 0 && vtx_count >= 0);
 
@@ -648,7 +648,7 @@ void ImDrawList::PrimUnreserve(int idx_count, int vtx_count) IMGUI_NOEXCEPT
 }
 
 // Fully unrolled with inline call to keep our debug builds decently fast.
-void ImDrawList::PrimRect(const ImVec2& a, const ImVec2& c, ImU32 col) IMGUI_NOEXCEPT
+void ImDrawList::PrimRect(const ImVec2& a, const ImVec2& c, ImU32 col) IM_NOEXCEPT
 {
     ImVec2 b(c.x, a.y), d(a.x, c.y), uv(_Data->TexUvWhitePixel);
     ImDrawIdx idx = (ImDrawIdx)_VtxCurrentIdx;
@@ -663,7 +663,7 @@ void ImDrawList::PrimRect(const ImVec2& a, const ImVec2& c, ImU32 col) IMGUI_NOE
     _IdxWritePtr += 6;
 }
 
-void ImDrawList::PrimRectUV(const ImVec2& a, const ImVec2& c, const ImVec2& uv_a, const ImVec2& uv_c, ImU32 col) IMGUI_NOEXCEPT
+void ImDrawList::PrimRectUV(const ImVec2& a, const ImVec2& c, const ImVec2& uv_a, const ImVec2& uv_c, ImU32 col) IM_NOEXCEPT
 {
     ImVec2 b(c.x, a.y), d(a.x, c.y), uv_b(uv_c.x, uv_a.y), uv_d(uv_a.x, uv_c.y);
     ImDrawIdx idx = (ImDrawIdx)_VtxCurrentIdx;
@@ -678,7 +678,7 @@ void ImDrawList::PrimRectUV(const ImVec2& a, const ImVec2& c, const ImVec2& uv_a
     _IdxWritePtr += 6;
 }
 
-void ImDrawList::PrimQuadUV(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& d, const ImVec2& uv_a, const ImVec2& uv_b, const ImVec2& uv_c, const ImVec2& uv_d, ImU32 col) IMGUI_NOEXCEPT
+void ImDrawList::PrimQuadUV(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& d, const ImVec2& uv_a, const ImVec2& uv_b, const ImVec2& uv_c, const ImVec2& uv_d, ImU32 col) IM_NOEXCEPT
 {
     ImDrawIdx idx = (ImDrawIdx)_VtxCurrentIdx;
     _IdxWritePtr[0] = idx; _IdxWritePtr[1] = (ImDrawIdx)(idx+1); _IdxWritePtr[2] = (ImDrawIdx)(idx+2);
@@ -700,7 +700,7 @@ void ImDrawList::PrimQuadUV(const ImVec2& a, const ImVec2& b, const ImVec2& c, c
 
 // TODO: Thickness anti-aliased lines cap are missing their AA fringe.
 // We avoid using the ImVec2 math operators here to reduce cost to a minimum for debug/non-inlined builds.
-void ImDrawList::AddPolyline(const ImVec2* points, const int points_count, ImU32 col, ImDrawFlags flags, float thickness) IMGUI_NOEXCEPT
+void ImDrawList::AddPolyline(const ImVec2* points, const int points_count, ImU32 col, ImDrawFlags flags, float thickness) IM_NOEXCEPT
 {
     if (points_count < 2)
         return;
@@ -956,7 +956,7 @@ void ImDrawList::AddPolyline(const ImVec2* points, const int points_count, ImU32
 }
 
 // We intentionally avoid using ImVec2 and its math operators here to reduce cost to a minimum for debug/non-inlined builds.
-void ImDrawList::AddConvexPolyFilled(const ImVec2* points, const int points_count, ImU32 col) IMGUI_NOEXCEPT
+void ImDrawList::AddConvexPolyFilled(const ImVec2* points, const int points_count, ImU32 col) IM_NOEXCEPT
 {
     if (points_count < 3)
         return;
@@ -1037,7 +1037,7 @@ void ImDrawList::AddConvexPolyFilled(const ImVec2* points, const int points_coun
     }
 }
 
-void ImDrawList::_PathArcToFastEx(const ImVec2& center, float radius, int a_min_sample, int a_max_sample, int a_step) IMGUI_NOEXCEPT
+void ImDrawList::_PathArcToFastEx(const ImVec2& center, float radius, int a_min_sample, int a_max_sample, int a_step) IM_NOEXCEPT
 {
     if (radius <= 0.0f)
     {
@@ -1129,7 +1129,7 @@ void ImDrawList::_PathArcToFastEx(const ImVec2& center, float radius, int a_min_
     IM_ASSERT_PARANOID(_Path.Data + _Path.Size == out_ptr);
 }
 
-void ImDrawList::_PathArcToN(const ImVec2& center, float radius, float a_min, float a_max, int num_segments) IMGUI_NOEXCEPT
+void ImDrawList::_PathArcToN(const ImVec2& center, float radius, float a_min, float a_max, int num_segments) IM_NOEXCEPT
 {
     if (radius <= 0.0f)
     {
@@ -1148,7 +1148,7 @@ void ImDrawList::_PathArcToN(const ImVec2& center, float radius, float a_min, fl
 }
 
 // 0: East, 3: South, 6: West, 9: North, 12: East
-void ImDrawList::PathArcToFast(const ImVec2& center, float radius, int a_min_of_12, int a_max_of_12) IMGUI_NOEXCEPT
+void ImDrawList::PathArcToFast(const ImVec2& center, float radius, int a_min_of_12, int a_max_of_12) IM_NOEXCEPT
 {
     if (radius <= 0.0f)
     {
@@ -1158,7 +1158,7 @@ void ImDrawList::PathArcToFast(const ImVec2& center, float radius, int a_min_of_
     _PathArcToFastEx(center, radius, a_min_of_12 * IM_DRAWLIST_ARCFAST_SAMPLE_MAX / 12, a_max_of_12 * IM_DRAWLIST_ARCFAST_SAMPLE_MAX / 12, 0);
 }
 
-void ImDrawList::PathArcTo(const ImVec2& center, float radius, float a_min, float a_max, int num_segments) IMGUI_NOEXCEPT
+void ImDrawList::PathArcTo(const ImVec2& center, float radius, float a_min, float a_max, int num_segments) IM_NOEXCEPT
 {
     if (radius <= 0.0f)
     {
@@ -1208,7 +1208,7 @@ void ImDrawList::PathArcTo(const ImVec2& center, float radius, float a_min, floa
     }
 }
 
-ImVec2 ImBezierCubicCalc(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, float t) IMGUI_NOEXCEPT
+ImVec2 ImBezierCubicCalc(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, float t) IM_NOEXCEPT
 {
     float u = 1.0f - t;
     float w1 = u * u * u;
@@ -1218,7 +1218,7 @@ ImVec2 ImBezierCubicCalc(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, c
     return ImVec2(w1 * p1.x + w2 * p2.x + w3 * p3.x + w4 * p4.x, w1 * p1.y + w2 * p2.y + w3 * p3.y + w4 * p4.y);
 }
 
-ImVec2 ImBezierQuadraticCalc(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, float t) IMGUI_NOEXCEPT
+ImVec2 ImBezierQuadraticCalc(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, float t) IM_NOEXCEPT
 {
     float u = 1.0f - t;
     float w1 = u * u;
@@ -1228,7 +1228,7 @@ ImVec2 ImBezierQuadraticCalc(const ImVec2& p1, const ImVec2& p2, const ImVec2& p
 }
 
 // Closely mimics ImBezierCubicClosestPointCasteljau() in imgui.cpp
-static void PathBezierCubicCurveToCasteljau(ImVector<ImVec2>* path, float x1, float y1, float x2, float y2, float x3, float y3, float x4, float y4, float tess_tol, int level) IMGUI_NOEXCEPT
+static void PathBezierCubicCurveToCasteljau(ImVector<ImVec2>* path, float x1, float y1, float x2, float y2, float x3, float y3, float x4, float y4, float tess_tol, int level) IM_NOEXCEPT
 {
     float dx = x4 - x1;
     float dy = y4 - y1;
@@ -1253,7 +1253,7 @@ static void PathBezierCubicCurveToCasteljau(ImVector<ImVec2>* path, float x1, fl
     }
 }
 
-static void PathBezierQuadraticCurveToCasteljau(ImVector<ImVec2>* path, float x1, float y1, float x2, float y2, float x3, float y3, float tess_tol, int level) IMGUI_NOEXCEPT
+static void PathBezierQuadraticCurveToCasteljau(ImVector<ImVec2>* path, float x1, float y1, float x2, float y2, float x3, float y3, float tess_tol, int level) IM_NOEXCEPT
 {
     float dx = x3 - x1, dy = y3 - y1;
     float det = (x2 - x3) * dy - (y2 - y3) * dx;
@@ -1271,7 +1271,7 @@ static void PathBezierQuadraticCurveToCasteljau(ImVector<ImVec2>* path, float x1
     }
 }
 
-void ImDrawList::PathBezierCubicCurveTo(const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, int num_segments) IMGUI_NOEXCEPT
+void ImDrawList::PathBezierCubicCurveTo(const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, int num_segments) IM_NOEXCEPT
 {
     ImVec2 p1 = _Path.back();
     if (num_segments == 0)
@@ -1286,7 +1286,7 @@ void ImDrawList::PathBezierCubicCurveTo(const ImVec2& p2, const ImVec2& p3, cons
     }
 }
 
-void ImDrawList::PathBezierQuadraticCurveTo(const ImVec2& p2, const ImVec2& p3, int num_segments) IMGUI_NOEXCEPT
+void ImDrawList::PathBezierQuadraticCurveTo(const ImVec2& p2, const ImVec2& p3, int num_segments) IM_NOEXCEPT
 {
     ImVec2 p1 = _Path.back();
     if (num_segments == 0)
@@ -1302,7 +1302,7 @@ void ImDrawList::PathBezierQuadraticCurveTo(const ImVec2& p2, const ImVec2& p3, 
 }
 
 IM_STATIC_ASSERT(ImDrawFlags_RoundCornersTopLeft == (1 << 4));
-static inline ImDrawFlags FixRectCornerFlags(ImDrawFlags flags) IMGUI_NOEXCEPT
+static inline ImDrawFlags FixRectCornerFlags(ImDrawFlags flags) IM_NOEXCEPT
 {
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
     // Legacy Support for hard coded ~0 (used to be a suggested equivalent to ImDrawCornerFlags_All)
@@ -1335,7 +1335,7 @@ static inline ImDrawFlags FixRectCornerFlags(ImDrawFlags flags) IMGUI_NOEXCEPT
     return flags;
 }
 
-void ImDrawList::PathRect(const ImVec2& a, const ImVec2& b, float rounding, ImDrawFlags flags) IMGUI_NOEXCEPT
+void ImDrawList::PathRect(const ImVec2& a, const ImVec2& b, float rounding, ImDrawFlags flags) IM_NOEXCEPT
 {
     flags = FixRectCornerFlags(flags);
     rounding = ImMin(rounding, ImFabs(b.x - a.x) * ( ((flags & ImDrawFlags_RoundCornersTop)  == ImDrawFlags_RoundCornersTop)  || ((flags & ImDrawFlags_RoundCornersBottom) == ImDrawFlags_RoundCornersBottom) ? 0.5f : 1.0f ) - 1.0f);
@@ -1361,7 +1361,7 @@ void ImDrawList::PathRect(const ImVec2& a, const ImVec2& b, float rounding, ImDr
     }
 }
 
-void ImDrawList::AddLine(const ImVec2& p1, const ImVec2& p2, ImU32 col, float thickness) IMGUI_NOEXCEPT
+void ImDrawList::AddLine(const ImVec2& p1, const ImVec2& p2, ImU32 col, float thickness) IM_NOEXCEPT
 {
     if ((col & IM_COL32_A_MASK) == 0)
         return;
@@ -1372,7 +1372,7 @@ void ImDrawList::AddLine(const ImVec2& p1, const ImVec2& p2, ImU32 col, float th
 
 // p_min = upper-left, p_max = lower-right
 // Note we don't render 1 pixels sized rectangles properly.
-void ImDrawList::AddRect(const ImVec2& p_min, const ImVec2& p_max, ImU32 col, float rounding, ImDrawFlags flags, float thickness) IMGUI_NOEXCEPT
+void ImDrawList::AddRect(const ImVec2& p_min, const ImVec2& p_max, ImU32 col, float rounding, ImDrawFlags flags, float thickness) IM_NOEXCEPT
 {
     if ((col & IM_COL32_A_MASK) == 0)
         return;
@@ -1383,7 +1383,7 @@ void ImDrawList::AddRect(const ImVec2& p_min, const ImVec2& p_max, ImU32 col, fl
     PathStroke(col, ImDrawFlags_Closed, thickness);
 }
 
-void ImDrawList::AddRectFilled(const ImVec2& p_min, const ImVec2& p_max, ImU32 col, float rounding, ImDrawFlags flags) IMGUI_NOEXCEPT
+void ImDrawList::AddRectFilled(const ImVec2& p_min, const ImVec2& p_max, ImU32 col, float rounding, ImDrawFlags flags) IM_NOEXCEPT
 {
     if ((col & IM_COL32_A_MASK) == 0)
         return;
@@ -1400,7 +1400,7 @@ void ImDrawList::AddRectFilled(const ImVec2& p_min, const ImVec2& p_max, ImU32 c
 }
 
 // p_min = upper-left, p_max = lower-right
-void ImDrawList::AddRectFilledMultiColor(const ImVec2& p_min, const ImVec2& p_max, ImU32 col_upr_left, ImU32 col_upr_right, ImU32 col_bot_right, ImU32 col_bot_left) IMGUI_NOEXCEPT
+void ImDrawList::AddRectFilledMultiColor(const ImVec2& p_min, const ImVec2& p_max, ImU32 col_upr_left, ImU32 col_upr_right, ImU32 col_bot_right, ImU32 col_bot_left) IM_NOEXCEPT
 {
     if (((col_upr_left | col_upr_right | col_bot_right | col_bot_left) & IM_COL32_A_MASK) == 0)
         return;
@@ -1415,7 +1415,7 @@ void ImDrawList::AddRectFilledMultiColor(const ImVec2& p_min, const ImVec2& p_ma
     PrimWriteVtx(ImVec2(p_min.x, p_max.y), uv, col_bot_left);
 }
 
-void ImDrawList::AddQuad(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, ImU32 col, float thickness) IMGUI_NOEXCEPT
+void ImDrawList::AddQuad(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, ImU32 col, float thickness) IM_NOEXCEPT
 {
     if ((col & IM_COL32_A_MASK) == 0)
         return;
@@ -1427,7 +1427,7 @@ void ImDrawList::AddQuad(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, c
     PathStroke(col, ImDrawFlags_Closed, thickness);
 }
 
-void ImDrawList::AddQuadFilled(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, ImU32 col) IMGUI_NOEXCEPT
+void ImDrawList::AddQuadFilled(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, ImU32 col) IM_NOEXCEPT
 {
     if ((col & IM_COL32_A_MASK) == 0)
         return;
@@ -1439,7 +1439,7 @@ void ImDrawList::AddQuadFilled(const ImVec2& p1, const ImVec2& p2, const ImVec2&
     PathFillConvex(col);
 }
 
-void ImDrawList::AddTriangle(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, ImU32 col, float thickness) IMGUI_NOEXCEPT
+void ImDrawList::AddTriangle(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, ImU32 col, float thickness) IM_NOEXCEPT
 {
     if ((col & IM_COL32_A_MASK) == 0)
         return;
@@ -1450,7 +1450,7 @@ void ImDrawList::AddTriangle(const ImVec2& p1, const ImVec2& p2, const ImVec2& p
     PathStroke(col, ImDrawFlags_Closed, thickness);
 }
 
-void ImDrawList::AddTriangleFilled(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, ImU32 col) IMGUI_NOEXCEPT
+void ImDrawList::AddTriangleFilled(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, ImU32 col) IM_NOEXCEPT
 {
     if ((col & IM_COL32_A_MASK) == 0)
         return;
@@ -1461,7 +1461,7 @@ void ImDrawList::AddTriangleFilled(const ImVec2& p1, const ImVec2& p2, const ImV
     PathFillConvex(col);
 }
 
-void ImDrawList::AddCircle(const ImVec2& center, float radius, ImU32 col, int num_segments, float thickness) IMGUI_NOEXCEPT
+void ImDrawList::AddCircle(const ImVec2& center, float radius, ImU32 col, int num_segments, float thickness) IM_NOEXCEPT
 {
     if ((col & IM_COL32_A_MASK) == 0 || radius <= 0.0f)
         return;
@@ -1487,7 +1487,7 @@ void ImDrawList::AddCircle(const ImVec2& center, float radius, ImU32 col, int nu
     PathStroke(col, ImDrawFlags_Closed, thickness);
 }
 
-void ImDrawList::AddCircleFilled(const ImVec2& center, float radius, ImU32 col, int num_segments) IMGUI_NOEXCEPT
+void ImDrawList::AddCircleFilled(const ImVec2& center, float radius, ImU32 col, int num_segments) IM_NOEXCEPT
 {
     if ((col & IM_COL32_A_MASK) == 0 || radius <= 0.0f)
         return;
@@ -1514,7 +1514,7 @@ void ImDrawList::AddCircleFilled(const ImVec2& center, float radius, ImU32 col, 
 }
 
 // Guaranteed to honor 'num_segments'
-void ImDrawList::AddNgon(const ImVec2& center, float radius, ImU32 col, int num_segments, float thickness) IMGUI_NOEXCEPT
+void ImDrawList::AddNgon(const ImVec2& center, float radius, ImU32 col, int num_segments, float thickness) IM_NOEXCEPT
 {
     if ((col & IM_COL32_A_MASK) == 0 || num_segments <= 2)
         return;
@@ -1526,7 +1526,7 @@ void ImDrawList::AddNgon(const ImVec2& center, float radius, ImU32 col, int num_
 }
 
 // Guaranteed to honor 'num_segments'
-void ImDrawList::AddNgonFilled(const ImVec2& center, float radius, ImU32 col, int num_segments) IMGUI_NOEXCEPT
+void ImDrawList::AddNgonFilled(const ImVec2& center, float radius, ImU32 col, int num_segments) IM_NOEXCEPT
 {
     if ((col & IM_COL32_A_MASK) == 0 || num_segments <= 2)
         return;
@@ -1538,7 +1538,7 @@ void ImDrawList::AddNgonFilled(const ImVec2& center, float radius, ImU32 col, in
 }
 
 // Cubic Bezier takes 4 controls points
-void ImDrawList::AddBezierCubic(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, ImU32 col, float thickness, int num_segments) IMGUI_NOEXCEPT
+void ImDrawList::AddBezierCubic(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, ImU32 col, float thickness, int num_segments) IM_NOEXCEPT
 {
     if ((col & IM_COL32_A_MASK) == 0)
         return;
@@ -1549,7 +1549,7 @@ void ImDrawList::AddBezierCubic(const ImVec2& p1, const ImVec2& p2, const ImVec2
 }
 
 // Quadratic Bezier takes 3 controls points
-void ImDrawList::AddBezierQuadratic(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, ImU32 col, float thickness, int num_segments) IMGUI_NOEXCEPT
+void ImDrawList::AddBezierQuadratic(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, ImU32 col, float thickness, int num_segments) IM_NOEXCEPT
 {
     if ((col & IM_COL32_A_MASK) == 0)
         return;
@@ -1559,7 +1559,7 @@ void ImDrawList::AddBezierQuadratic(const ImVec2& p1, const ImVec2& p2, const Im
     PathStroke(col, 0, thickness);
 }
 
-void ImDrawList::AddText(const ImFont* font, float font_size, const ImVec2& pos, ImU32 col, const char* text_begin, const char* text_end, float wrap_width, const ImVec4* cpu_fine_clip_rect) IMGUI_NOEXCEPT
+void ImDrawList::AddText(const ImFont* font, float font_size, const ImVec2& pos, ImU32 col, const char* text_begin, const char* text_end, float wrap_width, const ImVec4* cpu_fine_clip_rect) IM_NOEXCEPT
 {
     if ((col & IM_COL32_A_MASK) == 0)
         return;
@@ -1588,12 +1588,12 @@ void ImDrawList::AddText(const ImFont* font, float font_size, const ImVec2& pos,
     font->RenderText(this, font_size, pos, col, clip_rect, text_begin, text_end, wrap_width, cpu_fine_clip_rect != NULL);
 }
 
-void ImDrawList::AddText(const ImVec2& pos, ImU32 col, const char* text_begin, const char* text_end) IMGUI_NOEXCEPT
+void ImDrawList::AddText(const ImVec2& pos, ImU32 col, const char* text_begin, const char* text_end) IM_NOEXCEPT
 {
     AddText(NULL, 0.0f, pos, col, text_begin, text_end);
 }
 
-void ImDrawList::AddImage(ImTextureID user_texture_id, const ImVec2& p_min, const ImVec2& p_max, const ImVec2& uv_min, const ImVec2& uv_max, ImU32 col) IMGUI_NOEXCEPT
+void ImDrawList::AddImage(ImTextureID user_texture_id, const ImVec2& p_min, const ImVec2& p_max, const ImVec2& uv_min, const ImVec2& uv_max, ImU32 col) IM_NOEXCEPT
 {
     if ((col & IM_COL32_A_MASK) == 0)
         return;
@@ -1609,7 +1609,7 @@ void ImDrawList::AddImage(ImTextureID user_texture_id, const ImVec2& p_min, cons
         PopTextureID();
 }
 
-void ImDrawList::AddImageQuad(ImTextureID user_texture_id, const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, const ImVec2& uv1, const ImVec2& uv2, const ImVec2& uv3, const ImVec2& uv4, ImU32 col) IMGUI_NOEXCEPT
+void ImDrawList::AddImageQuad(ImTextureID user_texture_id, const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, const ImVec2& uv1, const ImVec2& uv2, const ImVec2& uv3, const ImVec2& uv4, ImU32 col) IM_NOEXCEPT
 {
     if ((col & IM_COL32_A_MASK) == 0)
         return;
@@ -1625,7 +1625,7 @@ void ImDrawList::AddImageQuad(ImTextureID user_texture_id, const ImVec2& p1, con
         PopTextureID();
 }
 
-void ImDrawList::AddImageRounded(ImTextureID user_texture_id, const ImVec2& p_min, const ImVec2& p_max, const ImVec2& uv_min, const ImVec2& uv_max, ImU32 col, float rounding, ImDrawFlags flags) IMGUI_NOEXCEPT
+void ImDrawList::AddImageRounded(ImTextureID user_texture_id, const ImVec2& p_min, const ImVec2& p_max, const ImVec2& uv_min, const ImVec2& uv_max, ImU32 col, float rounding, ImDrawFlags flags) IM_NOEXCEPT
 {
     if ((col & IM_COL32_A_MASK) == 0)
         return;
@@ -1658,7 +1658,7 @@ void ImDrawList::AddImageRounded(ImTextureID user_texture_id, const ImVec2& p_mi
 // FIXME: This may be a little confusing, trying to be a little too low-level/optimal instead of just doing vector swap..
 //-----------------------------------------------------------------------------
 
-void ImDrawListSplitter::ClearFreeMemory() IMGUI_NOEXCEPT
+void ImDrawListSplitter::ClearFreeMemory() IM_NOEXCEPT
 {
     for (int i = 0; i < _Channels.Size; i++)
     {
@@ -1672,7 +1672,7 @@ void ImDrawListSplitter::ClearFreeMemory() IMGUI_NOEXCEPT
     _Channels.clear();
 }
 
-void ImDrawListSplitter::Split(ImDrawList* draw_list, int channels_count) IMGUI_NOEXCEPT
+void ImDrawListSplitter::Split(ImDrawList* draw_list, int channels_count) IM_NOEXCEPT
 {
     IM_UNUSED(draw_list);
     IM_ASSERT(_Current == 0 && _Count <= 1 && "Nested channel splitting is not supported. Please use separate instances of ImDrawListSplitter.");
@@ -1702,7 +1702,7 @@ void ImDrawListSplitter::Split(ImDrawList* draw_list, int channels_count) IMGUI_
     }
 }
 
-void ImDrawListSplitter::Merge(ImDrawList* draw_list) IMGUI_NOEXCEPT
+void ImDrawListSplitter::Merge(ImDrawList* draw_list) IM_NOEXCEPT
 {
     // Note that we never use or rely on _Channels.Size because it is merely a buffer that we never shrink back to 0 to keep all sub-buffers ready for use.
     if (_Count <= 1)
@@ -1773,7 +1773,7 @@ void ImDrawListSplitter::Merge(ImDrawList* draw_list) IMGUI_NOEXCEPT
     _Count = 1;
 }
 
-void ImDrawListSplitter::SetCurrentChannel(ImDrawList* draw_list, int idx) IMGUI_NOEXCEPT
+void ImDrawListSplitter::SetCurrentChannel(ImDrawList* draw_list, int idx) IM_NOEXCEPT
 {
     IM_ASSERT(idx >= 0 && idx < _Count);
     if (_Current == idx)
@@ -1802,7 +1802,7 @@ void ImDrawListSplitter::SetCurrentChannel(ImDrawList* draw_list, int idx) IMGUI
 //-----------------------------------------------------------------------------
 
 // For backward compatibility: convert all buffers from indexed to de-indexed, in case you cannot render indexed. Note: this is slow and most likely a waste of resources. Always prefer indexed rendering!
-void ImDrawData::DeIndexAllBuffers() IMGUI_NOEXCEPT
+void ImDrawData::DeIndexAllBuffers() IM_NOEXCEPT
 {
     ImVector<ImDrawVert> new_vtx_buffer;
     TotalVtxCount = TotalIdxCount = 0;
@@ -1823,7 +1823,7 @@ void ImDrawData::DeIndexAllBuffers() IMGUI_NOEXCEPT
 // Helper to scale the ClipRect field of each ImDrawCmd.
 // Use if your final output buffer is at a different scale than draw_data->DisplaySize,
 // or if there is a difference between your window resolution and framebuffer resolution.
-void ImDrawData::ScaleClipRects(const ImVec2& fb_scale) IMGUI_NOEXCEPT
+void ImDrawData::ScaleClipRects(const ImVec2& fb_scale) IM_NOEXCEPT
 {
     for (int i = 0; i < CmdListsCount; i++)
     {
@@ -1841,7 +1841,7 @@ void ImDrawData::ScaleClipRects(const ImVec2& fb_scale) IMGUI_NOEXCEPT
 //-----------------------------------------------------------------------------
 
 // Generic linear color gradient, write to RGB fields, leave A untouched.
-void ImGui::ShadeVertsLinearColorGradientKeepAlpha(ImDrawList* draw_list, int vert_start_idx, int vert_end_idx, ImVec2 gradient_p0, ImVec2 gradient_p1, ImU32 col0, ImU32 col1) IMGUI_NOEXCEPT
+void ImGui::ShadeVertsLinearColorGradientKeepAlpha(ImDrawList* draw_list, int vert_start_idx, int vert_end_idx, ImVec2 gradient_p0, ImVec2 gradient_p1, ImU32 col0, ImU32 col1) IM_NOEXCEPT
 {
     ImVec2 gradient_extent = gradient_p1 - gradient_p0;
     float gradient_inv_length2 = 1.0f / ImLengthSqr(gradient_extent);
@@ -1865,7 +1865,7 @@ void ImGui::ShadeVertsLinearColorGradientKeepAlpha(ImDrawList* draw_list, int ve
 }
 
 // Distribute UV over (a, b) rectangle
-void ImGui::ShadeVertsLinearUV(ImDrawList* draw_list, int vert_start_idx, int vert_end_idx, const ImVec2& a, const ImVec2& b, const ImVec2& uv_a, const ImVec2& uv_b, bool clamp) IMGUI_NOEXCEPT
+void ImGui::ShadeVertsLinearUV(ImDrawList* draw_list, int vert_start_idx, int vert_end_idx, const ImVec2& a, const ImVec2& b, const ImVec2& uv_a, const ImVec2& uv_b, bool clamp) IM_NOEXCEPT
 {
     const ImVec2 size = b - a;
     const ImVec2 uv_size = uv_b - uv_a;
@@ -1893,7 +1893,7 @@ void ImGui::ShadeVertsLinearUV(ImDrawList* draw_list, int vert_start_idx, int ve
 // [SECTION] ImFontConfig
 //-----------------------------------------------------------------------------
 
-ImFontConfig::ImFontConfig() IMGUI_NOEXCEPT
+ImFontConfig::ImFontConfig() IM_NOEXCEPT
 {
     memset(this, 0, sizeof(*this));
     FontDataOwnedByAtlas = true;
@@ -1956,20 +1956,20 @@ static const ImVec2 FONT_ATLAS_DEFAULT_TEX_CURSOR_DATA[ImGuiMouseCursor_COUNT][3
     { ImVec2(91,0), ImVec2(17,22), ImVec2( 5, 0) }, // ImGuiMouseCursor_Hand
 };
 
-ImFontAtlas::ImFontAtlas() IMGUI_NOEXCEPT
+ImFontAtlas::ImFontAtlas() IM_NOEXCEPT
 {
     memset(this, 0, sizeof(*this));
     TexGlyphPadding = 1;
     PackIdMouseCursors = PackIdLines = -1;
 }
 
-ImFontAtlas::~ImFontAtlas() IMGUI_NOEXCEPT
+ImFontAtlas::~ImFontAtlas() IM_NOEXCEPT
 {
     IM_ASSERT(!Locked && "Cannot modify a locked ImFontAtlas between NewFrame() and EndFrame/Render()!");
     Clear();
 }
 
-void    ImFontAtlas::ClearInputData() IMGUI_NOEXCEPT
+void    ImFontAtlas::ClearInputData() IM_NOEXCEPT
 {
     IM_ASSERT(!Locked && "Cannot modify a locked ImFontAtlas between NewFrame() and EndFrame/Render()!");
     for (int i = 0; i < ConfigData.Size; i++)
@@ -1991,7 +1991,7 @@ void    ImFontAtlas::ClearInputData() IMGUI_NOEXCEPT
     PackIdMouseCursors = PackIdLines = -1;
 }
 
-void    ImFontAtlas::ClearTexData() IMGUI_NOEXCEPT
+void    ImFontAtlas::ClearTexData() IM_NOEXCEPT
 {
     IM_ASSERT(!Locked && "Cannot modify a locked ImFontAtlas between NewFrame() and EndFrame/Render()!");
     if (TexPixelsAlpha8)
@@ -2003,7 +2003,7 @@ void    ImFontAtlas::ClearTexData() IMGUI_NOEXCEPT
     TexPixelsUseColors = false;
 }
 
-void    ImFontAtlas::ClearFonts() IMGUI_NOEXCEPT
+void    ImFontAtlas::ClearFonts() IM_NOEXCEPT
 {
     IM_ASSERT(!Locked && "Cannot modify a locked ImFontAtlas between NewFrame() and EndFrame/Render()!");
     for (int i = 0; i < Fonts.Size; i++)
@@ -2011,14 +2011,14 @@ void    ImFontAtlas::ClearFonts() IMGUI_NOEXCEPT
     Fonts.clear();
 }
 
-void    ImFontAtlas::Clear() IMGUI_NOEXCEPT
+void    ImFontAtlas::Clear() IM_NOEXCEPT
 {
     ClearInputData();
     ClearTexData();
     ClearFonts();
 }
 
-void    ImFontAtlas::GetTexDataAsAlpha8(unsigned char** out_pixels, int* out_width, int* out_height, int* out_bytes_per_pixel) IMGUI_NOEXCEPT
+void    ImFontAtlas::GetTexDataAsAlpha8(unsigned char** out_pixels, int* out_width, int* out_height, int* out_bytes_per_pixel) IM_NOEXCEPT
 {
     // Build atlas on demand
     if (TexPixelsAlpha8 == NULL)
@@ -2034,7 +2034,7 @@ void    ImFontAtlas::GetTexDataAsAlpha8(unsigned char** out_pixels, int* out_wid
     if (out_bytes_per_pixel) *out_bytes_per_pixel = 1;
 }
 
-void    ImFontAtlas::GetTexDataAsRGBA32(unsigned char** out_pixels, int* out_width, int* out_height, int* out_bytes_per_pixel) IMGUI_NOEXCEPT
+void    ImFontAtlas::GetTexDataAsRGBA32(unsigned char** out_pixels, int* out_width, int* out_height, int* out_bytes_per_pixel) IM_NOEXCEPT
 {
     // Convert to RGBA32 format on demand
     // Although it is likely to be the most commonly used format, our font rendering is 1 channel / 8 bpp
@@ -2058,7 +2058,7 @@ void    ImFontAtlas::GetTexDataAsRGBA32(unsigned char** out_pixels, int* out_wid
     if (out_bytes_per_pixel) *out_bytes_per_pixel = 4;
 }
 
-ImFont* ImFontAtlas::AddFont(const ImFontConfig* font_cfg) IMGUI_NOEXCEPT
+ImFont* ImFontAtlas::AddFont(const ImFontConfig* font_cfg) IM_NOEXCEPT
 {
     IM_ASSERT(!Locked && "Cannot modify a locked ImFontAtlas between NewFrame() and EndFrame/Render()!");
     IM_ASSERT(font_cfg->FontData != NULL && font_cfg->FontDataSize > 0);
@@ -2090,11 +2090,11 @@ ImFont* ImFontAtlas::AddFont(const ImFontConfig* font_cfg) IMGUI_NOEXCEPT
 }
 
 // Default font TTF is compressed with stb_compress then base85 encoded (see misc/fonts/binary_to_compressed_c.cpp for encoder)
-static unsigned int stb_decompress_length(const unsigned char* input) IMGUI_NOEXCEPT;
-static unsigned int stb_decompress(unsigned char* output, const unsigned char* input, unsigned int length) IMGUI_NOEXCEPT;
-static const char*  GetDefaultCompressedFontDataTTFBase85() IMGUI_NOEXCEPT;
-static unsigned int Decode85Byte(char c) IMGUI_NOEXCEPT                      { return c >= '\\' ? c-36 : c-35; }
-static void         Decode85(const unsigned char* src, unsigned char* dst) IMGUI_NOEXCEPT
+static unsigned int stb_decompress_length(const unsigned char* input) IM_NOEXCEPT;
+static unsigned int stb_decompress(unsigned char* output, const unsigned char* input, unsigned int length) IM_NOEXCEPT;
+static const char*  GetDefaultCompressedFontDataTTFBase85() IM_NOEXCEPT;
+static unsigned int Decode85Byte(char c) IM_NOEXCEPT                      { return c >= '\\' ? c-36 : c-35; }
+static void         Decode85(const unsigned char* src, unsigned char* dst) IM_NOEXCEPT
 {
     while (*src)
     {
@@ -2106,7 +2106,7 @@ static void         Decode85(const unsigned char* src, unsigned char* dst) IMGUI
 }
 
 // Load embedded ProggyClean.ttf at size 13, disable oversampling
-ImFont* ImFontAtlas::AddFontDefault(const ImFontConfig* font_cfg_template) IMGUI_NOEXCEPT
+ImFont* ImFontAtlas::AddFontDefault(const ImFontConfig* font_cfg_template) IM_NOEXCEPT
 {
     ImFontConfig font_cfg = font_cfg_template ? *font_cfg_template : ImFontConfig();
     if (!font_cfg_template)
@@ -2127,7 +2127,7 @@ ImFont* ImFontAtlas::AddFontDefault(const ImFontConfig* font_cfg_template) IMGUI
     return font;
 }
 
-ImFont* ImFontAtlas::AddFontFromFileTTF(const char* filename, float size_pixels, const ImFontConfig* font_cfg_template, const ImWchar* glyph_ranges) IMGUI_NOEXCEPT
+ImFont* ImFontAtlas::AddFontFromFileTTF(const char* filename, float size_pixels, const ImFontConfig* font_cfg_template, const ImWchar* glyph_ranges) IM_NOEXCEPT
 {
     IM_ASSERT(!Locked && "Cannot modify a locked ImFontAtlas between NewFrame() and EndFrame/Render()!");
     size_t data_size = 0;
@@ -2149,7 +2149,7 @@ ImFont* ImFontAtlas::AddFontFromFileTTF(const char* filename, float size_pixels,
 }
 
 // NB: Transfer ownership of 'ttf_data' to ImFontAtlas, unless font_cfg_template->FontDataOwnedByAtlas == false. Owned TTF buffer will be deleted after Build().
-ImFont* ImFontAtlas::AddFontFromMemoryTTF(void* ttf_data, int ttf_size, float size_pixels, const ImFontConfig* font_cfg_template, const ImWchar* glyph_ranges) IMGUI_NOEXCEPT
+ImFont* ImFontAtlas::AddFontFromMemoryTTF(void* ttf_data, int ttf_size, float size_pixels, const ImFontConfig* font_cfg_template, const ImWchar* glyph_ranges) IM_NOEXCEPT
 {
     IM_ASSERT(!Locked && "Cannot modify a locked ImFontAtlas between NewFrame() and EndFrame/Render()!");
     ImFontConfig font_cfg = font_cfg_template ? *font_cfg_template : ImFontConfig();
@@ -2162,7 +2162,7 @@ ImFont* ImFontAtlas::AddFontFromMemoryTTF(void* ttf_data, int ttf_size, float si
     return AddFont(&font_cfg);
 }
 
-ImFont* ImFontAtlas::AddFontFromMemoryCompressedTTF(const void* compressed_ttf_data, int compressed_ttf_size, float size_pixels, const ImFontConfig* font_cfg_template, const ImWchar* glyph_ranges) IMGUI_NOEXCEPT
+ImFont* ImFontAtlas::AddFontFromMemoryCompressedTTF(const void* compressed_ttf_data, int compressed_ttf_size, float size_pixels, const ImFontConfig* font_cfg_template, const ImWchar* glyph_ranges) IM_NOEXCEPT
 {
     const unsigned int buf_decompressed_size = stb_decompress_length((const unsigned char*)compressed_ttf_data);
     unsigned char* buf_decompressed_data = (unsigned char*)IM_ALLOC(buf_decompressed_size);
@@ -2174,7 +2174,7 @@ ImFont* ImFontAtlas::AddFontFromMemoryCompressedTTF(const void* compressed_ttf_d
     return AddFontFromMemoryTTF(buf_decompressed_data, (int)buf_decompressed_size, size_pixels, &font_cfg, glyph_ranges);
 }
 
-ImFont* ImFontAtlas::AddFontFromMemoryCompressedBase85TTF(const char* compressed_ttf_data_base85, float size_pixels, const ImFontConfig* font_cfg, const ImWchar* glyph_ranges) IMGUI_NOEXCEPT
+ImFont* ImFontAtlas::AddFontFromMemoryCompressedBase85TTF(const char* compressed_ttf_data_base85, float size_pixels, const ImFontConfig* font_cfg, const ImWchar* glyph_ranges) IM_NOEXCEPT
 {
     int compressed_ttf_size = (((int)strlen(compressed_ttf_data_base85) + 4) / 5) * 4;
     void* compressed_ttf = IM_ALLOC((size_t)compressed_ttf_size);
@@ -2184,7 +2184,7 @@ ImFont* ImFontAtlas::AddFontFromMemoryCompressedBase85TTF(const char* compressed
     return font;
 }
 
-int ImFontAtlas::AddCustomRectRegular(int width, int height) IMGUI_NOEXCEPT
+int ImFontAtlas::AddCustomRectRegular(int width, int height) IM_NOEXCEPT
 {
     IM_ASSERT(width > 0 && width <= 0xFFFF);
     IM_ASSERT(height > 0 && height <= 0xFFFF);
@@ -2195,7 +2195,7 @@ int ImFontAtlas::AddCustomRectRegular(int width, int height) IMGUI_NOEXCEPT
     return CustomRects.Size - 1; // Return index
 }
 
-int ImFontAtlas::AddCustomRectFontGlyph(ImFont* font, ImWchar id, int width, int height, float advance_x, const ImVec2& offset) IMGUI_NOEXCEPT
+int ImFontAtlas::AddCustomRectFontGlyph(ImFont* font, ImWchar id, int width, int height, float advance_x, const ImVec2& offset) IM_NOEXCEPT
 {
 #ifdef IMGUI_USE_WCHAR32
     IM_ASSERT(id <= IM_UNICODE_CODEPOINT_MAX);
@@ -2214,7 +2214,7 @@ int ImFontAtlas::AddCustomRectFontGlyph(ImFont* font, ImWchar id, int width, int
     return CustomRects.Size - 1; // Return index
 }
 
-void ImFontAtlas::CalcCustomRectUV(const ImFontAtlasCustomRect* rect, ImVec2* out_uv_min, ImVec2* out_uv_max) const IMGUI_NOEXCEPT
+void ImFontAtlas::CalcCustomRectUV(const ImFontAtlasCustomRect* rect, ImVec2* out_uv_min, ImVec2* out_uv_max) const IM_NOEXCEPT
 {
     IM_ASSERT(TexWidth > 0 && TexHeight > 0);   // Font atlas needs to be built before we can calculate UV coordinates
     IM_ASSERT(rect->IsPacked());                // Make sure the rectangle has been packed
@@ -2222,7 +2222,7 @@ void ImFontAtlas::CalcCustomRectUV(const ImFontAtlasCustomRect* rect, ImVec2* ou
     *out_uv_max = ImVec2((float)(rect->X + rect->Width) * TexUvScale.x, (float)(rect->Y + rect->Height) * TexUvScale.y);
 }
 
-bool ImFontAtlas::GetMouseCursorTexData(ImGuiMouseCursor cursor_type, ImVec2* out_offset, ImVec2* out_size, ImVec2 out_uv_border[2], ImVec2 out_uv_fill[2]) IMGUI_NOEXCEPT
+bool ImFontAtlas::GetMouseCursorTexData(ImGuiMouseCursor cursor_type, ImVec2* out_offset, ImVec2* out_size, ImVec2 out_uv_border[2], ImVec2 out_uv_fill[2]) IM_NOEXCEPT
 {
     if (cursor_type <= ImGuiMouseCursor_None || cursor_type >= ImGuiMouseCursor_COUNT)
         return false;
@@ -2243,7 +2243,7 @@ bool ImFontAtlas::GetMouseCursorTexData(ImGuiMouseCursor cursor_type, ImVec2* ou
     return true;
 }
 
-bool    ImFontAtlas::Build() IMGUI_NOEXCEPT
+bool    ImFontAtlas::Build() IM_NOEXCEPT
 {
     IM_ASSERT(!Locked && "Cannot modify a locked ImFontAtlas between NewFrame() and EndFrame/Render()!");
 
@@ -2268,7 +2268,7 @@ bool    ImFontAtlas::Build() IMGUI_NOEXCEPT
     return builder_io->FontBuilder_Build(this);
 }
 
-void    ImFontAtlasBuildMultiplyCalcLookupTable(unsigned char out_table[256], float in_brighten_factor) IMGUI_NOEXCEPT
+void    ImFontAtlasBuildMultiplyCalcLookupTable(unsigned char out_table[256], float in_brighten_factor) IM_NOEXCEPT
 {
     for (unsigned int i = 0; i < 256; i++)
     {
@@ -2277,7 +2277,7 @@ void    ImFontAtlasBuildMultiplyCalcLookupTable(unsigned char out_table[256], fl
     }
 }
 
-void    ImFontAtlasBuildMultiplyRectAlpha8(const unsigned char table[256], unsigned char* pixels, int x, int y, int w, int h, int stride) IMGUI_NOEXCEPT
+void    ImFontAtlasBuildMultiplyRectAlpha8(const unsigned char table[256], unsigned char* pixels, int x, int y, int w, int h, int stride) IM_NOEXCEPT
 {
     unsigned char* data = pixels + x + y * stride;
     for (int j = h; j > 0; j--, data += stride)
@@ -2311,7 +2311,7 @@ struct ImFontBuildDstData
     ImBitVector         GlyphsSet;          // This is used to resolve collision when multiple sources are merged into a same destination font.
 };
 
-static void UnpackBitVectorToFlatIndexList(const ImBitVector* in, ImVector<int>* out) IMGUI_NOEXCEPT
+static void UnpackBitVectorToFlatIndexList(const ImBitVector* in, ImVector<int>* out) IM_NOEXCEPT
 {
     IM_ASSERT(sizeof(in->Storage.Data[0]) == sizeof(int));
     const ImU32* it_begin = in->Storage.begin();
@@ -2323,7 +2323,7 @@ static void UnpackBitVectorToFlatIndexList(const ImBitVector* in, ImVector<int>*
                     out->push_back((int)(((it - it_begin) << 5) + bit_n));
 }
 
-static bool ImFontAtlasBuildWithStbTruetype(ImFontAtlas* atlas) IMGUI_NOEXCEPT
+static bool ImFontAtlasBuildWithStbTruetype(ImFontAtlas* atlas) IM_NOEXCEPT
 {
     IM_ASSERT(atlas->ConfigData.Size > 0);
 
@@ -2576,7 +2576,7 @@ static bool ImFontAtlasBuildWithStbTruetype(ImFontAtlas* atlas) IMGUI_NOEXCEPT
     return true;
 }
 
-const ImFontBuilderIO* ImFontAtlasGetBuilderForStbTruetype() IMGUI_NOEXCEPT
+const ImFontBuilderIO* ImFontAtlasGetBuilderForStbTruetype() IM_NOEXCEPT
 {
     static ImFontBuilderIO io;
     io.FontBuilder_Build = ImFontAtlasBuildWithStbTruetype;
@@ -2585,7 +2585,7 @@ const ImFontBuilderIO* ImFontAtlasGetBuilderForStbTruetype() IMGUI_NOEXCEPT
 
 #endif // IMGUI_ENABLE_STB_TRUETYPE
 
-void ImFontAtlasBuildSetupFont(ImFontAtlas* atlas, ImFont* font, ImFontConfig* font_config, float ascent, float descent) IMGUI_NOEXCEPT
+void ImFontAtlasBuildSetupFont(ImFontAtlas* atlas, ImFont* font, ImFontConfig* font_config, float ascent, float descent) IM_NOEXCEPT
 {
     if (!font_config->MergeMode)
     {
@@ -2600,7 +2600,7 @@ void ImFontAtlasBuildSetupFont(ImFontAtlas* atlas, ImFont* font, ImFontConfig* f
     font->ConfigDataCount++;
 }
 
-void ImFontAtlasBuildPackCustomRects(ImFontAtlas* atlas, void* stbrp_context_opaque) IMGUI_NOEXCEPT
+void ImFontAtlasBuildPackCustomRects(ImFontAtlas* atlas, void* stbrp_context_opaque) IM_NOEXCEPT
 {
     stbrp_context* pack_context = (stbrp_context*)stbrp_context_opaque;
     IM_ASSERT(pack_context != NULL);
@@ -2627,7 +2627,7 @@ void ImFontAtlasBuildPackCustomRects(ImFontAtlas* atlas, void* stbrp_context_opa
         }
 }
 
-void ImFontAtlasBuildRender8bppRectFromString(ImFontAtlas* atlas, int x, int y, int w, int h, const char* in_str, char in_marker_char, unsigned char in_marker_pixel_value) IMGUI_NOEXCEPT
+void ImFontAtlasBuildRender8bppRectFromString(ImFontAtlas* atlas, int x, int y, int w, int h, const char* in_str, char in_marker_char, unsigned char in_marker_pixel_value) IM_NOEXCEPT
 {
     IM_ASSERT(x >= 0 && x + w <= atlas->TexWidth);
     IM_ASSERT(y >= 0 && y + h <= atlas->TexHeight);
@@ -2637,7 +2637,7 @@ void ImFontAtlasBuildRender8bppRectFromString(ImFontAtlas* atlas, int x, int y, 
             out_pixel[off_x] = (in_str[off_x] == in_marker_char) ? in_marker_pixel_value : 0x00;
 }
 
-void ImFontAtlasBuildRender32bppRectFromString(ImFontAtlas* atlas, int x, int y, int w, int h, const char* in_str, char in_marker_char, unsigned int in_marker_pixel_value) IMGUI_NOEXCEPT
+void ImFontAtlasBuildRender32bppRectFromString(ImFontAtlas* atlas, int x, int y, int w, int h, const char* in_str, char in_marker_char, unsigned int in_marker_pixel_value) IM_NOEXCEPT
 {
     IM_ASSERT(x >= 0 && x + w <= atlas->TexWidth);
     IM_ASSERT(y >= 0 && y + h <= atlas->TexHeight);
@@ -2647,7 +2647,7 @@ void ImFontAtlasBuildRender32bppRectFromString(ImFontAtlas* atlas, int x, int y,
             out_pixel[off_x] = (in_str[off_x] == in_marker_char) ? in_marker_pixel_value : IM_COL32_BLACK_TRANS;
 }
 
-static void ImFontAtlasBuildRenderDefaultTexData(ImFontAtlas* atlas) IMGUI_NOEXCEPT
+static void ImFontAtlasBuildRenderDefaultTexData(ImFontAtlas* atlas) IM_NOEXCEPT
 {
     ImFontAtlasCustomRect* r = atlas->GetCustomRectByIndex(atlas->PackIdMouseCursors);
     IM_ASSERT(r->IsPacked());
@@ -2687,7 +2687,7 @@ static void ImFontAtlasBuildRenderDefaultTexData(ImFontAtlas* atlas) IMGUI_NOEXC
     atlas->TexUvWhitePixel = ImVec2((r->X + 0.5f) * atlas->TexUvScale.x, (r->Y + 0.5f) * atlas->TexUvScale.y);
 }
 
-static void ImFontAtlasBuildRenderLinesTexData(ImFontAtlas* atlas) IMGUI_NOEXCEPT
+static void ImFontAtlasBuildRenderLinesTexData(ImFontAtlas* atlas) IM_NOEXCEPT
 {
     if (atlas->Flags & ImFontAtlasFlags_NoBakedLines)
         return;
@@ -2739,7 +2739,7 @@ static void ImFontAtlasBuildRenderLinesTexData(ImFontAtlas* atlas) IMGUI_NOEXCEP
 }
 
 // Note: this is called / shared by both the stb_truetype and the FreeType builder
-void ImFontAtlasBuildInit(ImFontAtlas* atlas) IMGUI_NOEXCEPT
+void ImFontAtlasBuildInit(ImFontAtlas* atlas) IM_NOEXCEPT
 {
     // Register texture region for mouse cursors or standard white pixels
     if (atlas->PackIdMouseCursors < 0)
@@ -2760,7 +2760,7 @@ void ImFontAtlasBuildInit(ImFontAtlas* atlas) IMGUI_NOEXCEPT
 }
 
 // This is called/shared by both the stb_truetype and the FreeType builder.
-void ImFontAtlasBuildFinish(ImFontAtlas* atlas) IMGUI_NOEXCEPT
+void ImFontAtlasBuildFinish(ImFontAtlas* atlas) IM_NOEXCEPT
 {
     // Render into our custom data blocks
     IM_ASSERT(atlas->TexPixelsAlpha8 != NULL || atlas->TexPixelsRGBA32 != NULL);
@@ -2805,7 +2805,7 @@ void ImFontAtlasBuildFinish(ImFontAtlas* atlas) IMGUI_NOEXCEPT
 }
 
 // Retrieve list of range (2 int per range, values are inclusive)
-const ImWchar*   ImFontAtlas::GetGlyphRangesDefault() IMGUI_NOEXCEPT
+const ImWchar*   ImFontAtlas::GetGlyphRangesDefault() IM_NOEXCEPT
 {
     static const ImWchar ranges[] =
     {
@@ -2815,7 +2815,7 @@ const ImWchar*   ImFontAtlas::GetGlyphRangesDefault() IMGUI_NOEXCEPT
     return &ranges[0];
 }
 
-const ImWchar*  ImFontAtlas::GetGlyphRangesKorean() IMGUI_NOEXCEPT
+const ImWchar*  ImFontAtlas::GetGlyphRangesKorean() IM_NOEXCEPT
 {
     static const ImWchar ranges[] =
     {
@@ -2827,7 +2827,7 @@ const ImWchar*  ImFontAtlas::GetGlyphRangesKorean() IMGUI_NOEXCEPT
     return &ranges[0];
 }
 
-const ImWchar*  ImFontAtlas::GetGlyphRangesChineseFull() IMGUI_NOEXCEPT
+const ImWchar*  ImFontAtlas::GetGlyphRangesChineseFull() IM_NOEXCEPT
 {
     static const ImWchar ranges[] =
     {
@@ -2842,7 +2842,7 @@ const ImWchar*  ImFontAtlas::GetGlyphRangesChineseFull() IMGUI_NOEXCEPT
     return &ranges[0];
 }
 
-static void UnpackAccumulativeOffsetsIntoRanges(int base_codepoint, const short* accumulative_offsets, int accumulative_offsets_count, ImWchar* out_ranges) IMGUI_NOEXCEPT
+static void UnpackAccumulativeOffsetsIntoRanges(int base_codepoint, const short* accumulative_offsets, int accumulative_offsets_count, ImWchar* out_ranges) IM_NOEXCEPT
 {
     for (int n = 0; n < accumulative_offsets_count; n++, out_ranges += 2)
     {
@@ -2856,7 +2856,7 @@ static void UnpackAccumulativeOffsetsIntoRanges(int base_codepoint, const short*
 // [SECTION] ImFontAtlas glyph ranges helpers
 //-------------------------------------------------------------------------
 
-const ImWchar*  ImFontAtlas::GetGlyphRangesChineseSimplifiedCommon() IMGUI_NOEXCEPT
+const ImWchar*  ImFontAtlas::GetGlyphRangesChineseSimplifiedCommon() IM_NOEXCEPT
 {
     // Store 2500 regularly used characters for Simplified Chinese.
     // Sourced from https://zh.wiktionary.org/wiki/%E9%99%84%E5%BD%95:%E7%8E%B0%E4%BB%A3%E6%B1%89%E8%AF%AD%E5%B8%B8%E7%94%A8%E5%AD%97%E8%A1%A8
@@ -2923,7 +2923,7 @@ const ImWchar*  ImFontAtlas::GetGlyphRangesChineseSimplifiedCommon() IMGUI_NOEXC
     return &full_ranges[0];
 }
 
-const ImWchar*  ImFontAtlas::GetGlyphRangesJapanese() IMGUI_NOEXCEPT
+const ImWchar*  ImFontAtlas::GetGlyphRangesJapanese() IM_NOEXCEPT
 {
     // 2999 ideograms code points for Japanese
     // - 2136 Joyo (meaning "for regular use" or "for common use") Kanji code points
@@ -3012,7 +3012,7 @@ const ImWchar*  ImFontAtlas::GetGlyphRangesJapanese() IMGUI_NOEXCEPT
     return &full_ranges[0];
 }
 
-const ImWchar*  ImFontAtlas::GetGlyphRangesCyrillic() IMGUI_NOEXCEPT
+const ImWchar*  ImFontAtlas::GetGlyphRangesCyrillic() IM_NOEXCEPT
 {
     static const ImWchar ranges[] =
     {
@@ -3025,7 +3025,7 @@ const ImWchar*  ImFontAtlas::GetGlyphRangesCyrillic() IMGUI_NOEXCEPT
     return &ranges[0];
 }
 
-const ImWchar*  ImFontAtlas::GetGlyphRangesThai() IMGUI_NOEXCEPT
+const ImWchar*  ImFontAtlas::GetGlyphRangesThai() IM_NOEXCEPT
 {
     static const ImWchar ranges[] =
     {
@@ -3037,7 +3037,7 @@ const ImWchar*  ImFontAtlas::GetGlyphRangesThai() IMGUI_NOEXCEPT
     return &ranges[0];
 }
 
-const ImWchar*  ImFontAtlas::GetGlyphRangesVietnamese() IMGUI_NOEXCEPT
+const ImWchar*  ImFontAtlas::GetGlyphRangesVietnamese() IM_NOEXCEPT
 {
     static const ImWchar ranges[] =
     {
@@ -3058,7 +3058,7 @@ const ImWchar*  ImFontAtlas::GetGlyphRangesVietnamese() IMGUI_NOEXCEPT
 // [SECTION] ImFontGlyphRangesBuilder
 //-----------------------------------------------------------------------------
 
-void ImFontGlyphRangesBuilder::AddText(const char* text, const char* text_end) IMGUI_NOEXCEPT
+void ImFontGlyphRangesBuilder::AddText(const char* text, const char* text_end) IM_NOEXCEPT
 {
     while (text_end ? (text < text_end) : *text)
     {
@@ -3071,14 +3071,14 @@ void ImFontGlyphRangesBuilder::AddText(const char* text, const char* text_end) I
     }
 }
 
-void ImFontGlyphRangesBuilder::AddRanges(const ImWchar* ranges) IMGUI_NOEXCEPT
+void ImFontGlyphRangesBuilder::AddRanges(const ImWchar* ranges) IM_NOEXCEPT
 {
     for (; ranges[0]; ranges += 2)
         for (ImWchar c = ranges[0]; c <= ranges[1]; c++)
             AddChar(c);
 }
 
-void ImFontGlyphRangesBuilder::BuildRanges(ImVector<ImWchar>* out_ranges) IMGUI_NOEXCEPT
+void ImFontGlyphRangesBuilder::BuildRanges(ImVector<ImWchar>* out_ranges) IM_NOEXCEPT
 {
     const int max_codepoint = IM_UNICODE_CODEPOINT_MAX;
     for (int n = 0; n <= max_codepoint; n++)
@@ -3096,7 +3096,7 @@ void ImFontGlyphRangesBuilder::BuildRanges(ImVector<ImWchar>* out_ranges) IMGUI_
 // [SECTION] ImFont
 //-----------------------------------------------------------------------------
 
-ImFont::ImFont() IMGUI_NOEXCEPT
+ImFont::ImFont() IM_NOEXCEPT
 {
     FontSize = 0.0f;
     FallbackAdvanceX = 0.0f;
@@ -3113,12 +3113,12 @@ ImFont::ImFont() IMGUI_NOEXCEPT
     memset(Used4kPagesMap, 0, sizeof(Used4kPagesMap));
 }
 
-ImFont::~ImFont() IMGUI_NOEXCEPT
+ImFont::~ImFont() IM_NOEXCEPT
 {
     ClearOutputData();
 }
 
-void    ImFont::ClearOutputData() IMGUI_NOEXCEPT
+void    ImFont::ClearOutputData() IM_NOEXCEPT
 {
     FontSize = 0.0f;
     FallbackAdvanceX = 0.0f;
@@ -3132,7 +3132,7 @@ void    ImFont::ClearOutputData() IMGUI_NOEXCEPT
     MetricsTotalSurface = 0;
 }
 
-void ImFont::BuildLookupTable() IMGUI_NOEXCEPT
+void ImFont::BuildLookupTable() IM_NOEXCEPT
 {
     int max_codepoint = 0;
     for (int i = 0; i != Glyphs.Size; i++)
@@ -3184,7 +3184,7 @@ void ImFont::BuildLookupTable() IMGUI_NOEXCEPT
 
 // API is designed this way to avoid exposing the 4K page size
 // e.g. use with IsGlyphRangeUnused(0, 255)
-bool ImFont::IsGlyphRangeUnused(unsigned int c_begin, unsigned int c_last) IMGUI_NOEXCEPT
+bool ImFont::IsGlyphRangeUnused(unsigned int c_begin, unsigned int c_last) IM_NOEXCEPT
 {
     unsigned int page_begin = (c_begin / 4096);
     unsigned int page_last = (c_last / 4096);
@@ -3195,19 +3195,19 @@ bool ImFont::IsGlyphRangeUnused(unsigned int c_begin, unsigned int c_last) IMGUI
     return true;
 }
 
-void ImFont::SetGlyphVisible(ImWchar c, bool visible) IMGUI_NOEXCEPT
+void ImFont::SetGlyphVisible(ImWchar c, bool visible) IM_NOEXCEPT
 {
     if (ImFontGlyph* glyph = (ImFontGlyph*)(void*)FindGlyph((ImWchar)c))
         glyph->Visible = visible ? 1 : 0;
 }
 
-void ImFont::SetFallbackChar(ImWchar c) IMGUI_NOEXCEPT
+void ImFont::SetFallbackChar(ImWchar c) IM_NOEXCEPT
 {
     FallbackChar = c;
     BuildLookupTable();
 }
 
-void ImFont::GrowIndex(int new_size) IMGUI_NOEXCEPT
+void ImFont::GrowIndex(int new_size) IM_NOEXCEPT
 {
     IM_ASSERT(IndexAdvanceX.Size == IndexLookup.Size);
     if (new_size <= IndexLookup.Size)
@@ -3219,7 +3219,7 @@ void ImFont::GrowIndex(int new_size) IMGUI_NOEXCEPT
 // x0/y0/x1/y1 are offset from the character upper-left layout position, in pixels. Therefore x0/y0 are often fairly close to zero.
 // Not to be mistaken with texture coordinates, which are held by u0/v0/u1/v1 in normalized format (0.0..1.0 on each texture axis).
 // 'cfg' is not necessarily == 'this->ConfigData' because multiple source fonts+configs can be used to build one target font.
-void ImFont::AddGlyph(const ImFontConfig* cfg, ImWchar codepoint, float x0, float y0, float x1, float y1, float u0, float v0, float u1, float v1, float advance_x) IMGUI_NOEXCEPT
+void ImFont::AddGlyph(const ImFontConfig* cfg, ImWchar codepoint, float x0, float y0, float x1, float y1, float u0, float v0, float u1, float v1, float advance_x) IM_NOEXCEPT
 {
     if (cfg != NULL)
     {
@@ -3263,7 +3263,7 @@ void ImFont::AddGlyph(const ImFontConfig* cfg, ImWchar codepoint, float x0, floa
     MetricsTotalSurface += (int)((glyph.U1 - glyph.U0) * ContainerAtlas->TexWidth + pad) * (int)((glyph.V1 - glyph.V0) * ContainerAtlas->TexHeight + pad);
 }
 
-void ImFont::AddRemapChar(ImWchar dst, ImWchar src, bool overwrite_dst) IMGUI_NOEXCEPT
+void ImFont::AddRemapChar(ImWchar dst, ImWchar src, bool overwrite_dst) IM_NOEXCEPT
 {
     IM_ASSERT(IndexLookup.Size > 0);    // Currently this can only be called AFTER the font has been built, aka after calling ImFontAtlas::GetTexDataAs*() function.
     unsigned int index_size = (unsigned int)IndexLookup.Size;
@@ -3278,7 +3278,7 @@ void ImFont::AddRemapChar(ImWchar dst, ImWchar src, bool overwrite_dst) IMGUI_NO
     IndexAdvanceX[dst] = (src < index_size) ? IndexAdvanceX.Data[src] : 1.0f;
 }
 
-const ImFontGlyph* ImFont::FindGlyph(ImWchar c) const IMGUI_NOEXCEPT
+const ImFontGlyph* ImFont::FindGlyph(ImWchar c) const IM_NOEXCEPT
 {
     if (c >= (size_t)IndexLookup.Size)
         return FallbackGlyph;
@@ -3288,7 +3288,7 @@ const ImFontGlyph* ImFont::FindGlyph(ImWchar c) const IMGUI_NOEXCEPT
     return &Glyphs.Data[i];
 }
 
-const ImFontGlyph* ImFont::FindGlyphNoFallback(ImWchar c) const IMGUI_NOEXCEPT
+const ImFontGlyph* ImFont::FindGlyphNoFallback(ImWchar c) const IM_NOEXCEPT
 {
     if (c >= (size_t)IndexLookup.Size)
         return NULL;
@@ -3298,7 +3298,7 @@ const ImFontGlyph* ImFont::FindGlyphNoFallback(ImWchar c) const IMGUI_NOEXCEPT
     return &Glyphs.Data[i];
 }
 
-const char* ImFont::CalcWordWrapPositionA(float scale, const char* text, const char* text_end, float wrap_width) const IMGUI_NOEXCEPT
+const char* ImFont::CalcWordWrapPositionA(float scale, const char* text, const char* text_end, float wrap_width) const IM_NOEXCEPT
 {
     // Simple word-wrapping for English, not full-featured. Please submit failing cases!
     // FIXME: Much possible improvements (don't cut things like "word !", "word!!!" but cut within "word,,,,", more sensible support for punctuations, support for Unicode punctuations, etc.)
@@ -3397,7 +3397,7 @@ const char* ImFont::CalcWordWrapPositionA(float scale, const char* text, const c
     return s;
 }
 
-ImVec2 ImFont::CalcTextSizeA(float size, float max_width, float wrap_width, const char* text_begin, const char* text_end, const char** remaining) const IMGUI_NOEXCEPT
+ImVec2 ImFont::CalcTextSizeA(float size, float max_width, float wrap_width, const char* text_begin, const char* text_end, const char** remaining) const IM_NOEXCEPT
 {
     if (!text_end)
         text_end = text_begin + strlen(text_begin); // FIXME-OPT: Need to avoid this.
@@ -3492,7 +3492,7 @@ ImVec2 ImFont::CalcTextSizeA(float size, float max_width, float wrap_width, cons
 }
 
 // Note: as with every ImDrawList drawing function, this expects that the font atlas texture is bound.
-void ImFont::RenderChar(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col, ImWchar c) const IMGUI_NOEXCEPT
+void ImFont::RenderChar(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col, ImWchar c) const IM_NOEXCEPT
 {
     const ImFontGlyph* glyph = FindGlyph(c);
     if (!glyph || !glyph->Visible)
@@ -3507,7 +3507,7 @@ void ImFont::RenderChar(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col
 }
 
 // Note: as with every ImDrawList drawing function, this expects that the font atlas texture is bound.
-void ImFont::RenderText(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col, const ImVec4& clip_rect, const char* text_begin, const char* text_end, float wrap_width, bool cpu_fine_clip) const IMGUI_NOEXCEPT
+void ImFont::RenderText(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col, const ImVec4& clip_rect, const char* text_begin, const char* text_end, float wrap_width, bool cpu_fine_clip) const IM_NOEXCEPT
 {
     if (!text_end)
         text_end = text_begin + strlen(text_begin); // ImGui:: functions generally already provides a valid text_end, so this is merely to handle direct calls.
@@ -3714,7 +3714,7 @@ void ImFont::RenderText(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col
 //-----------------------------------------------------------------------------
 
 // Render an arrow aimed to be aligned with text (p_min is a position in the same space text would be positioned). To e.g. denote expanded/collapsed state
-void ImGui::RenderArrow(ImDrawList* draw_list, ImVec2 pos, ImU32 col, ImGuiDir dir, float scale) IMGUI_NOEXCEPT
+void ImGui::RenderArrow(ImDrawList* draw_list, ImVec2 pos, ImU32 col, ImGuiDir dir, float scale) IM_NOEXCEPT
 {
     const float h = draw_list->_Data->FontSize * 1.00f;
     float r = h * 0.40f * scale;
@@ -3745,12 +3745,12 @@ void ImGui::RenderArrow(ImDrawList* draw_list, ImVec2 pos, ImU32 col, ImGuiDir d
     draw_list->AddTriangleFilled(center + a, center + b, center + c, col);
 }
 
-void ImGui::RenderBullet(ImDrawList* draw_list, ImVec2 pos, ImU32 col) IMGUI_NOEXCEPT
+void ImGui::RenderBullet(ImDrawList* draw_list, ImVec2 pos, ImU32 col) IM_NOEXCEPT
 {
     draw_list->AddCircleFilled(pos, draw_list->_Data->FontSize * 0.20f, col, 8);
 }
 
-void ImGui::RenderCheckMark(ImDrawList* draw_list, ImVec2 pos, ImU32 col, float sz) IMGUI_NOEXCEPT
+void ImGui::RenderCheckMark(ImDrawList* draw_list, ImVec2 pos, ImU32 col, float sz) IM_NOEXCEPT
 {
     float thickness = ImMax(sz / 5.0f, 1.0f);
     sz -= thickness * 0.5f;
@@ -3765,7 +3765,7 @@ void ImGui::RenderCheckMark(ImDrawList* draw_list, ImVec2 pos, ImU32 col, float 
     draw_list->PathStroke(col, 0, thickness);
 }
 
-void ImGui::RenderMouseCursor(ImDrawList* draw_list, ImVec2 pos, float scale, ImGuiMouseCursor mouse_cursor, ImU32 col_fill, ImU32 col_border, ImU32 col_shadow) IMGUI_NOEXCEPT
+void ImGui::RenderMouseCursor(ImDrawList* draw_list, ImVec2 pos, float scale, ImGuiMouseCursor mouse_cursor, ImU32 col_fill, ImU32 col_border, ImU32 col_shadow) IM_NOEXCEPT
 {
     if (mouse_cursor == ImGuiMouseCursor_None)
         return;
@@ -3787,7 +3787,7 @@ void ImGui::RenderMouseCursor(ImDrawList* draw_list, ImVec2 pos, float scale, Im
 }
 
 // Render an arrow. 'pos' is position of the arrow tip. half_sz.x is length from base to tip. half_sz.y is length on each side.
-void ImGui::RenderArrowPointingAt(ImDrawList* draw_list, ImVec2 pos, ImVec2 half_sz, ImGuiDir direction, ImU32 col) IMGUI_NOEXCEPT
+void ImGui::RenderArrowPointingAt(ImDrawList* draw_list, ImVec2 pos, ImVec2 half_sz, ImGuiDir direction, ImU32 col) IM_NOEXCEPT
 {
     switch (direction)
     {
@@ -3799,7 +3799,7 @@ void ImGui::RenderArrowPointingAt(ImDrawList* draw_list, ImVec2 pos, ImVec2 half
     }
 }
 
-static inline float ImAcos01(float x) IMGUI_NOEXCEPT
+static inline float ImAcos01(float x) IM_NOEXCEPT
 {
     if (x <= 0.0f) return IM_PI * 0.5f;
     if (x >= 1.0f) return 0.0f;
@@ -3808,7 +3808,7 @@ static inline float ImAcos01(float x) IMGUI_NOEXCEPT
 }
 
 // FIXME: Cleanup and move code to ImDrawList.
-void ImGui::RenderRectFilledRangeH(ImDrawList* draw_list, const ImRect& rect, ImU32 col, float x_start_norm, float x_end_norm, float rounding) IMGUI_NOEXCEPT
+void ImGui::RenderRectFilledRangeH(ImDrawList* draw_list, const ImRect& rect, ImU32 col, float x_start_norm, float x_end_norm, float rounding) IM_NOEXCEPT
 {
     if (x_end_norm == x_start_norm)
         return;
@@ -3868,7 +3868,7 @@ void ImGui::RenderRectFilledRangeH(ImDrawList* draw_list, const ImRect& rect, Im
     draw_list->PathFillConvex(col);
 }
 
-void ImGui::RenderRectFilledWithHole(ImDrawList* draw_list, ImRect outer, ImRect inner, ImU32 col, float rounding) IMGUI_NOEXCEPT
+void ImGui::RenderRectFilledWithHole(ImDrawList* draw_list, ImRect outer, ImRect inner, ImU32 col, float rounding) IM_NOEXCEPT
 {
     const bool fill_L = (inner.Min.x > outer.Min.x);
     const bool fill_R = (inner.Max.x < outer.Max.x);
@@ -3888,7 +3888,7 @@ void ImGui::RenderRectFilledWithHole(ImDrawList* draw_list, ImRect outer, ImRect
 // NB: This is rather brittle and will show artifact when rounding this enabled if rounded corners overlap multiple cells. Caller currently responsible for avoiding that.
 // Spent a non reasonable amount of time trying to getting this right for ColorButton with rounding+anti-aliasing+ImGuiColorEditFlags_HalfAlphaPreview flag + various grid sizes and offsets, and eventually gave up... probably more reasonable to disable rounding altogether.
 // FIXME: uses ImGui::GetColorU32
-void ImGui::RenderColorRectWithAlphaCheckerboard(ImDrawList* draw_list, ImVec2 p_min, ImVec2 p_max, ImU32 col, float grid_step, ImVec2 grid_off, float rounding, ImDrawFlags flags) IMGUI_NOEXCEPT
+void ImGui::RenderColorRectWithAlphaCheckerboard(ImDrawList* draw_list, ImVec2 p_min, ImVec2 p_max, ImU32 col, float grid_step, ImVec2 grid_off, float rounding, ImDrawFlags flags) IM_NOEXCEPT
 {
     if ((flags & ImDrawFlags_RoundCornersMask_) == 0)
         flags = ImDrawFlags_RoundCornersDefault_;
@@ -3934,7 +3934,7 @@ void ImGui::RenderColorRectWithAlphaCheckerboard(ImDrawList* draw_list, ImVec2 p
 // Decompression from stb.h (public domain) by Sean Barrett https://github.com/nothings/stb/blob/master/stb.h
 //-----------------------------------------------------------------------------
 
-static unsigned int stb_decompress_length(const unsigned char *input) IMGUI_NOEXCEPT
+static unsigned int stb_decompress_length(const unsigned char *input) IM_NOEXCEPT
 {
     return (input[8] << 24) + (input[9] << 16) + (input[10] << 8) + input[11];
 }
@@ -3942,7 +3942,7 @@ static unsigned int stb_decompress_length(const unsigned char *input) IMGUI_NOEX
 static unsigned char *stb__barrier_out_e, *stb__barrier_out_b;
 static const unsigned char *stb__barrier_in_b;
 static unsigned char *stb__dout;
-static void stb__match(const unsigned char *data, unsigned int length) IMGUI_NOEXCEPT
+static void stb__match(const unsigned char *data, unsigned int length) IM_NOEXCEPT
 {
     // INVERSE of memmove... write each byte before copying the next...
     IM_ASSERT(stb__dout + length <= stb__barrier_out_e);
@@ -3951,7 +3951,7 @@ static void stb__match(const unsigned char *data, unsigned int length) IMGUI_NOE
     while (length--) *stb__dout++ = *data++;
 }
 
-static void stb__lit(const unsigned char *data, unsigned int length) IMGUI_NOEXCEPT
+static void stb__lit(const unsigned char *data, unsigned int length) IM_NOEXCEPT
 {
     IM_ASSERT(stb__dout + length <= stb__barrier_out_e);
     if (stb__dout + length > stb__barrier_out_e) { stb__dout += length; return; }
@@ -3964,7 +3964,7 @@ static void stb__lit(const unsigned char *data, unsigned int length) IMGUI_NOEXC
 #define stb__in3(x)   ((i[x] << 16) + stb__in2((x)+1))
 #define stb__in4(x)   ((i[x] << 24) + stb__in3((x)+1))
 
-static const unsigned char *stb_decompress_token(const unsigned char *i) IMGUI_NOEXCEPT
+static const unsigned char *stb_decompress_token(const unsigned char *i) IM_NOEXCEPT
 {
     if (*i >= 0x20) { // use fewer if's for cases that expand small
         if (*i >= 0x80)       stb__match(stb__dout-i[1]-1, i[0] - 0x80 + 1), i += 2;
@@ -3981,7 +3981,7 @@ static const unsigned char *stb_decompress_token(const unsigned char *i) IMGUI_N
     return i;
 }
 
-static unsigned int stb_adler32(unsigned int adler32, unsigned char *buffer, unsigned int buflen) IMGUI_NOEXCEPT
+static unsigned int stb_adler32(unsigned int adler32, unsigned char *buffer, unsigned int buflen) IM_NOEXCEPT
 {
     const unsigned long ADLER_MOD = 65521;
     unsigned long s1 = adler32 & 0xffff, s2 = adler32 >> 16;
@@ -4012,7 +4012,7 @@ static unsigned int stb_adler32(unsigned int adler32, unsigned char *buffer, uns
     return (unsigned int)(s2 << 16) + (unsigned int)s1;
 }
 
-static unsigned int stb_decompress(unsigned char *output, const unsigned char *i, unsigned int /*length*/) IMGUI_NOEXCEPT
+static unsigned int stb_decompress(unsigned char *output, const unsigned char *i, unsigned int /*length*/) IM_NOEXCEPT
 {
     if (stb__in4(0) != 0x57bC0000) return 0;
     if (stb__in4(4) != 0)          return 0; // error! stream is > 4GB
@@ -4144,7 +4144,7 @@ static const char proggy_clean_ttf_compressed_data_base85[11980 + 1] =
     "GT4CPGT4CPGT4CPGT4CPGT4CPGT4CP-qekC`.9kEg^+F$kwViFJTB&5KTB&5KTB&5KTB&5KTB&5KTB&5KTB&5KTB&5KTB&5KTB&5KTB&5KTB&5KTB&5KTB&5KTB&5o,^<-28ZI'O?;xp"
     "O?;xpO?;xpO?;xpO?;xpO?;xpO?;xpO?;xpO?;xpO?;xpO?;xpO?;xpO?;xpO?;xp;7q-#lLYI:xvD=#";
 
-static const char* GetDefaultCompressedFontDataTTFBase85() IMGUI_NOEXCEPT
+static const char* GetDefaultCompressedFontDataTTFBase85() IM_NOEXCEPT
 {
     return proggy_clean_ttf_compressed_data_base85;
 }

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -187,7 +187,7 @@ using namespace IMGUI_STB_NAMESPACE;
 // [SECTION] Style functions
 //-----------------------------------------------------------------------------
 
-void ImGui::StyleColorsDark(ImGuiStyle* dst)
+void ImGui::StyleColorsDark(ImGuiStyle* dst) IMGUI_NOEXCEPT
 {
     ImGuiStyle* style = dst ? dst : &ImGui::GetStyle();
     ImVec4* colors = style->Colors;
@@ -247,7 +247,7 @@ void ImGui::StyleColorsDark(ImGuiStyle* dst)
     colors[ImGuiCol_ModalWindowDimBg]       = ImVec4(0.80f, 0.80f, 0.80f, 0.35f);
 }
 
-void ImGui::StyleColorsClassic(ImGuiStyle* dst)
+void ImGui::StyleColorsClassic(ImGuiStyle* dst) IMGUI_NOEXCEPT
 {
     ImGuiStyle* style = dst ? dst : &ImGui::GetStyle();
     ImVec4* colors = style->Colors;
@@ -308,7 +308,7 @@ void ImGui::StyleColorsClassic(ImGuiStyle* dst)
 }
 
 // Those light colors are better suited with a thicker font than the default one + FrameBorder
-void ImGui::StyleColorsLight(ImGuiStyle* dst)
+void ImGui::StyleColorsLight(ImGuiStyle* dst) IMGUI_NOEXCEPT
 {
     ImGuiStyle* style = dst ? dst : &ImGui::GetStyle();
     ImVec4* colors = style->Colors;
@@ -372,7 +372,7 @@ void ImGui::StyleColorsLight(ImGuiStyle* dst)
 // [SECTION] ImDrawList
 //-----------------------------------------------------------------------------
 
-ImDrawListSharedData::ImDrawListSharedData()
+ImDrawListSharedData::ImDrawListSharedData() IMGUI_NOEXCEPT
 {
     memset(this, 0, sizeof(*this));
     for (int i = 0; i < IM_ARRAYSIZE(ArcFastVtx); i++)
@@ -383,7 +383,7 @@ ImDrawListSharedData::ImDrawListSharedData()
     ArcFastRadiusCutoff = IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_CALC_R(IM_DRAWLIST_ARCFAST_SAMPLE_MAX, CircleSegmentMaxError);
 }
 
-void ImDrawListSharedData::SetCircleTessellationMaxError(float max_error)
+void ImDrawListSharedData::SetCircleTessellationMaxError(float max_error) IMGUI_NOEXCEPT
 {
     if (CircleSegmentMaxError == max_error)
         return;
@@ -399,7 +399,7 @@ void ImDrawListSharedData::SetCircleTessellationMaxError(float max_error)
 }
 
 // Initialize before use in a new frame. We always have a command ready in the buffer.
-void ImDrawList::_ResetForNewFrame()
+void ImDrawList::_ResetForNewFrame() IMGUI_NOEXCEPT
 {
     // Verify that the ImDrawCmd fields we want to memcmp() are contiguous in memory.
     // (those should be IM_STATIC_ASSERT() in theory but with our pre C++11 setup the whole check doesn't compile with GCC)
@@ -423,7 +423,7 @@ void ImDrawList::_ResetForNewFrame()
     _FringeScale = 1.0f;
 }
 
-void ImDrawList::_ClearFreeMemory()
+void ImDrawList::_ClearFreeMemory() IMGUI_NOEXCEPT
 {
     CmdBuffer.clear();
     IdxBuffer.clear();
@@ -438,7 +438,7 @@ void ImDrawList::_ClearFreeMemory()
     _Splitter.ClearFreeMemory();
 }
 
-ImDrawList* ImDrawList::CloneOutput() const
+ImDrawList* ImDrawList::CloneOutput() const IMGUI_NOEXCEPT
 {
     ImDrawList* dst = IM_NEW(ImDrawList(_Data));
     dst->CmdBuffer = CmdBuffer;
@@ -448,7 +448,7 @@ ImDrawList* ImDrawList::CloneOutput() const
     return dst;
 }
 
-void ImDrawList::AddDrawCmd()
+void ImDrawList::AddDrawCmd() IMGUI_NOEXCEPT
 {
     ImDrawCmd draw_cmd;
     draw_cmd.ClipRect = _CmdHeader.ClipRect;    // Same as calling ImDrawCmd_HeaderCopy()
@@ -462,7 +462,7 @@ void ImDrawList::AddDrawCmd()
 
 // Pop trailing draw command (used before merging or presenting to user)
 // Note that this leaves the ImDrawList in a state unfit for further commands, as most code assume that CmdBuffer.Size > 0 && CmdBuffer.back().UserCallback == NULL
-void ImDrawList::_PopUnusedDrawCmd()
+void ImDrawList::_PopUnusedDrawCmd() IMGUI_NOEXCEPT
 {
     if (CmdBuffer.Size == 0)
         return;
@@ -471,7 +471,7 @@ void ImDrawList::_PopUnusedDrawCmd()
         CmdBuffer.pop_back();
 }
 
-void ImDrawList::AddCallback(ImDrawCallback callback, void* callback_data)
+void ImDrawList::AddCallback(ImDrawCallback callback, void* callback_data) IMGUI_NOEXCEPT
 {
     ImDrawCmd* curr_cmd = &CmdBuffer.Data[CmdBuffer.Size - 1];
     IM_ASSERT(curr_cmd->UserCallback == NULL);
@@ -493,7 +493,7 @@ void ImDrawList::AddCallback(ImDrawCallback callback, void* callback_data)
 
 // Our scheme may appears a bit unusual, basically we want the most-common calls AddLine AddRect etc. to not have to perform any check so we always have a command ready in the stack.
 // The cost of figuring out if a new command has to be added or if we can merge is paid in those Update** functions only.
-void ImDrawList::_OnChangedClipRect()
+void ImDrawList::_OnChangedClipRect() IMGUI_NOEXCEPT
 {
     // If current command is used with different settings we need to add a new command
     ImDrawCmd* curr_cmd = &CmdBuffer.Data[CmdBuffer.Size - 1];
@@ -515,7 +515,7 @@ void ImDrawList::_OnChangedClipRect()
     curr_cmd->ClipRect = _CmdHeader.ClipRect;
 }
 
-void ImDrawList::_OnChangedTextureID()
+void ImDrawList::_OnChangedTextureID() IMGUI_NOEXCEPT
 {
     // If current command is used with different settings we need to add a new command
     ImDrawCmd* curr_cmd = &CmdBuffer.Data[CmdBuffer.Size - 1];
@@ -537,7 +537,7 @@ void ImDrawList::_OnChangedTextureID()
     curr_cmd->TextureId = _CmdHeader.TextureId;
 }
 
-void ImDrawList::_OnChangedVtxOffset()
+void ImDrawList::_OnChangedVtxOffset() IMGUI_NOEXCEPT
 {
     // We don't need to compare curr_cmd->VtxOffset != _CmdHeader.VtxOffset because we know it'll be different at the time we call this.
     _VtxCurrentIdx = 0;
@@ -552,7 +552,7 @@ void ImDrawList::_OnChangedVtxOffset()
     curr_cmd->VtxOffset = _CmdHeader.VtxOffset;
 }
 
-int ImDrawList::_CalcCircleAutoSegmentCount(float radius) const
+int ImDrawList::_CalcCircleAutoSegmentCount(float radius) const IMGUI_NOEXCEPT
 {
     // Automatic segment count
     const int radius_idx = (int)(radius + 0.999999f); // ceil to never reduce accuracy
@@ -563,7 +563,7 @@ int ImDrawList::_CalcCircleAutoSegmentCount(float radius) const
 }
 
 // Render-level scissoring. This is passed down to your render function but not used for CPU-side coarse clipping. Prefer using higher-level ImGui::PushClipRect() to affect logic (hit-testing and widget culling)
-void ImDrawList::PushClipRect(ImVec2 cr_min, ImVec2 cr_max, bool intersect_with_current_clip_rect)
+void ImDrawList::PushClipRect(ImVec2 cr_min, ImVec2 cr_max, bool intersect_with_current_clip_rect) IMGUI_NOEXCEPT
 {
     ImVec4 cr(cr_min.x, cr_min.y, cr_max.x, cr_max.y);
     if (intersect_with_current_clip_rect)
@@ -582,26 +582,26 @@ void ImDrawList::PushClipRect(ImVec2 cr_min, ImVec2 cr_max, bool intersect_with_
     _OnChangedClipRect();
 }
 
-void ImDrawList::PushClipRectFullScreen()
+void ImDrawList::PushClipRectFullScreen() IMGUI_NOEXCEPT
 {
     PushClipRect(ImVec2(_Data->ClipRectFullscreen.x, _Data->ClipRectFullscreen.y), ImVec2(_Data->ClipRectFullscreen.z, _Data->ClipRectFullscreen.w));
 }
 
-void ImDrawList::PopClipRect()
+void ImDrawList::PopClipRect() IMGUI_NOEXCEPT
 {
     _ClipRectStack.pop_back();
     _CmdHeader.ClipRect = (_ClipRectStack.Size == 0) ? _Data->ClipRectFullscreen : _ClipRectStack.Data[_ClipRectStack.Size - 1];
     _OnChangedClipRect();
 }
 
-void ImDrawList::PushTextureID(ImTextureID texture_id)
+void ImDrawList::PushTextureID(ImTextureID texture_id) IMGUI_NOEXCEPT
 {
     _TextureIdStack.push_back(texture_id);
     _CmdHeader.TextureId = texture_id;
     _OnChangedTextureID();
 }
 
-void ImDrawList::PopTextureID()
+void ImDrawList::PopTextureID() IMGUI_NOEXCEPT
 {
     _TextureIdStack.pop_back();
     _CmdHeader.TextureId = (_TextureIdStack.Size == 0) ? (ImTextureID)NULL : _TextureIdStack.Data[_TextureIdStack.Size - 1];
@@ -611,7 +611,7 @@ void ImDrawList::PopTextureID()
 // Reserve space for a number of vertices and indices.
 // You must finish filling your reserved data before calling PrimReserve() again, as it may reallocate or
 // submit the intermediate results. PrimUnreserve() can be used to release unused allocations.
-void ImDrawList::PrimReserve(int idx_count, int vtx_count)
+void ImDrawList::PrimReserve(int idx_count, int vtx_count) IMGUI_NOEXCEPT
 {
     // Large mesh support (when enabled)
     IM_ASSERT_PARANOID(idx_count >= 0 && vtx_count >= 0);
@@ -637,7 +637,7 @@ void ImDrawList::PrimReserve(int idx_count, int vtx_count)
 }
 
 // Release the a number of reserved vertices/indices from the end of the last reservation made with PrimReserve().
-void ImDrawList::PrimUnreserve(int idx_count, int vtx_count)
+void ImDrawList::PrimUnreserve(int idx_count, int vtx_count) IMGUI_NOEXCEPT
 {
     IM_ASSERT_PARANOID(idx_count >= 0 && vtx_count >= 0);
 
@@ -648,7 +648,7 @@ void ImDrawList::PrimUnreserve(int idx_count, int vtx_count)
 }
 
 // Fully unrolled with inline call to keep our debug builds decently fast.
-void ImDrawList::PrimRect(const ImVec2& a, const ImVec2& c, ImU32 col)
+void ImDrawList::PrimRect(const ImVec2& a, const ImVec2& c, ImU32 col) IMGUI_NOEXCEPT
 {
     ImVec2 b(c.x, a.y), d(a.x, c.y), uv(_Data->TexUvWhitePixel);
     ImDrawIdx idx = (ImDrawIdx)_VtxCurrentIdx;
@@ -663,7 +663,7 @@ void ImDrawList::PrimRect(const ImVec2& a, const ImVec2& c, ImU32 col)
     _IdxWritePtr += 6;
 }
 
-void ImDrawList::PrimRectUV(const ImVec2& a, const ImVec2& c, const ImVec2& uv_a, const ImVec2& uv_c, ImU32 col)
+void ImDrawList::PrimRectUV(const ImVec2& a, const ImVec2& c, const ImVec2& uv_a, const ImVec2& uv_c, ImU32 col) IMGUI_NOEXCEPT
 {
     ImVec2 b(c.x, a.y), d(a.x, c.y), uv_b(uv_c.x, uv_a.y), uv_d(uv_a.x, uv_c.y);
     ImDrawIdx idx = (ImDrawIdx)_VtxCurrentIdx;
@@ -678,7 +678,7 @@ void ImDrawList::PrimRectUV(const ImVec2& a, const ImVec2& c, const ImVec2& uv_a
     _IdxWritePtr += 6;
 }
 
-void ImDrawList::PrimQuadUV(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& d, const ImVec2& uv_a, const ImVec2& uv_b, const ImVec2& uv_c, const ImVec2& uv_d, ImU32 col)
+void ImDrawList::PrimQuadUV(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& d, const ImVec2& uv_a, const ImVec2& uv_b, const ImVec2& uv_c, const ImVec2& uv_d, ImU32 col) IMGUI_NOEXCEPT
 {
     ImDrawIdx idx = (ImDrawIdx)_VtxCurrentIdx;
     _IdxWritePtr[0] = idx; _IdxWritePtr[1] = (ImDrawIdx)(idx+1); _IdxWritePtr[2] = (ImDrawIdx)(idx+2);
@@ -700,7 +700,7 @@ void ImDrawList::PrimQuadUV(const ImVec2& a, const ImVec2& b, const ImVec2& c, c
 
 // TODO: Thickness anti-aliased lines cap are missing their AA fringe.
 // We avoid using the ImVec2 math operators here to reduce cost to a minimum for debug/non-inlined builds.
-void ImDrawList::AddPolyline(const ImVec2* points, const int points_count, ImU32 col, ImDrawFlags flags, float thickness)
+void ImDrawList::AddPolyline(const ImVec2* points, const int points_count, ImU32 col, ImDrawFlags flags, float thickness) IMGUI_NOEXCEPT
 {
     if (points_count < 2)
         return;
@@ -956,7 +956,7 @@ void ImDrawList::AddPolyline(const ImVec2* points, const int points_count, ImU32
 }
 
 // We intentionally avoid using ImVec2 and its math operators here to reduce cost to a minimum for debug/non-inlined builds.
-void ImDrawList::AddConvexPolyFilled(const ImVec2* points, const int points_count, ImU32 col)
+void ImDrawList::AddConvexPolyFilled(const ImVec2* points, const int points_count, ImU32 col) IMGUI_NOEXCEPT
 {
     if (points_count < 3)
         return;
@@ -1037,7 +1037,7 @@ void ImDrawList::AddConvexPolyFilled(const ImVec2* points, const int points_coun
     }
 }
 
-void ImDrawList::_PathArcToFastEx(const ImVec2& center, float radius, int a_min_sample, int a_max_sample, int a_step)
+void ImDrawList::_PathArcToFastEx(const ImVec2& center, float radius, int a_min_sample, int a_max_sample, int a_step) IMGUI_NOEXCEPT
 {
     if (radius <= 0.0f)
     {
@@ -1129,7 +1129,7 @@ void ImDrawList::_PathArcToFastEx(const ImVec2& center, float radius, int a_min_
     IM_ASSERT_PARANOID(_Path.Data + _Path.Size == out_ptr);
 }
 
-void ImDrawList::_PathArcToN(const ImVec2& center, float radius, float a_min, float a_max, int num_segments)
+void ImDrawList::_PathArcToN(const ImVec2& center, float radius, float a_min, float a_max, int num_segments) IMGUI_NOEXCEPT
 {
     if (radius <= 0.0f)
     {
@@ -1148,7 +1148,7 @@ void ImDrawList::_PathArcToN(const ImVec2& center, float radius, float a_min, fl
 }
 
 // 0: East, 3: South, 6: West, 9: North, 12: East
-void ImDrawList::PathArcToFast(const ImVec2& center, float radius, int a_min_of_12, int a_max_of_12)
+void ImDrawList::PathArcToFast(const ImVec2& center, float radius, int a_min_of_12, int a_max_of_12) IMGUI_NOEXCEPT
 {
     if (radius <= 0.0f)
     {
@@ -1158,7 +1158,7 @@ void ImDrawList::PathArcToFast(const ImVec2& center, float radius, int a_min_of_
     _PathArcToFastEx(center, radius, a_min_of_12 * IM_DRAWLIST_ARCFAST_SAMPLE_MAX / 12, a_max_of_12 * IM_DRAWLIST_ARCFAST_SAMPLE_MAX / 12, 0);
 }
 
-void ImDrawList::PathArcTo(const ImVec2& center, float radius, float a_min, float a_max, int num_segments)
+void ImDrawList::PathArcTo(const ImVec2& center, float radius, float a_min, float a_max, int num_segments) IMGUI_NOEXCEPT
 {
     if (radius <= 0.0f)
     {
@@ -1208,7 +1208,7 @@ void ImDrawList::PathArcTo(const ImVec2& center, float radius, float a_min, floa
     }
 }
 
-ImVec2 ImBezierCubicCalc(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, float t)
+ImVec2 ImBezierCubicCalc(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, float t) IMGUI_NOEXCEPT
 {
     float u = 1.0f - t;
     float w1 = u * u * u;
@@ -1218,7 +1218,7 @@ ImVec2 ImBezierCubicCalc(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, c
     return ImVec2(w1 * p1.x + w2 * p2.x + w3 * p3.x + w4 * p4.x, w1 * p1.y + w2 * p2.y + w3 * p3.y + w4 * p4.y);
 }
 
-ImVec2 ImBezierQuadraticCalc(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, float t)
+ImVec2 ImBezierQuadraticCalc(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, float t) IMGUI_NOEXCEPT
 {
     float u = 1.0f - t;
     float w1 = u * u;
@@ -1228,7 +1228,7 @@ ImVec2 ImBezierQuadraticCalc(const ImVec2& p1, const ImVec2& p2, const ImVec2& p
 }
 
 // Closely mimics ImBezierCubicClosestPointCasteljau() in imgui.cpp
-static void PathBezierCubicCurveToCasteljau(ImVector<ImVec2>* path, float x1, float y1, float x2, float y2, float x3, float y3, float x4, float y4, float tess_tol, int level)
+static void PathBezierCubicCurveToCasteljau(ImVector<ImVec2>* path, float x1, float y1, float x2, float y2, float x3, float y3, float x4, float y4, float tess_tol, int level) IMGUI_NOEXCEPT
 {
     float dx = x4 - x1;
     float dy = y4 - y1;
@@ -1253,7 +1253,7 @@ static void PathBezierCubicCurveToCasteljau(ImVector<ImVec2>* path, float x1, fl
     }
 }
 
-static void PathBezierQuadraticCurveToCasteljau(ImVector<ImVec2>* path, float x1, float y1, float x2, float y2, float x3, float y3, float tess_tol, int level)
+static void PathBezierQuadraticCurveToCasteljau(ImVector<ImVec2>* path, float x1, float y1, float x2, float y2, float x3, float y3, float tess_tol, int level) IMGUI_NOEXCEPT
 {
     float dx = x3 - x1, dy = y3 - y1;
     float det = (x2 - x3) * dy - (y2 - y3) * dx;
@@ -1271,7 +1271,7 @@ static void PathBezierQuadraticCurveToCasteljau(ImVector<ImVec2>* path, float x1
     }
 }
 
-void ImDrawList::PathBezierCubicCurveTo(const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, int num_segments)
+void ImDrawList::PathBezierCubicCurveTo(const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, int num_segments) IMGUI_NOEXCEPT
 {
     ImVec2 p1 = _Path.back();
     if (num_segments == 0)
@@ -1286,7 +1286,7 @@ void ImDrawList::PathBezierCubicCurveTo(const ImVec2& p2, const ImVec2& p3, cons
     }
 }
 
-void ImDrawList::PathBezierQuadraticCurveTo(const ImVec2& p2, const ImVec2& p3, int num_segments)
+void ImDrawList::PathBezierQuadraticCurveTo(const ImVec2& p2, const ImVec2& p3, int num_segments) IMGUI_NOEXCEPT
 {
     ImVec2 p1 = _Path.back();
     if (num_segments == 0)
@@ -1302,7 +1302,7 @@ void ImDrawList::PathBezierQuadraticCurveTo(const ImVec2& p2, const ImVec2& p3, 
 }
 
 IM_STATIC_ASSERT(ImDrawFlags_RoundCornersTopLeft == (1 << 4));
-static inline ImDrawFlags FixRectCornerFlags(ImDrawFlags flags)
+static inline ImDrawFlags FixRectCornerFlags(ImDrawFlags flags) IMGUI_NOEXCEPT
 {
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
     // Legacy Support for hard coded ~0 (used to be a suggested equivalent to ImDrawCornerFlags_All)
@@ -1335,7 +1335,7 @@ static inline ImDrawFlags FixRectCornerFlags(ImDrawFlags flags)
     return flags;
 }
 
-void ImDrawList::PathRect(const ImVec2& a, const ImVec2& b, float rounding, ImDrawFlags flags)
+void ImDrawList::PathRect(const ImVec2& a, const ImVec2& b, float rounding, ImDrawFlags flags) IMGUI_NOEXCEPT
 {
     flags = FixRectCornerFlags(flags);
     rounding = ImMin(rounding, ImFabs(b.x - a.x) * ( ((flags & ImDrawFlags_RoundCornersTop)  == ImDrawFlags_RoundCornersTop)  || ((flags & ImDrawFlags_RoundCornersBottom) == ImDrawFlags_RoundCornersBottom) ? 0.5f : 1.0f ) - 1.0f);
@@ -1361,7 +1361,7 @@ void ImDrawList::PathRect(const ImVec2& a, const ImVec2& b, float rounding, ImDr
     }
 }
 
-void ImDrawList::AddLine(const ImVec2& p1, const ImVec2& p2, ImU32 col, float thickness)
+void ImDrawList::AddLine(const ImVec2& p1, const ImVec2& p2, ImU32 col, float thickness) IMGUI_NOEXCEPT
 {
     if ((col & IM_COL32_A_MASK) == 0)
         return;
@@ -1372,7 +1372,7 @@ void ImDrawList::AddLine(const ImVec2& p1, const ImVec2& p2, ImU32 col, float th
 
 // p_min = upper-left, p_max = lower-right
 // Note we don't render 1 pixels sized rectangles properly.
-void ImDrawList::AddRect(const ImVec2& p_min, const ImVec2& p_max, ImU32 col, float rounding, ImDrawFlags flags, float thickness)
+void ImDrawList::AddRect(const ImVec2& p_min, const ImVec2& p_max, ImU32 col, float rounding, ImDrawFlags flags, float thickness) IMGUI_NOEXCEPT
 {
     if ((col & IM_COL32_A_MASK) == 0)
         return;
@@ -1383,7 +1383,7 @@ void ImDrawList::AddRect(const ImVec2& p_min, const ImVec2& p_max, ImU32 col, fl
     PathStroke(col, ImDrawFlags_Closed, thickness);
 }
 
-void ImDrawList::AddRectFilled(const ImVec2& p_min, const ImVec2& p_max, ImU32 col, float rounding, ImDrawFlags flags)
+void ImDrawList::AddRectFilled(const ImVec2& p_min, const ImVec2& p_max, ImU32 col, float rounding, ImDrawFlags flags) IMGUI_NOEXCEPT
 {
     if ((col & IM_COL32_A_MASK) == 0)
         return;
@@ -1400,7 +1400,7 @@ void ImDrawList::AddRectFilled(const ImVec2& p_min, const ImVec2& p_max, ImU32 c
 }
 
 // p_min = upper-left, p_max = lower-right
-void ImDrawList::AddRectFilledMultiColor(const ImVec2& p_min, const ImVec2& p_max, ImU32 col_upr_left, ImU32 col_upr_right, ImU32 col_bot_right, ImU32 col_bot_left)
+void ImDrawList::AddRectFilledMultiColor(const ImVec2& p_min, const ImVec2& p_max, ImU32 col_upr_left, ImU32 col_upr_right, ImU32 col_bot_right, ImU32 col_bot_left) IMGUI_NOEXCEPT
 {
     if (((col_upr_left | col_upr_right | col_bot_right | col_bot_left) & IM_COL32_A_MASK) == 0)
         return;
@@ -1415,7 +1415,7 @@ void ImDrawList::AddRectFilledMultiColor(const ImVec2& p_min, const ImVec2& p_ma
     PrimWriteVtx(ImVec2(p_min.x, p_max.y), uv, col_bot_left);
 }
 
-void ImDrawList::AddQuad(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, ImU32 col, float thickness)
+void ImDrawList::AddQuad(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, ImU32 col, float thickness) IMGUI_NOEXCEPT
 {
     if ((col & IM_COL32_A_MASK) == 0)
         return;
@@ -1427,7 +1427,7 @@ void ImDrawList::AddQuad(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, c
     PathStroke(col, ImDrawFlags_Closed, thickness);
 }
 
-void ImDrawList::AddQuadFilled(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, ImU32 col)
+void ImDrawList::AddQuadFilled(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, ImU32 col) IMGUI_NOEXCEPT
 {
     if ((col & IM_COL32_A_MASK) == 0)
         return;
@@ -1439,7 +1439,7 @@ void ImDrawList::AddQuadFilled(const ImVec2& p1, const ImVec2& p2, const ImVec2&
     PathFillConvex(col);
 }
 
-void ImDrawList::AddTriangle(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, ImU32 col, float thickness)
+void ImDrawList::AddTriangle(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, ImU32 col, float thickness) IMGUI_NOEXCEPT
 {
     if ((col & IM_COL32_A_MASK) == 0)
         return;
@@ -1450,7 +1450,7 @@ void ImDrawList::AddTriangle(const ImVec2& p1, const ImVec2& p2, const ImVec2& p
     PathStroke(col, ImDrawFlags_Closed, thickness);
 }
 
-void ImDrawList::AddTriangleFilled(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, ImU32 col)
+void ImDrawList::AddTriangleFilled(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, ImU32 col) IMGUI_NOEXCEPT
 {
     if ((col & IM_COL32_A_MASK) == 0)
         return;
@@ -1461,7 +1461,7 @@ void ImDrawList::AddTriangleFilled(const ImVec2& p1, const ImVec2& p2, const ImV
     PathFillConvex(col);
 }
 
-void ImDrawList::AddCircle(const ImVec2& center, float radius, ImU32 col, int num_segments, float thickness)
+void ImDrawList::AddCircle(const ImVec2& center, float radius, ImU32 col, int num_segments, float thickness) IMGUI_NOEXCEPT
 {
     if ((col & IM_COL32_A_MASK) == 0 || radius <= 0.0f)
         return;
@@ -1487,7 +1487,7 @@ void ImDrawList::AddCircle(const ImVec2& center, float radius, ImU32 col, int nu
     PathStroke(col, ImDrawFlags_Closed, thickness);
 }
 
-void ImDrawList::AddCircleFilled(const ImVec2& center, float radius, ImU32 col, int num_segments)
+void ImDrawList::AddCircleFilled(const ImVec2& center, float radius, ImU32 col, int num_segments) IMGUI_NOEXCEPT
 {
     if ((col & IM_COL32_A_MASK) == 0 || radius <= 0.0f)
         return;
@@ -1514,7 +1514,7 @@ void ImDrawList::AddCircleFilled(const ImVec2& center, float radius, ImU32 col, 
 }
 
 // Guaranteed to honor 'num_segments'
-void ImDrawList::AddNgon(const ImVec2& center, float radius, ImU32 col, int num_segments, float thickness)
+void ImDrawList::AddNgon(const ImVec2& center, float radius, ImU32 col, int num_segments, float thickness) IMGUI_NOEXCEPT
 {
     if ((col & IM_COL32_A_MASK) == 0 || num_segments <= 2)
         return;
@@ -1526,7 +1526,7 @@ void ImDrawList::AddNgon(const ImVec2& center, float radius, ImU32 col, int num_
 }
 
 // Guaranteed to honor 'num_segments'
-void ImDrawList::AddNgonFilled(const ImVec2& center, float radius, ImU32 col, int num_segments)
+void ImDrawList::AddNgonFilled(const ImVec2& center, float radius, ImU32 col, int num_segments) IMGUI_NOEXCEPT
 {
     if ((col & IM_COL32_A_MASK) == 0 || num_segments <= 2)
         return;
@@ -1538,7 +1538,7 @@ void ImDrawList::AddNgonFilled(const ImVec2& center, float radius, ImU32 col, in
 }
 
 // Cubic Bezier takes 4 controls points
-void ImDrawList::AddBezierCubic(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, ImU32 col, float thickness, int num_segments)
+void ImDrawList::AddBezierCubic(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, ImU32 col, float thickness, int num_segments) IMGUI_NOEXCEPT
 {
     if ((col & IM_COL32_A_MASK) == 0)
         return;
@@ -1549,7 +1549,7 @@ void ImDrawList::AddBezierCubic(const ImVec2& p1, const ImVec2& p2, const ImVec2
 }
 
 // Quadratic Bezier takes 3 controls points
-void ImDrawList::AddBezierQuadratic(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, ImU32 col, float thickness, int num_segments)
+void ImDrawList::AddBezierQuadratic(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, ImU32 col, float thickness, int num_segments) IMGUI_NOEXCEPT
 {
     if ((col & IM_COL32_A_MASK) == 0)
         return;
@@ -1559,7 +1559,7 @@ void ImDrawList::AddBezierQuadratic(const ImVec2& p1, const ImVec2& p2, const Im
     PathStroke(col, 0, thickness);
 }
 
-void ImDrawList::AddText(const ImFont* font, float font_size, const ImVec2& pos, ImU32 col, const char* text_begin, const char* text_end, float wrap_width, const ImVec4* cpu_fine_clip_rect)
+void ImDrawList::AddText(const ImFont* font, float font_size, const ImVec2& pos, ImU32 col, const char* text_begin, const char* text_end, float wrap_width, const ImVec4* cpu_fine_clip_rect) IMGUI_NOEXCEPT
 {
     if ((col & IM_COL32_A_MASK) == 0)
         return;
@@ -1588,12 +1588,12 @@ void ImDrawList::AddText(const ImFont* font, float font_size, const ImVec2& pos,
     font->RenderText(this, font_size, pos, col, clip_rect, text_begin, text_end, wrap_width, cpu_fine_clip_rect != NULL);
 }
 
-void ImDrawList::AddText(const ImVec2& pos, ImU32 col, const char* text_begin, const char* text_end)
+void ImDrawList::AddText(const ImVec2& pos, ImU32 col, const char* text_begin, const char* text_end) IMGUI_NOEXCEPT
 {
     AddText(NULL, 0.0f, pos, col, text_begin, text_end);
 }
 
-void ImDrawList::AddImage(ImTextureID user_texture_id, const ImVec2& p_min, const ImVec2& p_max, const ImVec2& uv_min, const ImVec2& uv_max, ImU32 col)
+void ImDrawList::AddImage(ImTextureID user_texture_id, const ImVec2& p_min, const ImVec2& p_max, const ImVec2& uv_min, const ImVec2& uv_max, ImU32 col) IMGUI_NOEXCEPT
 {
     if ((col & IM_COL32_A_MASK) == 0)
         return;
@@ -1609,7 +1609,7 @@ void ImDrawList::AddImage(ImTextureID user_texture_id, const ImVec2& p_min, cons
         PopTextureID();
 }
 
-void ImDrawList::AddImageQuad(ImTextureID user_texture_id, const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, const ImVec2& uv1, const ImVec2& uv2, const ImVec2& uv3, const ImVec2& uv4, ImU32 col)
+void ImDrawList::AddImageQuad(ImTextureID user_texture_id, const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, const ImVec2& uv1, const ImVec2& uv2, const ImVec2& uv3, const ImVec2& uv4, ImU32 col) IMGUI_NOEXCEPT
 {
     if ((col & IM_COL32_A_MASK) == 0)
         return;
@@ -1625,7 +1625,7 @@ void ImDrawList::AddImageQuad(ImTextureID user_texture_id, const ImVec2& p1, con
         PopTextureID();
 }
 
-void ImDrawList::AddImageRounded(ImTextureID user_texture_id, const ImVec2& p_min, const ImVec2& p_max, const ImVec2& uv_min, const ImVec2& uv_max, ImU32 col, float rounding, ImDrawFlags flags)
+void ImDrawList::AddImageRounded(ImTextureID user_texture_id, const ImVec2& p_min, const ImVec2& p_max, const ImVec2& uv_min, const ImVec2& uv_max, ImU32 col, float rounding, ImDrawFlags flags) IMGUI_NOEXCEPT
 {
     if ((col & IM_COL32_A_MASK) == 0)
         return;
@@ -1658,7 +1658,7 @@ void ImDrawList::AddImageRounded(ImTextureID user_texture_id, const ImVec2& p_mi
 // FIXME: This may be a little confusing, trying to be a little too low-level/optimal instead of just doing vector swap..
 //-----------------------------------------------------------------------------
 
-void ImDrawListSplitter::ClearFreeMemory()
+void ImDrawListSplitter::ClearFreeMemory() IMGUI_NOEXCEPT
 {
     for (int i = 0; i < _Channels.Size; i++)
     {
@@ -1672,7 +1672,7 @@ void ImDrawListSplitter::ClearFreeMemory()
     _Channels.clear();
 }
 
-void ImDrawListSplitter::Split(ImDrawList* draw_list, int channels_count)
+void ImDrawListSplitter::Split(ImDrawList* draw_list, int channels_count) IMGUI_NOEXCEPT
 {
     IM_UNUSED(draw_list);
     IM_ASSERT(_Current == 0 && _Count <= 1 && "Nested channel splitting is not supported. Please use separate instances of ImDrawListSplitter.");
@@ -1702,7 +1702,7 @@ void ImDrawListSplitter::Split(ImDrawList* draw_list, int channels_count)
     }
 }
 
-void ImDrawListSplitter::Merge(ImDrawList* draw_list)
+void ImDrawListSplitter::Merge(ImDrawList* draw_list) IMGUI_NOEXCEPT
 {
     // Note that we never use or rely on _Channels.Size because it is merely a buffer that we never shrink back to 0 to keep all sub-buffers ready for use.
     if (_Count <= 1)
@@ -1773,7 +1773,7 @@ void ImDrawListSplitter::Merge(ImDrawList* draw_list)
     _Count = 1;
 }
 
-void ImDrawListSplitter::SetCurrentChannel(ImDrawList* draw_list, int idx)
+void ImDrawListSplitter::SetCurrentChannel(ImDrawList* draw_list, int idx) IMGUI_NOEXCEPT
 {
     IM_ASSERT(idx >= 0 && idx < _Count);
     if (_Current == idx)
@@ -1802,7 +1802,7 @@ void ImDrawListSplitter::SetCurrentChannel(ImDrawList* draw_list, int idx)
 //-----------------------------------------------------------------------------
 
 // For backward compatibility: convert all buffers from indexed to de-indexed, in case you cannot render indexed. Note: this is slow and most likely a waste of resources. Always prefer indexed rendering!
-void ImDrawData::DeIndexAllBuffers()
+void ImDrawData::DeIndexAllBuffers() IMGUI_NOEXCEPT
 {
     ImVector<ImDrawVert> new_vtx_buffer;
     TotalVtxCount = TotalIdxCount = 0;
@@ -1823,7 +1823,7 @@ void ImDrawData::DeIndexAllBuffers()
 // Helper to scale the ClipRect field of each ImDrawCmd.
 // Use if your final output buffer is at a different scale than draw_data->DisplaySize,
 // or if there is a difference between your window resolution and framebuffer resolution.
-void ImDrawData::ScaleClipRects(const ImVec2& fb_scale)
+void ImDrawData::ScaleClipRects(const ImVec2& fb_scale) IMGUI_NOEXCEPT
 {
     for (int i = 0; i < CmdListsCount; i++)
     {
@@ -1841,7 +1841,7 @@ void ImDrawData::ScaleClipRects(const ImVec2& fb_scale)
 //-----------------------------------------------------------------------------
 
 // Generic linear color gradient, write to RGB fields, leave A untouched.
-void ImGui::ShadeVertsLinearColorGradientKeepAlpha(ImDrawList* draw_list, int vert_start_idx, int vert_end_idx, ImVec2 gradient_p0, ImVec2 gradient_p1, ImU32 col0, ImU32 col1)
+void ImGui::ShadeVertsLinearColorGradientKeepAlpha(ImDrawList* draw_list, int vert_start_idx, int vert_end_idx, ImVec2 gradient_p0, ImVec2 gradient_p1, ImU32 col0, ImU32 col1) IMGUI_NOEXCEPT
 {
     ImVec2 gradient_extent = gradient_p1 - gradient_p0;
     float gradient_inv_length2 = 1.0f / ImLengthSqr(gradient_extent);
@@ -1865,7 +1865,7 @@ void ImGui::ShadeVertsLinearColorGradientKeepAlpha(ImDrawList* draw_list, int ve
 }
 
 // Distribute UV over (a, b) rectangle
-void ImGui::ShadeVertsLinearUV(ImDrawList* draw_list, int vert_start_idx, int vert_end_idx, const ImVec2& a, const ImVec2& b, const ImVec2& uv_a, const ImVec2& uv_b, bool clamp)
+void ImGui::ShadeVertsLinearUV(ImDrawList* draw_list, int vert_start_idx, int vert_end_idx, const ImVec2& a, const ImVec2& b, const ImVec2& uv_a, const ImVec2& uv_b, bool clamp) IMGUI_NOEXCEPT
 {
     const ImVec2 size = b - a;
     const ImVec2 uv_size = uv_b - uv_a;
@@ -1893,7 +1893,7 @@ void ImGui::ShadeVertsLinearUV(ImDrawList* draw_list, int vert_start_idx, int ve
 // [SECTION] ImFontConfig
 //-----------------------------------------------------------------------------
 
-ImFontConfig::ImFontConfig()
+ImFontConfig::ImFontConfig() IMGUI_NOEXCEPT
 {
     memset(this, 0, sizeof(*this));
     FontDataOwnedByAtlas = true;
@@ -1956,20 +1956,20 @@ static const ImVec2 FONT_ATLAS_DEFAULT_TEX_CURSOR_DATA[ImGuiMouseCursor_COUNT][3
     { ImVec2(91,0), ImVec2(17,22), ImVec2( 5, 0) }, // ImGuiMouseCursor_Hand
 };
 
-ImFontAtlas::ImFontAtlas()
+ImFontAtlas::ImFontAtlas() IMGUI_NOEXCEPT
 {
     memset(this, 0, sizeof(*this));
     TexGlyphPadding = 1;
     PackIdMouseCursors = PackIdLines = -1;
 }
 
-ImFontAtlas::~ImFontAtlas()
+ImFontAtlas::~ImFontAtlas() IMGUI_NOEXCEPT
 {
     IM_ASSERT(!Locked && "Cannot modify a locked ImFontAtlas between NewFrame() and EndFrame/Render()!");
     Clear();
 }
 
-void    ImFontAtlas::ClearInputData()
+void    ImFontAtlas::ClearInputData() IMGUI_NOEXCEPT
 {
     IM_ASSERT(!Locked && "Cannot modify a locked ImFontAtlas between NewFrame() and EndFrame/Render()!");
     for (int i = 0; i < ConfigData.Size; i++)
@@ -1991,7 +1991,7 @@ void    ImFontAtlas::ClearInputData()
     PackIdMouseCursors = PackIdLines = -1;
 }
 
-void    ImFontAtlas::ClearTexData()
+void    ImFontAtlas::ClearTexData() IMGUI_NOEXCEPT
 {
     IM_ASSERT(!Locked && "Cannot modify a locked ImFontAtlas between NewFrame() and EndFrame/Render()!");
     if (TexPixelsAlpha8)
@@ -2003,7 +2003,7 @@ void    ImFontAtlas::ClearTexData()
     TexPixelsUseColors = false;
 }
 
-void    ImFontAtlas::ClearFonts()
+void    ImFontAtlas::ClearFonts() IMGUI_NOEXCEPT
 {
     IM_ASSERT(!Locked && "Cannot modify a locked ImFontAtlas between NewFrame() and EndFrame/Render()!");
     for (int i = 0; i < Fonts.Size; i++)
@@ -2011,14 +2011,14 @@ void    ImFontAtlas::ClearFonts()
     Fonts.clear();
 }
 
-void    ImFontAtlas::Clear()
+void    ImFontAtlas::Clear() IMGUI_NOEXCEPT
 {
     ClearInputData();
     ClearTexData();
     ClearFonts();
 }
 
-void    ImFontAtlas::GetTexDataAsAlpha8(unsigned char** out_pixels, int* out_width, int* out_height, int* out_bytes_per_pixel)
+void    ImFontAtlas::GetTexDataAsAlpha8(unsigned char** out_pixels, int* out_width, int* out_height, int* out_bytes_per_pixel) IMGUI_NOEXCEPT
 {
     // Build atlas on demand
     if (TexPixelsAlpha8 == NULL)
@@ -2034,7 +2034,7 @@ void    ImFontAtlas::GetTexDataAsAlpha8(unsigned char** out_pixels, int* out_wid
     if (out_bytes_per_pixel) *out_bytes_per_pixel = 1;
 }
 
-void    ImFontAtlas::GetTexDataAsRGBA32(unsigned char** out_pixels, int* out_width, int* out_height, int* out_bytes_per_pixel)
+void    ImFontAtlas::GetTexDataAsRGBA32(unsigned char** out_pixels, int* out_width, int* out_height, int* out_bytes_per_pixel) IMGUI_NOEXCEPT
 {
     // Convert to RGBA32 format on demand
     // Although it is likely to be the most commonly used format, our font rendering is 1 channel / 8 bpp
@@ -2058,7 +2058,7 @@ void    ImFontAtlas::GetTexDataAsRGBA32(unsigned char** out_pixels, int* out_wid
     if (out_bytes_per_pixel) *out_bytes_per_pixel = 4;
 }
 
-ImFont* ImFontAtlas::AddFont(const ImFontConfig* font_cfg)
+ImFont* ImFontAtlas::AddFont(const ImFontConfig* font_cfg) IMGUI_NOEXCEPT
 {
     IM_ASSERT(!Locked && "Cannot modify a locked ImFontAtlas between NewFrame() and EndFrame/Render()!");
     IM_ASSERT(font_cfg->FontData != NULL && font_cfg->FontDataSize > 0);
@@ -2090,11 +2090,11 @@ ImFont* ImFontAtlas::AddFont(const ImFontConfig* font_cfg)
 }
 
 // Default font TTF is compressed with stb_compress then base85 encoded (see misc/fonts/binary_to_compressed_c.cpp for encoder)
-static unsigned int stb_decompress_length(const unsigned char* input);
-static unsigned int stb_decompress(unsigned char* output, const unsigned char* input, unsigned int length);
-static const char*  GetDefaultCompressedFontDataTTFBase85();
-static unsigned int Decode85Byte(char c)                                    { return c >= '\\' ? c-36 : c-35; }
-static void         Decode85(const unsigned char* src, unsigned char* dst)
+static unsigned int stb_decompress_length(const unsigned char* input) IMGUI_NOEXCEPT;
+static unsigned int stb_decompress(unsigned char* output, const unsigned char* input, unsigned int length) IMGUI_NOEXCEPT;
+static const char*  GetDefaultCompressedFontDataTTFBase85() IMGUI_NOEXCEPT;
+static unsigned int Decode85Byte(char c) IMGUI_NOEXCEPT                      { return c >= '\\' ? c-36 : c-35; }
+static void         Decode85(const unsigned char* src, unsigned char* dst) IMGUI_NOEXCEPT
 {
     while (*src)
     {
@@ -2106,7 +2106,7 @@ static void         Decode85(const unsigned char* src, unsigned char* dst)
 }
 
 // Load embedded ProggyClean.ttf at size 13, disable oversampling
-ImFont* ImFontAtlas::AddFontDefault(const ImFontConfig* font_cfg_template)
+ImFont* ImFontAtlas::AddFontDefault(const ImFontConfig* font_cfg_template) IMGUI_NOEXCEPT
 {
     ImFontConfig font_cfg = font_cfg_template ? *font_cfg_template : ImFontConfig();
     if (!font_cfg_template)
@@ -2127,7 +2127,7 @@ ImFont* ImFontAtlas::AddFontDefault(const ImFontConfig* font_cfg_template)
     return font;
 }
 
-ImFont* ImFontAtlas::AddFontFromFileTTF(const char* filename, float size_pixels, const ImFontConfig* font_cfg_template, const ImWchar* glyph_ranges)
+ImFont* ImFontAtlas::AddFontFromFileTTF(const char* filename, float size_pixels, const ImFontConfig* font_cfg_template, const ImWchar* glyph_ranges) IMGUI_NOEXCEPT
 {
     IM_ASSERT(!Locked && "Cannot modify a locked ImFontAtlas between NewFrame() and EndFrame/Render()!");
     size_t data_size = 0;
@@ -2149,7 +2149,7 @@ ImFont* ImFontAtlas::AddFontFromFileTTF(const char* filename, float size_pixels,
 }
 
 // NB: Transfer ownership of 'ttf_data' to ImFontAtlas, unless font_cfg_template->FontDataOwnedByAtlas == false. Owned TTF buffer will be deleted after Build().
-ImFont* ImFontAtlas::AddFontFromMemoryTTF(void* ttf_data, int ttf_size, float size_pixels, const ImFontConfig* font_cfg_template, const ImWchar* glyph_ranges)
+ImFont* ImFontAtlas::AddFontFromMemoryTTF(void* ttf_data, int ttf_size, float size_pixels, const ImFontConfig* font_cfg_template, const ImWchar* glyph_ranges) IMGUI_NOEXCEPT
 {
     IM_ASSERT(!Locked && "Cannot modify a locked ImFontAtlas between NewFrame() and EndFrame/Render()!");
     ImFontConfig font_cfg = font_cfg_template ? *font_cfg_template : ImFontConfig();
@@ -2162,7 +2162,7 @@ ImFont* ImFontAtlas::AddFontFromMemoryTTF(void* ttf_data, int ttf_size, float si
     return AddFont(&font_cfg);
 }
 
-ImFont* ImFontAtlas::AddFontFromMemoryCompressedTTF(const void* compressed_ttf_data, int compressed_ttf_size, float size_pixels, const ImFontConfig* font_cfg_template, const ImWchar* glyph_ranges)
+ImFont* ImFontAtlas::AddFontFromMemoryCompressedTTF(const void* compressed_ttf_data, int compressed_ttf_size, float size_pixels, const ImFontConfig* font_cfg_template, const ImWchar* glyph_ranges) IMGUI_NOEXCEPT
 {
     const unsigned int buf_decompressed_size = stb_decompress_length((const unsigned char*)compressed_ttf_data);
     unsigned char* buf_decompressed_data = (unsigned char*)IM_ALLOC(buf_decompressed_size);
@@ -2174,7 +2174,7 @@ ImFont* ImFontAtlas::AddFontFromMemoryCompressedTTF(const void* compressed_ttf_d
     return AddFontFromMemoryTTF(buf_decompressed_data, (int)buf_decompressed_size, size_pixels, &font_cfg, glyph_ranges);
 }
 
-ImFont* ImFontAtlas::AddFontFromMemoryCompressedBase85TTF(const char* compressed_ttf_data_base85, float size_pixels, const ImFontConfig* font_cfg, const ImWchar* glyph_ranges)
+ImFont* ImFontAtlas::AddFontFromMemoryCompressedBase85TTF(const char* compressed_ttf_data_base85, float size_pixels, const ImFontConfig* font_cfg, const ImWchar* glyph_ranges) IMGUI_NOEXCEPT
 {
     int compressed_ttf_size = (((int)strlen(compressed_ttf_data_base85) + 4) / 5) * 4;
     void* compressed_ttf = IM_ALLOC((size_t)compressed_ttf_size);
@@ -2184,7 +2184,7 @@ ImFont* ImFontAtlas::AddFontFromMemoryCompressedBase85TTF(const char* compressed
     return font;
 }
 
-int ImFontAtlas::AddCustomRectRegular(int width, int height)
+int ImFontAtlas::AddCustomRectRegular(int width, int height) IMGUI_NOEXCEPT
 {
     IM_ASSERT(width > 0 && width <= 0xFFFF);
     IM_ASSERT(height > 0 && height <= 0xFFFF);
@@ -2195,7 +2195,7 @@ int ImFontAtlas::AddCustomRectRegular(int width, int height)
     return CustomRects.Size - 1; // Return index
 }
 
-int ImFontAtlas::AddCustomRectFontGlyph(ImFont* font, ImWchar id, int width, int height, float advance_x, const ImVec2& offset)
+int ImFontAtlas::AddCustomRectFontGlyph(ImFont* font, ImWchar id, int width, int height, float advance_x, const ImVec2& offset) IMGUI_NOEXCEPT
 {
 #ifdef IMGUI_USE_WCHAR32
     IM_ASSERT(id <= IM_UNICODE_CODEPOINT_MAX);
@@ -2214,7 +2214,7 @@ int ImFontAtlas::AddCustomRectFontGlyph(ImFont* font, ImWchar id, int width, int
     return CustomRects.Size - 1; // Return index
 }
 
-void ImFontAtlas::CalcCustomRectUV(const ImFontAtlasCustomRect* rect, ImVec2* out_uv_min, ImVec2* out_uv_max) const
+void ImFontAtlas::CalcCustomRectUV(const ImFontAtlasCustomRect* rect, ImVec2* out_uv_min, ImVec2* out_uv_max) const IMGUI_NOEXCEPT
 {
     IM_ASSERT(TexWidth > 0 && TexHeight > 0);   // Font atlas needs to be built before we can calculate UV coordinates
     IM_ASSERT(rect->IsPacked());                // Make sure the rectangle has been packed
@@ -2222,7 +2222,7 @@ void ImFontAtlas::CalcCustomRectUV(const ImFontAtlasCustomRect* rect, ImVec2* ou
     *out_uv_max = ImVec2((float)(rect->X + rect->Width) * TexUvScale.x, (float)(rect->Y + rect->Height) * TexUvScale.y);
 }
 
-bool ImFontAtlas::GetMouseCursorTexData(ImGuiMouseCursor cursor_type, ImVec2* out_offset, ImVec2* out_size, ImVec2 out_uv_border[2], ImVec2 out_uv_fill[2])
+bool ImFontAtlas::GetMouseCursorTexData(ImGuiMouseCursor cursor_type, ImVec2* out_offset, ImVec2* out_size, ImVec2 out_uv_border[2], ImVec2 out_uv_fill[2]) IMGUI_NOEXCEPT
 {
     if (cursor_type <= ImGuiMouseCursor_None || cursor_type >= ImGuiMouseCursor_COUNT)
         return false;
@@ -2243,7 +2243,7 @@ bool ImFontAtlas::GetMouseCursorTexData(ImGuiMouseCursor cursor_type, ImVec2* ou
     return true;
 }
 
-bool    ImFontAtlas::Build()
+bool    ImFontAtlas::Build() IMGUI_NOEXCEPT
 {
     IM_ASSERT(!Locked && "Cannot modify a locked ImFontAtlas between NewFrame() and EndFrame/Render()!");
 
@@ -2268,7 +2268,7 @@ bool    ImFontAtlas::Build()
     return builder_io->FontBuilder_Build(this);
 }
 
-void    ImFontAtlasBuildMultiplyCalcLookupTable(unsigned char out_table[256], float in_brighten_factor)
+void    ImFontAtlasBuildMultiplyCalcLookupTable(unsigned char out_table[256], float in_brighten_factor) IMGUI_NOEXCEPT
 {
     for (unsigned int i = 0; i < 256; i++)
     {
@@ -2277,7 +2277,7 @@ void    ImFontAtlasBuildMultiplyCalcLookupTable(unsigned char out_table[256], fl
     }
 }
 
-void    ImFontAtlasBuildMultiplyRectAlpha8(const unsigned char table[256], unsigned char* pixels, int x, int y, int w, int h, int stride)
+void    ImFontAtlasBuildMultiplyRectAlpha8(const unsigned char table[256], unsigned char* pixels, int x, int y, int w, int h, int stride) IMGUI_NOEXCEPT
 {
     unsigned char* data = pixels + x + y * stride;
     for (int j = h; j > 0; j--, data += stride)
@@ -2311,7 +2311,7 @@ struct ImFontBuildDstData
     ImBitVector         GlyphsSet;          // This is used to resolve collision when multiple sources are merged into a same destination font.
 };
 
-static void UnpackBitVectorToFlatIndexList(const ImBitVector* in, ImVector<int>* out)
+static void UnpackBitVectorToFlatIndexList(const ImBitVector* in, ImVector<int>* out) IMGUI_NOEXCEPT
 {
     IM_ASSERT(sizeof(in->Storage.Data[0]) == sizeof(int));
     const ImU32* it_begin = in->Storage.begin();
@@ -2323,7 +2323,7 @@ static void UnpackBitVectorToFlatIndexList(const ImBitVector* in, ImVector<int>*
                     out->push_back((int)(((it - it_begin) << 5) + bit_n));
 }
 
-static bool ImFontAtlasBuildWithStbTruetype(ImFontAtlas* atlas)
+static bool ImFontAtlasBuildWithStbTruetype(ImFontAtlas* atlas) IMGUI_NOEXCEPT
 {
     IM_ASSERT(atlas->ConfigData.Size > 0);
 
@@ -2576,7 +2576,7 @@ static bool ImFontAtlasBuildWithStbTruetype(ImFontAtlas* atlas)
     return true;
 }
 
-const ImFontBuilderIO* ImFontAtlasGetBuilderForStbTruetype()
+const ImFontBuilderIO* ImFontAtlasGetBuilderForStbTruetype() IMGUI_NOEXCEPT
 {
     static ImFontBuilderIO io;
     io.FontBuilder_Build = ImFontAtlasBuildWithStbTruetype;
@@ -2585,7 +2585,7 @@ const ImFontBuilderIO* ImFontAtlasGetBuilderForStbTruetype()
 
 #endif // IMGUI_ENABLE_STB_TRUETYPE
 
-void ImFontAtlasBuildSetupFont(ImFontAtlas* atlas, ImFont* font, ImFontConfig* font_config, float ascent, float descent)
+void ImFontAtlasBuildSetupFont(ImFontAtlas* atlas, ImFont* font, ImFontConfig* font_config, float ascent, float descent) IMGUI_NOEXCEPT
 {
     if (!font_config->MergeMode)
     {
@@ -2600,7 +2600,7 @@ void ImFontAtlasBuildSetupFont(ImFontAtlas* atlas, ImFont* font, ImFontConfig* f
     font->ConfigDataCount++;
 }
 
-void ImFontAtlasBuildPackCustomRects(ImFontAtlas* atlas, void* stbrp_context_opaque)
+void ImFontAtlasBuildPackCustomRects(ImFontAtlas* atlas, void* stbrp_context_opaque) IMGUI_NOEXCEPT
 {
     stbrp_context* pack_context = (stbrp_context*)stbrp_context_opaque;
     IM_ASSERT(pack_context != NULL);
@@ -2627,7 +2627,7 @@ void ImFontAtlasBuildPackCustomRects(ImFontAtlas* atlas, void* stbrp_context_opa
         }
 }
 
-void ImFontAtlasBuildRender8bppRectFromString(ImFontAtlas* atlas, int x, int y, int w, int h, const char* in_str, char in_marker_char, unsigned char in_marker_pixel_value)
+void ImFontAtlasBuildRender8bppRectFromString(ImFontAtlas* atlas, int x, int y, int w, int h, const char* in_str, char in_marker_char, unsigned char in_marker_pixel_value) IMGUI_NOEXCEPT
 {
     IM_ASSERT(x >= 0 && x + w <= atlas->TexWidth);
     IM_ASSERT(y >= 0 && y + h <= atlas->TexHeight);
@@ -2637,7 +2637,7 @@ void ImFontAtlasBuildRender8bppRectFromString(ImFontAtlas* atlas, int x, int y, 
             out_pixel[off_x] = (in_str[off_x] == in_marker_char) ? in_marker_pixel_value : 0x00;
 }
 
-void ImFontAtlasBuildRender32bppRectFromString(ImFontAtlas* atlas, int x, int y, int w, int h, const char* in_str, char in_marker_char, unsigned int in_marker_pixel_value)
+void ImFontAtlasBuildRender32bppRectFromString(ImFontAtlas* atlas, int x, int y, int w, int h, const char* in_str, char in_marker_char, unsigned int in_marker_pixel_value) IMGUI_NOEXCEPT
 {
     IM_ASSERT(x >= 0 && x + w <= atlas->TexWidth);
     IM_ASSERT(y >= 0 && y + h <= atlas->TexHeight);
@@ -2647,7 +2647,7 @@ void ImFontAtlasBuildRender32bppRectFromString(ImFontAtlas* atlas, int x, int y,
             out_pixel[off_x] = (in_str[off_x] == in_marker_char) ? in_marker_pixel_value : IM_COL32_BLACK_TRANS;
 }
 
-static void ImFontAtlasBuildRenderDefaultTexData(ImFontAtlas* atlas)
+static void ImFontAtlasBuildRenderDefaultTexData(ImFontAtlas* atlas) IMGUI_NOEXCEPT
 {
     ImFontAtlasCustomRect* r = atlas->GetCustomRectByIndex(atlas->PackIdMouseCursors);
     IM_ASSERT(r->IsPacked());
@@ -2687,7 +2687,7 @@ static void ImFontAtlasBuildRenderDefaultTexData(ImFontAtlas* atlas)
     atlas->TexUvWhitePixel = ImVec2((r->X + 0.5f) * atlas->TexUvScale.x, (r->Y + 0.5f) * atlas->TexUvScale.y);
 }
 
-static void ImFontAtlasBuildRenderLinesTexData(ImFontAtlas* atlas)
+static void ImFontAtlasBuildRenderLinesTexData(ImFontAtlas* atlas) IMGUI_NOEXCEPT
 {
     if (atlas->Flags & ImFontAtlasFlags_NoBakedLines)
         return;
@@ -2739,7 +2739,7 @@ static void ImFontAtlasBuildRenderLinesTexData(ImFontAtlas* atlas)
 }
 
 // Note: this is called / shared by both the stb_truetype and the FreeType builder
-void ImFontAtlasBuildInit(ImFontAtlas* atlas)
+void ImFontAtlasBuildInit(ImFontAtlas* atlas) IMGUI_NOEXCEPT
 {
     // Register texture region for mouse cursors or standard white pixels
     if (atlas->PackIdMouseCursors < 0)
@@ -2760,7 +2760,7 @@ void ImFontAtlasBuildInit(ImFontAtlas* atlas)
 }
 
 // This is called/shared by both the stb_truetype and the FreeType builder.
-void ImFontAtlasBuildFinish(ImFontAtlas* atlas)
+void ImFontAtlasBuildFinish(ImFontAtlas* atlas) IMGUI_NOEXCEPT
 {
     // Render into our custom data blocks
     IM_ASSERT(atlas->TexPixelsAlpha8 != NULL || atlas->TexPixelsRGBA32 != NULL);
@@ -2805,7 +2805,7 @@ void ImFontAtlasBuildFinish(ImFontAtlas* atlas)
 }
 
 // Retrieve list of range (2 int per range, values are inclusive)
-const ImWchar*   ImFontAtlas::GetGlyphRangesDefault()
+const ImWchar*   ImFontAtlas::GetGlyphRangesDefault() IMGUI_NOEXCEPT
 {
     static const ImWchar ranges[] =
     {
@@ -2815,7 +2815,7 @@ const ImWchar*   ImFontAtlas::GetGlyphRangesDefault()
     return &ranges[0];
 }
 
-const ImWchar*  ImFontAtlas::GetGlyphRangesKorean()
+const ImWchar*  ImFontAtlas::GetGlyphRangesKorean() IMGUI_NOEXCEPT
 {
     static const ImWchar ranges[] =
     {
@@ -2827,7 +2827,7 @@ const ImWchar*  ImFontAtlas::GetGlyphRangesKorean()
     return &ranges[0];
 }
 
-const ImWchar*  ImFontAtlas::GetGlyphRangesChineseFull()
+const ImWchar*  ImFontAtlas::GetGlyphRangesChineseFull() IMGUI_NOEXCEPT
 {
     static const ImWchar ranges[] =
     {
@@ -2842,7 +2842,7 @@ const ImWchar*  ImFontAtlas::GetGlyphRangesChineseFull()
     return &ranges[0];
 }
 
-static void UnpackAccumulativeOffsetsIntoRanges(int base_codepoint, const short* accumulative_offsets, int accumulative_offsets_count, ImWchar* out_ranges)
+static void UnpackAccumulativeOffsetsIntoRanges(int base_codepoint, const short* accumulative_offsets, int accumulative_offsets_count, ImWchar* out_ranges) IMGUI_NOEXCEPT
 {
     for (int n = 0; n < accumulative_offsets_count; n++, out_ranges += 2)
     {
@@ -2856,7 +2856,7 @@ static void UnpackAccumulativeOffsetsIntoRanges(int base_codepoint, const short*
 // [SECTION] ImFontAtlas glyph ranges helpers
 //-------------------------------------------------------------------------
 
-const ImWchar*  ImFontAtlas::GetGlyphRangesChineseSimplifiedCommon()
+const ImWchar*  ImFontAtlas::GetGlyphRangesChineseSimplifiedCommon() IMGUI_NOEXCEPT
 {
     // Store 2500 regularly used characters for Simplified Chinese.
     // Sourced from https://zh.wiktionary.org/wiki/%E9%99%84%E5%BD%95:%E7%8E%B0%E4%BB%A3%E6%B1%89%E8%AF%AD%E5%B8%B8%E7%94%A8%E5%AD%97%E8%A1%A8
@@ -2923,7 +2923,7 @@ const ImWchar*  ImFontAtlas::GetGlyphRangesChineseSimplifiedCommon()
     return &full_ranges[0];
 }
 
-const ImWchar*  ImFontAtlas::GetGlyphRangesJapanese()
+const ImWchar*  ImFontAtlas::GetGlyphRangesJapanese() IMGUI_NOEXCEPT
 {
     // 2999 ideograms code points for Japanese
     // - 2136 Joyo (meaning "for regular use" or "for common use") Kanji code points
@@ -3012,7 +3012,7 @@ const ImWchar*  ImFontAtlas::GetGlyphRangesJapanese()
     return &full_ranges[0];
 }
 
-const ImWchar*  ImFontAtlas::GetGlyphRangesCyrillic()
+const ImWchar*  ImFontAtlas::GetGlyphRangesCyrillic() IMGUI_NOEXCEPT
 {
     static const ImWchar ranges[] =
     {
@@ -3025,7 +3025,7 @@ const ImWchar*  ImFontAtlas::GetGlyphRangesCyrillic()
     return &ranges[0];
 }
 
-const ImWchar*  ImFontAtlas::GetGlyphRangesThai()
+const ImWchar*  ImFontAtlas::GetGlyphRangesThai() IMGUI_NOEXCEPT
 {
     static const ImWchar ranges[] =
     {
@@ -3037,7 +3037,7 @@ const ImWchar*  ImFontAtlas::GetGlyphRangesThai()
     return &ranges[0];
 }
 
-const ImWchar*  ImFontAtlas::GetGlyphRangesVietnamese()
+const ImWchar*  ImFontAtlas::GetGlyphRangesVietnamese() IMGUI_NOEXCEPT
 {
     static const ImWchar ranges[] =
     {
@@ -3058,7 +3058,7 @@ const ImWchar*  ImFontAtlas::GetGlyphRangesVietnamese()
 // [SECTION] ImFontGlyphRangesBuilder
 //-----------------------------------------------------------------------------
 
-void ImFontGlyphRangesBuilder::AddText(const char* text, const char* text_end)
+void ImFontGlyphRangesBuilder::AddText(const char* text, const char* text_end) IMGUI_NOEXCEPT
 {
     while (text_end ? (text < text_end) : *text)
     {
@@ -3071,14 +3071,14 @@ void ImFontGlyphRangesBuilder::AddText(const char* text, const char* text_end)
     }
 }
 
-void ImFontGlyphRangesBuilder::AddRanges(const ImWchar* ranges)
+void ImFontGlyphRangesBuilder::AddRanges(const ImWchar* ranges) IMGUI_NOEXCEPT
 {
     for (; ranges[0]; ranges += 2)
         for (ImWchar c = ranges[0]; c <= ranges[1]; c++)
             AddChar(c);
 }
 
-void ImFontGlyphRangesBuilder::BuildRanges(ImVector<ImWchar>* out_ranges)
+void ImFontGlyphRangesBuilder::BuildRanges(ImVector<ImWchar>* out_ranges) IMGUI_NOEXCEPT
 {
     const int max_codepoint = IM_UNICODE_CODEPOINT_MAX;
     for (int n = 0; n <= max_codepoint; n++)
@@ -3096,7 +3096,7 @@ void ImFontGlyphRangesBuilder::BuildRanges(ImVector<ImWchar>* out_ranges)
 // [SECTION] ImFont
 //-----------------------------------------------------------------------------
 
-ImFont::ImFont()
+ImFont::ImFont() IMGUI_NOEXCEPT
 {
     FontSize = 0.0f;
     FallbackAdvanceX = 0.0f;
@@ -3113,12 +3113,12 @@ ImFont::ImFont()
     memset(Used4kPagesMap, 0, sizeof(Used4kPagesMap));
 }
 
-ImFont::~ImFont()
+ImFont::~ImFont() IMGUI_NOEXCEPT
 {
     ClearOutputData();
 }
 
-void    ImFont::ClearOutputData()
+void    ImFont::ClearOutputData() IMGUI_NOEXCEPT
 {
     FontSize = 0.0f;
     FallbackAdvanceX = 0.0f;
@@ -3132,7 +3132,7 @@ void    ImFont::ClearOutputData()
     MetricsTotalSurface = 0;
 }
 
-void ImFont::BuildLookupTable()
+void ImFont::BuildLookupTable() IMGUI_NOEXCEPT
 {
     int max_codepoint = 0;
     for (int i = 0; i != Glyphs.Size; i++)
@@ -3184,7 +3184,7 @@ void ImFont::BuildLookupTable()
 
 // API is designed this way to avoid exposing the 4K page size
 // e.g. use with IsGlyphRangeUnused(0, 255)
-bool ImFont::IsGlyphRangeUnused(unsigned int c_begin, unsigned int c_last)
+bool ImFont::IsGlyphRangeUnused(unsigned int c_begin, unsigned int c_last) IMGUI_NOEXCEPT
 {
     unsigned int page_begin = (c_begin / 4096);
     unsigned int page_last = (c_last / 4096);
@@ -3195,19 +3195,19 @@ bool ImFont::IsGlyphRangeUnused(unsigned int c_begin, unsigned int c_last)
     return true;
 }
 
-void ImFont::SetGlyphVisible(ImWchar c, bool visible)
+void ImFont::SetGlyphVisible(ImWchar c, bool visible) IMGUI_NOEXCEPT
 {
     if (ImFontGlyph* glyph = (ImFontGlyph*)(void*)FindGlyph((ImWchar)c))
         glyph->Visible = visible ? 1 : 0;
 }
 
-void ImFont::SetFallbackChar(ImWchar c)
+void ImFont::SetFallbackChar(ImWchar c) IMGUI_NOEXCEPT
 {
     FallbackChar = c;
     BuildLookupTable();
 }
 
-void ImFont::GrowIndex(int new_size)
+void ImFont::GrowIndex(int new_size) IMGUI_NOEXCEPT
 {
     IM_ASSERT(IndexAdvanceX.Size == IndexLookup.Size);
     if (new_size <= IndexLookup.Size)
@@ -3219,7 +3219,7 @@ void ImFont::GrowIndex(int new_size)
 // x0/y0/x1/y1 are offset from the character upper-left layout position, in pixels. Therefore x0/y0 are often fairly close to zero.
 // Not to be mistaken with texture coordinates, which are held by u0/v0/u1/v1 in normalized format (0.0..1.0 on each texture axis).
 // 'cfg' is not necessarily == 'this->ConfigData' because multiple source fonts+configs can be used to build one target font.
-void ImFont::AddGlyph(const ImFontConfig* cfg, ImWchar codepoint, float x0, float y0, float x1, float y1, float u0, float v0, float u1, float v1, float advance_x)
+void ImFont::AddGlyph(const ImFontConfig* cfg, ImWchar codepoint, float x0, float y0, float x1, float y1, float u0, float v0, float u1, float v1, float advance_x) IMGUI_NOEXCEPT
 {
     if (cfg != NULL)
     {
@@ -3263,7 +3263,7 @@ void ImFont::AddGlyph(const ImFontConfig* cfg, ImWchar codepoint, float x0, floa
     MetricsTotalSurface += (int)((glyph.U1 - glyph.U0) * ContainerAtlas->TexWidth + pad) * (int)((glyph.V1 - glyph.V0) * ContainerAtlas->TexHeight + pad);
 }
 
-void ImFont::AddRemapChar(ImWchar dst, ImWchar src, bool overwrite_dst)
+void ImFont::AddRemapChar(ImWchar dst, ImWchar src, bool overwrite_dst) IMGUI_NOEXCEPT
 {
     IM_ASSERT(IndexLookup.Size > 0);    // Currently this can only be called AFTER the font has been built, aka after calling ImFontAtlas::GetTexDataAs*() function.
     unsigned int index_size = (unsigned int)IndexLookup.Size;
@@ -3278,7 +3278,7 @@ void ImFont::AddRemapChar(ImWchar dst, ImWchar src, bool overwrite_dst)
     IndexAdvanceX[dst] = (src < index_size) ? IndexAdvanceX.Data[src] : 1.0f;
 }
 
-const ImFontGlyph* ImFont::FindGlyph(ImWchar c) const
+const ImFontGlyph* ImFont::FindGlyph(ImWchar c) const IMGUI_NOEXCEPT
 {
     if (c >= (size_t)IndexLookup.Size)
         return FallbackGlyph;
@@ -3288,7 +3288,7 @@ const ImFontGlyph* ImFont::FindGlyph(ImWchar c) const
     return &Glyphs.Data[i];
 }
 
-const ImFontGlyph* ImFont::FindGlyphNoFallback(ImWchar c) const
+const ImFontGlyph* ImFont::FindGlyphNoFallback(ImWchar c) const IMGUI_NOEXCEPT
 {
     if (c >= (size_t)IndexLookup.Size)
         return NULL;
@@ -3298,7 +3298,7 @@ const ImFontGlyph* ImFont::FindGlyphNoFallback(ImWchar c) const
     return &Glyphs.Data[i];
 }
 
-const char* ImFont::CalcWordWrapPositionA(float scale, const char* text, const char* text_end, float wrap_width) const
+const char* ImFont::CalcWordWrapPositionA(float scale, const char* text, const char* text_end, float wrap_width) const IMGUI_NOEXCEPT
 {
     // Simple word-wrapping for English, not full-featured. Please submit failing cases!
     // FIXME: Much possible improvements (don't cut things like "word !", "word!!!" but cut within "word,,,,", more sensible support for punctuations, support for Unicode punctuations, etc.)
@@ -3397,7 +3397,7 @@ const char* ImFont::CalcWordWrapPositionA(float scale, const char* text, const c
     return s;
 }
 
-ImVec2 ImFont::CalcTextSizeA(float size, float max_width, float wrap_width, const char* text_begin, const char* text_end, const char** remaining) const
+ImVec2 ImFont::CalcTextSizeA(float size, float max_width, float wrap_width, const char* text_begin, const char* text_end, const char** remaining) const IMGUI_NOEXCEPT
 {
     if (!text_end)
         text_end = text_begin + strlen(text_begin); // FIXME-OPT: Need to avoid this.
@@ -3492,7 +3492,7 @@ ImVec2 ImFont::CalcTextSizeA(float size, float max_width, float wrap_width, cons
 }
 
 // Note: as with every ImDrawList drawing function, this expects that the font atlas texture is bound.
-void ImFont::RenderChar(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col, ImWchar c) const
+void ImFont::RenderChar(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col, ImWchar c) const IMGUI_NOEXCEPT
 {
     const ImFontGlyph* glyph = FindGlyph(c);
     if (!glyph || !glyph->Visible)
@@ -3507,7 +3507,7 @@ void ImFont::RenderChar(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col
 }
 
 // Note: as with every ImDrawList drawing function, this expects that the font atlas texture is bound.
-void ImFont::RenderText(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col, const ImVec4& clip_rect, const char* text_begin, const char* text_end, float wrap_width, bool cpu_fine_clip) const
+void ImFont::RenderText(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col, const ImVec4& clip_rect, const char* text_begin, const char* text_end, float wrap_width, bool cpu_fine_clip) const IMGUI_NOEXCEPT
 {
     if (!text_end)
         text_end = text_begin + strlen(text_begin); // ImGui:: functions generally already provides a valid text_end, so this is merely to handle direct calls.
@@ -3714,7 +3714,7 @@ void ImFont::RenderText(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col
 //-----------------------------------------------------------------------------
 
 // Render an arrow aimed to be aligned with text (p_min is a position in the same space text would be positioned). To e.g. denote expanded/collapsed state
-void ImGui::RenderArrow(ImDrawList* draw_list, ImVec2 pos, ImU32 col, ImGuiDir dir, float scale)
+void ImGui::RenderArrow(ImDrawList* draw_list, ImVec2 pos, ImU32 col, ImGuiDir dir, float scale) IMGUI_NOEXCEPT
 {
     const float h = draw_list->_Data->FontSize * 1.00f;
     float r = h * 0.40f * scale;
@@ -3745,12 +3745,12 @@ void ImGui::RenderArrow(ImDrawList* draw_list, ImVec2 pos, ImU32 col, ImGuiDir d
     draw_list->AddTriangleFilled(center + a, center + b, center + c, col);
 }
 
-void ImGui::RenderBullet(ImDrawList* draw_list, ImVec2 pos, ImU32 col)
+void ImGui::RenderBullet(ImDrawList* draw_list, ImVec2 pos, ImU32 col) IMGUI_NOEXCEPT
 {
     draw_list->AddCircleFilled(pos, draw_list->_Data->FontSize * 0.20f, col, 8);
 }
 
-void ImGui::RenderCheckMark(ImDrawList* draw_list, ImVec2 pos, ImU32 col, float sz)
+void ImGui::RenderCheckMark(ImDrawList* draw_list, ImVec2 pos, ImU32 col, float sz) IMGUI_NOEXCEPT
 {
     float thickness = ImMax(sz / 5.0f, 1.0f);
     sz -= thickness * 0.5f;
@@ -3765,7 +3765,7 @@ void ImGui::RenderCheckMark(ImDrawList* draw_list, ImVec2 pos, ImU32 col, float 
     draw_list->PathStroke(col, 0, thickness);
 }
 
-void ImGui::RenderMouseCursor(ImDrawList* draw_list, ImVec2 pos, float scale, ImGuiMouseCursor mouse_cursor, ImU32 col_fill, ImU32 col_border, ImU32 col_shadow)
+void ImGui::RenderMouseCursor(ImDrawList* draw_list, ImVec2 pos, float scale, ImGuiMouseCursor mouse_cursor, ImU32 col_fill, ImU32 col_border, ImU32 col_shadow) IMGUI_NOEXCEPT
 {
     if (mouse_cursor == ImGuiMouseCursor_None)
         return;
@@ -3787,7 +3787,7 @@ void ImGui::RenderMouseCursor(ImDrawList* draw_list, ImVec2 pos, float scale, Im
 }
 
 // Render an arrow. 'pos' is position of the arrow tip. half_sz.x is length from base to tip. half_sz.y is length on each side.
-void ImGui::RenderArrowPointingAt(ImDrawList* draw_list, ImVec2 pos, ImVec2 half_sz, ImGuiDir direction, ImU32 col)
+void ImGui::RenderArrowPointingAt(ImDrawList* draw_list, ImVec2 pos, ImVec2 half_sz, ImGuiDir direction, ImU32 col) IMGUI_NOEXCEPT
 {
     switch (direction)
     {
@@ -3799,7 +3799,7 @@ void ImGui::RenderArrowPointingAt(ImDrawList* draw_list, ImVec2 pos, ImVec2 half
     }
 }
 
-static inline float ImAcos01(float x)
+static inline float ImAcos01(float x) IMGUI_NOEXCEPT
 {
     if (x <= 0.0f) return IM_PI * 0.5f;
     if (x >= 1.0f) return 0.0f;
@@ -3808,7 +3808,7 @@ static inline float ImAcos01(float x)
 }
 
 // FIXME: Cleanup and move code to ImDrawList.
-void ImGui::RenderRectFilledRangeH(ImDrawList* draw_list, const ImRect& rect, ImU32 col, float x_start_norm, float x_end_norm, float rounding)
+void ImGui::RenderRectFilledRangeH(ImDrawList* draw_list, const ImRect& rect, ImU32 col, float x_start_norm, float x_end_norm, float rounding) IMGUI_NOEXCEPT
 {
     if (x_end_norm == x_start_norm)
         return;
@@ -3868,7 +3868,7 @@ void ImGui::RenderRectFilledRangeH(ImDrawList* draw_list, const ImRect& rect, Im
     draw_list->PathFillConvex(col);
 }
 
-void ImGui::RenderRectFilledWithHole(ImDrawList* draw_list, ImRect outer, ImRect inner, ImU32 col, float rounding)
+void ImGui::RenderRectFilledWithHole(ImDrawList* draw_list, ImRect outer, ImRect inner, ImU32 col, float rounding) IMGUI_NOEXCEPT
 {
     const bool fill_L = (inner.Min.x > outer.Min.x);
     const bool fill_R = (inner.Max.x < outer.Max.x);
@@ -3888,7 +3888,7 @@ void ImGui::RenderRectFilledWithHole(ImDrawList* draw_list, ImRect outer, ImRect
 // NB: This is rather brittle and will show artifact when rounding this enabled if rounded corners overlap multiple cells. Caller currently responsible for avoiding that.
 // Spent a non reasonable amount of time trying to getting this right for ColorButton with rounding+anti-aliasing+ImGuiColorEditFlags_HalfAlphaPreview flag + various grid sizes and offsets, and eventually gave up... probably more reasonable to disable rounding altogether.
 // FIXME: uses ImGui::GetColorU32
-void ImGui::RenderColorRectWithAlphaCheckerboard(ImDrawList* draw_list, ImVec2 p_min, ImVec2 p_max, ImU32 col, float grid_step, ImVec2 grid_off, float rounding, ImDrawFlags flags)
+void ImGui::RenderColorRectWithAlphaCheckerboard(ImDrawList* draw_list, ImVec2 p_min, ImVec2 p_max, ImU32 col, float grid_step, ImVec2 grid_off, float rounding, ImDrawFlags flags) IMGUI_NOEXCEPT
 {
     if ((flags & ImDrawFlags_RoundCornersMask_) == 0)
         flags = ImDrawFlags_RoundCornersDefault_;
@@ -3934,7 +3934,7 @@ void ImGui::RenderColorRectWithAlphaCheckerboard(ImDrawList* draw_list, ImVec2 p
 // Decompression from stb.h (public domain) by Sean Barrett https://github.com/nothings/stb/blob/master/stb.h
 //-----------------------------------------------------------------------------
 
-static unsigned int stb_decompress_length(const unsigned char *input)
+static unsigned int stb_decompress_length(const unsigned char *input) IMGUI_NOEXCEPT
 {
     return (input[8] << 24) + (input[9] << 16) + (input[10] << 8) + input[11];
 }
@@ -3942,7 +3942,7 @@ static unsigned int stb_decompress_length(const unsigned char *input)
 static unsigned char *stb__barrier_out_e, *stb__barrier_out_b;
 static const unsigned char *stb__barrier_in_b;
 static unsigned char *stb__dout;
-static void stb__match(const unsigned char *data, unsigned int length)
+static void stb__match(const unsigned char *data, unsigned int length) IMGUI_NOEXCEPT
 {
     // INVERSE of memmove... write each byte before copying the next...
     IM_ASSERT(stb__dout + length <= stb__barrier_out_e);
@@ -3951,7 +3951,7 @@ static void stb__match(const unsigned char *data, unsigned int length)
     while (length--) *stb__dout++ = *data++;
 }
 
-static void stb__lit(const unsigned char *data, unsigned int length)
+static void stb__lit(const unsigned char *data, unsigned int length) IMGUI_NOEXCEPT
 {
     IM_ASSERT(stb__dout + length <= stb__barrier_out_e);
     if (stb__dout + length > stb__barrier_out_e) { stb__dout += length; return; }
@@ -3964,7 +3964,7 @@ static void stb__lit(const unsigned char *data, unsigned int length)
 #define stb__in3(x)   ((i[x] << 16) + stb__in2((x)+1))
 #define stb__in4(x)   ((i[x] << 24) + stb__in3((x)+1))
 
-static const unsigned char *stb_decompress_token(const unsigned char *i)
+static const unsigned char *stb_decompress_token(const unsigned char *i) IMGUI_NOEXCEPT
 {
     if (*i >= 0x20) { // use fewer if's for cases that expand small
         if (*i >= 0x80)       stb__match(stb__dout-i[1]-1, i[0] - 0x80 + 1), i += 2;
@@ -3981,7 +3981,7 @@ static const unsigned char *stb_decompress_token(const unsigned char *i)
     return i;
 }
 
-static unsigned int stb_adler32(unsigned int adler32, unsigned char *buffer, unsigned int buflen)
+static unsigned int stb_adler32(unsigned int adler32, unsigned char *buffer, unsigned int buflen) IMGUI_NOEXCEPT
 {
     const unsigned long ADLER_MOD = 65521;
     unsigned long s1 = adler32 & 0xffff, s2 = adler32 >> 16;
@@ -4012,7 +4012,7 @@ static unsigned int stb_adler32(unsigned int adler32, unsigned char *buffer, uns
     return (unsigned int)(s2 << 16) + (unsigned int)s1;
 }
 
-static unsigned int stb_decompress(unsigned char *output, const unsigned char *i, unsigned int /*length*/)
+static unsigned int stb_decompress(unsigned char *output, const unsigned char *i, unsigned int /*length*/) IMGUI_NOEXCEPT
 {
     if (stb__in4(0) != 0x57bC0000) return 0;
     if (stb__in4(4) != 0)          return 0; // error! stream is > 4GB
@@ -4144,7 +4144,7 @@ static const char proggy_clean_ttf_compressed_data_base85[11980 + 1] =
     "GT4CPGT4CPGT4CPGT4CPGT4CPGT4CP-qekC`.9kEg^+F$kwViFJTB&5KTB&5KTB&5KTB&5KTB&5KTB&5KTB&5KTB&5KTB&5KTB&5KTB&5KTB&5KTB&5KTB&5KTB&5o,^<-28ZI'O?;xp"
     "O?;xpO?;xpO?;xpO?;xpO?;xpO?;xpO?;xpO?;xpO?;xpO?;xpO?;xpO?;xpO?;xp;7q-#lLYI:xvD=#";
 
-static const char* GetDefaultCompressedFontDataTTFBase85()
+static const char* GetDefaultCompressedFontDataTTFBase85() IMGUI_NOEXCEPT
 {
     return proggy_clean_ttf_compressed_data_base85;
 }

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -282,73 +282,73 @@ namespace ImStb
 //-----------------------------------------------------------------------------
 
 // Helpers: Hashing
-IMGUI_API ImGuiID       ImHashData(const void* data, size_t data_size, ImU32 seed = 0)    IMGUI_NOEXCEPT;
-IMGUI_API ImGuiID       ImHashStr(const char* data, size_t data_size = 0, ImU32 seed = 0) IMGUI_NOEXCEPT;
+IMGUI_API ImGuiID       ImHashData(const void* data, size_t data_size, ImU32 seed = 0)    IM_NOEXCEPT;
+IMGUI_API ImGuiID       ImHashStr(const char* data, size_t data_size = 0, ImU32 seed = 0) IM_NOEXCEPT;
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
-static inline ImGuiID   ImHash(const void* data, int size, ImU32 seed = 0) IMGUI_NOEXCEPT { return size ? ImHashData(data, (size_t)size, seed) : ImHashStr((const char*)data, 0, seed); } // [moved to ImHashStr/ImHashData in 1.68]
+static inline ImGuiID   ImHash(const void* data, int size, ImU32 seed = 0) IM_NOEXCEPT { return size ? ImHashData(data, (size_t)size, seed) : ImHashStr((const char*)data, 0, seed); } // [moved to ImHashStr/ImHashData in 1.68]
 #endif
 
 // Helpers: Sorting
 #define ImQsort         qsort
 
 // Helpers: Color Blending
-IMGUI_API ImU32         ImAlphaBlendColors(ImU32 col_a, ImU32 col_b) IMGUI_NOEXCEPT;
+IMGUI_API ImU32         ImAlphaBlendColors(ImU32 col_a, ImU32 col_b) IM_NOEXCEPT;
 
 // Helpers: Bit manipulation
-static inline bool      ImIsPowerOfTwo(int v)    IMGUI_NOEXCEPT        { return v != 0 && (v & (v - 1)) == 0; }
-static inline bool      ImIsPowerOfTwo(ImU64 v)  IMGUI_NOEXCEPT        { return v != 0 && (v & (v - 1)) == 0; }
-static inline int       ImUpperPowerOfTwo(int v) IMGUI_NOEXCEPT        { v--; v |= v >> 1; v |= v >> 2; v |= v >> 4; v |= v >> 8; v |= v >> 16; v++; return v; }
+static inline bool      ImIsPowerOfTwo(int v)    IM_NOEXCEPT        { return v != 0 && (v & (v - 1)) == 0; }
+static inline bool      ImIsPowerOfTwo(ImU64 v)  IM_NOEXCEPT        { return v != 0 && (v & (v - 1)) == 0; }
+static inline int       ImUpperPowerOfTwo(int v) IM_NOEXCEPT        { v--; v |= v >> 1; v |= v >> 2; v |= v >> 4; v |= v >> 8; v |= v >> 16; v++; return v; }
 
 // Helpers: String, Formatting
-IMGUI_API int           ImStricmp(const char* str1, const char* str2) IMGUI_NOEXCEPT;
-IMGUI_API int           ImStrnicmp(const char* str1, const char* str2, size_t count) IMGUI_NOEXCEPT;
-IMGUI_API void          ImStrncpy(char* dst, const char* src, size_t count) IMGUI_NOEXCEPT;
-IMGUI_API char*         ImStrdup(const char* str) IMGUI_NOEXCEPT;
-IMGUI_API char*         ImStrdupcpy(char* dst, size_t* p_dst_size, const char* str) IMGUI_NOEXCEPT;
-IMGUI_API const char*   ImStrchrRange(const char* str_begin, const char* str_end, char c) IMGUI_NOEXCEPT;
-IMGUI_API int           ImStrlenW(const ImWchar* str) IMGUI_NOEXCEPT;
-IMGUI_API const char*   ImStreolRange(const char* str, const char* str_end) IMGUI_NOEXCEPT;                // End end-of-line
-IMGUI_API const ImWchar*ImStrbolW(const ImWchar* buf_mid_line, const ImWchar* buf_begin) IMGUI_NOEXCEPT;   // Find beginning-of-line
-IMGUI_API const char*   ImStristr(const char* haystack, const char* haystack_end, const char* needle, const char* needle_end) IMGUI_NOEXCEPT;
-IMGUI_API void          ImStrTrimBlanks(char* str) IMGUI_NOEXCEPT;
-IMGUI_API const char*   ImStrSkipBlank(const char* str) IMGUI_NOEXCEPT;
-IMGUI_API int           ImFormatString(char* buf, size_t buf_size, const char* fmt, ...) IM_FMTARGS(3) IMGUI_NOEXCEPT;
-IMGUI_API int           ImFormatStringV(char* buf, size_t buf_size, const char* fmt, va_list args) IM_FMTLIST(3) IMGUI_NOEXCEPT;
-IMGUI_API const char*   ImParseFormatFindStart(const char* format) IMGUI_NOEXCEPT;
-IMGUI_API const char*   ImParseFormatFindEnd(const char* format) IMGUI_NOEXCEPT;
-IMGUI_API const char*   ImParseFormatTrimDecorations(const char* format, char* buf, size_t buf_size) IMGUI_NOEXCEPT;
-IMGUI_API int           ImParseFormatPrecision(const char* format, int default_value) IMGUI_NOEXCEPT;
-static inline bool      ImCharIsBlankA(char c)         IMGUI_NOEXCEPT  { return c == ' ' || c == '\t'; }
-static inline bool      ImCharIsBlankW(unsigned int c) IMGUI_NOEXCEPT  { return c == ' ' || c == '\t' || c == 0x3000; }
+IMGUI_API int           ImStricmp(const char* str1, const char* str2) IM_NOEXCEPT;
+IMGUI_API int           ImStrnicmp(const char* str1, const char* str2, size_t count) IM_NOEXCEPT;
+IMGUI_API void          ImStrncpy(char* dst, const char* src, size_t count) IM_NOEXCEPT;
+IMGUI_API char*         ImStrdup(const char* str) IM_NOEXCEPT;
+IMGUI_API char*         ImStrdupcpy(char* dst, size_t* p_dst_size, const char* str) IM_NOEXCEPT;
+IMGUI_API const char*   ImStrchrRange(const char* str_begin, const char* str_end, char c) IM_NOEXCEPT;
+IMGUI_API int           ImStrlenW(const ImWchar* str) IM_NOEXCEPT;
+IMGUI_API const char*   ImStreolRange(const char* str, const char* str_end) IM_NOEXCEPT;                // End end-of-line
+IMGUI_API const ImWchar*ImStrbolW(const ImWchar* buf_mid_line, const ImWchar* buf_begin) IM_NOEXCEPT;   // Find beginning-of-line
+IMGUI_API const char*   ImStristr(const char* haystack, const char* haystack_end, const char* needle, const char* needle_end) IM_NOEXCEPT;
+IMGUI_API void          ImStrTrimBlanks(char* str) IM_NOEXCEPT;
+IMGUI_API const char*   ImStrSkipBlank(const char* str) IM_NOEXCEPT;
+IMGUI_API int           ImFormatString(char* buf, size_t buf_size, const char* fmt, ...) IM_FMTARGS(3) IM_NOEXCEPT;
+IMGUI_API int           ImFormatStringV(char* buf, size_t buf_size, const char* fmt, va_list args) IM_FMTLIST(3) IM_NOEXCEPT;
+IMGUI_API const char*   ImParseFormatFindStart(const char* format) IM_NOEXCEPT;
+IMGUI_API const char*   ImParseFormatFindEnd(const char* format) IM_NOEXCEPT;
+IMGUI_API const char*   ImParseFormatTrimDecorations(const char* format, char* buf, size_t buf_size) IM_NOEXCEPT;
+IMGUI_API int           ImParseFormatPrecision(const char* format, int default_value) IM_NOEXCEPT;
+static inline bool      ImCharIsBlankA(char c)         IM_NOEXCEPT  { return c == ' ' || c == '\t'; }
+static inline bool      ImCharIsBlankW(unsigned int c) IM_NOEXCEPT  { return c == ' ' || c == '\t' || c == 0x3000; }
 
 // Helpers: UTF-8 <> wchar conversions
-IMGUI_API int           ImTextStrToUtf8(char* buf, int buf_size, const ImWchar* in_text, const ImWchar* in_text_end) IMGUI_NOEXCEPT;      // return output UTF-8 bytes count
-IMGUI_API int           ImTextCharFromUtf8(unsigned int* out_char, const char* in_text, const char* in_text_end) IMGUI_NOEXCEPT;          // read one character. return input UTF-8 bytes count
-IMGUI_API int           ImTextStrFromUtf8(ImWchar* buf, int buf_size, const char* in_text, const char* in_text_end, const char** in_remaining = NULL) IMGUI_NOEXCEPT;   // return input UTF-8 bytes count
-IMGUI_API int           ImTextCountCharsFromUtf8(const char* in_text, const char* in_text_end) IMGUI_NOEXCEPT;                            // return number of UTF-8 code-points (NOT bytes count)
-IMGUI_API int           ImTextCountUtf8BytesFromChar(const char* in_text, const char* in_text_end) IMGUI_NOEXCEPT;                        // return number of bytes to express one char in UTF-8
-IMGUI_API int           ImTextCountUtf8BytesFromStr(const ImWchar* in_text, const ImWchar* in_text_end) IMGUI_NOEXCEPT;                   // return number of bytes to express string in UTF-8
+IMGUI_API int           ImTextStrToUtf8(char* buf, int buf_size, const ImWchar* in_text, const ImWchar* in_text_end) IM_NOEXCEPT;      // return output UTF-8 bytes count
+IMGUI_API int           ImTextCharFromUtf8(unsigned int* out_char, const char* in_text, const char* in_text_end) IM_NOEXCEPT;          // read one character. return input UTF-8 bytes count
+IMGUI_API int           ImTextStrFromUtf8(ImWchar* buf, int buf_size, const char* in_text, const char* in_text_end, const char** in_remaining = NULL) IM_NOEXCEPT;   // return input UTF-8 bytes count
+IMGUI_API int           ImTextCountCharsFromUtf8(const char* in_text, const char* in_text_end) IM_NOEXCEPT;                            // return number of UTF-8 code-points (NOT bytes count)
+IMGUI_API int           ImTextCountUtf8BytesFromChar(const char* in_text, const char* in_text_end) IM_NOEXCEPT;                        // return number of bytes to express one char in UTF-8
+IMGUI_API int           ImTextCountUtf8BytesFromStr(const ImWchar* in_text, const ImWchar* in_text_end) IM_NOEXCEPT;                   // return number of bytes to express string in UTF-8
 
 // Helpers: ImVec2/ImVec4 operators
 // We are keeping those disabled by default so they don't leak in user space, to allow user enabling implicit cast operators between ImVec2 and their own types (using IM_VEC2_CLASS_EXTRA etc.)
 // We unfortunately don't have a unary- operator for ImVec2 because this would needs to be defined inside the class itself.
 #ifdef IMGUI_DEFINE_MATH_OPERATORS
 IM_MSVC_RUNTIME_CHECKS_OFF
-static inline ImVec2 operator*(const ImVec2& lhs, const float rhs)   IMGUI_NOEXCEPT            { return ImVec2(lhs.x * rhs, lhs.y * rhs); }
-static inline ImVec2 operator/(const ImVec2& lhs, const float rhs)   IMGUI_NOEXCEPT            { return ImVec2(lhs.x / rhs, lhs.y / rhs); }
-static inline ImVec2 operator+(const ImVec2& lhs, const ImVec2& rhs) IMGUI_NOEXCEPT            { return ImVec2(lhs.x + rhs.x, lhs.y + rhs.y); }
-static inline ImVec2 operator-(const ImVec2& lhs, const ImVec2& rhs) IMGUI_NOEXCEPT            { return ImVec2(lhs.x - rhs.x, lhs.y - rhs.y); }
-static inline ImVec2 operator*(const ImVec2& lhs, const ImVec2& rhs) IMGUI_NOEXCEPT            { return ImVec2(lhs.x * rhs.x, lhs.y * rhs.y); }
-static inline ImVec2 operator/(const ImVec2& lhs, const ImVec2& rhs) IMGUI_NOEXCEPT            { return ImVec2(lhs.x / rhs.x, lhs.y / rhs.y); }
-static inline ImVec2& operator*=(ImVec2& lhs, const float rhs)       IMGUI_NOEXCEPT            { lhs.x *= rhs; lhs.y *= rhs; return lhs; }
-static inline ImVec2& operator/=(ImVec2& lhs, const float rhs)       IMGUI_NOEXCEPT            { lhs.x /= rhs; lhs.y /= rhs; return lhs; }
-static inline ImVec2& operator+=(ImVec2& lhs, const ImVec2& rhs)     IMGUI_NOEXCEPT            { lhs.x += rhs.x; lhs.y += rhs.y; return lhs; }
-static inline ImVec2& operator-=(ImVec2& lhs, const ImVec2& rhs)     IMGUI_NOEXCEPT            { lhs.x -= rhs.x; lhs.y -= rhs.y; return lhs; }
-static inline ImVec2& operator*=(ImVec2& lhs, const ImVec2& rhs)     IMGUI_NOEXCEPT            { lhs.x *= rhs.x; lhs.y *= rhs.y; return lhs; }
-static inline ImVec2& operator/=(ImVec2& lhs, const ImVec2& rhs)     IMGUI_NOEXCEPT            { lhs.x /= rhs.x; lhs.y /= rhs.y; return lhs; }
-static inline ImVec4 operator+(const ImVec4& lhs, const ImVec4& rhs) IMGUI_NOEXCEPT            { return ImVec4(lhs.x + rhs.x, lhs.y + rhs.y, lhs.z + rhs.z, lhs.w + rhs.w); }
-static inline ImVec4 operator-(const ImVec4& lhs, const ImVec4& rhs) IMGUI_NOEXCEPT            { return ImVec4(lhs.x - rhs.x, lhs.y - rhs.y, lhs.z - rhs.z, lhs.w - rhs.w); }
-static inline ImVec4 operator*(const ImVec4& lhs, const ImVec4& rhs) IMGUI_NOEXCEPT            { return ImVec4(lhs.x * rhs.x, lhs.y * rhs.y, lhs.z * rhs.z, lhs.w * rhs.w); }
+static inline ImVec2 operator*(const ImVec2& lhs, const float rhs)   IM_NOEXCEPT            { return ImVec2(lhs.x * rhs, lhs.y * rhs); }
+static inline ImVec2 operator/(const ImVec2& lhs, const float rhs)   IM_NOEXCEPT            { return ImVec2(lhs.x / rhs, lhs.y / rhs); }
+static inline ImVec2 operator+(const ImVec2& lhs, const ImVec2& rhs) IM_NOEXCEPT            { return ImVec2(lhs.x + rhs.x, lhs.y + rhs.y); }
+static inline ImVec2 operator-(const ImVec2& lhs, const ImVec2& rhs) IM_NOEXCEPT            { return ImVec2(lhs.x - rhs.x, lhs.y - rhs.y); }
+static inline ImVec2 operator*(const ImVec2& lhs, const ImVec2& rhs) IM_NOEXCEPT            { return ImVec2(lhs.x * rhs.x, lhs.y * rhs.y); }
+static inline ImVec2 operator/(const ImVec2& lhs, const ImVec2& rhs) IM_NOEXCEPT            { return ImVec2(lhs.x / rhs.x, lhs.y / rhs.y); }
+static inline ImVec2& operator*=(ImVec2& lhs, const float rhs)       IM_NOEXCEPT            { lhs.x *= rhs; lhs.y *= rhs; return lhs; }
+static inline ImVec2& operator/=(ImVec2& lhs, const float rhs)       IM_NOEXCEPT            { lhs.x /= rhs; lhs.y /= rhs; return lhs; }
+static inline ImVec2& operator+=(ImVec2& lhs, const ImVec2& rhs)     IM_NOEXCEPT            { lhs.x += rhs.x; lhs.y += rhs.y; return lhs; }
+static inline ImVec2& operator-=(ImVec2& lhs, const ImVec2& rhs)     IM_NOEXCEPT            { lhs.x -= rhs.x; lhs.y -= rhs.y; return lhs; }
+static inline ImVec2& operator*=(ImVec2& lhs, const ImVec2& rhs)     IM_NOEXCEPT            { lhs.x *= rhs.x; lhs.y *= rhs.y; return lhs; }
+static inline ImVec2& operator/=(ImVec2& lhs, const ImVec2& rhs)     IM_NOEXCEPT            { lhs.x /= rhs.x; lhs.y /= rhs.y; return lhs; }
+static inline ImVec4 operator+(const ImVec4& lhs, const ImVec4& rhs) IM_NOEXCEPT            { return ImVec4(lhs.x + rhs.x, lhs.y + rhs.y, lhs.z + rhs.z, lhs.w + rhs.w); }
+static inline ImVec4 operator-(const ImVec4& lhs, const ImVec4& rhs) IM_NOEXCEPT            { return ImVec4(lhs.x - rhs.x, lhs.y - rhs.y, lhs.z - rhs.z, lhs.w - rhs.w); }
+static inline ImVec4 operator*(const ImVec4& lhs, const ImVec4& rhs) IM_NOEXCEPT            { return ImVec4(lhs.x * rhs.x, lhs.y * rhs.y, lhs.z * rhs.z, lhs.w * rhs.w); }
 IM_MSVC_RUNTIME_CHECKS_RESTORE
 #endif
 
@@ -356,23 +356,23 @@ IM_MSVC_RUNTIME_CHECKS_RESTORE
 #ifdef IMGUI_DISABLE_FILE_FUNCTIONS
 #define IMGUI_DISABLE_DEFAULT_FILE_FUNCTIONS
 typedef void* ImFileHandle;
-static inline ImFileHandle  ImFileOpen(const char*, const char*)                 IMGUI_NOEXCEPT    { return NULL; }
-static inline bool          ImFileClose(ImFileHandle)                            IMGUI_NOEXCEPT    { return false; }
-static inline ImU64         ImFileGetSize(ImFileHandle)                          IMGUI_NOEXCEPT    { return (ImU64)-1; }
-static inline ImU64         ImFileRead(void*, ImU64, ImU64, ImFileHandle)        IMGUI_NOEXCEPT    { return 0; }
-static inline ImU64         ImFileWrite(const void*, ImU64, ImU64, ImFileHandle) IMGUI_NOEXCEPT    { return 0; }
+static inline ImFileHandle  ImFileOpen(const char*, const char*)                 IM_NOEXCEPT    { return NULL; }
+static inline bool          ImFileClose(ImFileHandle)                            IM_NOEXCEPT    { return false; }
+static inline ImU64         ImFileGetSize(ImFileHandle)                          IM_NOEXCEPT    { return (ImU64)-1; }
+static inline ImU64         ImFileRead(void*, ImU64, ImU64, ImFileHandle)        IM_NOEXCEPT    { return 0; }
+static inline ImU64         ImFileWrite(const void*, ImU64, ImU64, ImFileHandle) IM_NOEXCEPT    { return 0; }
 #endif
 #ifndef IMGUI_DISABLE_DEFAULT_FILE_FUNCTIONS
 typedef FILE* ImFileHandle;
-IMGUI_API ImFileHandle      ImFileOpen(const char* filename, const char* mode) IMGUI_NOEXCEPT;
-IMGUI_API bool              ImFileClose(ImFileHandle file) IMGUI_NOEXCEPT;
-IMGUI_API ImU64             ImFileGetSize(ImFileHandle file) IMGUI_NOEXCEPT;
-IMGUI_API ImU64             ImFileRead(void* data, ImU64 size, ImU64 count, ImFileHandle file) IMGUI_NOEXCEPT;
-IMGUI_API ImU64             ImFileWrite(const void* data, ImU64 size, ImU64 count, ImFileHandle file) IMGUI_NOEXCEPT;
+IMGUI_API ImFileHandle      ImFileOpen(const char* filename, const char* mode) IM_NOEXCEPT;
+IMGUI_API bool              ImFileClose(ImFileHandle file) IM_NOEXCEPT;
+IMGUI_API ImU64             ImFileGetSize(ImFileHandle file) IM_NOEXCEPT;
+IMGUI_API ImU64             ImFileRead(void* data, ImU64 size, ImU64 count, ImFileHandle file) IM_NOEXCEPT;
+IMGUI_API ImU64             ImFileWrite(const void* data, ImU64 size, ImU64 count, ImFileHandle file) IM_NOEXCEPT;
 #else
 #define IMGUI_DISABLE_TTY_FUNCTIONS // Can't use stdout, fflush if we are not using default file functions
 #endif
-IMGUI_API void*             ImFileLoadToMemory(const char* filename, const char* mode, size_t* out_file_size = NULL, int padding_bytes = 0) IMGUI_NOEXCEPT;
+IMGUI_API void*             ImFileLoadToMemory(const char* filename, const char* mode, size_t* out_file_size = NULL, int padding_bytes = 0) IM_NOEXCEPT;
 
 // Helpers: Maths
 IM_MSVC_RUNTIME_CHECKS_OFF
@@ -388,63 +388,63 @@ IM_MSVC_RUNTIME_CHECKS_OFF
 #define ImAtof(STR)         atof(STR)
 //#define ImFloorStd(X)     floorf(X)           // We use our own, see ImFloor() and ImFloorSigned()
 #define ImCeil(X)           ceilf(X)
-static inline float  ImPow(float x, float y)   IMGUI_NOEXCEPT  { return powf(x, y); }          // DragBehaviorT/SliderBehaviorT uses ImPow with either float/double and need the precision
-static inline double ImPow(double x, double y) IMGUI_NOEXCEPT  { return pow(x, y); }
-static inline float  ImLog(float x)            IMGUI_NOEXCEPT  { return logf(x); }             // DragBehaviorT/SliderBehaviorT uses ImLog with either float/double and need the precision
-static inline double ImLog(double x)           IMGUI_NOEXCEPT  { return log(x); }
-static inline int    ImAbs(int x)              IMGUI_NOEXCEPT  { return x < 0 ? -x : x; }
-static inline float  ImAbs(float x)            IMGUI_NOEXCEPT  { return fabsf(x); }
-static inline double ImAbs(double x)           IMGUI_NOEXCEPT  { return fabs(x); }
-static inline float  ImSign(float x)           IMGUI_NOEXCEPT  { return (x < 0.0f) ? -1.0f : ((x > 0.0f) ? 1.0f : 0.0f); } // Sign operator - returns -1, 0 or 1 based on sign of argument
-static inline double ImSign(double x)          IMGUI_NOEXCEPT  { return (x < 0.0) ? -1.0 : ((x > 0.0) ? 1.0 : 0.0); }
+static inline float  ImPow(float x, float y)   IM_NOEXCEPT  { return powf(x, y); }          // DragBehaviorT/SliderBehaviorT uses ImPow with either float/double and need the precision
+static inline double ImPow(double x, double y) IM_NOEXCEPT  { return pow(x, y); }
+static inline float  ImLog(float x)            IM_NOEXCEPT  { return logf(x); }             // DragBehaviorT/SliderBehaviorT uses ImLog with either float/double and need the precision
+static inline double ImLog(double x)           IM_NOEXCEPT  { return log(x); }
+static inline int    ImAbs(int x)              IM_NOEXCEPT  { return x < 0 ? -x : x; }
+static inline float  ImAbs(float x)            IM_NOEXCEPT  { return fabsf(x); }
+static inline double ImAbs(double x)           IM_NOEXCEPT  { return fabs(x); }
+static inline float  ImSign(float x)           IM_NOEXCEPT  { return (x < 0.0f) ? -1.0f : ((x > 0.0f) ? 1.0f : 0.0f); } // Sign operator - returns -1, 0 or 1 based on sign of argument
+static inline double ImSign(double x)          IM_NOEXCEPT  { return (x < 0.0) ? -1.0 : ((x > 0.0) ? 1.0 : 0.0); }
 #ifdef IMGUI_ENABLE_SSE
-static inline float  ImRsqrt(float x)          IMGUI_NOEXCEPT  { return _mm_cvtss_f32(_mm_rsqrt_ss(_mm_set_ss(x))); }
+static inline float  ImRsqrt(float x)          IM_NOEXCEPT  { return _mm_cvtss_f32(_mm_rsqrt_ss(_mm_set_ss(x))); }
 #else
-static inline float  ImRsqrt(float x)          IMGUI_NOEXCEPT  { return 1.0f / sqrtf(x); }
+static inline float  ImRsqrt(float x)          IM_NOEXCEPT  { return 1.0f / sqrtf(x); }
 #endif
-static inline double ImRsqrt(double x)         IMGUI_NOEXCEPT  { return 1.0 / sqrt(x); }
+static inline double ImRsqrt(double x)         IM_NOEXCEPT  { return 1.0 / sqrt(x); }
 #endif
 // - ImMin/ImMax/ImClamp/ImLerp/ImSwap are used by widgets which support variety of types: signed/unsigned int/long long float/double
 // (Exceptionally using templates here but we could also redefine them for those types)
-template<typename T> static inline T ImMin(T lhs, T rhs)                      IMGUI_NOEXCEPT   { return lhs < rhs ? lhs : rhs; }
-template<typename T> static inline T ImMax(T lhs, T rhs)                      IMGUI_NOEXCEPT   { return lhs >= rhs ? lhs : rhs; }
-template<typename T> static inline T ImClamp(T v, T mn, T mx)                 IMGUI_NOEXCEPT   { return (v < mn) ? mn : (v > mx) ? mx : v; }
-template<typename T> static inline T ImLerp(T a, T b, float t)                IMGUI_NOEXCEPT   { return (T)(a + (b - a) * t); }
-template<typename T> static inline void ImSwap(T& a, T& b)                    IMGUI_NOEXCEPT   { T tmp = a; a = b; b = tmp; }
-template<typename T> static inline T ImAddClampOverflow(T a, T b, T mn, T mx) IMGUI_NOEXCEPT   { if (b < 0 && (a < mn - b)) return mn; if (b > 0 && (a > mx - b)) return mx; return a + b; }
-template<typename T> static inline T ImSubClampOverflow(T a, T b, T mn, T mx) IMGUI_NOEXCEPT   { if (b > 0 && (a < mn + b)) return mn; if (b < 0 && (a > mx + b)) return mx; return a - b; }
-// - Misc IMGUI_NOEXCEPT maths helpers
-static inline ImVec2 ImMin(const ImVec2& lhs, const ImVec2& rhs)               IMGUI_NOEXCEPT  { return ImVec2(lhs.x < rhs.x ? lhs.x : rhs.x, lhs.y < rhs.y ? lhs.y : rhs.y); }
-static inline ImVec2 ImMax(const ImVec2& lhs, const ImVec2& rhs)               IMGUI_NOEXCEPT  { return ImVec2(lhs.x >= rhs.x ? lhs.x : rhs.x, lhs.y >= rhs.y ? lhs.y : rhs.y); }
-static inline ImVec2 ImClamp(const ImVec2& v, const ImVec2& mn, ImVec2 mx)     IMGUI_NOEXCEPT  { return ImVec2((v.x < mn.x) ? mn.x : (v.x > mx.x) ? mx.x : v.x, (v.y < mn.y) ? mn.y : (v.y > mx.y) ? mx.y : v.y); }
-static inline ImVec2 ImLerp(const ImVec2& a, const ImVec2& b, float t)         IMGUI_NOEXCEPT  { return ImVec2(a.x + (b.x - a.x) * t, a.y + (b.y - a.y) * t); }
-static inline ImVec2 ImLerp(const ImVec2& a, const ImVec2& b, const ImVec2& t) IMGUI_NOEXCEPT  { return ImVec2(a.x + (b.x - a.x) * t.x, a.y + (b.y - a.y) * t.y); }
-static inline ImVec4 ImLerp(const ImVec4& a, const ImVec4& b, float t)         IMGUI_NOEXCEPT  { return ImVec4(a.x + (b.x - a.x) * t, a.y + (b.y - a.y) * t, a.z + (b.z - a.z) * t, a.w + (b.w - a.w) * t); }
-static inline float  ImSaturate(float f)                                       IMGUI_NOEXCEPT  { return (f < 0.0f) ? 0.0f : (f > 1.0f) ? 1.0f : f; }
-static inline float  ImLengthSqr(const ImVec2& lhs)                            IMGUI_NOEXCEPT  { return (lhs.x * lhs.x) + (lhs.y * lhs.y); }
-static inline float  ImLengthSqr(const ImVec4& lhs)                            IMGUI_NOEXCEPT  { return (lhs.x * lhs.x) + (lhs.y * lhs.y) + (lhs.z * lhs.z) + (lhs.w * lhs.w); }
-static inline float  ImInvLength(const ImVec2& lhs, float fail_value)          IMGUI_NOEXCEPT  { float d = (lhs.x * lhs.x) + (lhs.y * lhs.y); if (d > 0.0f) return ImRsqrt(d); return fail_value; }
-static inline float  ImFloor(float f)                                          IMGUI_NOEXCEPT  { return (float)(int)(f); }
-static inline float  ImFloorSigned(float f)                                    IMGUI_NOEXCEPT  { return (float)((f >= 0 || (int)f == f) ? (int)f : (int)f - 1); } // Decent replacement for floorf()
-static inline ImVec2 ImFloor(const ImVec2& v)                                  IMGUI_NOEXCEPT  { return ImVec2((float)(int)(v.x), (float)(int)(v.y)); }
-static inline int    ImModPositive(int a, int b)                               IMGUI_NOEXCEPT  { return (a + b) % b; }
-static inline float  ImDot(const ImVec2& a, const ImVec2& b)                   IMGUI_NOEXCEPT  { return a.x * b.x + a.y * b.y; }
-static inline ImVec2 ImRotate(const ImVec2& v, float cos_a, float sin_a)       IMGUI_NOEXCEPT  { return ImVec2(v.x * cos_a - v.y * sin_a, v.x * sin_a + v.y * cos_a); }
-static inline float  ImLinearSweep(float current, float target, float speed)   IMGUI_NOEXCEPT  { if (current < target) return ImMin(current + speed, target); if (current > target) return ImMax(current - speed, target); return current; }
-static inline ImVec2 ImMul(const ImVec2& lhs, const ImVec2& rhs)               IMGUI_NOEXCEPT  { return ImVec2(lhs.x * rhs.x, lhs.y * rhs.y); }
+template<typename T> static inline T ImMin(T lhs, T rhs)                      IM_NOEXCEPT   { return lhs < rhs ? lhs : rhs; }
+template<typename T> static inline T ImMax(T lhs, T rhs)                      IM_NOEXCEPT   { return lhs >= rhs ? lhs : rhs; }
+template<typename T> static inline T ImClamp(T v, T mn, T mx)                 IM_NOEXCEPT   { return (v < mn) ? mn : (v > mx) ? mx : v; }
+template<typename T> static inline T ImLerp(T a, T b, float t)                IM_NOEXCEPT   { return (T)(a + (b - a) * t); }
+template<typename T> static inline void ImSwap(T& a, T& b)                    IM_NOEXCEPT   { T tmp = a; a = b; b = tmp; }
+template<typename T> static inline T ImAddClampOverflow(T a, T b, T mn, T mx) IM_NOEXCEPT   { if (b < 0 && (a < mn - b)) return mn; if (b > 0 && (a > mx - b)) return mx; return a + b; }
+template<typename T> static inline T ImSubClampOverflow(T a, T b, T mn, T mx) IM_NOEXCEPT   { if (b > 0 && (a < mn + b)) return mn; if (b < 0 && (a > mx + b)) return mx; return a - b; }
+// - Misc IM_NOEXCEPT maths helpers
+static inline ImVec2 ImMin(const ImVec2& lhs, const ImVec2& rhs)               IM_NOEXCEPT  { return ImVec2(lhs.x < rhs.x ? lhs.x : rhs.x, lhs.y < rhs.y ? lhs.y : rhs.y); }
+static inline ImVec2 ImMax(const ImVec2& lhs, const ImVec2& rhs)               IM_NOEXCEPT  { return ImVec2(lhs.x >= rhs.x ? lhs.x : rhs.x, lhs.y >= rhs.y ? lhs.y : rhs.y); }
+static inline ImVec2 ImClamp(const ImVec2& v, const ImVec2& mn, ImVec2 mx)     IM_NOEXCEPT  { return ImVec2((v.x < mn.x) ? mn.x : (v.x > mx.x) ? mx.x : v.x, (v.y < mn.y) ? mn.y : (v.y > mx.y) ? mx.y : v.y); }
+static inline ImVec2 ImLerp(const ImVec2& a, const ImVec2& b, float t)         IM_NOEXCEPT  { return ImVec2(a.x + (b.x - a.x) * t, a.y + (b.y - a.y) * t); }
+static inline ImVec2 ImLerp(const ImVec2& a, const ImVec2& b, const ImVec2& t) IM_NOEXCEPT  { return ImVec2(a.x + (b.x - a.x) * t.x, a.y + (b.y - a.y) * t.y); }
+static inline ImVec4 ImLerp(const ImVec4& a, const ImVec4& b, float t)         IM_NOEXCEPT  { return ImVec4(a.x + (b.x - a.x) * t, a.y + (b.y - a.y) * t, a.z + (b.z - a.z) * t, a.w + (b.w - a.w) * t); }
+static inline float  ImSaturate(float f)                                       IM_NOEXCEPT  { return (f < 0.0f) ? 0.0f : (f > 1.0f) ? 1.0f : f; }
+static inline float  ImLengthSqr(const ImVec2& lhs)                            IM_NOEXCEPT  { return (lhs.x * lhs.x) + (lhs.y * lhs.y); }
+static inline float  ImLengthSqr(const ImVec4& lhs)                            IM_NOEXCEPT  { return (lhs.x * lhs.x) + (lhs.y * lhs.y) + (lhs.z * lhs.z) + (lhs.w * lhs.w); }
+static inline float  ImInvLength(const ImVec2& lhs, float fail_value)          IM_NOEXCEPT  { float d = (lhs.x * lhs.x) + (lhs.y * lhs.y); if (d > 0.0f) return ImRsqrt(d); return fail_value; }
+static inline float  ImFloor(float f)                                          IM_NOEXCEPT  { return (float)(int)(f); }
+static inline float  ImFloorSigned(float f)                                    IM_NOEXCEPT  { return (float)((f >= 0 || (int)f == f) ? (int)f : (int)f - 1); } // Decent replacement for floorf()
+static inline ImVec2 ImFloor(const ImVec2& v)                                  IM_NOEXCEPT  { return ImVec2((float)(int)(v.x), (float)(int)(v.y)); }
+static inline int    ImModPositive(int a, int b)                               IM_NOEXCEPT  { return (a + b) % b; }
+static inline float  ImDot(const ImVec2& a, const ImVec2& b)                   IM_NOEXCEPT  { return a.x * b.x + a.y * b.y; }
+static inline ImVec2 ImRotate(const ImVec2& v, float cos_a, float sin_a)       IM_NOEXCEPT  { return ImVec2(v.x * cos_a - v.y * sin_a, v.x * sin_a + v.y * cos_a); }
+static inline float  ImLinearSweep(float current, float target, float speed)   IM_NOEXCEPT  { if (current < target) return ImMin(current + speed, target); if (current > target) return ImMax(current - speed, target); return current; }
+static inline ImVec2 ImMul(const ImVec2& lhs, const ImVec2& rhs)               IM_NOEXCEPT  { return ImVec2(lhs.x * rhs.x, lhs.y * rhs.y); }
 IM_MSVC_RUNTIME_CHECKS_RESTORE
 
 // Helpers: Geometry
-IMGUI_API ImVec2     ImBezierCubicCalc(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, float t) IMGUI_NOEXCEPT;
-IMGUI_API ImVec2     ImBezierCubicClosestPoint(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, const ImVec2& p, int num_segments) IMGUI_NOEXCEPT;       // For curves with explicit number of segments
-IMGUI_API ImVec2     ImBezierCubicClosestPointCasteljau(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, const ImVec2& p, float tess_tol) IMGUI_NOEXCEPT;// For auto-tessellated curves you can use tess_tol = style.CurveTessellationTol
-IMGUI_API ImVec2     ImBezierQuadraticCalc(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, float t) IMGUI_NOEXCEPT;
-IMGUI_API ImVec2     ImLineClosestPoint(const ImVec2& a, const ImVec2& b, const ImVec2& p) IMGUI_NOEXCEPT;
-IMGUI_API bool       ImTriangleContainsPoint(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& p) IMGUI_NOEXCEPT;
-IMGUI_API ImVec2     ImTriangleClosestPoint(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& p) IMGUI_NOEXCEPT;
-IMGUI_API void       ImTriangleBarycentricCoords(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& p, float& out_u, float& out_v, float& out_w) IMGUI_NOEXCEPT;
-inline float         ImTriangleArea(const ImVec2& a, const ImVec2& b, const ImVec2& c) IMGUI_NOEXCEPT { return ImFabs((a.x * (b.y - c.y)) + (b.x * (c.y - a.y)) + (c.x * (a.y - b.y))) * 0.5f; }
-IMGUI_API ImGuiDir   ImGetDirQuadrantFromDelta(float dx, float dy) IMGUI_NOEXCEPT;
+IMGUI_API ImVec2     ImBezierCubicCalc(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, float t) IM_NOEXCEPT;
+IMGUI_API ImVec2     ImBezierCubicClosestPoint(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, const ImVec2& p, int num_segments) IM_NOEXCEPT;       // For curves with explicit number of segments
+IMGUI_API ImVec2     ImBezierCubicClosestPointCasteljau(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, const ImVec2& p, float tess_tol) IM_NOEXCEPT;// For auto-tessellated curves you can use tess_tol = style.CurveTessellationTol
+IMGUI_API ImVec2     ImBezierQuadraticCalc(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, float t) IM_NOEXCEPT;
+IMGUI_API ImVec2     ImLineClosestPoint(const ImVec2& a, const ImVec2& b, const ImVec2& p) IM_NOEXCEPT;
+IMGUI_API bool       ImTriangleContainsPoint(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& p) IM_NOEXCEPT;
+IMGUI_API ImVec2     ImTriangleClosestPoint(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& p) IM_NOEXCEPT;
+IMGUI_API void       ImTriangleBarycentricCoords(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& p, float& out_u, float& out_v, float& out_w) IM_NOEXCEPT;
+inline float         ImTriangleArea(const ImVec2& a, const ImVec2& b, const ImVec2& c) IM_NOEXCEPT { return ImFabs((a.x * (b.y - c.y)) + (b.x * (c.y - a.y)) + (c.x * (a.y - b.y))) * 0.5f; }
+IMGUI_API ImGuiDir   ImGetDirQuadrantFromDelta(float dx, float dy) IM_NOEXCEPT;
 
 // Helper: ImVec1 (1D vector)
 // (this odd construct is used to facilitate the transition between 1D and 2D, and the maintenance of some branches/patches)
@@ -452,17 +452,17 @@ IM_MSVC_RUNTIME_CHECKS_OFF
 struct ImVec1
 {
     float   x;
-    ImVec1()         IMGUI_NOEXCEPT { x = 0.0f; }
-    ImVec1(float _x) IMGUI_NOEXCEPT { x = _x; }
+    ImVec1()         IM_NOEXCEPT { x = 0.0f; }
+    ImVec1(float _x) IM_NOEXCEPT { x = _x; }
 };
 
 // Helper: ImVec2ih (2D vector, half-size integer, for long-term packed storage)
 struct ImVec2ih
 {
     short   x, y;
-    ImVec2ih()                           IMGUI_NOEXCEPT { x = y = 0; }
-    ImVec2ih(short _x, short _y)         IMGUI_NOEXCEPT { x = _x; y = _y; }
-    explicit ImVec2ih(const ImVec2& rhs) IMGUI_NOEXCEPT { x = (short)rhs.x; y = (short)rhs.y; }
+    ImVec2ih()                           IM_NOEXCEPT { x = y = 0; }
+    ImVec2ih(short _x, short _y)         IM_NOEXCEPT { x = _x; y = _y; }
+    explicit ImVec2ih(const ImVec2& rhs) IM_NOEXCEPT { x = (short)rhs.x; y = (short)rhs.y; }
 };
 
 // Helper: ImRect (2D axis aligned bounding-box)
@@ -472,43 +472,43 @@ struct IMGUI_API ImRect
     ImVec2      Min;    // Upper-left
     ImVec2      Max;    // Lower-right
 
-    ImRect()                                       IMGUI_NOEXCEPT  : Min(0.0f, 0.0f), Max(0.0f, 0.0f)  {}
-    ImRect(const ImVec2& min, const ImVec2& max)   IMGUI_NOEXCEPT  : Min(min), Max(max)                {}
-    ImRect(const ImVec4& v)                        IMGUI_NOEXCEPT  : Min(v.x, v.y), Max(v.z, v.w)      {}
-    ImRect(float x1, float y1, float x2, float y2) IMGUI_NOEXCEPT  : Min(x1, y1), Max(x2, y2)          {}
+    ImRect()                                       IM_NOEXCEPT  : Min(0.0f, 0.0f), Max(0.0f, 0.0f)  {}
+    ImRect(const ImVec2& min, const ImVec2& max)   IM_NOEXCEPT  : Min(min), Max(max)                {}
+    ImRect(const ImVec4& v)                        IM_NOEXCEPT  : Min(v.x, v.y), Max(v.z, v.w)      {}
+    ImRect(float x1, float y1, float x2, float y2) IM_NOEXCEPT  : Min(x1, y1), Max(x2, y2)          {}
 
-    ImVec2      GetCenter() const                IMGUI_NOEXCEPT    { return ImVec2((Min.x + Max.x) * 0.5f, (Min.y + Max.y) * 0.5f); }
-    ImVec2      GetSize() const                  IMGUI_NOEXCEPT    { return ImVec2(Max.x - Min.x, Max.y - Min.y); }
-    float       GetWidth() const                 IMGUI_NOEXCEPT    { return Max.x - Min.x; }
-    float       GetHeight() const                IMGUI_NOEXCEPT    { return Max.y - Min.y; }
-    float       GetArea() const                  IMGUI_NOEXCEPT    { return (Max.x - Min.x) * (Max.y - Min.y); }
-    ImVec2      GetTL() const                    IMGUI_NOEXCEPT    { return Min; }                   // Top-left
-    ImVec2      GetTR() const                    IMGUI_NOEXCEPT    { return ImVec2(Max.x, Min.y); }  // Top-right
-    ImVec2      GetBL() const                    IMGUI_NOEXCEPT    { return ImVec2(Min.x, Max.y); }  // Bottom-left
-    ImVec2      GetBR() const                    IMGUI_NOEXCEPT    { return Max; }                   // Bottom-right
-    bool        Contains(const ImVec2& p) const  IMGUI_NOEXCEPT    { return p.x     >= Min.x && p.y     >= Min.y && p.x     <  Max.x && p.y     <  Max.y; }
-    bool        Contains(const ImRect& r) const  IMGUI_NOEXCEPT    { return r.Min.x >= Min.x && r.Min.y >= Min.y && r.Max.x <= Max.x && r.Max.y <= Max.y; }
-    bool        Overlaps(const ImRect& r) const  IMGUI_NOEXCEPT    { return r.Min.y <  Max.y && r.Max.y >  Min.y && r.Min.x <  Max.x && r.Max.x >  Min.x; }
-    void        Add(const ImVec2& p)             IMGUI_NOEXCEPT    { if (Min.x > p.x)     Min.x = p.x;     if (Min.y > p.y)     Min.y = p.y;     if (Max.x < p.x)     Max.x = p.x;     if (Max.y < p.y)     Max.y = p.y; }
-    void        Add(const ImRect& r)             IMGUI_NOEXCEPT    { if (Min.x > r.Min.x) Min.x = r.Min.x; if (Min.y > r.Min.y) Min.y = r.Min.y; if (Max.x < r.Max.x) Max.x = r.Max.x; if (Max.y < r.Max.y) Max.y = r.Max.y; }
-    void        Expand(const float amount)       IMGUI_NOEXCEPT    { Min.x -= amount;   Min.y -= amount;   Max.x += amount;   Max.y += amount; }
-    void        Expand(const ImVec2& amount)     IMGUI_NOEXCEPT    { Min.x -= amount.x; Min.y -= amount.y; Max.x += amount.x; Max.y += amount.y; }
-    void        Translate(const ImVec2& d)       IMGUI_NOEXCEPT    { Min.x += d.x; Min.y += d.y; Max.x += d.x; Max.y += d.y; }
-    void        TranslateX(float dx)             IMGUI_NOEXCEPT    { Min.x += dx; Max.x += dx; }
-    void        TranslateY(float dy)             IMGUI_NOEXCEPT    { Min.y += dy; Max.y += dy; }
-    void        ClipWith(const ImRect& r)        IMGUI_NOEXCEPT    { Min = ImMax(Min, r.Min); Max = ImMin(Max, r.Max); }                   // Simple version, may lead to an inverted rectangle, which is fine for Contains/Overlaps test but not for display.
-    void        ClipWithFull(const ImRect& r)    IMGUI_NOEXCEPT    { Min = ImClamp(Min, r.Min, r.Max); Max = ImClamp(Max, r.Min, r.Max); } // Full version, ensure both points are fully clipped.
-    void        Floor()                          IMGUI_NOEXCEPT    { Min.x = IM_FLOOR(Min.x); Min.y = IM_FLOOR(Min.y); Max.x = IM_FLOOR(Max.x); Max.y = IM_FLOOR(Max.y); }
-    bool        IsInverted() const               IMGUI_NOEXCEPT    { return Min.x > Max.x || Min.y > Max.y; }
-    ImVec4      ToVec4() const                   IMGUI_NOEXCEPT    { return ImVec4(Min.x, Min.y, Max.x, Max.y); }
+    ImVec2      GetCenter() const                IM_NOEXCEPT    { return ImVec2((Min.x + Max.x) * 0.5f, (Min.y + Max.y) * 0.5f); }
+    ImVec2      GetSize() const                  IM_NOEXCEPT    { return ImVec2(Max.x - Min.x, Max.y - Min.y); }
+    float       GetWidth() const                 IM_NOEXCEPT    { return Max.x - Min.x; }
+    float       GetHeight() const                IM_NOEXCEPT    { return Max.y - Min.y; }
+    float       GetArea() const                  IM_NOEXCEPT    { return (Max.x - Min.x) * (Max.y - Min.y); }
+    ImVec2      GetTL() const                    IM_NOEXCEPT    { return Min; }                   // Top-left
+    ImVec2      GetTR() const                    IM_NOEXCEPT    { return ImVec2(Max.x, Min.y); }  // Top-right
+    ImVec2      GetBL() const                    IM_NOEXCEPT    { return ImVec2(Min.x, Max.y); }  // Bottom-left
+    ImVec2      GetBR() const                    IM_NOEXCEPT    { return Max; }                   // Bottom-right
+    bool        Contains(const ImVec2& p) const  IM_NOEXCEPT    { return p.x     >= Min.x && p.y     >= Min.y && p.x     <  Max.x && p.y     <  Max.y; }
+    bool        Contains(const ImRect& r) const  IM_NOEXCEPT    { return r.Min.x >= Min.x && r.Min.y >= Min.y && r.Max.x <= Max.x && r.Max.y <= Max.y; }
+    bool        Overlaps(const ImRect& r) const  IM_NOEXCEPT    { return r.Min.y <  Max.y && r.Max.y >  Min.y && r.Min.x <  Max.x && r.Max.x >  Min.x; }
+    void        Add(const ImVec2& p)             IM_NOEXCEPT    { if (Min.x > p.x)     Min.x = p.x;     if (Min.y > p.y)     Min.y = p.y;     if (Max.x < p.x)     Max.x = p.x;     if (Max.y < p.y)     Max.y = p.y; }
+    void        Add(const ImRect& r)             IM_NOEXCEPT    { if (Min.x > r.Min.x) Min.x = r.Min.x; if (Min.y > r.Min.y) Min.y = r.Min.y; if (Max.x < r.Max.x) Max.x = r.Max.x; if (Max.y < r.Max.y) Max.y = r.Max.y; }
+    void        Expand(const float amount)       IM_NOEXCEPT    { Min.x -= amount;   Min.y -= amount;   Max.x += amount;   Max.y += amount; }
+    void        Expand(const ImVec2& amount)     IM_NOEXCEPT    { Min.x -= amount.x; Min.y -= amount.y; Max.x += amount.x; Max.y += amount.y; }
+    void        Translate(const ImVec2& d)       IM_NOEXCEPT    { Min.x += d.x; Min.y += d.y; Max.x += d.x; Max.y += d.y; }
+    void        TranslateX(float dx)             IM_NOEXCEPT    { Min.x += dx; Max.x += dx; }
+    void        TranslateY(float dy)             IM_NOEXCEPT    { Min.y += dy; Max.y += dy; }
+    void        ClipWith(const ImRect& r)        IM_NOEXCEPT    { Min = ImMax(Min, r.Min); Max = ImMin(Max, r.Max); }                   // Simple version, may lead to an inverted rectangle, which is fine for Contains/Overlaps test but not for display.
+    void        ClipWithFull(const ImRect& r)    IM_NOEXCEPT    { Min = ImClamp(Min, r.Min, r.Max); Max = ImClamp(Max, r.Min, r.Max); } // Full version, ensure both points are fully clipped.
+    void        Floor()                          IM_NOEXCEPT    { Min.x = IM_FLOOR(Min.x); Min.y = IM_FLOOR(Min.y); Max.x = IM_FLOOR(Max.x); Max.y = IM_FLOOR(Max.y); }
+    bool        IsInverted() const               IM_NOEXCEPT    { return Min.x > Max.x || Min.y > Max.y; }
+    ImVec4      ToVec4() const                   IM_NOEXCEPT    { return ImVec4(Min.x, Min.y, Max.x, Max.y); }
 };
 IM_MSVC_RUNTIME_CHECKS_RESTORE
 
 // Helper: ImBitArray
-inline bool     ImBitArrayTestBit(const ImU32* arr, int n)  IMGUI_NOEXCEPT     { ImU32 mask = (ImU32)1 << (n & 31); return (arr[n >> 5] & mask) != 0; }
-inline void     ImBitArrayClearBit(ImU32* arr, int n)       IMGUI_NOEXCEPT     { ImU32 mask = (ImU32)1 << (n & 31); arr[n >> 5] &= ~mask; }
-inline void     ImBitArraySetBit(ImU32* arr, int n)         IMGUI_NOEXCEPT     { ImU32 mask = (ImU32)1 << (n & 31); arr[n >> 5] |= mask; }
-inline void     ImBitArraySetBitRange(ImU32* arr, int n, int n2) IMGUI_NOEXCEPT // Works on range [n..n2)
+inline bool     ImBitArrayTestBit(const ImU32* arr, int n)  IM_NOEXCEPT     { ImU32 mask = (ImU32)1 << (n & 31); return (arr[n >> 5] & mask) != 0; }
+inline void     ImBitArrayClearBit(ImU32* arr, int n)       IM_NOEXCEPT     { ImU32 mask = (ImU32)1 << (n & 31); arr[n >> 5] &= ~mask; }
+inline void     ImBitArraySetBit(ImU32* arr, int n)         IM_NOEXCEPT     { ImU32 mask = (ImU32)1 << (n & 31); arr[n >> 5] |= mask; }
+inline void     ImBitArraySetBitRange(ImU32* arr, int n, int n2) IM_NOEXCEPT // Works on range [n..n2)
 {
     n2--;
     while (n <= n2)
@@ -527,13 +527,13 @@ template<int BITCOUNT>
 struct IMGUI_API ImBitArray
 {
     ImU32           Storage[(BITCOUNT + 31) >> 5];
-    ImBitArray()                               IMGUI_NOEXCEPT  { ClearAllBits(); }
-    void            ClearAllBits()             IMGUI_NOEXCEPT  { memset(Storage, 0, sizeof(Storage)); }
-    void            SetAllBits()               IMGUI_NOEXCEPT  { memset(Storage, 255, sizeof(Storage)); }
-    bool            TestBit(int n) const       IMGUI_NOEXCEPT  { IM_ASSERT(n < BITCOUNT); return ImBitArrayTestBit(Storage, n); }
-    void            SetBit(int n)              IMGUI_NOEXCEPT  { IM_ASSERT(n < BITCOUNT); ImBitArraySetBit(Storage, n); }
-    void            ClearBit(int n)            IMGUI_NOEXCEPT  { IM_ASSERT(n < BITCOUNT); ImBitArrayClearBit(Storage, n); }
-    void            SetBitRange(int n, int n2) IMGUI_NOEXCEPT  { ImBitArraySetBitRange(Storage, n, n2); } // Works on range [n..n2)
+    ImBitArray()                               IM_NOEXCEPT  { ClearAllBits(); }
+    void            ClearAllBits()             IM_NOEXCEPT  { memset(Storage, 0, sizeof(Storage)); }
+    void            SetAllBits()               IM_NOEXCEPT  { memset(Storage, 255, sizeof(Storage)); }
+    bool            TestBit(int n) const       IM_NOEXCEPT  { IM_ASSERT(n < BITCOUNT); return ImBitArrayTestBit(Storage, n); }
+    void            SetBit(int n)              IM_NOEXCEPT  { IM_ASSERT(n < BITCOUNT); ImBitArraySetBit(Storage, n); }
+    void            ClearBit(int n)            IM_NOEXCEPT  { IM_ASSERT(n < BITCOUNT); ImBitArrayClearBit(Storage, n); }
+    void            SetBitRange(int n, int n2) IM_NOEXCEPT  { ImBitArraySetBitRange(Storage, n, n2); } // Works on range [n..n2)
 };
 
 // Helper: ImBitVector
@@ -541,11 +541,11 @@ struct IMGUI_API ImBitArray
 struct IMGUI_API ImBitVector
 {
     ImVector<ImU32> Storage;
-    void            Create(int sz)       IMGUI_NOEXCEPT        { Storage.resize((sz + 31) >> 5); memset(Storage.Data, 0, (size_t)Storage.Size * sizeof(Storage.Data[0])); }
-    void            Clear()              IMGUI_NOEXCEPT        { Storage.clear(); }
-    bool            TestBit(int n) const IMGUI_NOEXCEPT        { IM_ASSERT(n < (Storage.Size << 5)); return ImBitArrayTestBit(Storage.Data, n); }
-    void            SetBit(int n)        IMGUI_NOEXCEPT        { IM_ASSERT(n < (Storage.Size << 5)); ImBitArraySetBit(Storage.Data, n); }
-    void            ClearBit(int n)      IMGUI_NOEXCEPT        { IM_ASSERT(n < (Storage.Size << 5)); ImBitArrayClearBit(Storage.Data, n); }
+    void            Create(int sz)       IM_NOEXCEPT        { Storage.resize((sz + 31) >> 5); memset(Storage.Data, 0, (size_t)Storage.Size * sizeof(Storage.Data[0])); }
+    void            Clear()              IM_NOEXCEPT        { Storage.clear(); }
+    bool            TestBit(int n) const IM_NOEXCEPT        { IM_ASSERT(n < (Storage.Size << 5)); return ImBitArrayTestBit(Storage.Data, n); }
+    void            SetBit(int n)        IM_NOEXCEPT        { IM_ASSERT(n < (Storage.Size << 5)); ImBitArraySetBit(Storage.Data, n); }
+    void            ClearBit(int n)      IM_NOEXCEPT        { IM_ASSERT(n < (Storage.Size << 5)); ImBitArrayClearBit(Storage.Data, n); }
 };
 
 // Helper: ImSpan<>
@@ -557,21 +557,21 @@ struct ImSpan
     T*                  DataEnd;
 
     // Constructors, destructor
-    inline ImSpan()                               IMGUI_NOEXCEPT   { Data = DataEnd = NULL; }
-    inline ImSpan(T* data, int size)              IMGUI_NOEXCEPT   { Data = data; DataEnd = data + size; }
-    inline ImSpan(T* data, T* data_end)           IMGUI_NOEXCEPT   { Data = data; DataEnd = data_end; }
+    inline ImSpan()                               IM_NOEXCEPT   { Data = DataEnd = NULL; }
+    inline ImSpan(T* data, int size)              IM_NOEXCEPT   { Data = data; DataEnd = data + size; }
+    inline ImSpan(T* data, T* data_end)           IM_NOEXCEPT   { Data = data; DataEnd = data_end; }
     
-    inline void         set(T* data, int size)    IMGUI_NOEXCEPT   { Data = data; DataEnd = data + size; }
-    inline void         set(T* data, T* data_end) IMGUI_NOEXCEPT   { Data = data; DataEnd = data_end; }
-    inline int          size() const              IMGUI_NOEXCEPT   { return (int)(ptrdiff_t)(DataEnd - Data); }
-    inline int          size_in_bytes() const     IMGUI_NOEXCEPT   { return (int)(ptrdiff_t)(DataEnd - Data) * (int)sizeof(T); }
-    inline T&           operator[](int i)         IMGUI_NOEXCEPT   { T* p = Data + i; IM_ASSERT(p >= Data && p < DataEnd); return *p; }
-    inline const T&     operator[](int i) const   IMGUI_NOEXCEPT   { const T* p = Data + i; IM_ASSERT(p >= Data && p < DataEnd); return *p; }
+    inline void         set(T* data, int size)    IM_NOEXCEPT   { Data = data; DataEnd = data + size; }
+    inline void         set(T* data, T* data_end) IM_NOEXCEPT   { Data = data; DataEnd = data_end; }
+    inline int          size() const              IM_NOEXCEPT   { return (int)(ptrdiff_t)(DataEnd - Data); }
+    inline int          size_in_bytes() const     IM_NOEXCEPT   { return (int)(ptrdiff_t)(DataEnd - Data) * (int)sizeof(T); }
+    inline T&           operator[](int i)         IM_NOEXCEPT   { T* p = Data + i; IM_ASSERT(p >= Data && p < DataEnd); return *p; }
+    inline const T&     operator[](int i) const   IM_NOEXCEPT   { const T* p = Data + i; IM_ASSERT(p >= Data && p < DataEnd); return *p; }
     
-    inline T*           begin()                   IMGUI_NOEXCEPT   { return Data; }
-    inline const T*     begin() const             IMGUI_NOEXCEPT   { return Data; }
-    inline T*           end()                     IMGUI_NOEXCEPT   { return DataEnd; }
-    inline const T*     end() const               IMGUI_NOEXCEPT   { return DataEnd; }
+    inline T*           begin()                   IM_NOEXCEPT   { return Data; }
+    inline const T*     begin() const             IM_NOEXCEPT   { return Data; }
+    inline T*           end()                     IM_NOEXCEPT   { return DataEnd; }
+    inline const T*     end() const               IM_NOEXCEPT   { return DataEnd; }
 
     // Utilities
     inline int  index_from_ptr(const T* it) const   { IM_ASSERT(it >= Data && it < DataEnd); const ptrdiff_t off = it - Data; return (int)off; }
@@ -589,14 +589,14 @@ struct ImSpanAllocator
     int     Offsets[CHUNKS];
     int     Sizes[CHUNKS];
 
-    ImSpanAllocator()                               IMGUI_NOEXCEPT { memset(this, 0, sizeof(*this)); }
-    inline void  Reserve(int n, size_t sz, int a=4) IMGUI_NOEXCEPT { IM_ASSERT(n == CurrIdx && n < CHUNKS); CurrOff = IM_MEMALIGN(CurrOff, a); Offsets[n] = CurrOff; Sizes[n] = (int)sz; CurrIdx++; CurrOff += (int)sz; }
-    inline int   GetArenaSizeInBytes()              IMGUI_NOEXCEPT { return CurrOff; }
-    inline void  SetArenaBasePtr(void* base_ptr)    IMGUI_NOEXCEPT { BasePtr = (char*)base_ptr; }
-    inline void* GetSpanPtrBegin(int n)             IMGUI_NOEXCEPT { IM_ASSERT(n >= 0 && n < CHUNKS && CurrIdx == CHUNKS); return (void*)(BasePtr + Offsets[n]); }
-    inline void* GetSpanPtrEnd(int n)               IMGUI_NOEXCEPT { IM_ASSERT(n >= 0 && n < CHUNKS && CurrIdx == CHUNKS); return (void*)(BasePtr + Offsets[n] + Sizes[n]); }
+    ImSpanAllocator()                               IM_NOEXCEPT { memset(this, 0, sizeof(*this)); }
+    inline void  Reserve(int n, size_t sz, int a=4) IM_NOEXCEPT { IM_ASSERT(n == CurrIdx && n < CHUNKS); CurrOff = IM_MEMALIGN(CurrOff, a); Offsets[n] = CurrOff; Sizes[n] = (int)sz; CurrIdx++; CurrOff += (int)sz; }
+    inline int   GetArenaSizeInBytes()              IM_NOEXCEPT { return CurrOff; }
+    inline void  SetArenaBasePtr(void* base_ptr)    IM_NOEXCEPT { BasePtr = (char*)base_ptr; }
+    inline void* GetSpanPtrBegin(int n)             IM_NOEXCEPT { IM_ASSERT(n >= 0 && n < CHUNKS && CurrIdx == CHUNKS); return (void*)(BasePtr + Offsets[n]); }
+    inline void* GetSpanPtrEnd(int n)               IM_NOEXCEPT { IM_ASSERT(n >= 0 && n < CHUNKS && CurrIdx == CHUNKS); return (void*)(BasePtr + Offsets[n] + Sizes[n]); }
     template<typename T>
-    inline void  GetSpan(int n, ImSpan<T>* span)    IMGUI_NOEXCEPT { span->set((T*)GetSpanPtrBegin(n), (T*)GetSpanPtrEnd(n)); }
+    inline void  GetSpan(int n, ImSpan<T>* span)    IM_NOEXCEPT { span->set((T*)GetSpanPtrBegin(n), (T*)GetSpanPtrEnd(n)); }
 };
 
 // Helper: ImPool<>
@@ -610,19 +610,19 @@ struct IMGUI_API ImPool
     ImGuiStorage    Map;        // ID->Index
     ImPoolIdx       FreeIdx;    // Next free idx to use
 
-    ImPool()    IMGUI_NOEXCEPT { FreeIdx = 0; }
-    ~ImPool()   IMGUI_NOEXCEPT { Clear(); }
-    T*          GetByKey(ImGuiID key)              IMGUI_NOEXCEPT  { int idx = Map.GetInt(key, -1); return (idx != -1) ? &Buf[idx] : NULL; }
-    T*          GetByIndex(ImPoolIdx n)            IMGUI_NOEXCEPT  { return &Buf[n]; }
-    ImPoolIdx   GetIndex(const T* p) const         IMGUI_NOEXCEPT  { IM_ASSERT(p >= Buf.Data && p < Buf.Data + Buf.Size); return (ImPoolIdx)(p - Buf.Data); }
-    T*          GetOrAddByKey(ImGuiID key)         IMGUI_NOEXCEPT  { int* p_idx = Map.GetIntRef(key, -1); if (*p_idx != -1) return &Buf[*p_idx]; *p_idx = FreeIdx; return Add(); }
-    bool        Contains(const T* p) const         IMGUI_NOEXCEPT  { return (p >= Buf.Data && p < Buf.Data + Buf.Size); }
-    void        Clear()                            IMGUI_NOEXCEPT  { for (int n = 0; n < Map.Data.Size; n++) { int idx = Map.Data[n].val_i; if (idx != -1) Buf[idx].~T(); } Map.Clear(); Buf.clear(); FreeIdx = 0; }
-    T*          Add()                              IMGUI_NOEXCEPT  { int idx = FreeIdx; if (idx == Buf.Size) { Buf.resize(Buf.Size + 1); FreeIdx++; } else { FreeIdx = *(int*)&Buf[idx]; } IM_PLACEMENT_NEW(&Buf[idx]) T(); return &Buf[idx]; }
-    void        Remove(ImGuiID key, const T* p)    IMGUI_NOEXCEPT  { Remove(key, GetIndex(p)); }
-    void        Remove(ImGuiID key, ImPoolIdx idx) IMGUI_NOEXCEPT  { Buf[idx].~T(); *(int*)&Buf[idx] = FreeIdx; FreeIdx = idx; Map.SetInt(key, -1); }
-    void        Reserve(int capacity)              IMGUI_NOEXCEPT  { Buf.reserve(capacity); Map.Data.reserve(capacity); }
-    int         GetSize() const                    IMGUI_NOEXCEPT  { return Buf.Size; }
+    ImPool()    IM_NOEXCEPT { FreeIdx = 0; }
+    ~ImPool()   IM_NOEXCEPT { Clear(); }
+    T*          GetByKey(ImGuiID key)              IM_NOEXCEPT  { int idx = Map.GetInt(key, -1); return (idx != -1) ? &Buf[idx] : NULL; }
+    T*          GetByIndex(ImPoolIdx n)            IM_NOEXCEPT  { return &Buf[n]; }
+    ImPoolIdx   GetIndex(const T* p) const         IM_NOEXCEPT  { IM_ASSERT(p >= Buf.Data && p < Buf.Data + Buf.Size); return (ImPoolIdx)(p - Buf.Data); }
+    T*          GetOrAddByKey(ImGuiID key)         IM_NOEXCEPT  { int* p_idx = Map.GetIntRef(key, -1); if (*p_idx != -1) return &Buf[*p_idx]; *p_idx = FreeIdx; return Add(); }
+    bool        Contains(const T* p) const         IM_NOEXCEPT  { return (p >= Buf.Data && p < Buf.Data + Buf.Size); }
+    void        Clear()                            IM_NOEXCEPT  { for (int n = 0; n < Map.Data.Size; n++) { int idx = Map.Data[n].val_i; if (idx != -1) Buf[idx].~T(); } Map.Clear(); Buf.clear(); FreeIdx = 0; }
+    T*          Add()                              IM_NOEXCEPT  { int idx = FreeIdx; if (idx == Buf.Size) { Buf.resize(Buf.Size + 1); FreeIdx++; } else { FreeIdx = *(int*)&Buf[idx]; } IM_PLACEMENT_NEW(&Buf[idx]) T(); return &Buf[idx]; }
+    void        Remove(ImGuiID key, const T* p)    IM_NOEXCEPT  { Remove(key, GetIndex(p)); }
+    void        Remove(ImGuiID key, ImPoolIdx idx) IM_NOEXCEPT  { Buf[idx].~T(); *(int*)&Buf[idx] = FreeIdx; FreeIdx = idx; Map.SetInt(key, -1); }
+    void        Reserve(int capacity)              IM_NOEXCEPT  { Buf.reserve(capacity); Map.Data.reserve(capacity); }
+    int         GetSize() const                    IM_NOEXCEPT  { return Buf.Size; }
 };
 
 // Helper: ImChunkStream<>
@@ -635,17 +635,17 @@ struct IMGUI_API ImChunkStream
 {
     ImVector<char>  Buf;
 
-    void    clear()                     IMGUI_NOEXCEPT { Buf.clear(); }
-    bool    empty() const               IMGUI_NOEXCEPT { return Buf.Size == 0; }
-    int     size() const                IMGUI_NOEXCEPT { return Buf.Size; }
-    T*      alloc_chunk(size_t sz)      IMGUI_NOEXCEPT { size_t HDR_SZ = 4; sz = IM_MEMALIGN(HDR_SZ + sz, 4u); int off = Buf.Size; Buf.resize(off + (int)sz); ((int*)(void*)(Buf.Data + off))[0] = (int)sz; return (T*)(void*)(Buf.Data + off + (int)HDR_SZ); }
-    T*      begin()                     IMGUI_NOEXCEPT { size_t HDR_SZ = 4; if (!Buf.Data) return NULL; return (T*)(void*)(Buf.Data + HDR_SZ); }
-    T*      next_chunk(T* p)            IMGUI_NOEXCEPT { size_t HDR_SZ = 4; IM_ASSERT(p >= begin() && p < end()); p = (T*)(void*)((char*)(void*)p + chunk_size(p)); if (p == (T*)(void*)((char*)end() + HDR_SZ)) return (T*)0; IM_ASSERT(p < end()); return p; }
-    int     chunk_size(const T* p)      IMGUI_NOEXCEPT { return ((const int*)p)[-1]; }
-    T*      end()                       IMGUI_NOEXCEPT { return (T*)(void*)(Buf.Data + Buf.Size); }
-    int     offset_from_ptr(const T* p) IMGUI_NOEXCEPT { IM_ASSERT(p >= begin() && p < end()); const ptrdiff_t off = (const char*)p - Buf.Data; return (int)off; }
-    T*      ptr_from_offset(int off)    IMGUI_NOEXCEPT { IM_ASSERT(off >= 4 && off < Buf.Size); return (T*)(void*)(Buf.Data + off); }
-    void    swap(ImChunkStream<T>& rhs) IMGUI_NOEXCEPT { rhs.Buf.swap(Buf); }
+    void    clear()                     IM_NOEXCEPT { Buf.clear(); }
+    bool    empty() const               IM_NOEXCEPT { return Buf.Size == 0; }
+    int     size() const                IM_NOEXCEPT { return Buf.Size; }
+    T*      alloc_chunk(size_t sz)      IM_NOEXCEPT { size_t HDR_SZ = 4; sz = IM_MEMALIGN(HDR_SZ + sz, 4u); int off = Buf.Size; Buf.resize(off + (int)sz); ((int*)(void*)(Buf.Data + off))[0] = (int)sz; return (T*)(void*)(Buf.Data + off + (int)HDR_SZ); }
+    T*      begin()                     IM_NOEXCEPT { size_t HDR_SZ = 4; if (!Buf.Data) return NULL; return (T*)(void*)(Buf.Data + HDR_SZ); }
+    T*      next_chunk(T* p)            IM_NOEXCEPT { size_t HDR_SZ = 4; IM_ASSERT(p >= begin() && p < end()); p = (T*)(void*)((char*)(void*)p + chunk_size(p)); if (p == (T*)(void*)((char*)end() + HDR_SZ)) return (T*)0; IM_ASSERT(p < end()); return p; }
+    int     chunk_size(const T* p)      IM_NOEXCEPT { return ((const int*)p)[-1]; }
+    T*      end()                       IM_NOEXCEPT { return (T*)(void*)(Buf.Data + Buf.Size); }
+    int     offset_from_ptr(const T* p) IM_NOEXCEPT { IM_ASSERT(p >= begin() && p < end()); const ptrdiff_t off = (const char*)p - Buf.Data; return (int)off; }
+    T*      ptr_from_offset(int off)    IM_NOEXCEPT { IM_ASSERT(off >= 4 && off < Buf.Size); return (T*)(void*)(Buf.Data + off); }
+    void    swap(ImChunkStream<T>& rhs) IM_NOEXCEPT { rhs.Buf.swap(Buf); }
 
 };
 
@@ -697,18 +697,18 @@ struct IMGUI_API ImDrawListSharedData
     ImU8            CircleSegmentCounts[64];    // Precomputed segment count for given radius before we calculate it dynamically (to avoid calculation overhead)
     const ImVec4*   TexUvLines;                 // UV of anti-aliased lines in the atlas
 
-    ImDrawListSharedData() IMGUI_NOEXCEPT;
-    void SetCircleTessellationMaxError(float max_error) IMGUI_NOEXCEPT;
+    ImDrawListSharedData() IM_NOEXCEPT;
+    void SetCircleTessellationMaxError(float max_error) IM_NOEXCEPT;
 };
 
 struct ImDrawDataBuilder
 {
     ImVector<ImDrawList*>   Layers[2];           // Global layers for: regular, tooltip
 
-    void Clear()                  IMGUI_NOEXCEPT   { for (int n = 0; n < IM_ARRAYSIZE(Layers); n++) Layers[n].resize(0); }
-    void ClearFreeMemory()        IMGUI_NOEXCEPT   { for (int n = 0; n < IM_ARRAYSIZE(Layers); n++) Layers[n].clear(); }
-    int  GetDrawListCount() const IMGUI_NOEXCEPT   { int count = 0; for (int n = 0; n < IM_ARRAYSIZE(Layers); n++) count += Layers[n].Size; return count; }
-    IMGUI_API void FlattenIntoSingleLayer() IMGUI_NOEXCEPT;
+    void Clear()                  IM_NOEXCEPT   { for (int n = 0; n < IM_ARRAYSIZE(Layers); n++) Layers[n].resize(0); }
+    void ClearFreeMemory()        IM_NOEXCEPT   { for (int n = 0; n < IM_ARRAYSIZE(Layers); n++) Layers[n].clear(); }
+    int  GetDrawListCount() const IM_NOEXCEPT   { int count = 0; for (int n = 0; n < IM_ARRAYSIZE(Layers); n++) count += Layers[n].Size; return count; }
+    IMGUI_API void FlattenIntoSingleLayer() IM_NOEXCEPT;
 };
 
 //-----------------------------------------------------------------------------
@@ -978,9 +978,9 @@ struct ImGuiStyleMod
 {
     ImGuiStyleVar   VarIdx;
     union           { int BackupInt[2]; float BackupFloat[2]; };
-    ImGuiStyleMod(ImGuiStyleVar idx, int v)    IMGUI_NOEXCEPT  { VarIdx = idx; BackupInt[0] = v; }
-    ImGuiStyleMod(ImGuiStyleVar idx, float v)  IMGUI_NOEXCEPT  { VarIdx = idx; BackupFloat[0] = v; }
-    ImGuiStyleMod(ImGuiStyleVar idx, ImVec2 v) IMGUI_NOEXCEPT  { VarIdx = idx; BackupFloat[0] = v.x; BackupFloat[1] = v.y; }
+    ImGuiStyleMod(ImGuiStyleVar idx, int v)    IM_NOEXCEPT  { VarIdx = idx; BackupInt[0] = v; }
+    ImGuiStyleMod(ImGuiStyleVar idx, float v)  IM_NOEXCEPT  { VarIdx = idx; BackupFloat[0] = v; }
+    ImGuiStyleMod(ImGuiStyleVar idx, ImVec2 v) IM_NOEXCEPT  { VarIdx = idx; BackupFloat[0] = v.x; BackupFloat[1] = v.y; }
 };
 
 // Stacked storage data for BeginGroup()/EndGroup()
@@ -1006,10 +1006,10 @@ struct IMGUI_API ImGuiMenuColumns
     float       Width, NextWidth;
     float       Pos[3], NextWidths[3];
 
-    ImGuiMenuColumns() IMGUI_NOEXCEPT { memset(this, 0, sizeof(*this)); }
-    void        Update(int count, float spacing, bool clear) IMGUI_NOEXCEPT;
-    float       DeclColumns(float w0, float w1, float w2) IMGUI_NOEXCEPT;
-    float       CalcExtraSpace(float avail_w) const IMGUI_NOEXCEPT;
+    ImGuiMenuColumns() IM_NOEXCEPT { memset(this, 0, sizeof(*this)); }
+    void        Update(int count, float spacing, bool clear) IM_NOEXCEPT;
+    float       DeclColumns(float w0, float w1, float w2) IM_NOEXCEPT;
+    float       CalcExtraSpace(float avail_w) const IM_NOEXCEPT;
 };
 
 // Internal state of the currently focused/edited text input box
@@ -1033,19 +1033,19 @@ struct IMGUI_API ImGuiInputTextState
     ImGuiInputTextCallback  UserCallback;           // "
     void*                   UserCallbackData;       // "
 
-    ImGuiInputTextState()                 IMGUI_NOEXCEPT   { memset(this, 0, sizeof(*this)); }
-    void        ClearText()               IMGUI_NOEXCEPT   { CurLenW = CurLenA = 0; TextW[0] = 0; TextA[0] = 0; CursorClamp(); }
-    void        ClearFreeMemory()         IMGUI_NOEXCEPT   { TextW.clear(); TextA.clear(); InitialTextA.clear(); }
-    int         GetUndoAvailCount() const IMGUI_NOEXCEPT   { return Stb.undostate.undo_point; }
-    int         GetRedoAvailCount() const IMGUI_NOEXCEPT   { return STB_TEXTEDIT_UNDOSTATECOUNT - Stb.undostate.redo_point; }
-    void        OnKeyPressed(int key) IMGUI_NOEXCEPT;      // Cannot be inline because we call in code in stb_textedit.h implementation
+    ImGuiInputTextState()                 IM_NOEXCEPT   { memset(this, 0, sizeof(*this)); }
+    void        ClearText()               IM_NOEXCEPT   { CurLenW = CurLenA = 0; TextW[0] = 0; TextA[0] = 0; CursorClamp(); }
+    void        ClearFreeMemory()         IM_NOEXCEPT   { TextW.clear(); TextA.clear(); InitialTextA.clear(); }
+    int         GetUndoAvailCount() const IM_NOEXCEPT   { return Stb.undostate.undo_point; }
+    int         GetRedoAvailCount() const IM_NOEXCEPT   { return STB_TEXTEDIT_UNDOSTATECOUNT - Stb.undostate.redo_point; }
+    void        OnKeyPressed(int key) IM_NOEXCEPT;      // Cannot be inline because we call in code in stb_textedit.h implementation
 
     // Cursor & Selection
-    void        CursorAnimReset()         IMGUI_NOEXCEPT   { CursorAnim = -0.30f; }                                   // After a user-input the cursor stays on for a while without blinking
-    void        CursorClamp()             IMGUI_NOEXCEPT   { Stb.cursor = ImMin(Stb.cursor, CurLenW); Stb.select_start = ImMin(Stb.select_start, CurLenW); Stb.select_end = ImMin(Stb.select_end, CurLenW); }
-    bool        HasSelection() const      IMGUI_NOEXCEPT   { return Stb.select_start != Stb.select_end; }
-    void        ClearSelection()          IMGUI_NOEXCEPT   { Stb.select_start = Stb.select_end = Stb.cursor; }
-    void        SelectAll()               IMGUI_NOEXCEPT   { Stb.select_start = 0; Stb.cursor = Stb.select_end = CurLenW; Stb.has_preferred_x = 0; }
+    void        CursorAnimReset()         IM_NOEXCEPT   { CursorAnim = -0.30f; }                                   // After a user-input the cursor stays on for a while without blinking
+    void        CursorClamp()             IM_NOEXCEPT   { Stb.cursor = ImMin(Stb.cursor, CurLenW); Stb.select_start = ImMin(Stb.select_start, CurLenW); Stb.select_end = ImMin(Stb.select_end, CurLenW); }
+    bool        HasSelection() const      IM_NOEXCEPT   { return Stb.select_start != Stb.select_end; }
+    void        ClearSelection()          IM_NOEXCEPT   { Stb.select_start = Stb.select_end = Stb.cursor; }
+    void        SelectAll()               IM_NOEXCEPT   { Stb.select_start = 0; Stb.cursor = Stb.select_end = CurLenW; Stb.has_preferred_x = 0; }
 };
 
 // Storage for current popup stack
@@ -1059,7 +1059,7 @@ struct ImGuiPopupData
     ImVec2              OpenPopupPos;   // Set on OpenPopup(), preferred popup position (typically == OpenMousePos when using mouse)
     ImVec2              OpenMousePos;   // Set on OpenPopup(), copy of mouse position at the time of opening popup
 
-    ImGuiPopupData() IMGUI_NOEXCEPT    { memset(this, 0, sizeof(*this)); OpenFrameCount = -1; }
+    ImGuiPopupData() IM_NOEXCEPT    { memset(this, 0, sizeof(*this)); OpenFrameCount = -1; }
 };
 
 struct ImGuiNavItemData
@@ -1072,8 +1072,8 @@ struct ImGuiNavItemData
     float               DistCenter;     //      Move    // Best candidate center distance to current NavId
     float               DistAxial;      //      Move    // Best candidate axial distance to current NavId
 
-    ImGuiNavItemData() IMGUI_NOEXCEPT  { Clear(); }
-    void Clear()       IMGUI_NOEXCEPT  { Window = NULL; ID = FocusScopeId = 0; RectRel = ImRect(); DistBox = DistCenter = DistAxial = FLT_MAX; }
+    ImGuiNavItemData() IM_NOEXCEPT  { Clear(); }
+    void Clear()       IM_NOEXCEPT  { Window = NULL; ID = FocusScopeId = 0; RectRel = ImRect(); DistBox = DistCenter = DistAxial = FLT_MAX; }
 };
 
 enum ImGuiNextWindowDataFlags_
@@ -1108,8 +1108,8 @@ struct ImGuiNextWindowData
     float                       BgAlphaVal;             // Override background alpha
     ImVec2                      MenuBarOffsetMinVal;    // *Always on* This is not exposed publicly, so we don't clear it.
 
-    ImGuiNextWindowData()    IMGUI_NOEXCEPT    { memset(this, 0, sizeof(*this)); }
-    inline void ClearFlags() IMGUI_NOEXCEPT    { Flags = ImGuiNextWindowDataFlags_None; }
+    ImGuiNextWindowData()    IM_NOEXCEPT    { memset(this, 0, sizeof(*this)); }
+    inline void ClearFlags() IM_NOEXCEPT    { Flags = ImGuiNextWindowDataFlags_None; }
 };
 
 enum ImGuiNextItemDataFlags_
@@ -1127,8 +1127,8 @@ struct ImGuiNextItemData
     ImGuiCond                   OpenCond;
     bool                        OpenVal;        // Set by SetNextItemOpen()
 
-    ImGuiNextItemData()      IMGUI_NOEXCEPT    { memset(this, 0, sizeof(*this)); }
-    inline void ClearFlags() IMGUI_NOEXCEPT    { Flags = ImGuiNextItemDataFlags_None; } // Also cleared manually by ItemAdd()!
+    ImGuiNextItemData()      IM_NOEXCEPT    { memset(this, 0, sizeof(*this)); }
+    inline void ClearFlags() IM_NOEXCEPT    { Flags = ImGuiNextItemDataFlags_None; } // Also cleared manually by ItemAdd()!
 };
 
 struct ImGuiShrinkWidthItem
@@ -1142,8 +1142,8 @@ struct ImGuiPtrOrIndex
     void*       Ptr;            // Either field can be set, not both. e.g. Dock node tab bars are loose while BeginTabBar() ones are in a pool.
     int         Index;          // Usually index in a main pool.
 
-    ImGuiPtrOrIndex(void* ptr) IMGUI_NOEXCEPT  { Ptr = ptr; Index = -1; }
-    ImGuiPtrOrIndex(int index) IMGUI_NOEXCEPT  { Ptr = NULL; Index = index; }
+    ImGuiPtrOrIndex(void* ptr) IM_NOEXCEPT  { Ptr = ptr; Index = -1; }
+    ImGuiPtrOrIndex(int index) IM_NOEXCEPT  { Ptr = NULL; Index = index; }
 };
 
 //-----------------------------------------------------------------------------
@@ -1178,7 +1178,7 @@ struct ImGuiOldColumnData
     ImGuiOldColumnFlags Flags;              // Not exposed
     ImRect              ClipRect;
 
-    ImGuiOldColumnData() IMGUI_NOEXCEPT { memset(this, 0, sizeof(*this)); }
+    ImGuiOldColumnData() IM_NOEXCEPT { memset(this, 0, sizeof(*this)); }
 };
 
 struct ImGuiOldColumns
@@ -1199,7 +1199,7 @@ struct ImGuiOldColumns
     ImVector<ImGuiOldColumnData> Columns;
     ImDrawListSplitter  Splitter;
 
-    ImGuiOldColumns() IMGUI_NOEXCEPT   { memset(this, 0, sizeof(*this)); }
+    ImGuiOldColumns() IM_NOEXCEPT   { memset(this, 0, sizeof(*this)); }
 };
 
 //-----------------------------------------------------------------------------
@@ -1236,18 +1236,18 @@ struct ImGuiViewportP : public ImGuiViewport
     ImVec2              BuildWorkOffsetMin;     // Work Area: Offset being built during current frame. Generally >= 0.0f.
     ImVec2              BuildWorkOffsetMax;     // Work Area: Offset being built during current frame. Generally <= 0.0f.
 
-    ImGuiViewportP()  IMGUI_NOEXCEPT   { DrawListsLastFrame[0] = DrawListsLastFrame[1] = -1; DrawLists[0] = DrawLists[1] = NULL; }
-    ~ImGuiViewportP() IMGUI_NOEXCEPT   { if (DrawLists[0]) IM_DELETE(DrawLists[0]); if (DrawLists[1]) IM_DELETE(DrawLists[1]); }
+    ImGuiViewportP()  IM_NOEXCEPT   { DrawListsLastFrame[0] = DrawListsLastFrame[1] = -1; DrawLists[0] = DrawLists[1] = NULL; }
+    ~ImGuiViewportP() IM_NOEXCEPT   { if (DrawLists[0]) IM_DELETE(DrawLists[0]); if (DrawLists[1]) IM_DELETE(DrawLists[1]); }
 
     // Calculate work rect pos/size given a set of offset (we have 1 pair of offset for rect locked from last frame data, and 1 pair for currently building rect)
-    ImVec2  CalcWorkRectPos(const ImVec2& off_min) const                         IMGUI_NOEXCEPT    { return ImVec2(Pos.x + off_min.x, Pos.y + off_min.y); }
-    ImVec2  CalcWorkRectSize(const ImVec2& off_min, const ImVec2& off_max) const IMGUI_NOEXCEPT    { return ImVec2(ImMax(0.0f, Size.x - off_min.x + off_max.x), ImMax(0.0f, Size.y - off_min.y + off_max.y)); }
-    void    UpdateWorkRect() IMGUI_NOEXCEPT            { WorkPos = CalcWorkRectPos(WorkOffsetMin); WorkSize = CalcWorkRectSize(WorkOffsetMin, WorkOffsetMax); } // Update public fields
+    ImVec2  CalcWorkRectPos(const ImVec2& off_min) const                         IM_NOEXCEPT    { return ImVec2(Pos.x + off_min.x, Pos.y + off_min.y); }
+    ImVec2  CalcWorkRectSize(const ImVec2& off_min, const ImVec2& off_max) const IM_NOEXCEPT    { return ImVec2(ImMax(0.0f, Size.x - off_min.x + off_max.x), ImMax(0.0f, Size.y - off_min.y + off_max.y)); }
+    void    UpdateWorkRect() IM_NOEXCEPT            { WorkPos = CalcWorkRectPos(WorkOffsetMin); WorkSize = CalcWorkRectSize(WorkOffsetMin, WorkOffsetMax); } // Update public fields
 
     // Helpers to retrieve ImRect (we don't need to store BuildWorkRect as every access tend to change it, hence the code asymmetry)
-    ImRect  GetMainRect() const      IMGUI_NOEXCEPT    { return ImRect(Pos.x, Pos.y, Pos.x + Size.x, Pos.y + Size.y); }
-    ImRect  GetWorkRect() const      IMGUI_NOEXCEPT    { return ImRect(WorkPos.x, WorkPos.y, WorkPos.x + WorkSize.x, WorkPos.y + WorkSize.y); }
-    ImRect  GetBuildWorkRect() const IMGUI_NOEXCEPT    { ImVec2 pos = CalcWorkRectPos(BuildWorkOffsetMin); ImVec2 size = CalcWorkRectSize(BuildWorkOffsetMin, BuildWorkOffsetMax); return ImRect(pos.x, pos.y, pos.x + size.x, pos.y + size.y); }
+    ImRect  GetMainRect() const      IM_NOEXCEPT    { return ImRect(Pos.x, Pos.y, Pos.x + Size.x, Pos.y + Size.y); }
+    ImRect  GetWorkRect() const      IM_NOEXCEPT    { return ImRect(WorkPos.x, WorkPos.y, WorkPos.x + WorkSize.x, WorkPos.y + WorkSize.y); }
+    ImRect  GetBuildWorkRect() const IM_NOEXCEPT    { ImVec2 pos = CalcWorkRectPos(BuildWorkOffsetMin); ImVec2 size = CalcWorkRectSize(BuildWorkOffsetMin, BuildWorkOffsetMax); return ImRect(pos.x, pos.y, pos.x + size.x, pos.y + size.y); }
 };
 
 //-----------------------------------------------------------------------------
@@ -1265,8 +1265,8 @@ struct ImGuiWindowSettings
     bool        Collapsed;
     bool        WantApply;      // Set when loaded from .ini data (to enable merging/loading .ini data into an already running context)
 
-    ImGuiWindowSettings() IMGUI_NOEXCEPT       { memset(this, 0, sizeof(*this)); }
-    char* GetName()       IMGUI_NOEXCEPT       { return (char*)(this + 1); }
+    ImGuiWindowSettings() IM_NOEXCEPT       { memset(this, 0, sizeof(*this)); }
+    char* GetName()       IM_NOEXCEPT       { return (char*)(this + 1); }
 };
 
 struct ImGuiSettingsHandler
@@ -1276,12 +1276,12 @@ struct ImGuiSettingsHandler
     void        (*ClearAllFn)(ImGuiContext* ctx, ImGuiSettingsHandler* handler);                                // Clear all settings data
     void        (*ReadInitFn)(ImGuiContext* ctx, ImGuiSettingsHandler* handler);                                // Read: Called before reading (in registration order)
     void*       (*ReadOpenFn)(ImGuiContext* ctx, ImGuiSettingsHandler* handler, const char* name);              // Read: Called when entering into a new ini entry e.g. "[Window][Name]"
-    void        (*ReadLineFn)(ImGuiContext* ctx, ImGuiSettingsHandler* handler, void* entry, const char* line) IMGUI_NOEXCEPT; // Read: Called for every line of text within an ini entry
+    void        (*ReadLineFn)(ImGuiContext* ctx, ImGuiSettingsHandler* handler, void* entry, const char* line) IM_NOEXCEPT; // Read: Called for every line of text within an ini entry
     void        (*ApplyAllFn)(ImGuiContext* ctx, ImGuiSettingsHandler* handler);                                // Read: Called after reading (in registration order)
     void        (*WriteAllFn)(ImGuiContext* ctx, ImGuiSettingsHandler* handler, ImGuiTextBuffer* out_buf);      // Write: Output every entries into 'out_buf'
     void*       UserData;
 
-    ImGuiSettingsHandler() IMGUI_NOEXCEPT { memset(this, 0, sizeof(*this)); }
+    ImGuiSettingsHandler() IM_NOEXCEPT { memset(this, 0, sizeof(*this)); }
 };
 
 //-----------------------------------------------------------------------------
@@ -1298,7 +1298,7 @@ struct ImGuiMetricsConfig
     int         ShowWindowsRectsType;
     int         ShowTablesRectsType;
 
-    ImGuiMetricsConfig() IMGUI_NOEXCEPT
+    ImGuiMetricsConfig() IM_NOEXCEPT
     {
         ShowWindowsRects = false;
         ShowWindowsBeginOrder = false;
@@ -1320,9 +1320,9 @@ struct IMGUI_API ImGuiStackSizes
     short   SizeOfGroupStack;
     short   SizeOfBeginPopupStack;
 
-    ImGuiStackSizes() IMGUI_NOEXCEPT { memset(this, 0, sizeof(*this)); }
-    void SetToCurrentState() IMGUI_NOEXCEPT;
-    void CompareWithCurrentState() IMGUI_NOEXCEPT;
+    ImGuiStackSizes() IM_NOEXCEPT { memset(this, 0, sizeof(*this)); }
+    void SetToCurrentState() IM_NOEXCEPT;
+    void CompareWithCurrentState() IM_NOEXCEPT;
 };
 
 //-----------------------------------------------------------------------------
@@ -1340,7 +1340,7 @@ struct ImGuiContextHook
     ImGuiContextHookCallback    Callback;
     void*                       UserData;
 
-    ImGuiContextHook() IMGUI_NOEXCEPT { memset(this, 0, sizeof(*this)); }
+    ImGuiContextHook() IM_NOEXCEPT { memset(this, 0, sizeof(*this)); }
 };
 
 //-----------------------------------------------------------------------------
@@ -1593,7 +1593,7 @@ struct ImGuiContext
     int                     WantTextInputNextFrame;
     char                    TempBuffer[1024 * 3 + 1];           // Temporary text buffer
 
-    ImGuiContext(ImFontAtlas* shared_font_atlas) IMGUI_NOEXCEPT
+    ImGuiContext(ImFontAtlas* shared_font_atlas) IM_NOEXCEPT
     {
         Initialized = false;
         FontAtlasOwnedByContext = shared_font_atlas ? false : true;
@@ -1896,24 +1896,24 @@ struct IMGUI_API ImGuiWindow
     bool                    MemoryCompacted;                    // Set when window extraneous data have been garbage collected
 
 public:
-    ImGuiWindow(ImGuiContext* context, const char* name) IMGUI_NOEXCEPT;
-    ~ImGuiWindow()                                       IMGUI_NOEXCEPT;
+    ImGuiWindow(ImGuiContext* context, const char* name) IM_NOEXCEPT;
+    ~ImGuiWindow()                                       IM_NOEXCEPT;
 
-    ImGuiID     GetID(const char* str, const char* str_end = NULL) IMGUI_NOEXCEPT;
-    ImGuiID     GetID(const void* ptr)                             IMGUI_NOEXCEPT;
-    ImGuiID     GetID(int n)                                       IMGUI_NOEXCEPT;
-    ImGuiID     GetIDNoKeepAlive(const char* str, const char* str_end = NULL) IMGUI_NOEXCEPT;
-    ImGuiID     GetIDNoKeepAlive(const void* ptr)                  IMGUI_NOEXCEPT;
-    ImGuiID     GetIDNoKeepAlive(int n)                            IMGUI_NOEXCEPT;
-    ImGuiID     GetIDFromRectangle(const ImRect& r_abs)             IMGUI_NOEXCEPT;
+    ImGuiID     GetID(const char* str, const char* str_end = NULL) IM_NOEXCEPT;
+    ImGuiID     GetID(const void* ptr)                             IM_NOEXCEPT;
+    ImGuiID     GetID(int n)                                       IM_NOEXCEPT;
+    ImGuiID     GetIDNoKeepAlive(const char* str, const char* str_end = NULL) IM_NOEXCEPT;
+    ImGuiID     GetIDNoKeepAlive(const void* ptr)                  IM_NOEXCEPT;
+    ImGuiID     GetIDNoKeepAlive(int n)                            IM_NOEXCEPT;
+    ImGuiID     GetIDFromRectangle(const ImRect& r_abs)             IM_NOEXCEPT;
 
     // We don't use g.FontSize because the window may be != g.CurrentWidow.
-    ImRect      Rect() const           IMGUI_NOEXCEPT  { return ImRect(Pos.x, Pos.y, Pos.x + Size.x, Pos.y + Size.y); }
-    float       CalcFontSize() const   IMGUI_NOEXCEPT  { ImGuiContext& g = *GImGui; float scale = g.FontBaseSize * FontWindowScale; if (ParentWindow) scale *= ParentWindow->FontWindowScale; return scale; }
-    float       TitleBarHeight() const IMGUI_NOEXCEPT  { ImGuiContext& g = *GImGui; return (Flags & ImGuiWindowFlags_NoTitleBar) ? 0.0f : CalcFontSize() + g.Style.FramePadding.y * 2.0f; }
-    ImRect      TitleBarRect() const   IMGUI_NOEXCEPT  { return ImRect(Pos, ImVec2(Pos.x + SizeFull.x, Pos.y + TitleBarHeight())); }
-    float       MenuBarHeight() const  IMGUI_NOEXCEPT  { ImGuiContext& g = *GImGui; return (Flags & ImGuiWindowFlags_MenuBar) ? DC.MenuBarOffset.y + CalcFontSize() + g.Style.FramePadding.y * 2.0f : 0.0f; }
-    ImRect      MenuBarRect() const    IMGUI_NOEXCEPT  { float y1 = Pos.y + TitleBarHeight(); return ImRect(Pos.x, y1, Pos.x + SizeFull.x, y1 + MenuBarHeight()); }
+    ImRect      Rect() const           IM_NOEXCEPT  { return ImRect(Pos.x, Pos.y, Pos.x + Size.x, Pos.y + Size.y); }
+    float       CalcFontSize() const   IM_NOEXCEPT  { ImGuiContext& g = *GImGui; float scale = g.FontBaseSize * FontWindowScale; if (ParentWindow) scale *= ParentWindow->FontWindowScale; return scale; }
+    float       TitleBarHeight() const IM_NOEXCEPT  { ImGuiContext& g = *GImGui; return (Flags & ImGuiWindowFlags_NoTitleBar) ? 0.0f : CalcFontSize() + g.Style.FramePadding.y * 2.0f; }
+    ImRect      TitleBarRect() const   IM_NOEXCEPT  { return ImRect(Pos, ImVec2(Pos.x + SizeFull.x, Pos.y + TitleBarHeight())); }
+    float       MenuBarHeight() const  IM_NOEXCEPT  { ImGuiContext& g = *GImGui; return (Flags & ImGuiWindowFlags_MenuBar) ? DC.MenuBarOffset.y + CalcFontSize() + g.Style.FramePadding.y * 2.0f : 0.0f; }
+    ImRect      MenuBarRect() const    IM_NOEXCEPT  { float y1 = Pos.y + TitleBarHeight(); return ImRect(Pos.x, y1, Pos.x + SizeFull.x, y1 + MenuBarHeight()); }
 };
 
 // Backup and restore just enough data to be able to use IsItemHovered() on item A after another B in the same window has overwritten the data.
@@ -1924,9 +1924,9 @@ struct ImGuiLastItemDataBackup
     ImRect                  LastItemRect;
     ImRect                  LastItemDisplayRect;
 
-    ImGuiLastItemDataBackup() IMGUI_NOEXCEPT { Backup(); }
-    void Backup()             IMGUI_NOEXCEPT { ImGuiWindow* window = GImGui->CurrentWindow; LastItemId = window->DC.LastItemId; LastItemStatusFlags = window->DC.LastItemStatusFlags; LastItemRect = window->DC.LastItemRect; LastItemDisplayRect = window->DC.LastItemDisplayRect; }
-    void Restore() const      IMGUI_NOEXCEPT { ImGuiWindow* window = GImGui->CurrentWindow; window->DC.LastItemId = LastItemId; window->DC.LastItemStatusFlags = LastItemStatusFlags; window->DC.LastItemRect = LastItemRect; window->DC.LastItemDisplayRect = LastItemDisplayRect; }
+    ImGuiLastItemDataBackup() IM_NOEXCEPT { Backup(); }
+    void Backup()             IM_NOEXCEPT { ImGuiWindow* window = GImGui->CurrentWindow; LastItemId = window->DC.LastItemId; LastItemStatusFlags = window->DC.LastItemStatusFlags; LastItemRect = window->DC.LastItemRect; LastItemDisplayRect = window->DC.LastItemDisplayRect; }
+    void Restore() const      IM_NOEXCEPT { ImGuiWindow* window = GImGui->CurrentWindow; window->DC.LastItemId = LastItemId; window->DC.LastItemStatusFlags = LastItemStatusFlags; window->DC.LastItemRect = LastItemRect; window->DC.LastItemDisplayRect = LastItemDisplayRect; }
 };
 
 //-----------------------------------------------------------------------------
@@ -1964,7 +1964,7 @@ struct ImGuiTabItem
     ImS16               IndexDuringLayout;      // Index only used during TabBarLayout()
     bool                WantClose;              // Marked as closed by SetTabItemClosed()
 
-    ImGuiTabItem() IMGUI_NOEXCEPT { memset(this, 0, sizeof(*this)); LastFrameVisible = LastFrameSelected = -1; NameOffset = BeginOrder = IndexDuringLayout = -1; }
+    ImGuiTabItem() IM_NOEXCEPT { memset(this, 0, sizeof(*this)); LastFrameVisible = LastFrameSelected = -1; NameOffset = BeginOrder = IndexDuringLayout = -1; }
 };
 
 // Storage for a tab bar (sizeof() 152 bytes)
@@ -2002,9 +2002,9 @@ struct ImGuiTabBar
     ImVec2              BackupCursorPos;
     ImGuiTextBuffer     TabsNames;              // For non-docking tab bar we re-append names in a contiguous buffer.
 
-    ImGuiTabBar() IMGUI_NOEXCEPT;
-    int                 GetTabOrder(const ImGuiTabItem* tab) const IMGUI_NOEXCEPT { return Tabs.index_from_ptr(tab); }
-    const char*         GetTabName(const ImGuiTabItem* tab) const  IMGUI_NOEXCEPT
+    ImGuiTabBar() IM_NOEXCEPT;
+    int                 GetTabOrder(const ImGuiTabItem* tab) const IM_NOEXCEPT { return Tabs.index_from_ptr(tab); }
+    const char*         GetTabName(const ImGuiTabItem* tab) const  IM_NOEXCEPT
     {
         IM_ASSERT(tab->NameOffset != -1 && (int)tab->NameOffset < TabsNames.Buf.Size);
         return TabsNames.Buf.Data + tab->NameOffset;
@@ -2072,7 +2072,7 @@ struct ImGuiTableColumn
     ImU8                    SortDirectionsAvailMask : 4;    // Mask of available sort directions (1-bit each)
     ImU8                    SortDirectionsAvailList;        // Ordered of available sort directions (2-bits each)
 
-    ImGuiTableColumn() IMGUI_NOEXCEPT
+    ImGuiTableColumn() IM_NOEXCEPT
     {
         memset(this, 0, sizeof(*this));
         StretchWeight = WidthRequest = -1.0f;
@@ -2198,8 +2198,8 @@ struct ImGuiTable
     bool                        MemoryCompacted;
     bool                        HostSkipItems;              // Backup of InnerWindow->SkipItem at the end of BeginTable(), because we will overwrite InnerWindow->SkipItem on a per-column basis
 
-    IMGUI_API ImGuiTable()  IMGUI_NOEXCEPT { memset(this, 0, sizeof(*this)); LastFrameActive = -1; }
-    IMGUI_API ~ImGuiTable() IMGUI_NOEXCEPT { IM_FREE(RawData); }
+    IMGUI_API ImGuiTable()  IM_NOEXCEPT { memset(this, 0, sizeof(*this)); LastFrameActive = -1; }
+    IMGUI_API ~ImGuiTable() IM_NOEXCEPT { IM_FREE(RawData); }
 };
 
 // Transient data that are only needed between BeginTable() and EndTable(), those buffers are shared (1 per level of stacked table).
@@ -2240,7 +2240,7 @@ struct ImGuiTableColumnSettings
     ImU8                    IsEnabled : 1; // "Visible" in ini file
     ImU8                    IsStretch : 1;
 
-    ImGuiTableColumnSettings() IMGUI_NOEXCEPT
+    ImGuiTableColumnSettings() IM_NOEXCEPT
     {
         WidthOrWeight = 0.0f;
         UserID = 0;
@@ -2262,8 +2262,8 @@ struct ImGuiTableSettings
     ImGuiTableColumnIdx         ColumnsCountMax;        // Maximum number of columns this settings instance can store, we can recycle a settings instance with lower number of columns but not higher
     bool                        WantApply;              // Set when loaded from .ini data (to enable merging/loading .ini data into an already running context)
 
-    ImGuiTableSettings()                          IMGUI_NOEXCEPT  { memset(this, 0, sizeof(*this)); }
-    ImGuiTableColumnSettings* GetColumnSettings() IMGUI_NOEXCEPT  { return (ImGuiTableColumnSettings*)(this + 1); }
+    ImGuiTableSettings()                          IM_NOEXCEPT  { memset(this, 0, sizeof(*this)); }
+    ImGuiTableColumnSettings* GetColumnSettings() IM_NOEXCEPT  { return (ImGuiTableColumnSettings*)(this + 1); }
 };
 
 #endif // #ifdef IMGUI_HAS_TABLE
@@ -2280,355 +2280,355 @@ namespace ImGui
     // If this ever crash because g.CurrentWindow is NULL it means that either
     // - ImGui::NewFrame() has never been called, which is illegal.
     // - You are calling ImGui functions after ImGui::EndFrame()/ImGui::Render() and before the next ImGui::NewFrame(), which is also illegal.
-    inline    ImGuiWindow*  GetCurrentWindowRead()              IMGUI_NOEXCEPT { ImGuiContext& g = *GImGui; return g.CurrentWindow; }
-    inline    ImGuiWindow*  GetCurrentWindow()                  IMGUI_NOEXCEPT { ImGuiContext& g = *GImGui; g.CurrentWindow->WriteAccessed = true; return g.CurrentWindow; }
-    IMGUI_API ImGuiWindow*  FindWindowByID(ImGuiID id)          IMGUI_NOEXCEPT;
-    IMGUI_API ImGuiWindow*  FindWindowByName(const char* name)  IMGUI_NOEXCEPT;
-    IMGUI_API void          UpdateWindowParentAndRootLinks(ImGuiWindow* window, ImGuiWindowFlags flags, ImGuiWindow* parent_window) IMGUI_NOEXCEPT;
-    IMGUI_API ImVec2        CalcWindowNextAutoFitSize(ImGuiWindow* window) IMGUI_NOEXCEPT;
-    IMGUI_API bool          IsWindowChildOf(ImGuiWindow* window, ImGuiWindow* potential_parent) IMGUI_NOEXCEPT;
-    IMGUI_API bool          IsWindowAbove(ImGuiWindow* potential_above, ImGuiWindow* potential_below) IMGUI_NOEXCEPT;
-    IMGUI_API bool          IsWindowNavFocusable(ImGuiWindow* window) IMGUI_NOEXCEPT;
-    IMGUI_API ImRect        GetWindowAllowedExtentRect(ImGuiWindow* window) IMGUI_NOEXCEPT;
-    IMGUI_API void          SetWindowPos(ImGuiWindow* window, const ImVec2& pos, ImGuiCond cond = 0) IMGUI_NOEXCEPT;
-    IMGUI_API void          SetWindowSize(ImGuiWindow* window, const ImVec2& size, ImGuiCond cond = 0) IMGUI_NOEXCEPT;
-    IMGUI_API void          SetWindowCollapsed(ImGuiWindow* window, bool collapsed, ImGuiCond cond = 0) IMGUI_NOEXCEPT;
-    IMGUI_API void          SetWindowHitTestHole(ImGuiWindow* window, const ImVec2& pos, const ImVec2& size) IMGUI_NOEXCEPT;
+    inline    ImGuiWindow*  GetCurrentWindowRead()              IM_NOEXCEPT { ImGuiContext& g = *GImGui; return g.CurrentWindow; }
+    inline    ImGuiWindow*  GetCurrentWindow()                  IM_NOEXCEPT { ImGuiContext& g = *GImGui; g.CurrentWindow->WriteAccessed = true; return g.CurrentWindow; }
+    IMGUI_API ImGuiWindow*  FindWindowByID(ImGuiID id)          IM_NOEXCEPT;
+    IMGUI_API ImGuiWindow*  FindWindowByName(const char* name)  IM_NOEXCEPT;
+    IMGUI_API void          UpdateWindowParentAndRootLinks(ImGuiWindow* window, ImGuiWindowFlags flags, ImGuiWindow* parent_window) IM_NOEXCEPT;
+    IMGUI_API ImVec2        CalcWindowNextAutoFitSize(ImGuiWindow* window) IM_NOEXCEPT;
+    IMGUI_API bool          IsWindowChildOf(ImGuiWindow* window, ImGuiWindow* potential_parent) IM_NOEXCEPT;
+    IMGUI_API bool          IsWindowAbove(ImGuiWindow* potential_above, ImGuiWindow* potential_below) IM_NOEXCEPT;
+    IMGUI_API bool          IsWindowNavFocusable(ImGuiWindow* window) IM_NOEXCEPT;
+    IMGUI_API ImRect        GetWindowAllowedExtentRect(ImGuiWindow* window) IM_NOEXCEPT;
+    IMGUI_API void          SetWindowPos(ImGuiWindow* window, const ImVec2& pos, ImGuiCond cond = 0) IM_NOEXCEPT;
+    IMGUI_API void          SetWindowSize(ImGuiWindow* window, const ImVec2& size, ImGuiCond cond = 0) IM_NOEXCEPT;
+    IMGUI_API void          SetWindowCollapsed(ImGuiWindow* window, bool collapsed, ImGuiCond cond = 0) IM_NOEXCEPT;
+    IMGUI_API void          SetWindowHitTestHole(ImGuiWindow* window, const ImVec2& pos, const ImVec2& size) IM_NOEXCEPT;
 
     // Windows: Display Order and Focus Order
-    IMGUI_API void          FocusWindow(ImGuiWindow* window)     IMGUI_NOEXCEPT;
-    IMGUI_API void          FocusTopMostWindowUnderOne(ImGuiWindow* under_this_window, ImGuiWindow* ignore_window) IMGUI_NOEXCEPT;
-    IMGUI_API void          BringWindowToFocusFront(ImGuiWindow* window) IMGUI_NOEXCEPT;
-    IMGUI_API void          BringWindowToDisplayFront(ImGuiWindow* window) IMGUI_NOEXCEPT;
-    IMGUI_API void          BringWindowToDisplayBack(ImGuiWindow* window) IMGUI_NOEXCEPT;
+    IMGUI_API void          FocusWindow(ImGuiWindow* window)     IM_NOEXCEPT;
+    IMGUI_API void          FocusTopMostWindowUnderOne(ImGuiWindow* under_this_window, ImGuiWindow* ignore_window) IM_NOEXCEPT;
+    IMGUI_API void          BringWindowToFocusFront(ImGuiWindow* window) IM_NOEXCEPT;
+    IMGUI_API void          BringWindowToDisplayFront(ImGuiWindow* window) IM_NOEXCEPT;
+    IMGUI_API void          BringWindowToDisplayBack(ImGuiWindow* window) IM_NOEXCEPT;
 
     // Fonts, drawing
-    IMGUI_API void          SetCurrentFont(ImFont* font) IMGUI_NOEXCEPT;
-    inline ImFont*          GetDefaultFont() IMGUI_NOEXCEPT { ImGuiContext& g = *GImGui; return g.IO.FontDefault ? g.IO.FontDefault : g.IO.Fonts->Fonts[0]; }
-    inline ImDrawList*      GetForegroundDrawList(ImGuiWindow* window) IMGUI_NOEXCEPT { IM_UNUSED(window); return GetForegroundDrawList(); } // This seemingly unnecessary wrapper simplifies compatibility between the 'master' and 'docking' branches.
-    IMGUI_API ImDrawList*   GetBackgroundDrawList(ImGuiViewport* viewport) IMGUI_NOEXCEPT;   // get background draw list for the given viewport. this draw list will be the first rendering one. Useful to quickly draw shapes/text behind dear imgui contents.
-    IMGUI_API ImDrawList*   GetForegroundDrawList(ImGuiViewport* viewport) IMGUI_NOEXCEPT;   // get foreground draw list for the given viewport. this draw list will be the last rendered one. Useful to quickly draw shapes/text over dear imgui contents.
+    IMGUI_API void          SetCurrentFont(ImFont* font) IM_NOEXCEPT;
+    inline ImFont*          GetDefaultFont() IM_NOEXCEPT { ImGuiContext& g = *GImGui; return g.IO.FontDefault ? g.IO.FontDefault : g.IO.Fonts->Fonts[0]; }
+    inline ImDrawList*      GetForegroundDrawList(ImGuiWindow* window) IM_NOEXCEPT { IM_UNUSED(window); return GetForegroundDrawList(); } // This seemingly unnecessary wrapper simplifies compatibility between the 'master' and 'docking' branches.
+    IMGUI_API ImDrawList*   GetBackgroundDrawList(ImGuiViewport* viewport) IM_NOEXCEPT;   // get background draw list for the given viewport. this draw list will be the first rendering one. Useful to quickly draw shapes/text behind dear imgui contents.
+    IMGUI_API ImDrawList*   GetForegroundDrawList(ImGuiViewport* viewport) IM_NOEXCEPT;   // get foreground draw list for the given viewport. this draw list will be the last rendered one. Useful to quickly draw shapes/text over dear imgui contents.
 
     // Init
-    IMGUI_API void          Initialize(ImGuiContext* context) IMGUI_NOEXCEPT;
-    IMGUI_API void          Shutdown(ImGuiContext* context) IMGUI_NOEXCEPT;  // Since 1.60 this is a _private_ function. You can call DestroyContext() to destroy the context created by CreateContext().
+    IMGUI_API void          Initialize(ImGuiContext* context) IM_NOEXCEPT;
+    IMGUI_API void          Shutdown(ImGuiContext* context) IM_NOEXCEPT;  // Since 1.60 this is a _private_ function. You can call DestroyContext() to destroy the context created by CreateContext().
 
     // NewFrame
-    IMGUI_API void          UpdateHoveredWindowAndCaptureFlags() IMGUI_NOEXCEPT;
-    IMGUI_API void          StartMouseMovingWindow(ImGuiWindow* window) IMGUI_NOEXCEPT;
-    IMGUI_API void          UpdateMouseMovingWindowNewFrame() IMGUI_NOEXCEPT;
-    IMGUI_API void          UpdateMouseMovingWindowEndFrame() IMGUI_NOEXCEPT;
+    IMGUI_API void          UpdateHoveredWindowAndCaptureFlags() IM_NOEXCEPT;
+    IMGUI_API void          StartMouseMovingWindow(ImGuiWindow* window) IM_NOEXCEPT;
+    IMGUI_API void          UpdateMouseMovingWindowNewFrame() IM_NOEXCEPT;
+    IMGUI_API void          UpdateMouseMovingWindowEndFrame() IM_NOEXCEPT;
 
     // Generic context hooks
-    IMGUI_API ImGuiID       AddContextHook(ImGuiContext* context, const ImGuiContextHook* hook) IMGUI_NOEXCEPT;
-    IMGUI_API void          RemoveContextHook(ImGuiContext* context, ImGuiID hook_to_remove) IMGUI_NOEXCEPT;
-    IMGUI_API void          CallContextHooks(ImGuiContext* context, ImGuiContextHookType type) IMGUI_NOEXCEPT;
+    IMGUI_API ImGuiID       AddContextHook(ImGuiContext* context, const ImGuiContextHook* hook) IM_NOEXCEPT;
+    IMGUI_API void          RemoveContextHook(ImGuiContext* context, ImGuiID hook_to_remove) IM_NOEXCEPT;
+    IMGUI_API void          CallContextHooks(ImGuiContext* context, ImGuiContextHookType type) IM_NOEXCEPT;
 
     // Settings
-    IMGUI_API void                  MarkIniSettingsDirty() IMGUI_NOEXCEPT;
-    IMGUI_API void                  MarkIniSettingsDirty(ImGuiWindow* window) IMGUI_NOEXCEPT;
-    IMGUI_API void                  ClearIniSettings() IMGUI_NOEXCEPT;
-    IMGUI_API ImGuiWindowSettings*  CreateNewWindowSettings(const char* name) IMGUI_NOEXCEPT;
-    IMGUI_API ImGuiWindowSettings*  FindWindowSettings(ImGuiID id) IMGUI_NOEXCEPT;
-    IMGUI_API ImGuiWindowSettings*  FindOrCreateWindowSettings(const char* name) IMGUI_NOEXCEPT;
-    IMGUI_API ImGuiSettingsHandler* FindSettingsHandler(const char* type_name) IMGUI_NOEXCEPT;
+    IMGUI_API void                  MarkIniSettingsDirty() IM_NOEXCEPT;
+    IMGUI_API void                  MarkIniSettingsDirty(ImGuiWindow* window) IM_NOEXCEPT;
+    IMGUI_API void                  ClearIniSettings() IM_NOEXCEPT;
+    IMGUI_API ImGuiWindowSettings*  CreateNewWindowSettings(const char* name) IM_NOEXCEPT;
+    IMGUI_API ImGuiWindowSettings*  FindWindowSettings(ImGuiID id) IM_NOEXCEPT;
+    IMGUI_API ImGuiWindowSettings*  FindOrCreateWindowSettings(const char* name) IM_NOEXCEPT;
+    IMGUI_API ImGuiSettingsHandler* FindSettingsHandler(const char* type_name) IM_NOEXCEPT;
 
     // Scrolling
-    IMGUI_API void          SetNextWindowScroll(const ImVec2& scroll)       IMGUI_NOEXCEPT; // Use -1.0f on one axis to leave as-is
-    IMGUI_API void          SetScrollX(ImGuiWindow* window, float scroll_x) IMGUI_NOEXCEPT;
-    IMGUI_API void          SetScrollY(ImGuiWindow* window, float scroll_y) IMGUI_NOEXCEPT;
-    IMGUI_API void          SetScrollFromPosX(ImGuiWindow* window, float local_x, float center_x_ratio) IMGUI_NOEXCEPT;
-    IMGUI_API void          SetScrollFromPosY(ImGuiWindow* window, float local_y, float center_y_ratio) IMGUI_NOEXCEPT;
-    IMGUI_API ImVec2        ScrollToBringRectIntoView(ImGuiWindow* window, const ImRect& item_rect) IMGUI_NOEXCEPT;
+    IMGUI_API void          SetNextWindowScroll(const ImVec2& scroll)       IM_NOEXCEPT; // Use -1.0f on one axis to leave as-is
+    IMGUI_API void          SetScrollX(ImGuiWindow* window, float scroll_x) IM_NOEXCEPT;
+    IMGUI_API void          SetScrollY(ImGuiWindow* window, float scroll_y) IM_NOEXCEPT;
+    IMGUI_API void          SetScrollFromPosX(ImGuiWindow* window, float local_x, float center_x_ratio) IM_NOEXCEPT;
+    IMGUI_API void          SetScrollFromPosY(ImGuiWindow* window, float local_y, float center_y_ratio) IM_NOEXCEPT;
+    IMGUI_API ImVec2        ScrollToBringRectIntoView(ImGuiWindow* window, const ImRect& item_rect) IM_NOEXCEPT;
 
     // Basic Accessors
-    inline ImGuiID          GetItemID()    IMGUI_NOEXCEPT   { ImGuiContext& g = *GImGui; return g.CurrentWindow->DC.LastItemId; }   // Get ID of last item (~~ often same ImGui::GetID(label) beforehand)
-    inline ImGuiItemStatusFlags GetItemStatusFlags() IMGUI_NOEXCEPT { ImGuiContext& g = *GImGui; return g.CurrentWindow->DC.LastItemStatusFlags; }
-    inline ImGuiID          GetActiveID()  IMGUI_NOEXCEPT   { ImGuiContext& g = *GImGui; return g.ActiveId; }
-    inline ImGuiID          GetFocusID()   IMGUI_NOEXCEPT   { ImGuiContext& g = *GImGui; return g.NavId; }
-    inline ImGuiItemFlags   GetItemFlags() IMGUI_NOEXCEPT   { ImGuiContext& g = *GImGui; return g.CurrentItemFlags; }
-    IMGUI_API void          SetActiveID(ImGuiID id, ImGuiWindow* window) IMGUI_NOEXCEPT;
-    IMGUI_API void          SetFocusID(ImGuiID id, ImGuiWindow* window) IMGUI_NOEXCEPT;
-    IMGUI_API void          ClearActiveID() IMGUI_NOEXCEPT;
-    IMGUI_API ImGuiID       GetHoveredID()  IMGUI_NOEXCEPT;
-    IMGUI_API void          SetHoveredID(ImGuiID id) IMGUI_NOEXCEPT;
-    IMGUI_API void          KeepAliveID(ImGuiID id) IMGUI_NOEXCEPT;
-    IMGUI_API void          MarkItemEdited(ImGuiID id) IMGUI_NOEXCEPT;     // Mark data associated to given item as "edited", used by IsItemDeactivatedAfterEdit() function.
-    IMGUI_API void          PushOverrideID(ImGuiID id) IMGUI_NOEXCEPT;     // Push given value as-is at the top of the ID stack (whereas PushID combines old and new hashes)
-    IMGUI_API ImGuiID       GetIDWithSeed(const char* str_id_begin, const char* str_id_end, ImGuiID seed) IMGUI_NOEXCEPT;
+    inline ImGuiID          GetItemID()    IM_NOEXCEPT   { ImGuiContext& g = *GImGui; return g.CurrentWindow->DC.LastItemId; }   // Get ID of last item (~~ often same ImGui::GetID(label) beforehand)
+    inline ImGuiItemStatusFlags GetItemStatusFlags() IM_NOEXCEPT { ImGuiContext& g = *GImGui; return g.CurrentWindow->DC.LastItemStatusFlags; }
+    inline ImGuiID          GetActiveID()  IM_NOEXCEPT   { ImGuiContext& g = *GImGui; return g.ActiveId; }
+    inline ImGuiID          GetFocusID()   IM_NOEXCEPT   { ImGuiContext& g = *GImGui; return g.NavId; }
+    inline ImGuiItemFlags   GetItemFlags() IM_NOEXCEPT   { ImGuiContext& g = *GImGui; return g.CurrentItemFlags; }
+    IMGUI_API void          SetActiveID(ImGuiID id, ImGuiWindow* window) IM_NOEXCEPT;
+    IMGUI_API void          SetFocusID(ImGuiID id, ImGuiWindow* window) IM_NOEXCEPT;
+    IMGUI_API void          ClearActiveID() IM_NOEXCEPT;
+    IMGUI_API ImGuiID       GetHoveredID()  IM_NOEXCEPT;
+    IMGUI_API void          SetHoveredID(ImGuiID id) IM_NOEXCEPT;
+    IMGUI_API void          KeepAliveID(ImGuiID id) IM_NOEXCEPT;
+    IMGUI_API void          MarkItemEdited(ImGuiID id) IM_NOEXCEPT;     // Mark data associated to given item as "edited", used by IsItemDeactivatedAfterEdit() function.
+    IMGUI_API void          PushOverrideID(ImGuiID id) IM_NOEXCEPT;     // Push given value as-is at the top of the ID stack (whereas PushID combines old and new hashes)
+    IMGUI_API ImGuiID       GetIDWithSeed(const char* str_id_begin, const char* str_id_end, ImGuiID seed) IM_NOEXCEPT;
 
     // Basic Helpers for widget code
-    IMGUI_API void          ItemSize(const ImVec2& size, float text_baseline_y = -1.0f) IMGUI_NOEXCEPT;
-    IMGUI_API void          ItemSize(const ImRect& bb, float text_baseline_y = -1.0f) IMGUI_NOEXCEPT;
-    IMGUI_API bool          ItemAdd(const ImRect& bb, ImGuiID id, const ImRect* nav_bb = NULL, ImGuiItemAddFlags flags = 0) IMGUI_NOEXCEPT;
-    IMGUI_API bool          ItemHoverable(const ImRect& bb, ImGuiID id) IMGUI_NOEXCEPT;
-    IMGUI_API void          ItemFocusable(ImGuiWindow* window, ImGuiID id) IMGUI_NOEXCEPT;
-    IMGUI_API bool          IsClippedEx(const ImRect& bb, ImGuiID id, bool clip_even_when_logged) IMGUI_NOEXCEPT;
-    IMGUI_API void          SetLastItemData(ImGuiWindow* window, ImGuiID item_id, ImGuiItemStatusFlags status_flags, const ImRect& item_rect) IMGUI_NOEXCEPT;
-    IMGUI_API ImVec2        CalcItemSize(ImVec2 size, float default_w, float default_h) IMGUI_NOEXCEPT;
-    IMGUI_API float         CalcWrapWidthForPos(const ImVec2& pos, float wrap_pos_x) IMGUI_NOEXCEPT;
-    IMGUI_API void          PushMultiItemsWidths(int components, float width_full) IMGUI_NOEXCEPT;
-    IMGUI_API void          PushItemFlag(ImGuiItemFlags option, bool enabled) IMGUI_NOEXCEPT;
-    IMGUI_API void          PopItemFlag() IMGUI_NOEXCEPT;
-    IMGUI_API bool          IsItemToggledSelection() IMGUI_NOEXCEPT;                    // Was the last item selection toggled? (after Selectable(), TreeNode() etc. We only returns toggle _event_ in order to handle clipping correctly)
-    IMGUI_API ImVec2        GetContentRegionMaxAbs() IMGUI_NOEXCEPT;
-    IMGUI_API void          ShrinkWidths(ImGuiShrinkWidthItem* items, int count, float width_excess) IMGUI_NOEXCEPT;
+    IMGUI_API void          ItemSize(const ImVec2& size, float text_baseline_y = -1.0f) IM_NOEXCEPT;
+    IMGUI_API void          ItemSize(const ImRect& bb, float text_baseline_y = -1.0f) IM_NOEXCEPT;
+    IMGUI_API bool          ItemAdd(const ImRect& bb, ImGuiID id, const ImRect* nav_bb = NULL, ImGuiItemAddFlags flags = 0) IM_NOEXCEPT;
+    IMGUI_API bool          ItemHoverable(const ImRect& bb, ImGuiID id) IM_NOEXCEPT;
+    IMGUI_API void          ItemFocusable(ImGuiWindow* window, ImGuiID id) IM_NOEXCEPT;
+    IMGUI_API bool          IsClippedEx(const ImRect& bb, ImGuiID id, bool clip_even_when_logged) IM_NOEXCEPT;
+    IMGUI_API void          SetLastItemData(ImGuiWindow* window, ImGuiID item_id, ImGuiItemStatusFlags status_flags, const ImRect& item_rect) IM_NOEXCEPT;
+    IMGUI_API ImVec2        CalcItemSize(ImVec2 size, float default_w, float default_h) IM_NOEXCEPT;
+    IMGUI_API float         CalcWrapWidthForPos(const ImVec2& pos, float wrap_pos_x) IM_NOEXCEPT;
+    IMGUI_API void          PushMultiItemsWidths(int components, float width_full) IM_NOEXCEPT;
+    IMGUI_API void          PushItemFlag(ImGuiItemFlags option, bool enabled) IM_NOEXCEPT;
+    IMGUI_API void          PopItemFlag() IM_NOEXCEPT;
+    IMGUI_API bool          IsItemToggledSelection() IM_NOEXCEPT;                    // Was the last item selection toggled? (after Selectable(), TreeNode() etc. We only returns toggle _event_ in order to handle clipping correctly)
+    IMGUI_API ImVec2        GetContentRegionMaxAbs() IM_NOEXCEPT;
+    IMGUI_API void          ShrinkWidths(ImGuiShrinkWidthItem* items, int count, float width_excess) IM_NOEXCEPT;
 
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
     // If you have old/custom copy-and-pasted widgets that used FocusableItemRegister():
     //  (Old) IMGUI_VERSION_NUM  < 18209: using 'ItemAdd(....)'                              and 'bool focused = FocusableItemRegister(...)'
     //  (New) IMGUI_VERSION_NUM >= 18209: using 'ItemAdd(..., ImGuiItemAddFlags_Focusable)'  and 'bool focused = (GetItemStatusFlags() & ImGuiItemStatusFlags_Focused) != 0'
     // Widget code are simplified as there's no need to call FocusableItemUnregister() while managing the transition from regular widget to TempInputText()
-    inline bool FocusableItemRegister(ImGuiWindow* window, ImGuiID id) IMGUI_NOEXCEPT  { IM_ASSERT(0); IM_UNUSED(window); IM_UNUSED(id); return false; } // -> pass ImGuiItemAddFlags_Focusable flag to ItemAdd()
-    inline void FocusableItemUnregister(ImGuiWindow* window)           IMGUI_NOEXCEPT  { IM_ASSERT(0); IM_UNUSED(window); }                              // -> unnecessary: TempInputText() uses ImGuiInputTextFlags_MergedItem
+    inline bool FocusableItemRegister(ImGuiWindow* window, ImGuiID id) IM_NOEXCEPT  { IM_ASSERT(0); IM_UNUSED(window); IM_UNUSED(id); return false; } // -> pass ImGuiItemAddFlags_Focusable flag to ItemAdd()
+    inline void FocusableItemUnregister(ImGuiWindow* window)           IM_NOEXCEPT  { IM_ASSERT(0); IM_UNUSED(window); }                              // -> unnecessary: TempInputText() uses ImGuiInputTextFlags_MergedItem
 #endif
 
     // Logging/Capture
-    IMGUI_API void          LogBegin(ImGuiLogType type, int auto_open_depth) IMGUI_NOEXCEPT;           // -> BeginCapture() when we design v2 api, for now stay under the radar by using the old name.
-    IMGUI_API void          LogToBuffer(int auto_open_depth = -1)            IMGUI_NOEXCEPT;           // Start logging/capturing to internal buffer
-    IMGUI_API void          LogRenderedText(const ImVec2* ref_pos, const char* text, const char* text_end = NULL) IMGUI_NOEXCEPT;
-    IMGUI_API void          LogSetNextTextDecoration(const char* prefix, const char* suffix) IMGUI_NOEXCEPT;
+    IMGUI_API void          LogBegin(ImGuiLogType type, int auto_open_depth) IM_NOEXCEPT;           // -> BeginCapture() when we design v2 api, for now stay under the radar by using the old name.
+    IMGUI_API void          LogToBuffer(int auto_open_depth = -1)            IM_NOEXCEPT;           // Start logging/capturing to internal buffer
+    IMGUI_API void          LogRenderedText(const ImVec2* ref_pos, const char* text, const char* text_end = NULL) IM_NOEXCEPT;
+    IMGUI_API void          LogSetNextTextDecoration(const char* prefix, const char* suffix) IM_NOEXCEPT;
 
     // Popups, Modals, Tooltips
-    IMGUI_API bool          BeginChildEx(const char* name, ImGuiID id, const ImVec2& size_arg, bool border, ImGuiWindowFlags flags) IMGUI_NOEXCEPT;
-    IMGUI_API void          OpenPopupEx(ImGuiID id, ImGuiPopupFlags popup_flags = ImGuiPopupFlags_None) IMGUI_NOEXCEPT;
-    IMGUI_API void          ClosePopupToLevel(int remaining, bool restore_focus_to_window_under_popup) IMGUI_NOEXCEPT;
-    IMGUI_API void          ClosePopupsOverWindow(ImGuiWindow* ref_window, bool restore_focus_to_window_under_popup) IMGUI_NOEXCEPT;
-    IMGUI_API bool          IsPopupOpen(ImGuiID id, ImGuiPopupFlags popup_flags) IMGUI_NOEXCEPT;
-    IMGUI_API bool          BeginPopupEx(ImGuiID id, ImGuiWindowFlags extra_flags) IMGUI_NOEXCEPT;
-    IMGUI_API void          BeginTooltipEx(ImGuiWindowFlags extra_flags, ImGuiTooltipFlags tooltip_flags) IMGUI_NOEXCEPT;
-    IMGUI_API ImGuiWindow*  GetTopMostPopupModal() IMGUI_NOEXCEPT;
-    IMGUI_API ImVec2        FindBestWindowPosForPopup(ImGuiWindow* window) IMGUI_NOEXCEPT;
-    IMGUI_API ImVec2        FindBestWindowPosForPopupEx(const ImVec2& ref_pos, const ImVec2& size, ImGuiDir* last_dir, const ImRect& r_outer, const ImRect& r_avoid, ImGuiPopupPositionPolicy policy) IMGUI_NOEXCEPT;
-    IMGUI_API bool          BeginViewportSideBar(const char* name, ImGuiViewport* viewport, ImGuiDir dir, float size, ImGuiWindowFlags window_flags) IMGUI_NOEXCEPT;
+    IMGUI_API bool          BeginChildEx(const char* name, ImGuiID id, const ImVec2& size_arg, bool border, ImGuiWindowFlags flags) IM_NOEXCEPT;
+    IMGUI_API void          OpenPopupEx(ImGuiID id, ImGuiPopupFlags popup_flags = ImGuiPopupFlags_None) IM_NOEXCEPT;
+    IMGUI_API void          ClosePopupToLevel(int remaining, bool restore_focus_to_window_under_popup) IM_NOEXCEPT;
+    IMGUI_API void          ClosePopupsOverWindow(ImGuiWindow* ref_window, bool restore_focus_to_window_under_popup) IM_NOEXCEPT;
+    IMGUI_API bool          IsPopupOpen(ImGuiID id, ImGuiPopupFlags popup_flags) IM_NOEXCEPT;
+    IMGUI_API bool          BeginPopupEx(ImGuiID id, ImGuiWindowFlags extra_flags) IM_NOEXCEPT;
+    IMGUI_API void          BeginTooltipEx(ImGuiWindowFlags extra_flags, ImGuiTooltipFlags tooltip_flags) IM_NOEXCEPT;
+    IMGUI_API ImGuiWindow*  GetTopMostPopupModal() IM_NOEXCEPT;
+    IMGUI_API ImVec2        FindBestWindowPosForPopup(ImGuiWindow* window) IM_NOEXCEPT;
+    IMGUI_API ImVec2        FindBestWindowPosForPopupEx(const ImVec2& ref_pos, const ImVec2& size, ImGuiDir* last_dir, const ImRect& r_outer, const ImRect& r_avoid, ImGuiPopupPositionPolicy policy) IM_NOEXCEPT;
+    IMGUI_API bool          BeginViewportSideBar(const char* name, ImGuiViewport* viewport, ImGuiDir dir, float size, ImGuiWindowFlags window_flags) IM_NOEXCEPT;
 
     // Gamepad/Keyboard Navigation
-    IMGUI_API void          NavInitWindow(ImGuiWindow* window, bool force_reinit) IMGUI_NOEXCEPT;
-    IMGUI_API bool          NavMoveRequestButNoResultYet() IMGUI_NOEXCEPT;
-    IMGUI_API void          NavMoveRequestCancel() IMGUI_NOEXCEPT;
-    IMGUI_API void          NavMoveRequestForward(ImGuiDir move_dir, ImGuiDir clip_dir, const ImRect& bb_rel, ImGuiNavMoveFlags move_flags) IMGUI_NOEXCEPT;
-    IMGUI_API void          NavMoveRequestTryWrapping(ImGuiWindow* window, ImGuiNavMoveFlags move_flags) IMGUI_NOEXCEPT;
-    IMGUI_API float         GetNavInputAmount(ImGuiNavInput n, ImGuiInputReadMode mode) IMGUI_NOEXCEPT;
-    IMGUI_API ImVec2        GetNavInputAmount2d(ImGuiNavDirSourceFlags dir_sources, ImGuiInputReadMode mode, float slow_factor = 0.0f, float fast_factor = 0.0f) IMGUI_NOEXCEPT;
-    IMGUI_API int           CalcTypematicRepeatAmount(float t0, float t1, float repeat_delay, float repeat_rate) IMGUI_NOEXCEPT;
-    IMGUI_API void          ActivateItem(ImGuiID id) IMGUI_NOEXCEPT;   // Remotely activate a button, checkbox, tree node etc. given its unique ID. activation is queued and processed on the next frame when the item is encountered again.
-    IMGUI_API void          SetNavID(ImGuiID id, ImGuiNavLayer nav_layer, ImGuiID focus_scope_id, const ImRect& rect_rel) IMGUI_NOEXCEPT;
+    IMGUI_API void          NavInitWindow(ImGuiWindow* window, bool force_reinit) IM_NOEXCEPT;
+    IMGUI_API bool          NavMoveRequestButNoResultYet() IM_NOEXCEPT;
+    IMGUI_API void          NavMoveRequestCancel() IM_NOEXCEPT;
+    IMGUI_API void          NavMoveRequestForward(ImGuiDir move_dir, ImGuiDir clip_dir, const ImRect& bb_rel, ImGuiNavMoveFlags move_flags) IM_NOEXCEPT;
+    IMGUI_API void          NavMoveRequestTryWrapping(ImGuiWindow* window, ImGuiNavMoveFlags move_flags) IM_NOEXCEPT;
+    IMGUI_API float         GetNavInputAmount(ImGuiNavInput n, ImGuiInputReadMode mode) IM_NOEXCEPT;
+    IMGUI_API ImVec2        GetNavInputAmount2d(ImGuiNavDirSourceFlags dir_sources, ImGuiInputReadMode mode, float slow_factor = 0.0f, float fast_factor = 0.0f) IM_NOEXCEPT;
+    IMGUI_API int           CalcTypematicRepeatAmount(float t0, float t1, float repeat_delay, float repeat_rate) IM_NOEXCEPT;
+    IMGUI_API void          ActivateItem(ImGuiID id) IM_NOEXCEPT;   // Remotely activate a button, checkbox, tree node etc. given its unique ID. activation is queued and processed on the next frame when the item is encountered again.
+    IMGUI_API void          SetNavID(ImGuiID id, ImGuiNavLayer nav_layer, ImGuiID focus_scope_id, const ImRect& rect_rel) IM_NOEXCEPT;
 
     // Focus Scope (WIP)
     // This is generally used to identify a selection set (multiple of which may be in the same window), as selection
     // patterns generally need to react (e.g. clear selection) when landing on an item of the set.
-    IMGUI_API void          PushFocusScope(ImGuiID id) IMGUI_NOEXCEPT;
-    IMGUI_API void          PopFocusScope() IMGUI_NOEXCEPT;
-    inline ImGuiID          GetFocusedFocusScope() IMGUI_NOEXCEPT { ImGuiContext& g = *GImGui; return g.NavFocusScopeId; }                            // Focus scope which is actually active
-    inline ImGuiID          GetFocusScope()        IMGUI_NOEXCEPT { ImGuiContext& g = *GImGui; return g.CurrentWindow->DC.NavFocusScopeIdCurrent; }   // Focus scope we are outputting into, set by PushFocusScope()
+    IMGUI_API void          PushFocusScope(ImGuiID id) IM_NOEXCEPT;
+    IMGUI_API void          PopFocusScope() IM_NOEXCEPT;
+    inline ImGuiID          GetFocusedFocusScope() IM_NOEXCEPT { ImGuiContext& g = *GImGui; return g.NavFocusScopeId; }                            // Focus scope which is actually active
+    inline ImGuiID          GetFocusScope()        IM_NOEXCEPT { ImGuiContext& g = *GImGui; return g.CurrentWindow->DC.NavFocusScopeIdCurrent; }   // Focus scope we are outputting into, set by PushFocusScope()
 
     // Inputs
     // FIXME: Eventually we should aim to move e.g. IsActiveIdUsingKey() into IsKeyXXX functions.
-    IMGUI_API void          SetItemUsingMouseWheel()                                IMGUI_NOEXCEPT;
-    inline bool             IsActiveIdUsingNavDir(ImGuiDir dir)                     IMGUI_NOEXCEPT { ImGuiContext& g = *GImGui; return (g.ActiveIdUsingNavDirMask & (1 << dir)) != 0; }
-    inline bool             IsActiveIdUsingNavInput(ImGuiNavInput input)            IMGUI_NOEXCEPT { ImGuiContext& g = *GImGui; return (g.ActiveIdUsingNavInputMask & (1 << input)) != 0; }
-    inline bool             IsActiveIdUsingKey(ImGuiKey key)                        IMGUI_NOEXCEPT { ImGuiContext& g = *GImGui; IM_ASSERT(key < 64); return (g.ActiveIdUsingKeyInputMask & ((ImU64)1 << key)) != 0; }
-    IMGUI_API bool          IsMouseDragPastThreshold(ImGuiMouseButton button, float lock_threshold = -1.0f) IMGUI_NOEXCEPT;
-    inline bool             IsKeyPressedMap(ImGuiKey key, bool repeat = true)       IMGUI_NOEXCEPT { ImGuiContext& g = *GImGui; const int key_index = g.IO.KeyMap[key]; return (key_index >= 0) ? IsKeyPressed(key_index, repeat) : false; }
-    inline bool             IsNavInputDown(ImGuiNavInput n)                         IMGUI_NOEXCEPT { ImGuiContext& g = *GImGui; return g.IO.NavInputs[n] > 0.0f; }
-    inline bool             IsNavInputTest(ImGuiNavInput n, ImGuiInputReadMode rm)  IMGUI_NOEXCEPT { return (GetNavInputAmount(n, rm) > 0.0f); }
-    IMGUI_API ImGuiKeyModFlags GetMergedKeyModFlags()                               IMGUI_NOEXCEPT;
+    IMGUI_API void          SetItemUsingMouseWheel()                                IM_NOEXCEPT;
+    inline bool             IsActiveIdUsingNavDir(ImGuiDir dir)                     IM_NOEXCEPT { ImGuiContext& g = *GImGui; return (g.ActiveIdUsingNavDirMask & (1 << dir)) != 0; }
+    inline bool             IsActiveIdUsingNavInput(ImGuiNavInput input)            IM_NOEXCEPT { ImGuiContext& g = *GImGui; return (g.ActiveIdUsingNavInputMask & (1 << input)) != 0; }
+    inline bool             IsActiveIdUsingKey(ImGuiKey key)                        IM_NOEXCEPT { ImGuiContext& g = *GImGui; IM_ASSERT(key < 64); return (g.ActiveIdUsingKeyInputMask & ((ImU64)1 << key)) != 0; }
+    IMGUI_API bool          IsMouseDragPastThreshold(ImGuiMouseButton button, float lock_threshold = -1.0f) IM_NOEXCEPT;
+    inline bool             IsKeyPressedMap(ImGuiKey key, bool repeat = true)       IM_NOEXCEPT { ImGuiContext& g = *GImGui; const int key_index = g.IO.KeyMap[key]; return (key_index >= 0) ? IsKeyPressed(key_index, repeat) : false; }
+    inline bool             IsNavInputDown(ImGuiNavInput n)                         IM_NOEXCEPT { ImGuiContext& g = *GImGui; return g.IO.NavInputs[n] > 0.0f; }
+    inline bool             IsNavInputTest(ImGuiNavInput n, ImGuiInputReadMode rm)  IM_NOEXCEPT { return (GetNavInputAmount(n, rm) > 0.0f); }
+    IMGUI_API ImGuiKeyModFlags GetMergedKeyModFlags()                               IM_NOEXCEPT;
 
     // Drag and Drop
-    IMGUI_API bool          BeginDragDropTargetCustom(const ImRect& bb, ImGuiID id) IMGUI_NOEXCEPT;
-    IMGUI_API void          ClearDragDrop()                                         IMGUI_NOEXCEPT;
-    IMGUI_API bool          IsDragDropPayloadBeingAccepted()                        IMGUI_NOEXCEPT;
+    IMGUI_API bool          BeginDragDropTargetCustom(const ImRect& bb, ImGuiID id) IM_NOEXCEPT;
+    IMGUI_API void          ClearDragDrop()                                         IM_NOEXCEPT;
+    IMGUI_API bool          IsDragDropPayloadBeingAccepted()                        IM_NOEXCEPT;
 
     // Internal Columns API (this is not exposed because we will encourage transitioning to the Tables API)
-    IMGUI_API void          SetWindowClipRectBeforeSetChannel(ImGuiWindow* window, const ImRect& clip_rect) IMGUI_NOEXCEPT;
-    IMGUI_API void          BeginColumns(const char* str_id, int count, ImGuiOldColumnFlags flags = 0) IMGUI_NOEXCEPT; // setup number of columns. use an identifier to distinguish multiple column sets. close with EndColumns().
-    IMGUI_API void          EndColumns() IMGUI_NOEXCEPT;                                                               // close columns
-    IMGUI_API void          PushColumnClipRect(int column_index) IMGUI_NOEXCEPT;
-    IMGUI_API void          PushColumnsBackground() IMGUI_NOEXCEPT;
-    IMGUI_API void          PopColumnsBackground() IMGUI_NOEXCEPT;
-    IMGUI_API ImGuiID       GetColumnsID(const char* str_id, int count) IMGUI_NOEXCEPT;
-    IMGUI_API ImGuiOldColumns* FindOrCreateColumns(ImGuiWindow* window, ImGuiID id) IMGUI_NOEXCEPT;
-    IMGUI_API float         GetColumnOffsetFromNorm(const ImGuiOldColumns* columns, float offset_norm) IMGUI_NOEXCEPT;
-    IMGUI_API float         GetColumnNormFromOffset(const ImGuiOldColumns* columns, float offset) IMGUI_NOEXCEPT;
+    IMGUI_API void          SetWindowClipRectBeforeSetChannel(ImGuiWindow* window, const ImRect& clip_rect) IM_NOEXCEPT;
+    IMGUI_API void          BeginColumns(const char* str_id, int count, ImGuiOldColumnFlags flags = 0) IM_NOEXCEPT; // setup number of columns. use an identifier to distinguish multiple column sets. close with EndColumns().
+    IMGUI_API void          EndColumns() IM_NOEXCEPT;                                                               // close columns
+    IMGUI_API void          PushColumnClipRect(int column_index) IM_NOEXCEPT;
+    IMGUI_API void          PushColumnsBackground() IM_NOEXCEPT;
+    IMGUI_API void          PopColumnsBackground() IM_NOEXCEPT;
+    IMGUI_API ImGuiID       GetColumnsID(const char* str_id, int count) IM_NOEXCEPT;
+    IMGUI_API ImGuiOldColumns* FindOrCreateColumns(ImGuiWindow* window, ImGuiID id) IM_NOEXCEPT;
+    IMGUI_API float         GetColumnOffsetFromNorm(const ImGuiOldColumns* columns, float offset_norm) IM_NOEXCEPT;
+    IMGUI_API float         GetColumnNormFromOffset(const ImGuiOldColumns* columns, float offset) IM_NOEXCEPT;
 
     // Tables: Candidates for public API
-    IMGUI_API void          TableOpenContextMenu(int column_n = -1) IMGUI_NOEXCEPT;
-    IMGUI_API void          TableSetColumnWidth(int column_n, float width) IMGUI_NOEXCEPT;
-    IMGUI_API void          TableSetColumnSortDirection(int column_n, ImGuiSortDirection sort_direction, bool append_to_sort_specs) IMGUI_NOEXCEPT;
-    IMGUI_API int           TableGetHoveredColumn() IMGUI_NOEXCEPT; // May use (TableGetColumnFlags() & ImGuiTableColumnFlags_IsHovered) instead. Return hovered column. return -1 when table is not hovered. return columns_count if the unused space at the right of visible columns is hovered.
-    IMGUI_API float         TableGetHeaderRowHeight() IMGUI_NOEXCEPT;
-    IMGUI_API void          TablePushBackgroundChannel() IMGUI_NOEXCEPT;
-    IMGUI_API void          TablePopBackgroundChannel() IMGUI_NOEXCEPT;
+    IMGUI_API void          TableOpenContextMenu(int column_n = -1) IM_NOEXCEPT;
+    IMGUI_API void          TableSetColumnWidth(int column_n, float width) IM_NOEXCEPT;
+    IMGUI_API void          TableSetColumnSortDirection(int column_n, ImGuiSortDirection sort_direction, bool append_to_sort_specs) IM_NOEXCEPT;
+    IMGUI_API int           TableGetHoveredColumn() IM_NOEXCEPT; // May use (TableGetColumnFlags() & ImGuiTableColumnFlags_IsHovered) instead. Return hovered column. return -1 when table is not hovered. return columns_count if the unused space at the right of visible columns is hovered.
+    IMGUI_API float         TableGetHeaderRowHeight() IM_NOEXCEPT;
+    IMGUI_API void          TablePushBackgroundChannel() IM_NOEXCEPT;
+    IMGUI_API void          TablePopBackgroundChannel() IM_NOEXCEPT;
 
     // Tables: Internals
-    inline    ImGuiTable*   GetCurrentTable() IMGUI_NOEXCEPT { ImGuiContext& g = *GImGui; return g.CurrentTable; }
-    IMGUI_API ImGuiTable*   TableFindByID(ImGuiID id) IMGUI_NOEXCEPT;
-    IMGUI_API bool          BeginTableEx(const char* name, ImGuiID id, int columns_count, ImGuiTableFlags flags = 0, const ImVec2& outer_size = ImVec2(0, 0), float inner_width = 0.0f) IMGUI_NOEXCEPT;
-    IMGUI_API void          TableBeginInitMemory(ImGuiTable* table, int columns_count) IMGUI_NOEXCEPT;
-    IMGUI_API void          TableBeginApplyRequests(ImGuiTable* table) IMGUI_NOEXCEPT;
-    IMGUI_API void          TableSetupDrawChannels(ImGuiTable* table) IMGUI_NOEXCEPT;
-    IMGUI_API void          TableUpdateLayout(ImGuiTable* table) IMGUI_NOEXCEPT;
-    IMGUI_API void          TableUpdateBorders(ImGuiTable* table) IMGUI_NOEXCEPT;
-    IMGUI_API void          TableUpdateColumnsWeightFromWidth(ImGuiTable* table) IMGUI_NOEXCEPT;
-    IMGUI_API void          TableDrawBorders(ImGuiTable* table) IMGUI_NOEXCEPT;
-    IMGUI_API void          TableDrawContextMenu(ImGuiTable* table) IMGUI_NOEXCEPT;
-    IMGUI_API void          TableMergeDrawChannels(ImGuiTable* table) IMGUI_NOEXCEPT;
-    IMGUI_API void          TableSortSpecsSanitize(ImGuiTable* table) IMGUI_NOEXCEPT;
-    IMGUI_API void          TableSortSpecsBuild(ImGuiTable* table) IMGUI_NOEXCEPT;
-    IMGUI_API ImGuiSortDirection TableGetColumnNextSortDirection(ImGuiTableColumn* column) IMGUI_NOEXCEPT;
-    IMGUI_API void          TableFixColumnSortDirection(ImGuiTable* table, ImGuiTableColumn* column) IMGUI_NOEXCEPT;
-    IMGUI_API float         TableGetColumnWidthAuto(ImGuiTable* table, ImGuiTableColumn* column) IMGUI_NOEXCEPT;
-    IMGUI_API void          TableBeginRow(ImGuiTable* table) IMGUI_NOEXCEPT;
-    IMGUI_API void          TableEndRow(ImGuiTable* table) IMGUI_NOEXCEPT;
-    IMGUI_API void          TableBeginCell(ImGuiTable* table, int column_n) IMGUI_NOEXCEPT;
-    IMGUI_API void          TableEndCell(ImGuiTable* table) IMGUI_NOEXCEPT;
-    IMGUI_API ImRect        TableGetCellBgRect(const ImGuiTable* table, int column_n) IMGUI_NOEXCEPT;
-    IMGUI_API const char*   TableGetColumnName(const ImGuiTable* table, int column_n) IMGUI_NOEXCEPT;
-    IMGUI_API ImGuiID       TableGetColumnResizeID(const ImGuiTable* table, int column_n, int instance_no = 0) IMGUI_NOEXCEPT;
-    IMGUI_API float         TableGetMaxColumnWidth(const ImGuiTable* table, int column_n) IMGUI_NOEXCEPT;
-    IMGUI_API void          TableSetColumnWidthAutoSingle(ImGuiTable* table, int column_n) IMGUI_NOEXCEPT;
-    IMGUI_API void          TableSetColumnWidthAutoAll(ImGuiTable* table) IMGUI_NOEXCEPT;
-    IMGUI_API void          TableRemove(ImGuiTable* table) IMGUI_NOEXCEPT;
-    IMGUI_API void          TableGcCompactTransientBuffers(ImGuiTable* table) IMGUI_NOEXCEPT;
-    IMGUI_API void          TableGcCompactTransientBuffers(ImGuiTableTempData* table) IMGUI_NOEXCEPT;
-    IMGUI_API void          TableGcCompactSettings() IMGUI_NOEXCEPT;
+    inline    ImGuiTable*   GetCurrentTable() IM_NOEXCEPT { ImGuiContext& g = *GImGui; return g.CurrentTable; }
+    IMGUI_API ImGuiTable*   TableFindByID(ImGuiID id) IM_NOEXCEPT;
+    IMGUI_API bool          BeginTableEx(const char* name, ImGuiID id, int columns_count, ImGuiTableFlags flags = 0, const ImVec2& outer_size = ImVec2(0, 0), float inner_width = 0.0f) IM_NOEXCEPT;
+    IMGUI_API void          TableBeginInitMemory(ImGuiTable* table, int columns_count) IM_NOEXCEPT;
+    IMGUI_API void          TableBeginApplyRequests(ImGuiTable* table) IM_NOEXCEPT;
+    IMGUI_API void          TableSetupDrawChannels(ImGuiTable* table) IM_NOEXCEPT;
+    IMGUI_API void          TableUpdateLayout(ImGuiTable* table) IM_NOEXCEPT;
+    IMGUI_API void          TableUpdateBorders(ImGuiTable* table) IM_NOEXCEPT;
+    IMGUI_API void          TableUpdateColumnsWeightFromWidth(ImGuiTable* table) IM_NOEXCEPT;
+    IMGUI_API void          TableDrawBorders(ImGuiTable* table) IM_NOEXCEPT;
+    IMGUI_API void          TableDrawContextMenu(ImGuiTable* table) IM_NOEXCEPT;
+    IMGUI_API void          TableMergeDrawChannels(ImGuiTable* table) IM_NOEXCEPT;
+    IMGUI_API void          TableSortSpecsSanitize(ImGuiTable* table) IM_NOEXCEPT;
+    IMGUI_API void          TableSortSpecsBuild(ImGuiTable* table) IM_NOEXCEPT;
+    IMGUI_API ImGuiSortDirection TableGetColumnNextSortDirection(ImGuiTableColumn* column) IM_NOEXCEPT;
+    IMGUI_API void          TableFixColumnSortDirection(ImGuiTable* table, ImGuiTableColumn* column) IM_NOEXCEPT;
+    IMGUI_API float         TableGetColumnWidthAuto(ImGuiTable* table, ImGuiTableColumn* column) IM_NOEXCEPT;
+    IMGUI_API void          TableBeginRow(ImGuiTable* table) IM_NOEXCEPT;
+    IMGUI_API void          TableEndRow(ImGuiTable* table) IM_NOEXCEPT;
+    IMGUI_API void          TableBeginCell(ImGuiTable* table, int column_n) IM_NOEXCEPT;
+    IMGUI_API void          TableEndCell(ImGuiTable* table) IM_NOEXCEPT;
+    IMGUI_API ImRect        TableGetCellBgRect(const ImGuiTable* table, int column_n) IM_NOEXCEPT;
+    IMGUI_API const char*   TableGetColumnName(const ImGuiTable* table, int column_n) IM_NOEXCEPT;
+    IMGUI_API ImGuiID       TableGetColumnResizeID(const ImGuiTable* table, int column_n, int instance_no = 0) IM_NOEXCEPT;
+    IMGUI_API float         TableGetMaxColumnWidth(const ImGuiTable* table, int column_n) IM_NOEXCEPT;
+    IMGUI_API void          TableSetColumnWidthAutoSingle(ImGuiTable* table, int column_n) IM_NOEXCEPT;
+    IMGUI_API void          TableSetColumnWidthAutoAll(ImGuiTable* table) IM_NOEXCEPT;
+    IMGUI_API void          TableRemove(ImGuiTable* table) IM_NOEXCEPT;
+    IMGUI_API void          TableGcCompactTransientBuffers(ImGuiTable* table) IM_NOEXCEPT;
+    IMGUI_API void          TableGcCompactTransientBuffers(ImGuiTableTempData* table) IM_NOEXCEPT;
+    IMGUI_API void          TableGcCompactSettings() IM_NOEXCEPT;
 
     // Tables: Settings
-    IMGUI_API void                  TableLoadSettings(ImGuiTable* table) IMGUI_NOEXCEPT;
-    IMGUI_API void                  TableSaveSettings(ImGuiTable* table) IMGUI_NOEXCEPT;
-    IMGUI_API void                  TableResetSettings(ImGuiTable* table) IMGUI_NOEXCEPT;
-    IMGUI_API ImGuiTableSettings*   TableGetBoundSettings(ImGuiTable* table) IMGUI_NOEXCEPT;
-    IMGUI_API void                  TableSettingsInstallHandler(ImGuiContext* context) IMGUI_NOEXCEPT;
-    IMGUI_API ImGuiTableSettings*   TableSettingsCreate(ImGuiID id, int columns_count) IMGUI_NOEXCEPT;
-    IMGUI_API ImGuiTableSettings*   TableSettingsFindByID(ImGuiID id) IMGUI_NOEXCEPT;
+    IMGUI_API void                  TableLoadSettings(ImGuiTable* table) IM_NOEXCEPT;
+    IMGUI_API void                  TableSaveSettings(ImGuiTable* table) IM_NOEXCEPT;
+    IMGUI_API void                  TableResetSettings(ImGuiTable* table) IM_NOEXCEPT;
+    IMGUI_API ImGuiTableSettings*   TableGetBoundSettings(ImGuiTable* table) IM_NOEXCEPT;
+    IMGUI_API void                  TableSettingsInstallHandler(ImGuiContext* context) IM_NOEXCEPT;
+    IMGUI_API ImGuiTableSettings*   TableSettingsCreate(ImGuiID id, int columns_count) IM_NOEXCEPT;
+    IMGUI_API ImGuiTableSettings*   TableSettingsFindByID(ImGuiID id) IM_NOEXCEPT;
 
     // Tab Bars
-    IMGUI_API bool          BeginTabBarEx(ImGuiTabBar* tab_bar, const ImRect& bb, ImGuiTabBarFlags flags) IMGUI_NOEXCEPT;
-    IMGUI_API ImGuiTabItem* TabBarFindTabByID(ImGuiTabBar* tab_bar, ImGuiID tab_id) IMGUI_NOEXCEPT;
-    IMGUI_API void          TabBarRemoveTab(ImGuiTabBar* tab_bar, ImGuiID tab_id) IMGUI_NOEXCEPT;
-    IMGUI_API void          TabBarCloseTab(ImGuiTabBar* tab_bar, ImGuiTabItem* tab) IMGUI_NOEXCEPT;
-    IMGUI_API void          TabBarQueueReorder(ImGuiTabBar* tab_bar, const ImGuiTabItem* tab, int offset) IMGUI_NOEXCEPT;
-    IMGUI_API void          TabBarQueueReorderFromMousePos(ImGuiTabBar* tab_bar, const ImGuiTabItem* tab, ImVec2 mouse_pos) IMGUI_NOEXCEPT;
-    IMGUI_API bool          TabBarProcessReorder(ImGuiTabBar* tab_bar) IMGUI_NOEXCEPT;
-    IMGUI_API bool          TabItemEx(ImGuiTabBar* tab_bar, const char* label, bool* p_open, ImGuiTabItemFlags flags) IMGUI_NOEXCEPT;
-    IMGUI_API ImVec2        TabItemCalcSize(const char* label, bool has_close_button) IMGUI_NOEXCEPT;
-    IMGUI_API void          TabItemBackground(ImDrawList* draw_list, const ImRect& bb, ImGuiTabItemFlags flags, ImU32 col) IMGUI_NOEXCEPT;
-    IMGUI_API void          TabItemLabelAndCloseButton(ImDrawList* draw_list, const ImRect& bb, ImGuiTabItemFlags flags, ImVec2 frame_padding, const char* label, ImGuiID tab_id, ImGuiID close_button_id, bool is_contents_visible, bool* out_just_closed, bool* out_text_clipped) IMGUI_NOEXCEPT;
+    IMGUI_API bool          BeginTabBarEx(ImGuiTabBar* tab_bar, const ImRect& bb, ImGuiTabBarFlags flags) IM_NOEXCEPT;
+    IMGUI_API ImGuiTabItem* TabBarFindTabByID(ImGuiTabBar* tab_bar, ImGuiID tab_id) IM_NOEXCEPT;
+    IMGUI_API void          TabBarRemoveTab(ImGuiTabBar* tab_bar, ImGuiID tab_id) IM_NOEXCEPT;
+    IMGUI_API void          TabBarCloseTab(ImGuiTabBar* tab_bar, ImGuiTabItem* tab) IM_NOEXCEPT;
+    IMGUI_API void          TabBarQueueReorder(ImGuiTabBar* tab_bar, const ImGuiTabItem* tab, int offset) IM_NOEXCEPT;
+    IMGUI_API void          TabBarQueueReorderFromMousePos(ImGuiTabBar* tab_bar, const ImGuiTabItem* tab, ImVec2 mouse_pos) IM_NOEXCEPT;
+    IMGUI_API bool          TabBarProcessReorder(ImGuiTabBar* tab_bar) IM_NOEXCEPT;
+    IMGUI_API bool          TabItemEx(ImGuiTabBar* tab_bar, const char* label, bool* p_open, ImGuiTabItemFlags flags) IM_NOEXCEPT;
+    IMGUI_API ImVec2        TabItemCalcSize(const char* label, bool has_close_button) IM_NOEXCEPT;
+    IMGUI_API void          TabItemBackground(ImDrawList* draw_list, const ImRect& bb, ImGuiTabItemFlags flags, ImU32 col) IM_NOEXCEPT;
+    IMGUI_API void          TabItemLabelAndCloseButton(ImDrawList* draw_list, const ImRect& bb, ImGuiTabItemFlags flags, ImVec2 frame_padding, const char* label, ImGuiID tab_id, ImGuiID close_button_id, bool is_contents_visible, bool* out_just_closed, bool* out_text_clipped) IM_NOEXCEPT;
 
     // Render helpers
     // AVOID USING OUTSIDE OF IMGUI.CPP! NOT FOR PUBLIC CONSUMPTION. THOSE FUNCTIONS ARE A MESS. THEIR SIGNATURE AND BEHAVIOR WILL CHANGE, THEY NEED TO BE REFACTORED INTO SOMETHING DECENT.
     // NB: All position are in absolute pixels coordinates (we are never using window coordinates internally)
-    IMGUI_API void          RenderText(ImVec2 pos, const char* text, const char* text_end = NULL, bool hide_text_after_hash = true) IMGUI_NOEXCEPT;
-    IMGUI_API void          RenderTextWrapped(ImVec2 pos, const char* text, const char* text_end, float wrap_width) IMGUI_NOEXCEPT;
-    IMGUI_API void          RenderTextClipped(const ImVec2& pos_min, const ImVec2& pos_max, const char* text, const char* text_end, const ImVec2* text_size_if_known, const ImVec2& align = ImVec2(0, 0), const ImRect* clip_rect = NULL) IMGUI_NOEXCEPT;
-    IMGUI_API void          RenderTextClippedEx(ImDrawList* draw_list, const ImVec2& pos_min, const ImVec2& pos_max, const char* text, const char* text_end, const ImVec2* text_size_if_known, const ImVec2& align = ImVec2(0, 0), const ImRect* clip_rect = NULL) IMGUI_NOEXCEPT;
-    IMGUI_API void          RenderTextEllipsis(ImDrawList* draw_list, const ImVec2& pos_min, const ImVec2& pos_max, float clip_max_x, float ellipsis_max_x, const char* text, const char* text_end, const ImVec2* text_size_if_known) IMGUI_NOEXCEPT;
-    IMGUI_API void          RenderFrame(ImVec2 p_min, ImVec2 p_max, ImU32 fill_col, bool border = true, float rounding = 0.0f) IMGUI_NOEXCEPT;
-    IMGUI_API void          RenderFrameBorder(ImVec2 p_min, ImVec2 p_max, float rounding = 0.0f) IMGUI_NOEXCEPT;
-    IMGUI_API void          RenderColorRectWithAlphaCheckerboard(ImDrawList* draw_list, ImVec2 p_min, ImVec2 p_max, ImU32 fill_col, float grid_step, ImVec2 grid_off, float rounding = 0.0f, ImDrawFlags flags = 0) IMGUI_NOEXCEPT;
-    IMGUI_API void          RenderNavHighlight(const ImRect& bb, ImGuiID id, ImGuiNavHighlightFlags flags = ImGuiNavHighlightFlags_TypeDefault) IMGUI_NOEXCEPT; // Navigation highlight
-    IMGUI_API const char*   FindRenderedTextEnd(const char* text, const char* text_end = NULL) IMGUI_NOEXCEPT; // Find the optional ## from which we stop displaying text.
+    IMGUI_API void          RenderText(ImVec2 pos, const char* text, const char* text_end = NULL, bool hide_text_after_hash = true) IM_NOEXCEPT;
+    IMGUI_API void          RenderTextWrapped(ImVec2 pos, const char* text, const char* text_end, float wrap_width) IM_NOEXCEPT;
+    IMGUI_API void          RenderTextClipped(const ImVec2& pos_min, const ImVec2& pos_max, const char* text, const char* text_end, const ImVec2* text_size_if_known, const ImVec2& align = ImVec2(0, 0), const ImRect* clip_rect = NULL) IM_NOEXCEPT;
+    IMGUI_API void          RenderTextClippedEx(ImDrawList* draw_list, const ImVec2& pos_min, const ImVec2& pos_max, const char* text, const char* text_end, const ImVec2* text_size_if_known, const ImVec2& align = ImVec2(0, 0), const ImRect* clip_rect = NULL) IM_NOEXCEPT;
+    IMGUI_API void          RenderTextEllipsis(ImDrawList* draw_list, const ImVec2& pos_min, const ImVec2& pos_max, float clip_max_x, float ellipsis_max_x, const char* text, const char* text_end, const ImVec2* text_size_if_known) IM_NOEXCEPT;
+    IMGUI_API void          RenderFrame(ImVec2 p_min, ImVec2 p_max, ImU32 fill_col, bool border = true, float rounding = 0.0f) IM_NOEXCEPT;
+    IMGUI_API void          RenderFrameBorder(ImVec2 p_min, ImVec2 p_max, float rounding = 0.0f) IM_NOEXCEPT;
+    IMGUI_API void          RenderColorRectWithAlphaCheckerboard(ImDrawList* draw_list, ImVec2 p_min, ImVec2 p_max, ImU32 fill_col, float grid_step, ImVec2 grid_off, float rounding = 0.0f, ImDrawFlags flags = 0) IM_NOEXCEPT;
+    IMGUI_API void          RenderNavHighlight(const ImRect& bb, ImGuiID id, ImGuiNavHighlightFlags flags = ImGuiNavHighlightFlags_TypeDefault) IM_NOEXCEPT; // Navigation highlight
+    IMGUI_API const char*   FindRenderedTextEnd(const char* text, const char* text_end = NULL) IM_NOEXCEPT; // Find the optional ## from which we stop displaying text.
 
     // Render helpers (those functions don't access any ImGui state!)
-    IMGUI_API void          RenderArrow(ImDrawList* draw_list, ImVec2 pos, ImU32 col, ImGuiDir dir, float scale = 1.0f) IMGUI_NOEXCEPT;
-    IMGUI_API void          RenderBullet(ImDrawList* draw_list, ImVec2 pos, ImU32 col) IMGUI_NOEXCEPT;
-    IMGUI_API void          RenderCheckMark(ImDrawList* draw_list, ImVec2 pos, ImU32 col, float sz) IMGUI_NOEXCEPT;
-    IMGUI_API void          RenderMouseCursor(ImDrawList* draw_list, ImVec2 pos, float scale, ImGuiMouseCursor mouse_cursor, ImU32 col_fill, ImU32 col_border, ImU32 col_shadow) IMGUI_NOEXCEPT;
-    IMGUI_API void          RenderArrowPointingAt(ImDrawList* draw_list, ImVec2 pos, ImVec2 half_sz, ImGuiDir direction, ImU32 col) IMGUI_NOEXCEPT;
-    IMGUI_API void          RenderRectFilledRangeH(ImDrawList* draw_list, const ImRect& rect, ImU32 col, float x_start_norm, float x_end_norm, float rounding) IMGUI_NOEXCEPT;
-    IMGUI_API void          RenderRectFilledWithHole(ImDrawList* draw_list, ImRect outer, ImRect inner, ImU32 col, float rounding) IMGUI_NOEXCEPT;
+    IMGUI_API void          RenderArrow(ImDrawList* draw_list, ImVec2 pos, ImU32 col, ImGuiDir dir, float scale = 1.0f) IM_NOEXCEPT;
+    IMGUI_API void          RenderBullet(ImDrawList* draw_list, ImVec2 pos, ImU32 col) IM_NOEXCEPT;
+    IMGUI_API void          RenderCheckMark(ImDrawList* draw_list, ImVec2 pos, ImU32 col, float sz) IM_NOEXCEPT;
+    IMGUI_API void          RenderMouseCursor(ImDrawList* draw_list, ImVec2 pos, float scale, ImGuiMouseCursor mouse_cursor, ImU32 col_fill, ImU32 col_border, ImU32 col_shadow) IM_NOEXCEPT;
+    IMGUI_API void          RenderArrowPointingAt(ImDrawList* draw_list, ImVec2 pos, ImVec2 half_sz, ImGuiDir direction, ImU32 col) IM_NOEXCEPT;
+    IMGUI_API void          RenderRectFilledRangeH(ImDrawList* draw_list, const ImRect& rect, ImU32 col, float x_start_norm, float x_end_norm, float rounding) IM_NOEXCEPT;
+    IMGUI_API void          RenderRectFilledWithHole(ImDrawList* draw_list, ImRect outer, ImRect inner, ImU32 col, float rounding) IM_NOEXCEPT;
 
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
     // [1.71: 2019/06/07: Updating prototypes of some of the internal functions. Leaving those for reference for a short while]
-    inline void RenderArrow(ImVec2 pos, ImGuiDir dir, float scale=1.0f) IMGUI_NOEXCEPT { ImGuiWindow* window = GetCurrentWindow(); RenderArrow(window->DrawList, pos, GetColorU32(ImGuiCol_Text), dir, scale); }
-    inline void RenderBullet(ImVec2 pos)                                IMGUI_NOEXCEPT { ImGuiWindow* window = GetCurrentWindow(); RenderBullet(window->DrawList, pos, GetColorU32(ImGuiCol_Text)); }
+    inline void RenderArrow(ImVec2 pos, ImGuiDir dir, float scale=1.0f) IM_NOEXCEPT { ImGuiWindow* window = GetCurrentWindow(); RenderArrow(window->DrawList, pos, GetColorU32(ImGuiCol_Text), dir, scale); }
+    inline void RenderBullet(ImVec2 pos)                                IM_NOEXCEPT { ImGuiWindow* window = GetCurrentWindow(); RenderBullet(window->DrawList, pos, GetColorU32(ImGuiCol_Text)); }
 #endif
 
     // Widgets
-    IMGUI_API void          TextEx(const char* text, const char* text_end = NULL, ImGuiTextFlags flags = 0) IMGUI_NOEXCEPT;
-    IMGUI_API bool          ButtonEx(const char* label, const ImVec2& size_arg = ImVec2(0, 0), ImGuiButtonFlags flags = 0) IMGUI_NOEXCEPT;
-    IMGUI_API bool          CloseButton(ImGuiID id, const ImVec2& pos) IMGUI_NOEXCEPT;
-    IMGUI_API bool          CollapseButton(ImGuiID id, const ImVec2& pos) IMGUI_NOEXCEPT;
-    IMGUI_API bool          ArrowButtonEx(const char* str_id, ImGuiDir dir, ImVec2 size_arg, ImGuiButtonFlags flags = 0) IMGUI_NOEXCEPT;
-    IMGUI_API void          Scrollbar(ImGuiAxis axis) IMGUI_NOEXCEPT;
-    IMGUI_API bool          ScrollbarEx(const ImRect& bb, ImGuiID id, ImGuiAxis axis, float* p_scroll_v, float avail_v, float contents_v, ImDrawFlags flags) IMGUI_NOEXCEPT;
-    IMGUI_API bool          ImageButtonEx(ImGuiID id, ImTextureID texture_id, const ImVec2& size, const ImVec2& uv0, const ImVec2& uv1, const ImVec2& padding, const ImVec4& bg_col, const ImVec4& tint_col) IMGUI_NOEXCEPT;
-    IMGUI_API ImRect        GetWindowScrollbarRect(ImGuiWindow* window, ImGuiAxis axis) IMGUI_NOEXCEPT;
-    IMGUI_API ImGuiID       GetWindowScrollbarID(ImGuiWindow* window, ImGuiAxis axis) IMGUI_NOEXCEPT;
-    IMGUI_API ImGuiID       GetWindowResizeCornerID(ImGuiWindow* window, int n) IMGUI_NOEXCEPT; // 0..3: corners
-    IMGUI_API ImGuiID       GetWindowResizeBorderID(ImGuiWindow* window, ImGuiDir dir) IMGUI_NOEXCEPT;
-    IMGUI_API void          SeparatorEx(ImGuiSeparatorFlags flags) IMGUI_NOEXCEPT;
-    IMGUI_API bool          CheckboxFlags(const char* label, ImS64* flags, ImS64 flags_value) IMGUI_NOEXCEPT;
-    IMGUI_API bool          CheckboxFlags(const char* label, ImU64* flags, ImU64 flags_value) IMGUI_NOEXCEPT;
+    IMGUI_API void          TextEx(const char* text, const char* text_end = NULL, ImGuiTextFlags flags = 0) IM_NOEXCEPT;
+    IMGUI_API bool          ButtonEx(const char* label, const ImVec2& size_arg = ImVec2(0, 0), ImGuiButtonFlags flags = 0) IM_NOEXCEPT;
+    IMGUI_API bool          CloseButton(ImGuiID id, const ImVec2& pos) IM_NOEXCEPT;
+    IMGUI_API bool          CollapseButton(ImGuiID id, const ImVec2& pos) IM_NOEXCEPT;
+    IMGUI_API bool          ArrowButtonEx(const char* str_id, ImGuiDir dir, ImVec2 size_arg, ImGuiButtonFlags flags = 0) IM_NOEXCEPT;
+    IMGUI_API void          Scrollbar(ImGuiAxis axis) IM_NOEXCEPT;
+    IMGUI_API bool          ScrollbarEx(const ImRect& bb, ImGuiID id, ImGuiAxis axis, float* p_scroll_v, float avail_v, float contents_v, ImDrawFlags flags) IM_NOEXCEPT;
+    IMGUI_API bool          ImageButtonEx(ImGuiID id, ImTextureID texture_id, const ImVec2& size, const ImVec2& uv0, const ImVec2& uv1, const ImVec2& padding, const ImVec4& bg_col, const ImVec4& tint_col) IM_NOEXCEPT;
+    IMGUI_API ImRect        GetWindowScrollbarRect(ImGuiWindow* window, ImGuiAxis axis) IM_NOEXCEPT;
+    IMGUI_API ImGuiID       GetWindowScrollbarID(ImGuiWindow* window, ImGuiAxis axis) IM_NOEXCEPT;
+    IMGUI_API ImGuiID       GetWindowResizeCornerID(ImGuiWindow* window, int n) IM_NOEXCEPT; // 0..3: corners
+    IMGUI_API ImGuiID       GetWindowResizeBorderID(ImGuiWindow* window, ImGuiDir dir) IM_NOEXCEPT;
+    IMGUI_API void          SeparatorEx(ImGuiSeparatorFlags flags) IM_NOEXCEPT;
+    IMGUI_API bool          CheckboxFlags(const char* label, ImS64* flags, ImS64 flags_value) IM_NOEXCEPT;
+    IMGUI_API bool          CheckboxFlags(const char* label, ImU64* flags, ImU64 flags_value) IM_NOEXCEPT;
 
     // Widgets low-level behaviors
-    IMGUI_API bool          ButtonBehavior(const ImRect& bb, ImGuiID id, bool* out_hovered, bool* out_held, ImGuiButtonFlags flags = 0) IMGUI_NOEXCEPT;
-    IMGUI_API bool          DragBehavior(ImGuiID id, ImGuiDataType data_type, void* p_v, float v_speed, const void* p_min, const void* p_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT;
-    IMGUI_API bool          SliderBehavior(const ImRect& bb, ImGuiID id, ImGuiDataType data_type, void* p_v, const void* p_min, const void* p_max, const char* format, ImGuiSliderFlags flags, ImRect* out_grab_bb) IMGUI_NOEXCEPT;
-    IMGUI_API bool          SplitterBehavior(const ImRect& bb, ImGuiID id, ImGuiAxis axis, float* size1, float* size2, float min_size1, float min_size2, float hover_extend = 0.0f, float hover_visibility_delay = 0.0f) IMGUI_NOEXCEPT;
-    IMGUI_API bool          TreeNodeBehavior(ImGuiID id, ImGuiTreeNodeFlags flags, const char* label, const char* label_end = NULL) IMGUI_NOEXCEPT;
-    IMGUI_API bool          TreeNodeBehaviorIsOpen(ImGuiID id, ImGuiTreeNodeFlags flags = 0) IMGUI_NOEXCEPT;                     // Consume previous SetNextItemOpen() data, if any. May return true when logging
-    IMGUI_API void          TreePushOverrideID(ImGuiID id) IMGUI_NOEXCEPT;
+    IMGUI_API bool          ButtonBehavior(const ImRect& bb, ImGuiID id, bool* out_hovered, bool* out_held, ImGuiButtonFlags flags = 0) IM_NOEXCEPT;
+    IMGUI_API bool          DragBehavior(ImGuiID id, ImGuiDataType data_type, void* p_v, float v_speed, const void* p_min, const void* p_max, const char* format, ImGuiSliderFlags flags) IM_NOEXCEPT;
+    IMGUI_API bool          SliderBehavior(const ImRect& bb, ImGuiID id, ImGuiDataType data_type, void* p_v, const void* p_min, const void* p_max, const char* format, ImGuiSliderFlags flags, ImRect* out_grab_bb) IM_NOEXCEPT;
+    IMGUI_API bool          SplitterBehavior(const ImRect& bb, ImGuiID id, ImGuiAxis axis, float* size1, float* size2, float min_size1, float min_size2, float hover_extend = 0.0f, float hover_visibility_delay = 0.0f) IM_NOEXCEPT;
+    IMGUI_API bool          TreeNodeBehavior(ImGuiID id, ImGuiTreeNodeFlags flags, const char* label, const char* label_end = NULL) IM_NOEXCEPT;
+    IMGUI_API bool          TreeNodeBehaviorIsOpen(ImGuiID id, ImGuiTreeNodeFlags flags = 0) IM_NOEXCEPT;                     // Consume previous SetNextItemOpen() data, if any. May return true when logging
+    IMGUI_API void          TreePushOverrideID(ImGuiID id) IM_NOEXCEPT;
 
     // Template functions are instantiated in imgui_widgets.cpp for a finite number of types.
     // To use them externally (for custom widget) you may need an "extern template" statement in your code in order to link to existing instances and silence Clang warnings (see #2036).
     // e.g. " extern template IMGUI_API float RoundScalarWithFormatT<float, float>(const char* format, ImGuiDataType data_type, float v); "
-    template<typename T, typename SIGNED_T, typename FLOAT_T>   IMGUI_API float ScaleRatioFromValueT(ImGuiDataType data_type, T v, T v_min, T v_max, bool is_logarithmic, float logarithmic_zero_epsilon, float zero_deadzone_size) IMGUI_NOEXCEPT;
-    template<typename T, typename SIGNED_T, typename FLOAT_T>   IMGUI_API T     ScaleValueFromRatioT(ImGuiDataType data_type, float t, T v_min, T v_max, bool is_logarithmic, float logarithmic_zero_epsilon, float zero_deadzone_size) IMGUI_NOEXCEPT;
-    template<typename T, typename SIGNED_T, typename FLOAT_T>   IMGUI_API bool  DragBehaviorT(ImGuiDataType data_type, T* v, float v_speed, T v_min, T v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT;
-    template<typename T, typename SIGNED_T, typename FLOAT_T>   IMGUI_API bool  SliderBehaviorT(const ImRect& bb, ImGuiID id, ImGuiDataType data_type, T* v, T v_min, T v_max, const char* format, ImGuiSliderFlags flags, ImRect* out_grab_bb) IMGUI_NOEXCEPT;
-    template<typename T, typename SIGNED_T>                     IMGUI_API T     RoundScalarWithFormatT(const char* format, ImGuiDataType data_type, T v) IMGUI_NOEXCEPT;
-    template<typename T>                                        IMGUI_API bool  CheckboxFlagsT(const char* label, T* flags, T flags_value) IMGUI_NOEXCEPT;
+    template<typename T, typename SIGNED_T, typename FLOAT_T>   IMGUI_API float ScaleRatioFromValueT(ImGuiDataType data_type, T v, T v_min, T v_max, bool is_logarithmic, float logarithmic_zero_epsilon, float zero_deadzone_size) IM_NOEXCEPT;
+    template<typename T, typename SIGNED_T, typename FLOAT_T>   IMGUI_API T     ScaleValueFromRatioT(ImGuiDataType data_type, float t, T v_min, T v_max, bool is_logarithmic, float logarithmic_zero_epsilon, float zero_deadzone_size) IM_NOEXCEPT;
+    template<typename T, typename SIGNED_T, typename FLOAT_T>   IMGUI_API bool  DragBehaviorT(ImGuiDataType data_type, T* v, float v_speed, T v_min, T v_max, const char* format, ImGuiSliderFlags flags) IM_NOEXCEPT;
+    template<typename T, typename SIGNED_T, typename FLOAT_T>   IMGUI_API bool  SliderBehaviorT(const ImRect& bb, ImGuiID id, ImGuiDataType data_type, T* v, T v_min, T v_max, const char* format, ImGuiSliderFlags flags, ImRect* out_grab_bb) IM_NOEXCEPT;
+    template<typename T, typename SIGNED_T>                     IMGUI_API T     RoundScalarWithFormatT(const char* format, ImGuiDataType data_type, T v) IM_NOEXCEPT;
+    template<typename T>                                        IMGUI_API bool  CheckboxFlagsT(const char* label, T* flags, T flags_value) IM_NOEXCEPT;
 
     // Data type helpers
-    IMGUI_API const ImGuiDataTypeInfo*  DataTypeGetInfo(ImGuiDataType data_type) IMGUI_NOEXCEPT;
-    IMGUI_API int           DataTypeFormatString(char* buf, int buf_size, ImGuiDataType data_type, const void* p_data, const char* format) IMGUI_NOEXCEPT;
-    IMGUI_API void          DataTypeApplyOp(ImGuiDataType data_type, int op, void* output, const void* arg_1, const void* arg_2) IMGUI_NOEXCEPT;
-    IMGUI_API bool          DataTypeApplyOpFromText(const char* buf, const char* initial_value_buf, ImGuiDataType data_type, void* p_data, const char* format) IMGUI_NOEXCEPT;
-    IMGUI_API int           DataTypeCompare(ImGuiDataType data_type, const void* arg_1, const void* arg_2) IMGUI_NOEXCEPT;
-    IMGUI_API bool          DataTypeClamp(ImGuiDataType data_type, void* p_data, const void* p_min, const void* p_max) IMGUI_NOEXCEPT;
+    IMGUI_API const ImGuiDataTypeInfo*  DataTypeGetInfo(ImGuiDataType data_type) IM_NOEXCEPT;
+    IMGUI_API int           DataTypeFormatString(char* buf, int buf_size, ImGuiDataType data_type, const void* p_data, const char* format) IM_NOEXCEPT;
+    IMGUI_API void          DataTypeApplyOp(ImGuiDataType data_type, int op, void* output, const void* arg_1, const void* arg_2) IM_NOEXCEPT;
+    IMGUI_API bool          DataTypeApplyOpFromText(const char* buf, const char* initial_value_buf, ImGuiDataType data_type, void* p_data, const char* format) IM_NOEXCEPT;
+    IMGUI_API int           DataTypeCompare(ImGuiDataType data_type, const void* arg_1, const void* arg_2) IM_NOEXCEPT;
+    IMGUI_API bool          DataTypeClamp(ImGuiDataType data_type, void* p_data, const void* p_min, const void* p_max) IM_NOEXCEPT;
 
     // InputText
-    IMGUI_API bool          InputTextEx(const char* label, const char* hint, char* buf, int buf_size, const ImVec2& size_arg, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback = NULL, void* user_data = NULL) IMGUI_NOEXCEPT;
-    IMGUI_API bool          TempInputText(const ImRect& bb, ImGuiID id, const char* label, char* buf, int buf_size, ImGuiInputTextFlags flags) IMGUI_NOEXCEPT;
-    IMGUI_API bool          TempInputScalar(const ImRect& bb, ImGuiID id, const char* label, ImGuiDataType data_type, void* p_data, const char* format, const void* p_clamp_min = NULL, const void* p_clamp_max = NULL) IMGUI_NOEXCEPT;
-    inline bool             TempInputIsActive(ImGuiID id)     IMGUI_NOEXCEPT   { ImGuiContext& g = *GImGui; return (g.ActiveId == id && g.TempInputId == id); }
-    inline ImGuiInputTextState* GetInputTextState(ImGuiID id) IMGUI_NOEXCEPT   { ImGuiContext& g = *GImGui; return (g.InputTextState.ID == id) ? &g.InputTextState : NULL; } // Get input text state if active
+    IMGUI_API bool          InputTextEx(const char* label, const char* hint, char* buf, int buf_size, const ImVec2& size_arg, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback = NULL, void* user_data = NULL) IM_NOEXCEPT;
+    IMGUI_API bool          TempInputText(const ImRect& bb, ImGuiID id, const char* label, char* buf, int buf_size, ImGuiInputTextFlags flags) IM_NOEXCEPT;
+    IMGUI_API bool          TempInputScalar(const ImRect& bb, ImGuiID id, const char* label, ImGuiDataType data_type, void* p_data, const char* format, const void* p_clamp_min = NULL, const void* p_clamp_max = NULL) IM_NOEXCEPT;
+    inline bool             TempInputIsActive(ImGuiID id)     IM_NOEXCEPT   { ImGuiContext& g = *GImGui; return (g.ActiveId == id && g.TempInputId == id); }
+    inline ImGuiInputTextState* GetInputTextState(ImGuiID id) IM_NOEXCEPT   { ImGuiContext& g = *GImGui; return (g.InputTextState.ID == id) ? &g.InputTextState : NULL; } // Get input text state if active
 
     // Color
-    IMGUI_API void          ColorTooltip(const char* text, const float* col, ImGuiColorEditFlags flags) IMGUI_NOEXCEPT;
-    IMGUI_API void          ColorEditOptionsPopup(const float* col, ImGuiColorEditFlags flags) IMGUI_NOEXCEPT;
-    IMGUI_API void          ColorPickerOptionsPopup(const float* ref_col, ImGuiColorEditFlags flags) IMGUI_NOEXCEPT;
+    IMGUI_API void          ColorTooltip(const char* text, const float* col, ImGuiColorEditFlags flags) IM_NOEXCEPT;
+    IMGUI_API void          ColorEditOptionsPopup(const float* col, ImGuiColorEditFlags flags) IM_NOEXCEPT;
+    IMGUI_API void          ColorPickerOptionsPopup(const float* ref_col, ImGuiColorEditFlags flags) IM_NOEXCEPT;
 
     // Plot
-    IMGUI_API int           PlotEx(ImGuiPlotType plot_type, const char* label, float (*values_getter)(void* data, int idx), void* data, int values_count, int values_offset, const char* overlay_text, float scale_min, float scale_max, ImVec2 frame_size) IMGUI_NOEXCEPT;
+    IMGUI_API int           PlotEx(ImGuiPlotType plot_type, const char* label, float (*values_getter)(void* data, int idx), void* data, int values_count, int values_offset, const char* overlay_text, float scale_min, float scale_max, ImVec2 frame_size) IM_NOEXCEPT;
 
     // Shade functions (write over already created vertices)
-    IMGUI_API void          ShadeVertsLinearColorGradientKeepAlpha(ImDrawList* draw_list, int vert_start_idx, int vert_end_idx, ImVec2 gradient_p0, ImVec2 gradient_p1, ImU32 col0, ImU32 col1) IMGUI_NOEXCEPT;
-    IMGUI_API void          ShadeVertsLinearUV(ImDrawList* draw_list, int vert_start_idx, int vert_end_idx, const ImVec2& a, const ImVec2& b, const ImVec2& uv_a, const ImVec2& uv_b, bool clamp) IMGUI_NOEXCEPT;
+    IMGUI_API void          ShadeVertsLinearColorGradientKeepAlpha(ImDrawList* draw_list, int vert_start_idx, int vert_end_idx, ImVec2 gradient_p0, ImVec2 gradient_p1, ImU32 col0, ImU32 col1) IM_NOEXCEPT;
+    IMGUI_API void          ShadeVertsLinearUV(ImDrawList* draw_list, int vert_start_idx, int vert_end_idx, const ImVec2& a, const ImVec2& b, const ImVec2& uv_a, const ImVec2& uv_b, bool clamp) IM_NOEXCEPT;
 
     // Garbage collection
-    IMGUI_API void          GcCompactTransientMiscBuffers() IMGUI_NOEXCEPT;
-    IMGUI_API void          GcCompactTransientWindowBuffers(ImGuiWindow* window) IMGUI_NOEXCEPT;
-    IMGUI_API void          GcAwakeTransientWindowBuffers(ImGuiWindow* window) IMGUI_NOEXCEPT;
+    IMGUI_API void          GcCompactTransientMiscBuffers() IM_NOEXCEPT;
+    IMGUI_API void          GcCompactTransientWindowBuffers(ImGuiWindow* window) IM_NOEXCEPT;
+    IMGUI_API void          GcAwakeTransientWindowBuffers(ImGuiWindow* window) IM_NOEXCEPT;
 
     // Debug Tools
-    IMGUI_API void          ErrorCheckEndFrameRecover(ImGuiErrorLogCallback log_callback, void* user_data = NULL) IMGUI_NOEXCEPT;
-    inline void             DebugDrawItemRect(ImU32 col = IM_COL32(255,0,0,255)) IMGUI_NOEXCEPT    { ImGuiContext& g = *GImGui; ImGuiWindow* window = g.CurrentWindow; GetForegroundDrawList(window)->AddRect(window->DC.LastItemRect.Min, window->DC.LastItemRect.Max, col); }
-    inline void             DebugStartItemPicker()                               IMGUI_NOEXCEPT    { ImGuiContext& g = *GImGui; g.DebugItemPickerActive = true; }
+    IMGUI_API void          ErrorCheckEndFrameRecover(ImGuiErrorLogCallback log_callback, void* user_data = NULL) IM_NOEXCEPT;
+    inline void             DebugDrawItemRect(ImU32 col = IM_COL32(255,0,0,255)) IM_NOEXCEPT    { ImGuiContext& g = *GImGui; ImGuiWindow* window = g.CurrentWindow; GetForegroundDrawList(window)->AddRect(window->DC.LastItemRect.Min, window->DC.LastItemRect.Max, col); }
+    inline void             DebugStartItemPicker()                               IM_NOEXCEPT    { ImGuiContext& g = *GImGui; g.DebugItemPickerActive = true; }
 
-    IMGUI_API void          DebugNodeColumns(ImGuiOldColumns* columns) IMGUI_NOEXCEPT;
-    IMGUI_API void          DebugNodeDrawList(ImGuiWindow* window, const ImDrawList* draw_list, const char* label) IMGUI_NOEXCEPT;
-    IMGUI_API void          DebugNodeDrawCmdShowMeshAndBoundingBox(ImDrawList* out_draw_list, const ImDrawList* draw_list, const ImDrawCmd* draw_cmd, bool show_mesh, bool show_aabb) IMGUI_NOEXCEPT;
-    IMGUI_API void          DebugNodeStorage(ImGuiStorage* storage, const char* label) IMGUI_NOEXCEPT;
-    IMGUI_API void          DebugNodeTabBar(ImGuiTabBar* tab_bar, const char* label) IMGUI_NOEXCEPT;
-    IMGUI_API void          DebugNodeTable(ImGuiTable* table) IMGUI_NOEXCEPT;
-    IMGUI_API void          DebugNodeTableSettings(ImGuiTableSettings* settings) IMGUI_NOEXCEPT;
-    IMGUI_API void          DebugNodeWindow(ImGuiWindow* window, const char* label) IMGUI_NOEXCEPT;
-    IMGUI_API void          DebugNodeWindowSettings(ImGuiWindowSettings* settings) IMGUI_NOEXCEPT;
-    IMGUI_API void          DebugNodeWindowsList(ImVector<ImGuiWindow*>* windows, const char* label) IMGUI_NOEXCEPT;
-    IMGUI_API void          DebugNodeViewport(ImGuiViewportP* viewport) IMGUI_NOEXCEPT;
-    IMGUI_API void          DebugRenderViewportThumbnail(ImDrawList* draw_list, ImGuiViewportP* viewport, const ImRect& bb) IMGUI_NOEXCEPT;
+    IMGUI_API void          DebugNodeColumns(ImGuiOldColumns* columns) IM_NOEXCEPT;
+    IMGUI_API void          DebugNodeDrawList(ImGuiWindow* window, const ImDrawList* draw_list, const char* label) IM_NOEXCEPT;
+    IMGUI_API void          DebugNodeDrawCmdShowMeshAndBoundingBox(ImDrawList* out_draw_list, const ImDrawList* draw_list, const ImDrawCmd* draw_cmd, bool show_mesh, bool show_aabb) IM_NOEXCEPT;
+    IMGUI_API void          DebugNodeStorage(ImGuiStorage* storage, const char* label) IM_NOEXCEPT;
+    IMGUI_API void          DebugNodeTabBar(ImGuiTabBar* tab_bar, const char* label) IM_NOEXCEPT;
+    IMGUI_API void          DebugNodeTable(ImGuiTable* table) IM_NOEXCEPT;
+    IMGUI_API void          DebugNodeTableSettings(ImGuiTableSettings* settings) IM_NOEXCEPT;
+    IMGUI_API void          DebugNodeWindow(ImGuiWindow* window, const char* label) IM_NOEXCEPT;
+    IMGUI_API void          DebugNodeWindowSettings(ImGuiWindowSettings* settings) IM_NOEXCEPT;
+    IMGUI_API void          DebugNodeWindowsList(ImVector<ImGuiWindow*>* windows, const char* label) IM_NOEXCEPT;
+    IMGUI_API void          DebugNodeViewport(ImGuiViewportP* viewport) IM_NOEXCEPT;
+    IMGUI_API void          DebugRenderViewportThumbnail(ImDrawList* draw_list, ImGuiViewportP* viewport, const ImRect& bb) IM_NOEXCEPT;
 
 } // namespace ImGui
 
@@ -2640,30 +2640,30 @@ namespace ImGui
 // This structure is likely to evolve as we add support for incremental atlas updates
 struct ImFontBuilderIO
 {
-    bool    (*FontBuilder_Build)(ImFontAtlas* atlas) IMGUI_NOEXCEPT;
+    bool    (*FontBuilder_Build)(ImFontAtlas* atlas) IM_NOEXCEPT;
 };
 
 // Helper for font builder
-IMGUI_API const ImFontBuilderIO* ImFontAtlasGetBuilderForStbTruetype() IMGUI_NOEXCEPT;
-IMGUI_API void      ImFontAtlasBuildInit(ImFontAtlas* atlas) IMGUI_NOEXCEPT;
-IMGUI_API void      ImFontAtlasBuildSetupFont(ImFontAtlas* atlas, ImFont* font, ImFontConfig* font_config, float ascent, float descent) IMGUI_NOEXCEPT;
-IMGUI_API void      ImFontAtlasBuildPackCustomRects(ImFontAtlas* atlas, void* stbrp_context_opaque) IMGUI_NOEXCEPT;
-IMGUI_API void      ImFontAtlasBuildFinish(ImFontAtlas* atlas) IMGUI_NOEXCEPT;
-IMGUI_API void      ImFontAtlasBuildRender8bppRectFromString(ImFontAtlas* atlas, int x, int y, int w, int h, const char* in_str, char in_marker_char, unsigned char in_marker_pixel_value) IMGUI_NOEXCEPT;
-IMGUI_API void      ImFontAtlasBuildRender32bppRectFromString(ImFontAtlas* atlas, int x, int y, int w, int h, const char* in_str, char in_marker_char, unsigned int in_marker_pixel_value) IMGUI_NOEXCEPT;
-IMGUI_API void      ImFontAtlasBuildMultiplyCalcLookupTable(unsigned char out_table[256], float in_multiply_factor) IMGUI_NOEXCEPT;
-IMGUI_API void      ImFontAtlasBuildMultiplyRectAlpha8(const unsigned char table[256], unsigned char* pixels, int x, int y, int w, int h, int stride) IMGUI_NOEXCEPT;
+IMGUI_API const ImFontBuilderIO* ImFontAtlasGetBuilderForStbTruetype() IM_NOEXCEPT;
+IMGUI_API void      ImFontAtlasBuildInit(ImFontAtlas* atlas) IM_NOEXCEPT;
+IMGUI_API void      ImFontAtlasBuildSetupFont(ImFontAtlas* atlas, ImFont* font, ImFontConfig* font_config, float ascent, float descent) IM_NOEXCEPT;
+IMGUI_API void      ImFontAtlasBuildPackCustomRects(ImFontAtlas* atlas, void* stbrp_context_opaque) IM_NOEXCEPT;
+IMGUI_API void      ImFontAtlasBuildFinish(ImFontAtlas* atlas) IM_NOEXCEPT;
+IMGUI_API void      ImFontAtlasBuildRender8bppRectFromString(ImFontAtlas* atlas, int x, int y, int w, int h, const char* in_str, char in_marker_char, unsigned char in_marker_pixel_value) IM_NOEXCEPT;
+IMGUI_API void      ImFontAtlasBuildRender32bppRectFromString(ImFontAtlas* atlas, int x, int y, int w, int h, const char* in_str, char in_marker_char, unsigned int in_marker_pixel_value) IM_NOEXCEPT;
+IMGUI_API void      ImFontAtlasBuildMultiplyCalcLookupTable(unsigned char out_table[256], float in_multiply_factor) IM_NOEXCEPT;
+IMGUI_API void      ImFontAtlasBuildMultiplyRectAlpha8(const unsigned char table[256], unsigned char* pixels, int x, int y, int w, int h, int stride) IM_NOEXCEPT;
 
 //-----------------------------------------------------------------------------
 // [SECTION] Test Engine specific hooks (imgui_test_engine)
 //-----------------------------------------------------------------------------
 
 #ifdef IMGUI_ENABLE_TEST_ENGINE
-extern void         ImGuiTestEngineHook_ItemAdd(ImGuiContext* ctx, const ImRect& bb, ImGuiID id) IMGUI_NOEXCEPT;
-extern void         ImGuiTestEngineHook_ItemInfo(ImGuiContext* ctx, ImGuiID id, const char* label, ImGuiItemStatusFlags flags) IMGUI_NOEXCEPT;
-extern void         ImGuiTestEngineHook_IdInfo(ImGuiContext* ctx, ImGuiDataType data_type, ImGuiID id, const void* data_id) IMGUI_NOEXCEPT;
-extern void         ImGuiTestEngineHook_IdInfo(ImGuiContext* ctx, ImGuiDataType data_type, ImGuiID id, const void* data_id, const void* data_id_end) IMGUI_NOEXCEPT;
-extern void         ImGuiTestEngineHook_Log(ImGuiContext* ctx, const char* fmt, ...) IMGUI_NOEXCEPT;
+extern void         ImGuiTestEngineHook_ItemAdd(ImGuiContext* ctx, const ImRect& bb, ImGuiID id) IM_NOEXCEPT;
+extern void         ImGuiTestEngineHook_ItemInfo(ImGuiContext* ctx, ImGuiID id, const char* label, ImGuiItemStatusFlags flags) IM_NOEXCEPT;
+extern void         ImGuiTestEngineHook_IdInfo(ImGuiContext* ctx, ImGuiDataType data_type, ImGuiID id, const void* data_id) IM_NOEXCEPT;
+extern void         ImGuiTestEngineHook_IdInfo(ImGuiContext* ctx, ImGuiDataType data_type, ImGuiID id, const void* data_id, const void* data_id_end) IM_NOEXCEPT;
+extern void         ImGuiTestEngineHook_Log(ImGuiContext* ctx, const char* fmt, ...) IM_NOEXCEPT;
 #define IMGUI_TEST_ENGINE_ITEM_ADD(_BB,_ID)                 if (g.TestEngineHookItems) ImGuiTestEngineHook_ItemAdd(&g, _BB, _ID)               // Register item bounding box
 #define IMGUI_TEST_ENGINE_ITEM_INFO(_ID,_LABEL,_FLAGS)      if (g.TestEngineHookItems) ImGuiTestEngineHook_ItemInfo(&g, _ID, _LABEL, _FLAGS)   // Register item label and status flags (optional)
 #define IMGUI_TEST_ENGINE_LOG(_FMT,...)                     if (g.TestEngineHookItems) ImGuiTestEngineHook_Log(&g, _FMT, __VA_ARGS__)          // Custom log entry from user land into test log

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -282,73 +282,73 @@ namespace ImStb
 //-----------------------------------------------------------------------------
 
 // Helpers: Hashing
-IMGUI_API ImGuiID       ImHashData(const void* data, size_t data_size, ImU32 seed = 0);
-IMGUI_API ImGuiID       ImHashStr(const char* data, size_t data_size = 0, ImU32 seed = 0);
+IMGUI_API ImGuiID       ImHashData(const void* data, size_t data_size, ImU32 seed = 0)    IMGUI_NOEXCEPT;
+IMGUI_API ImGuiID       ImHashStr(const char* data, size_t data_size = 0, ImU32 seed = 0) IMGUI_NOEXCEPT;
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
-static inline ImGuiID   ImHash(const void* data, int size, ImU32 seed = 0) { return size ? ImHashData(data, (size_t)size, seed) : ImHashStr((const char*)data, 0, seed); } // [moved to ImHashStr/ImHashData in 1.68]
+static inline ImGuiID   ImHash(const void* data, int size, ImU32 seed = 0) IMGUI_NOEXCEPT { return size ? ImHashData(data, (size_t)size, seed) : ImHashStr((const char*)data, 0, seed); } // [moved to ImHashStr/ImHashData in 1.68]
 #endif
 
 // Helpers: Sorting
 #define ImQsort         qsort
 
 // Helpers: Color Blending
-IMGUI_API ImU32         ImAlphaBlendColors(ImU32 col_a, ImU32 col_b);
+IMGUI_API ImU32         ImAlphaBlendColors(ImU32 col_a, ImU32 col_b) IMGUI_NOEXCEPT;
 
 // Helpers: Bit manipulation
-static inline bool      ImIsPowerOfTwo(int v)           { return v != 0 && (v & (v - 1)) == 0; }
-static inline bool      ImIsPowerOfTwo(ImU64 v)         { return v != 0 && (v & (v - 1)) == 0; }
-static inline int       ImUpperPowerOfTwo(int v)        { v--; v |= v >> 1; v |= v >> 2; v |= v >> 4; v |= v >> 8; v |= v >> 16; v++; return v; }
+static inline bool      ImIsPowerOfTwo(int v)    IMGUI_NOEXCEPT        { return v != 0 && (v & (v - 1)) == 0; }
+static inline bool      ImIsPowerOfTwo(ImU64 v)  IMGUI_NOEXCEPT        { return v != 0 && (v & (v - 1)) == 0; }
+static inline int       ImUpperPowerOfTwo(int v) IMGUI_NOEXCEPT        { v--; v |= v >> 1; v |= v >> 2; v |= v >> 4; v |= v >> 8; v |= v >> 16; v++; return v; }
 
 // Helpers: String, Formatting
-IMGUI_API int           ImStricmp(const char* str1, const char* str2);
-IMGUI_API int           ImStrnicmp(const char* str1, const char* str2, size_t count);
-IMGUI_API void          ImStrncpy(char* dst, const char* src, size_t count);
-IMGUI_API char*         ImStrdup(const char* str);
-IMGUI_API char*         ImStrdupcpy(char* dst, size_t* p_dst_size, const char* str);
-IMGUI_API const char*   ImStrchrRange(const char* str_begin, const char* str_end, char c);
-IMGUI_API int           ImStrlenW(const ImWchar* str);
-IMGUI_API const char*   ImStreolRange(const char* str, const char* str_end);                // End end-of-line
-IMGUI_API const ImWchar*ImStrbolW(const ImWchar* buf_mid_line, const ImWchar* buf_begin);   // Find beginning-of-line
-IMGUI_API const char*   ImStristr(const char* haystack, const char* haystack_end, const char* needle, const char* needle_end);
-IMGUI_API void          ImStrTrimBlanks(char* str);
-IMGUI_API const char*   ImStrSkipBlank(const char* str);
-IMGUI_API int           ImFormatString(char* buf, size_t buf_size, const char* fmt, ...) IM_FMTARGS(3);
-IMGUI_API int           ImFormatStringV(char* buf, size_t buf_size, const char* fmt, va_list args) IM_FMTLIST(3);
-IMGUI_API const char*   ImParseFormatFindStart(const char* format);
-IMGUI_API const char*   ImParseFormatFindEnd(const char* format);
-IMGUI_API const char*   ImParseFormatTrimDecorations(const char* format, char* buf, size_t buf_size);
-IMGUI_API int           ImParseFormatPrecision(const char* format, int default_value);
-static inline bool      ImCharIsBlankA(char c)          { return c == ' ' || c == '\t'; }
-static inline bool      ImCharIsBlankW(unsigned int c)  { return c == ' ' || c == '\t' || c == 0x3000; }
+IMGUI_API int           ImStricmp(const char* str1, const char* str2) IMGUI_NOEXCEPT;
+IMGUI_API int           ImStrnicmp(const char* str1, const char* str2, size_t count) IMGUI_NOEXCEPT;
+IMGUI_API void          ImStrncpy(char* dst, const char* src, size_t count) IMGUI_NOEXCEPT;
+IMGUI_API char*         ImStrdup(const char* str) IMGUI_NOEXCEPT;
+IMGUI_API char*         ImStrdupcpy(char* dst, size_t* p_dst_size, const char* str) IMGUI_NOEXCEPT;
+IMGUI_API const char*   ImStrchrRange(const char* str_begin, const char* str_end, char c) IMGUI_NOEXCEPT;
+IMGUI_API int           ImStrlenW(const ImWchar* str) IMGUI_NOEXCEPT;
+IMGUI_API const char*   ImStreolRange(const char* str, const char* str_end) IMGUI_NOEXCEPT;                // End end-of-line
+IMGUI_API const ImWchar*ImStrbolW(const ImWchar* buf_mid_line, const ImWchar* buf_begin) IMGUI_NOEXCEPT;   // Find beginning-of-line
+IMGUI_API const char*   ImStristr(const char* haystack, const char* haystack_end, const char* needle, const char* needle_end) IMGUI_NOEXCEPT;
+IMGUI_API void          ImStrTrimBlanks(char* str) IMGUI_NOEXCEPT;
+IMGUI_API const char*   ImStrSkipBlank(const char* str) IMGUI_NOEXCEPT;
+IMGUI_API int           ImFormatString(char* buf, size_t buf_size, const char* fmt, ...) IM_FMTARGS(3) IMGUI_NOEXCEPT;
+IMGUI_API int           ImFormatStringV(char* buf, size_t buf_size, const char* fmt, va_list args) IM_FMTLIST(3) IMGUI_NOEXCEPT;
+IMGUI_API const char*   ImParseFormatFindStart(const char* format) IMGUI_NOEXCEPT;
+IMGUI_API const char*   ImParseFormatFindEnd(const char* format) IMGUI_NOEXCEPT;
+IMGUI_API const char*   ImParseFormatTrimDecorations(const char* format, char* buf, size_t buf_size) IMGUI_NOEXCEPT;
+IMGUI_API int           ImParseFormatPrecision(const char* format, int default_value) IMGUI_NOEXCEPT;
+static inline bool      ImCharIsBlankA(char c)         IMGUI_NOEXCEPT  { return c == ' ' || c == '\t'; }
+static inline bool      ImCharIsBlankW(unsigned int c) IMGUI_NOEXCEPT  { return c == ' ' || c == '\t' || c == 0x3000; }
 
 // Helpers: UTF-8 <> wchar conversions
-IMGUI_API int           ImTextStrToUtf8(char* buf, int buf_size, const ImWchar* in_text, const ImWchar* in_text_end);      // return output UTF-8 bytes count
-IMGUI_API int           ImTextCharFromUtf8(unsigned int* out_char, const char* in_text, const char* in_text_end);          // read one character. return input UTF-8 bytes count
-IMGUI_API int           ImTextStrFromUtf8(ImWchar* buf, int buf_size, const char* in_text, const char* in_text_end, const char** in_remaining = NULL);   // return input UTF-8 bytes count
-IMGUI_API int           ImTextCountCharsFromUtf8(const char* in_text, const char* in_text_end);                            // return number of UTF-8 code-points (NOT bytes count)
-IMGUI_API int           ImTextCountUtf8BytesFromChar(const char* in_text, const char* in_text_end);                        // return number of bytes to express one char in UTF-8
-IMGUI_API int           ImTextCountUtf8BytesFromStr(const ImWchar* in_text, const ImWchar* in_text_end);                   // return number of bytes to express string in UTF-8
+IMGUI_API int           ImTextStrToUtf8(char* buf, int buf_size, const ImWchar* in_text, const ImWchar* in_text_end) IMGUI_NOEXCEPT;      // return output UTF-8 bytes count
+IMGUI_API int           ImTextCharFromUtf8(unsigned int* out_char, const char* in_text, const char* in_text_end) IMGUI_NOEXCEPT;          // read one character. return input UTF-8 bytes count
+IMGUI_API int           ImTextStrFromUtf8(ImWchar* buf, int buf_size, const char* in_text, const char* in_text_end, const char** in_remaining = NULL) IMGUI_NOEXCEPT;   // return input UTF-8 bytes count
+IMGUI_API int           ImTextCountCharsFromUtf8(const char* in_text, const char* in_text_end) IMGUI_NOEXCEPT;                            // return number of UTF-8 code-points (NOT bytes count)
+IMGUI_API int           ImTextCountUtf8BytesFromChar(const char* in_text, const char* in_text_end) IMGUI_NOEXCEPT;                        // return number of bytes to express one char in UTF-8
+IMGUI_API int           ImTextCountUtf8BytesFromStr(const ImWchar* in_text, const ImWchar* in_text_end) IMGUI_NOEXCEPT;                   // return number of bytes to express string in UTF-8
 
 // Helpers: ImVec2/ImVec4 operators
 // We are keeping those disabled by default so they don't leak in user space, to allow user enabling implicit cast operators between ImVec2 and their own types (using IM_VEC2_CLASS_EXTRA etc.)
 // We unfortunately don't have a unary- operator for ImVec2 because this would needs to be defined inside the class itself.
 #ifdef IMGUI_DEFINE_MATH_OPERATORS
 IM_MSVC_RUNTIME_CHECKS_OFF
-static inline ImVec2 operator*(const ImVec2& lhs, const float rhs)              { return ImVec2(lhs.x * rhs, lhs.y * rhs); }
-static inline ImVec2 operator/(const ImVec2& lhs, const float rhs)              { return ImVec2(lhs.x / rhs, lhs.y / rhs); }
-static inline ImVec2 operator+(const ImVec2& lhs, const ImVec2& rhs)            { return ImVec2(lhs.x + rhs.x, lhs.y + rhs.y); }
-static inline ImVec2 operator-(const ImVec2& lhs, const ImVec2& rhs)            { return ImVec2(lhs.x - rhs.x, lhs.y - rhs.y); }
-static inline ImVec2 operator*(const ImVec2& lhs, const ImVec2& rhs)            { return ImVec2(lhs.x * rhs.x, lhs.y * rhs.y); }
-static inline ImVec2 operator/(const ImVec2& lhs, const ImVec2& rhs)            { return ImVec2(lhs.x / rhs.x, lhs.y / rhs.y); }
-static inline ImVec2& operator*=(ImVec2& lhs, const float rhs)                  { lhs.x *= rhs; lhs.y *= rhs; return lhs; }
-static inline ImVec2& operator/=(ImVec2& lhs, const float rhs)                  { lhs.x /= rhs; lhs.y /= rhs; return lhs; }
-static inline ImVec2& operator+=(ImVec2& lhs, const ImVec2& rhs)                { lhs.x += rhs.x; lhs.y += rhs.y; return lhs; }
-static inline ImVec2& operator-=(ImVec2& lhs, const ImVec2& rhs)                { lhs.x -= rhs.x; lhs.y -= rhs.y; return lhs; }
-static inline ImVec2& operator*=(ImVec2& lhs, const ImVec2& rhs)                { lhs.x *= rhs.x; lhs.y *= rhs.y; return lhs; }
-static inline ImVec2& operator/=(ImVec2& lhs, const ImVec2& rhs)                { lhs.x /= rhs.x; lhs.y /= rhs.y; return lhs; }
-static inline ImVec4 operator+(const ImVec4& lhs, const ImVec4& rhs)            { return ImVec4(lhs.x + rhs.x, lhs.y + rhs.y, lhs.z + rhs.z, lhs.w + rhs.w); }
-static inline ImVec4 operator-(const ImVec4& lhs, const ImVec4& rhs)            { return ImVec4(lhs.x - rhs.x, lhs.y - rhs.y, lhs.z - rhs.z, lhs.w - rhs.w); }
-static inline ImVec4 operator*(const ImVec4& lhs, const ImVec4& rhs)            { return ImVec4(lhs.x * rhs.x, lhs.y * rhs.y, lhs.z * rhs.z, lhs.w * rhs.w); }
+static inline ImVec2 operator*(const ImVec2& lhs, const float rhs)   IMGUI_NOEXCEPT            { return ImVec2(lhs.x * rhs, lhs.y * rhs); }
+static inline ImVec2 operator/(const ImVec2& lhs, const float rhs)   IMGUI_NOEXCEPT            { return ImVec2(lhs.x / rhs, lhs.y / rhs); }
+static inline ImVec2 operator+(const ImVec2& lhs, const ImVec2& rhs) IMGUI_NOEXCEPT            { return ImVec2(lhs.x + rhs.x, lhs.y + rhs.y); }
+static inline ImVec2 operator-(const ImVec2& lhs, const ImVec2& rhs) IMGUI_NOEXCEPT            { return ImVec2(lhs.x - rhs.x, lhs.y - rhs.y); }
+static inline ImVec2 operator*(const ImVec2& lhs, const ImVec2& rhs) IMGUI_NOEXCEPT            { return ImVec2(lhs.x * rhs.x, lhs.y * rhs.y); }
+static inline ImVec2 operator/(const ImVec2& lhs, const ImVec2& rhs) IMGUI_NOEXCEPT            { return ImVec2(lhs.x / rhs.x, lhs.y / rhs.y); }
+static inline ImVec2& operator*=(ImVec2& lhs, const float rhs)       IMGUI_NOEXCEPT            { lhs.x *= rhs; lhs.y *= rhs; return lhs; }
+static inline ImVec2& operator/=(ImVec2& lhs, const float rhs)       IMGUI_NOEXCEPT            { lhs.x /= rhs; lhs.y /= rhs; return lhs; }
+static inline ImVec2& operator+=(ImVec2& lhs, const ImVec2& rhs)     IMGUI_NOEXCEPT            { lhs.x += rhs.x; lhs.y += rhs.y; return lhs; }
+static inline ImVec2& operator-=(ImVec2& lhs, const ImVec2& rhs)     IMGUI_NOEXCEPT            { lhs.x -= rhs.x; lhs.y -= rhs.y; return lhs; }
+static inline ImVec2& operator*=(ImVec2& lhs, const ImVec2& rhs)     IMGUI_NOEXCEPT            { lhs.x *= rhs.x; lhs.y *= rhs.y; return lhs; }
+static inline ImVec2& operator/=(ImVec2& lhs, const ImVec2& rhs)     IMGUI_NOEXCEPT            { lhs.x /= rhs.x; lhs.y /= rhs.y; return lhs; }
+static inline ImVec4 operator+(const ImVec4& lhs, const ImVec4& rhs) IMGUI_NOEXCEPT            { return ImVec4(lhs.x + rhs.x, lhs.y + rhs.y, lhs.z + rhs.z, lhs.w + rhs.w); }
+static inline ImVec4 operator-(const ImVec4& lhs, const ImVec4& rhs) IMGUI_NOEXCEPT            { return ImVec4(lhs.x - rhs.x, lhs.y - rhs.y, lhs.z - rhs.z, lhs.w - rhs.w); }
+static inline ImVec4 operator*(const ImVec4& lhs, const ImVec4& rhs) IMGUI_NOEXCEPT            { return ImVec4(lhs.x * rhs.x, lhs.y * rhs.y, lhs.z * rhs.z, lhs.w * rhs.w); }
 IM_MSVC_RUNTIME_CHECKS_RESTORE
 #endif
 
@@ -356,23 +356,23 @@ IM_MSVC_RUNTIME_CHECKS_RESTORE
 #ifdef IMGUI_DISABLE_FILE_FUNCTIONS
 #define IMGUI_DISABLE_DEFAULT_FILE_FUNCTIONS
 typedef void* ImFileHandle;
-static inline ImFileHandle  ImFileOpen(const char*, const char*)                    { return NULL; }
-static inline bool          ImFileClose(ImFileHandle)                               { return false; }
-static inline ImU64         ImFileGetSize(ImFileHandle)                             { return (ImU64)-1; }
-static inline ImU64         ImFileRead(void*, ImU64, ImU64, ImFileHandle)           { return 0; }
-static inline ImU64         ImFileWrite(const void*, ImU64, ImU64, ImFileHandle)    { return 0; }
+static inline ImFileHandle  ImFileOpen(const char*, const char*)                 IMGUI_NOEXCEPT    { return NULL; }
+static inline bool          ImFileClose(ImFileHandle)                            IMGUI_NOEXCEPT    { return false; }
+static inline ImU64         ImFileGetSize(ImFileHandle)                          IMGUI_NOEXCEPT    { return (ImU64)-1; }
+static inline ImU64         ImFileRead(void*, ImU64, ImU64, ImFileHandle)        IMGUI_NOEXCEPT    { return 0; }
+static inline ImU64         ImFileWrite(const void*, ImU64, ImU64, ImFileHandle) IMGUI_NOEXCEPT    { return 0; }
 #endif
 #ifndef IMGUI_DISABLE_DEFAULT_FILE_FUNCTIONS
 typedef FILE* ImFileHandle;
-IMGUI_API ImFileHandle      ImFileOpen(const char* filename, const char* mode);
-IMGUI_API bool              ImFileClose(ImFileHandle file);
-IMGUI_API ImU64             ImFileGetSize(ImFileHandle file);
-IMGUI_API ImU64             ImFileRead(void* data, ImU64 size, ImU64 count, ImFileHandle file);
-IMGUI_API ImU64             ImFileWrite(const void* data, ImU64 size, ImU64 count, ImFileHandle file);
+IMGUI_API ImFileHandle      ImFileOpen(const char* filename, const char* mode) IMGUI_NOEXCEPT;
+IMGUI_API bool              ImFileClose(ImFileHandle file) IMGUI_NOEXCEPT;
+IMGUI_API ImU64             ImFileGetSize(ImFileHandle file) IMGUI_NOEXCEPT;
+IMGUI_API ImU64             ImFileRead(void* data, ImU64 size, ImU64 count, ImFileHandle file) IMGUI_NOEXCEPT;
+IMGUI_API ImU64             ImFileWrite(const void* data, ImU64 size, ImU64 count, ImFileHandle file) IMGUI_NOEXCEPT;
 #else
 #define IMGUI_DISABLE_TTY_FUNCTIONS // Can't use stdout, fflush if we are not using default file functions
 #endif
-IMGUI_API void*             ImFileLoadToMemory(const char* filename, const char* mode, size_t* out_file_size = NULL, int padding_bytes = 0);
+IMGUI_API void*             ImFileLoadToMemory(const char* filename, const char* mode, size_t* out_file_size = NULL, int padding_bytes = 0) IMGUI_NOEXCEPT;
 
 // Helpers: Maths
 IM_MSVC_RUNTIME_CHECKS_OFF
@@ -388,63 +388,63 @@ IM_MSVC_RUNTIME_CHECKS_OFF
 #define ImAtof(STR)         atof(STR)
 //#define ImFloorStd(X)     floorf(X)           // We use our own, see ImFloor() and ImFloorSigned()
 #define ImCeil(X)           ceilf(X)
-static inline float  ImPow(float x, float y)    { return powf(x, y); }          // DragBehaviorT/SliderBehaviorT uses ImPow with either float/double and need the precision
-static inline double ImPow(double x, double y)  { return pow(x, y); }
-static inline float  ImLog(float x)             { return logf(x); }             // DragBehaviorT/SliderBehaviorT uses ImLog with either float/double and need the precision
-static inline double ImLog(double x)            { return log(x); }
-static inline int    ImAbs(int x)               { return x < 0 ? -x : x; }
-static inline float  ImAbs(float x)             { return fabsf(x); }
-static inline double ImAbs(double x)            { return fabs(x); }
-static inline float  ImSign(float x)            { return (x < 0.0f) ? -1.0f : ((x > 0.0f) ? 1.0f : 0.0f); } // Sign operator - returns -1, 0 or 1 based on sign of argument
-static inline double ImSign(double x)           { return (x < 0.0) ? -1.0 : ((x > 0.0) ? 1.0 : 0.0); }
+static inline float  ImPow(float x, float y)   IMGUI_NOEXCEPT  { return powf(x, y); }          // DragBehaviorT/SliderBehaviorT uses ImPow with either float/double and need the precision
+static inline double ImPow(double x, double y) IMGUI_NOEXCEPT  { return pow(x, y); }
+static inline float  ImLog(float x)            IMGUI_NOEXCEPT  { return logf(x); }             // DragBehaviorT/SliderBehaviorT uses ImLog with either float/double and need the precision
+static inline double ImLog(double x)           IMGUI_NOEXCEPT  { return log(x); }
+static inline int    ImAbs(int x)              IMGUI_NOEXCEPT  { return x < 0 ? -x : x; }
+static inline float  ImAbs(float x)            IMGUI_NOEXCEPT  { return fabsf(x); }
+static inline double ImAbs(double x)           IMGUI_NOEXCEPT  { return fabs(x); }
+static inline float  ImSign(float x)           IMGUI_NOEXCEPT  { return (x < 0.0f) ? -1.0f : ((x > 0.0f) ? 1.0f : 0.0f); } // Sign operator - returns -1, 0 or 1 based on sign of argument
+static inline double ImSign(double x)          IMGUI_NOEXCEPT  { return (x < 0.0) ? -1.0 : ((x > 0.0) ? 1.0 : 0.0); }
 #ifdef IMGUI_ENABLE_SSE
-static inline float  ImRsqrt(float x)           { return _mm_cvtss_f32(_mm_rsqrt_ss(_mm_set_ss(x))); }
+static inline float  ImRsqrt(float x)          IMGUI_NOEXCEPT  { return _mm_cvtss_f32(_mm_rsqrt_ss(_mm_set_ss(x))); }
 #else
-static inline float  ImRsqrt(float x)           { return 1.0f / sqrtf(x); }
+static inline float  ImRsqrt(float x)          IMGUI_NOEXCEPT  { return 1.0f / sqrtf(x); }
 #endif
-static inline double ImRsqrt(double x)          { return 1.0 / sqrt(x); }
+static inline double ImRsqrt(double x)         IMGUI_NOEXCEPT  { return 1.0 / sqrt(x); }
 #endif
 // - ImMin/ImMax/ImClamp/ImLerp/ImSwap are used by widgets which support variety of types: signed/unsigned int/long long float/double
 // (Exceptionally using templates here but we could also redefine them for those types)
-template<typename T> static inline T ImMin(T lhs, T rhs)                        { return lhs < rhs ? lhs : rhs; }
-template<typename T> static inline T ImMax(T lhs, T rhs)                        { return lhs >= rhs ? lhs : rhs; }
-template<typename T> static inline T ImClamp(T v, T mn, T mx)                   { return (v < mn) ? mn : (v > mx) ? mx : v; }
-template<typename T> static inline T ImLerp(T a, T b, float t)                  { return (T)(a + (b - a) * t); }
-template<typename T> static inline void ImSwap(T& a, T& b)                      { T tmp = a; a = b; b = tmp; }
-template<typename T> static inline T ImAddClampOverflow(T a, T b, T mn, T mx)   { if (b < 0 && (a < mn - b)) return mn; if (b > 0 && (a > mx - b)) return mx; return a + b; }
-template<typename T> static inline T ImSubClampOverflow(T a, T b, T mn, T mx)   { if (b > 0 && (a < mn + b)) return mn; if (b < 0 && (a > mx + b)) return mx; return a - b; }
-// - Misc maths helpers
-static inline ImVec2 ImMin(const ImVec2& lhs, const ImVec2& rhs)                { return ImVec2(lhs.x < rhs.x ? lhs.x : rhs.x, lhs.y < rhs.y ? lhs.y : rhs.y); }
-static inline ImVec2 ImMax(const ImVec2& lhs, const ImVec2& rhs)                { return ImVec2(lhs.x >= rhs.x ? lhs.x : rhs.x, lhs.y >= rhs.y ? lhs.y : rhs.y); }
-static inline ImVec2 ImClamp(const ImVec2& v, const ImVec2& mn, ImVec2 mx)      { return ImVec2((v.x < mn.x) ? mn.x : (v.x > mx.x) ? mx.x : v.x, (v.y < mn.y) ? mn.y : (v.y > mx.y) ? mx.y : v.y); }
-static inline ImVec2 ImLerp(const ImVec2& a, const ImVec2& b, float t)          { return ImVec2(a.x + (b.x - a.x) * t, a.y + (b.y - a.y) * t); }
-static inline ImVec2 ImLerp(const ImVec2& a, const ImVec2& b, const ImVec2& t)  { return ImVec2(a.x + (b.x - a.x) * t.x, a.y + (b.y - a.y) * t.y); }
-static inline ImVec4 ImLerp(const ImVec4& a, const ImVec4& b, float t)          { return ImVec4(a.x + (b.x - a.x) * t, a.y + (b.y - a.y) * t, a.z + (b.z - a.z) * t, a.w + (b.w - a.w) * t); }
-static inline float  ImSaturate(float f)                                        { return (f < 0.0f) ? 0.0f : (f > 1.0f) ? 1.0f : f; }
-static inline float  ImLengthSqr(const ImVec2& lhs)                             { return (lhs.x * lhs.x) + (lhs.y * lhs.y); }
-static inline float  ImLengthSqr(const ImVec4& lhs)                             { return (lhs.x * lhs.x) + (lhs.y * lhs.y) + (lhs.z * lhs.z) + (lhs.w * lhs.w); }
-static inline float  ImInvLength(const ImVec2& lhs, float fail_value)           { float d = (lhs.x * lhs.x) + (lhs.y * lhs.y); if (d > 0.0f) return ImRsqrt(d); return fail_value; }
-static inline float  ImFloor(float f)                                           { return (float)(int)(f); }
-static inline float  ImFloorSigned(float f)                                     { return (float)((f >= 0 || (int)f == f) ? (int)f : (int)f - 1); } // Decent replacement for floorf()
-static inline ImVec2 ImFloor(const ImVec2& v)                                   { return ImVec2((float)(int)(v.x), (float)(int)(v.y)); }
-static inline int    ImModPositive(int a, int b)                                { return (a + b) % b; }
-static inline float  ImDot(const ImVec2& a, const ImVec2& b)                    { return a.x * b.x + a.y * b.y; }
-static inline ImVec2 ImRotate(const ImVec2& v, float cos_a, float sin_a)        { return ImVec2(v.x * cos_a - v.y * sin_a, v.x * sin_a + v.y * cos_a); }
-static inline float  ImLinearSweep(float current, float target, float speed)    { if (current < target) return ImMin(current + speed, target); if (current > target) return ImMax(current - speed, target); return current; }
-static inline ImVec2 ImMul(const ImVec2& lhs, const ImVec2& rhs)                { return ImVec2(lhs.x * rhs.x, lhs.y * rhs.y); }
+template<typename T> static inline T ImMin(T lhs, T rhs)                      IMGUI_NOEXCEPT   { return lhs < rhs ? lhs : rhs; }
+template<typename T> static inline T ImMax(T lhs, T rhs)                      IMGUI_NOEXCEPT   { return lhs >= rhs ? lhs : rhs; }
+template<typename T> static inline T ImClamp(T v, T mn, T mx)                 IMGUI_NOEXCEPT   { return (v < mn) ? mn : (v > mx) ? mx : v; }
+template<typename T> static inline T ImLerp(T a, T b, float t)                IMGUI_NOEXCEPT   { return (T)(a + (b - a) * t); }
+template<typename T> static inline void ImSwap(T& a, T& b)                    IMGUI_NOEXCEPT   { T tmp = a; a = b; b = tmp; }
+template<typename T> static inline T ImAddClampOverflow(T a, T b, T mn, T mx) IMGUI_NOEXCEPT   { if (b < 0 && (a < mn - b)) return mn; if (b > 0 && (a > mx - b)) return mx; return a + b; }
+template<typename T> static inline T ImSubClampOverflow(T a, T b, T mn, T mx) IMGUI_NOEXCEPT   { if (b > 0 && (a < mn + b)) return mn; if (b < 0 && (a > mx + b)) return mx; return a - b; }
+// - Misc IMGUI_NOEXCEPT maths helpers
+static inline ImVec2 ImMin(const ImVec2& lhs, const ImVec2& rhs)               IMGUI_NOEXCEPT  { return ImVec2(lhs.x < rhs.x ? lhs.x : rhs.x, lhs.y < rhs.y ? lhs.y : rhs.y); }
+static inline ImVec2 ImMax(const ImVec2& lhs, const ImVec2& rhs)               IMGUI_NOEXCEPT  { return ImVec2(lhs.x >= rhs.x ? lhs.x : rhs.x, lhs.y >= rhs.y ? lhs.y : rhs.y); }
+static inline ImVec2 ImClamp(const ImVec2& v, const ImVec2& mn, ImVec2 mx)     IMGUI_NOEXCEPT  { return ImVec2((v.x < mn.x) ? mn.x : (v.x > mx.x) ? mx.x : v.x, (v.y < mn.y) ? mn.y : (v.y > mx.y) ? mx.y : v.y); }
+static inline ImVec2 ImLerp(const ImVec2& a, const ImVec2& b, float t)         IMGUI_NOEXCEPT  { return ImVec2(a.x + (b.x - a.x) * t, a.y + (b.y - a.y) * t); }
+static inline ImVec2 ImLerp(const ImVec2& a, const ImVec2& b, const ImVec2& t) IMGUI_NOEXCEPT  { return ImVec2(a.x + (b.x - a.x) * t.x, a.y + (b.y - a.y) * t.y); }
+static inline ImVec4 ImLerp(const ImVec4& a, const ImVec4& b, float t)         IMGUI_NOEXCEPT  { return ImVec4(a.x + (b.x - a.x) * t, a.y + (b.y - a.y) * t, a.z + (b.z - a.z) * t, a.w + (b.w - a.w) * t); }
+static inline float  ImSaturate(float f)                                       IMGUI_NOEXCEPT  { return (f < 0.0f) ? 0.0f : (f > 1.0f) ? 1.0f : f; }
+static inline float  ImLengthSqr(const ImVec2& lhs)                            IMGUI_NOEXCEPT  { return (lhs.x * lhs.x) + (lhs.y * lhs.y); }
+static inline float  ImLengthSqr(const ImVec4& lhs)                            IMGUI_NOEXCEPT  { return (lhs.x * lhs.x) + (lhs.y * lhs.y) + (lhs.z * lhs.z) + (lhs.w * lhs.w); }
+static inline float  ImInvLength(const ImVec2& lhs, float fail_value)          IMGUI_NOEXCEPT  { float d = (lhs.x * lhs.x) + (lhs.y * lhs.y); if (d > 0.0f) return ImRsqrt(d); return fail_value; }
+static inline float  ImFloor(float f)                                          IMGUI_NOEXCEPT  { return (float)(int)(f); }
+static inline float  ImFloorSigned(float f)                                    IMGUI_NOEXCEPT  { return (float)((f >= 0 || (int)f == f) ? (int)f : (int)f - 1); } // Decent replacement for floorf()
+static inline ImVec2 ImFloor(const ImVec2& v)                                  IMGUI_NOEXCEPT  { return ImVec2((float)(int)(v.x), (float)(int)(v.y)); }
+static inline int    ImModPositive(int a, int b)                               IMGUI_NOEXCEPT  { return (a + b) % b; }
+static inline float  ImDot(const ImVec2& a, const ImVec2& b)                   IMGUI_NOEXCEPT  { return a.x * b.x + a.y * b.y; }
+static inline ImVec2 ImRotate(const ImVec2& v, float cos_a, float sin_a)       IMGUI_NOEXCEPT  { return ImVec2(v.x * cos_a - v.y * sin_a, v.x * sin_a + v.y * cos_a); }
+static inline float  ImLinearSweep(float current, float target, float speed)   IMGUI_NOEXCEPT  { if (current < target) return ImMin(current + speed, target); if (current > target) return ImMax(current - speed, target); return current; }
+static inline ImVec2 ImMul(const ImVec2& lhs, const ImVec2& rhs)               IMGUI_NOEXCEPT  { return ImVec2(lhs.x * rhs.x, lhs.y * rhs.y); }
 IM_MSVC_RUNTIME_CHECKS_RESTORE
 
 // Helpers: Geometry
-IMGUI_API ImVec2     ImBezierCubicCalc(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, float t);
-IMGUI_API ImVec2     ImBezierCubicClosestPoint(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, const ImVec2& p, int num_segments);       // For curves with explicit number of segments
-IMGUI_API ImVec2     ImBezierCubicClosestPointCasteljau(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, const ImVec2& p, float tess_tol);// For auto-tessellated curves you can use tess_tol = style.CurveTessellationTol
-IMGUI_API ImVec2     ImBezierQuadraticCalc(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, float t);
-IMGUI_API ImVec2     ImLineClosestPoint(const ImVec2& a, const ImVec2& b, const ImVec2& p);
-IMGUI_API bool       ImTriangleContainsPoint(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& p);
-IMGUI_API ImVec2     ImTriangleClosestPoint(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& p);
-IMGUI_API void       ImTriangleBarycentricCoords(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& p, float& out_u, float& out_v, float& out_w);
-inline float         ImTriangleArea(const ImVec2& a, const ImVec2& b, const ImVec2& c) { return ImFabs((a.x * (b.y - c.y)) + (b.x * (c.y - a.y)) + (c.x * (a.y - b.y))) * 0.5f; }
-IMGUI_API ImGuiDir   ImGetDirQuadrantFromDelta(float dx, float dy);
+IMGUI_API ImVec2     ImBezierCubicCalc(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, float t) IMGUI_NOEXCEPT;
+IMGUI_API ImVec2     ImBezierCubicClosestPoint(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, const ImVec2& p, int num_segments) IMGUI_NOEXCEPT;       // For curves with explicit number of segments
+IMGUI_API ImVec2     ImBezierCubicClosestPointCasteljau(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, const ImVec2& p, float tess_tol) IMGUI_NOEXCEPT;// For auto-tessellated curves you can use tess_tol = style.CurveTessellationTol
+IMGUI_API ImVec2     ImBezierQuadraticCalc(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, float t) IMGUI_NOEXCEPT;
+IMGUI_API ImVec2     ImLineClosestPoint(const ImVec2& a, const ImVec2& b, const ImVec2& p) IMGUI_NOEXCEPT;
+IMGUI_API bool       ImTriangleContainsPoint(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& p) IMGUI_NOEXCEPT;
+IMGUI_API ImVec2     ImTriangleClosestPoint(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& p) IMGUI_NOEXCEPT;
+IMGUI_API void       ImTriangleBarycentricCoords(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& p, float& out_u, float& out_v, float& out_w) IMGUI_NOEXCEPT;
+inline float         ImTriangleArea(const ImVec2& a, const ImVec2& b, const ImVec2& c) IMGUI_NOEXCEPT { return ImFabs((a.x * (b.y - c.y)) + (b.x * (c.y - a.y)) + (c.x * (a.y - b.y))) * 0.5f; }
+IMGUI_API ImGuiDir   ImGetDirQuadrantFromDelta(float dx, float dy) IMGUI_NOEXCEPT;
 
 // Helper: ImVec1 (1D vector)
 // (this odd construct is used to facilitate the transition between 1D and 2D, and the maintenance of some branches/patches)
@@ -452,17 +452,17 @@ IM_MSVC_RUNTIME_CHECKS_OFF
 struct ImVec1
 {
     float   x;
-    ImVec1()         { x = 0.0f; }
-    ImVec1(float _x) { x = _x; }
+    ImVec1()         IMGUI_NOEXCEPT { x = 0.0f; }
+    ImVec1(float _x) IMGUI_NOEXCEPT { x = _x; }
 };
 
 // Helper: ImVec2ih (2D vector, half-size integer, for long-term packed storage)
 struct ImVec2ih
 {
     short   x, y;
-    ImVec2ih()                           { x = y = 0; }
-    ImVec2ih(short _x, short _y)         { x = _x; y = _y; }
-    explicit ImVec2ih(const ImVec2& rhs) { x = (short)rhs.x; y = (short)rhs.y; }
+    ImVec2ih()                           IMGUI_NOEXCEPT { x = y = 0; }
+    ImVec2ih(short _x, short _y)         IMGUI_NOEXCEPT { x = _x; y = _y; }
+    explicit ImVec2ih(const ImVec2& rhs) IMGUI_NOEXCEPT { x = (short)rhs.x; y = (short)rhs.y; }
 };
 
 // Helper: ImRect (2D axis aligned bounding-box)
@@ -472,43 +472,43 @@ struct IMGUI_API ImRect
     ImVec2      Min;    // Upper-left
     ImVec2      Max;    // Lower-right
 
-    ImRect()                                        : Min(0.0f, 0.0f), Max(0.0f, 0.0f)  {}
-    ImRect(const ImVec2& min, const ImVec2& max)    : Min(min), Max(max)                {}
-    ImRect(const ImVec4& v)                         : Min(v.x, v.y), Max(v.z, v.w)      {}
-    ImRect(float x1, float y1, float x2, float y2)  : Min(x1, y1), Max(x2, y2)          {}
+    ImRect()                                       IMGUI_NOEXCEPT  : Min(0.0f, 0.0f), Max(0.0f, 0.0f)  {}
+    ImRect(const ImVec2& min, const ImVec2& max)   IMGUI_NOEXCEPT  : Min(min), Max(max)                {}
+    ImRect(const ImVec4& v)                        IMGUI_NOEXCEPT  : Min(v.x, v.y), Max(v.z, v.w)      {}
+    ImRect(float x1, float y1, float x2, float y2) IMGUI_NOEXCEPT  : Min(x1, y1), Max(x2, y2)          {}
 
-    ImVec2      GetCenter() const                   { return ImVec2((Min.x + Max.x) * 0.5f, (Min.y + Max.y) * 0.5f); }
-    ImVec2      GetSize() const                     { return ImVec2(Max.x - Min.x, Max.y - Min.y); }
-    float       GetWidth() const                    { return Max.x - Min.x; }
-    float       GetHeight() const                   { return Max.y - Min.y; }
-    float       GetArea() const                     { return (Max.x - Min.x) * (Max.y - Min.y); }
-    ImVec2      GetTL() const                       { return Min; }                   // Top-left
-    ImVec2      GetTR() const                       { return ImVec2(Max.x, Min.y); }  // Top-right
-    ImVec2      GetBL() const                       { return ImVec2(Min.x, Max.y); }  // Bottom-left
-    ImVec2      GetBR() const                       { return Max; }                   // Bottom-right
-    bool        Contains(const ImVec2& p) const     { return p.x     >= Min.x && p.y     >= Min.y && p.x     <  Max.x && p.y     <  Max.y; }
-    bool        Contains(const ImRect& r) const     { return r.Min.x >= Min.x && r.Min.y >= Min.y && r.Max.x <= Max.x && r.Max.y <= Max.y; }
-    bool        Overlaps(const ImRect& r) const     { return r.Min.y <  Max.y && r.Max.y >  Min.y && r.Min.x <  Max.x && r.Max.x >  Min.x; }
-    void        Add(const ImVec2& p)                { if (Min.x > p.x)     Min.x = p.x;     if (Min.y > p.y)     Min.y = p.y;     if (Max.x < p.x)     Max.x = p.x;     if (Max.y < p.y)     Max.y = p.y; }
-    void        Add(const ImRect& r)                { if (Min.x > r.Min.x) Min.x = r.Min.x; if (Min.y > r.Min.y) Min.y = r.Min.y; if (Max.x < r.Max.x) Max.x = r.Max.x; if (Max.y < r.Max.y) Max.y = r.Max.y; }
-    void        Expand(const float amount)          { Min.x -= amount;   Min.y -= amount;   Max.x += amount;   Max.y += amount; }
-    void        Expand(const ImVec2& amount)        { Min.x -= amount.x; Min.y -= amount.y; Max.x += amount.x; Max.y += amount.y; }
-    void        Translate(const ImVec2& d)          { Min.x += d.x; Min.y += d.y; Max.x += d.x; Max.y += d.y; }
-    void        TranslateX(float dx)                { Min.x += dx; Max.x += dx; }
-    void        TranslateY(float dy)                { Min.y += dy; Max.y += dy; }
-    void        ClipWith(const ImRect& r)           { Min = ImMax(Min, r.Min); Max = ImMin(Max, r.Max); }                   // Simple version, may lead to an inverted rectangle, which is fine for Contains/Overlaps test but not for display.
-    void        ClipWithFull(const ImRect& r)       { Min = ImClamp(Min, r.Min, r.Max); Max = ImClamp(Max, r.Min, r.Max); } // Full version, ensure both points are fully clipped.
-    void        Floor()                             { Min.x = IM_FLOOR(Min.x); Min.y = IM_FLOOR(Min.y); Max.x = IM_FLOOR(Max.x); Max.y = IM_FLOOR(Max.y); }
-    bool        IsInverted() const                  { return Min.x > Max.x || Min.y > Max.y; }
-    ImVec4      ToVec4() const                      { return ImVec4(Min.x, Min.y, Max.x, Max.y); }
+    ImVec2      GetCenter() const                IMGUI_NOEXCEPT    { return ImVec2((Min.x + Max.x) * 0.5f, (Min.y + Max.y) * 0.5f); }
+    ImVec2      GetSize() const                  IMGUI_NOEXCEPT    { return ImVec2(Max.x - Min.x, Max.y - Min.y); }
+    float       GetWidth() const                 IMGUI_NOEXCEPT    { return Max.x - Min.x; }
+    float       GetHeight() const                IMGUI_NOEXCEPT    { return Max.y - Min.y; }
+    float       GetArea() const                  IMGUI_NOEXCEPT    { return (Max.x - Min.x) * (Max.y - Min.y); }
+    ImVec2      GetTL() const                    IMGUI_NOEXCEPT    { return Min; }                   // Top-left
+    ImVec2      GetTR() const                    IMGUI_NOEXCEPT    { return ImVec2(Max.x, Min.y); }  // Top-right
+    ImVec2      GetBL() const                    IMGUI_NOEXCEPT    { return ImVec2(Min.x, Max.y); }  // Bottom-left
+    ImVec2      GetBR() const                    IMGUI_NOEXCEPT    { return Max; }                   // Bottom-right
+    bool        Contains(const ImVec2& p) const  IMGUI_NOEXCEPT    { return p.x     >= Min.x && p.y     >= Min.y && p.x     <  Max.x && p.y     <  Max.y; }
+    bool        Contains(const ImRect& r) const  IMGUI_NOEXCEPT    { return r.Min.x >= Min.x && r.Min.y >= Min.y && r.Max.x <= Max.x && r.Max.y <= Max.y; }
+    bool        Overlaps(const ImRect& r) const  IMGUI_NOEXCEPT    { return r.Min.y <  Max.y && r.Max.y >  Min.y && r.Min.x <  Max.x && r.Max.x >  Min.x; }
+    void        Add(const ImVec2& p)             IMGUI_NOEXCEPT    { if (Min.x > p.x)     Min.x = p.x;     if (Min.y > p.y)     Min.y = p.y;     if (Max.x < p.x)     Max.x = p.x;     if (Max.y < p.y)     Max.y = p.y; }
+    void        Add(const ImRect& r)             IMGUI_NOEXCEPT    { if (Min.x > r.Min.x) Min.x = r.Min.x; if (Min.y > r.Min.y) Min.y = r.Min.y; if (Max.x < r.Max.x) Max.x = r.Max.x; if (Max.y < r.Max.y) Max.y = r.Max.y; }
+    void        Expand(const float amount)       IMGUI_NOEXCEPT    { Min.x -= amount;   Min.y -= amount;   Max.x += amount;   Max.y += amount; }
+    void        Expand(const ImVec2& amount)     IMGUI_NOEXCEPT    { Min.x -= amount.x; Min.y -= amount.y; Max.x += amount.x; Max.y += amount.y; }
+    void        Translate(const ImVec2& d)       IMGUI_NOEXCEPT    { Min.x += d.x; Min.y += d.y; Max.x += d.x; Max.y += d.y; }
+    void        TranslateX(float dx)             IMGUI_NOEXCEPT    { Min.x += dx; Max.x += dx; }
+    void        TranslateY(float dy)             IMGUI_NOEXCEPT    { Min.y += dy; Max.y += dy; }
+    void        ClipWith(const ImRect& r)        IMGUI_NOEXCEPT    { Min = ImMax(Min, r.Min); Max = ImMin(Max, r.Max); }                   // Simple version, may lead to an inverted rectangle, which is fine for Contains/Overlaps test but not for display.
+    void        ClipWithFull(const ImRect& r)    IMGUI_NOEXCEPT    { Min = ImClamp(Min, r.Min, r.Max); Max = ImClamp(Max, r.Min, r.Max); } // Full version, ensure both points are fully clipped.
+    void        Floor()                          IMGUI_NOEXCEPT    { Min.x = IM_FLOOR(Min.x); Min.y = IM_FLOOR(Min.y); Max.x = IM_FLOOR(Max.x); Max.y = IM_FLOOR(Max.y); }
+    bool        IsInverted() const               IMGUI_NOEXCEPT    { return Min.x > Max.x || Min.y > Max.y; }
+    ImVec4      ToVec4() const                   IMGUI_NOEXCEPT    { return ImVec4(Min.x, Min.y, Max.x, Max.y); }
 };
 IM_MSVC_RUNTIME_CHECKS_RESTORE
 
 // Helper: ImBitArray
-inline bool     ImBitArrayTestBit(const ImU32* arr, int n)      { ImU32 mask = (ImU32)1 << (n & 31); return (arr[n >> 5] & mask) != 0; }
-inline void     ImBitArrayClearBit(ImU32* arr, int n)           { ImU32 mask = (ImU32)1 << (n & 31); arr[n >> 5] &= ~mask; }
-inline void     ImBitArraySetBit(ImU32* arr, int n)             { ImU32 mask = (ImU32)1 << (n & 31); arr[n >> 5] |= mask; }
-inline void     ImBitArraySetBitRange(ImU32* arr, int n, int n2) // Works on range [n..n2)
+inline bool     ImBitArrayTestBit(const ImU32* arr, int n)  IMGUI_NOEXCEPT     { ImU32 mask = (ImU32)1 << (n & 31); return (arr[n >> 5] & mask) != 0; }
+inline void     ImBitArrayClearBit(ImU32* arr, int n)       IMGUI_NOEXCEPT     { ImU32 mask = (ImU32)1 << (n & 31); arr[n >> 5] &= ~mask; }
+inline void     ImBitArraySetBit(ImU32* arr, int n)         IMGUI_NOEXCEPT     { ImU32 mask = (ImU32)1 << (n & 31); arr[n >> 5] |= mask; }
+inline void     ImBitArraySetBitRange(ImU32* arr, int n, int n2) IMGUI_NOEXCEPT // Works on range [n..n2)
 {
     n2--;
     while (n <= n2)
@@ -527,13 +527,13 @@ template<int BITCOUNT>
 struct IMGUI_API ImBitArray
 {
     ImU32           Storage[(BITCOUNT + 31) >> 5];
-    ImBitArray()                                { ClearAllBits(); }
-    void            ClearAllBits()              { memset(Storage, 0, sizeof(Storage)); }
-    void            SetAllBits()                { memset(Storage, 255, sizeof(Storage)); }
-    bool            TestBit(int n) const        { IM_ASSERT(n < BITCOUNT); return ImBitArrayTestBit(Storage, n); }
-    void            SetBit(int n)               { IM_ASSERT(n < BITCOUNT); ImBitArraySetBit(Storage, n); }
-    void            ClearBit(int n)             { IM_ASSERT(n < BITCOUNT); ImBitArrayClearBit(Storage, n); }
-    void            SetBitRange(int n, int n2)  { ImBitArraySetBitRange(Storage, n, n2); } // Works on range [n..n2)
+    ImBitArray()                               IMGUI_NOEXCEPT  { ClearAllBits(); }
+    void            ClearAllBits()             IMGUI_NOEXCEPT  { memset(Storage, 0, sizeof(Storage)); }
+    void            SetAllBits()               IMGUI_NOEXCEPT  { memset(Storage, 255, sizeof(Storage)); }
+    bool            TestBit(int n) const       IMGUI_NOEXCEPT  { IM_ASSERT(n < BITCOUNT); return ImBitArrayTestBit(Storage, n); }
+    void            SetBit(int n)              IMGUI_NOEXCEPT  { IM_ASSERT(n < BITCOUNT); ImBitArraySetBit(Storage, n); }
+    void            ClearBit(int n)            IMGUI_NOEXCEPT  { IM_ASSERT(n < BITCOUNT); ImBitArrayClearBit(Storage, n); }
+    void            SetBitRange(int n, int n2) IMGUI_NOEXCEPT  { ImBitArraySetBitRange(Storage, n, n2); } // Works on range [n..n2)
 };
 
 // Helper: ImBitVector
@@ -541,11 +541,11 @@ struct IMGUI_API ImBitArray
 struct IMGUI_API ImBitVector
 {
     ImVector<ImU32> Storage;
-    void            Create(int sz)              { Storage.resize((sz + 31) >> 5); memset(Storage.Data, 0, (size_t)Storage.Size * sizeof(Storage.Data[0])); }
-    void            Clear()                     { Storage.clear(); }
-    bool            TestBit(int n) const        { IM_ASSERT(n < (Storage.Size << 5)); return ImBitArrayTestBit(Storage.Data, n); }
-    void            SetBit(int n)               { IM_ASSERT(n < (Storage.Size << 5)); ImBitArraySetBit(Storage.Data, n); }
-    void            ClearBit(int n)             { IM_ASSERT(n < (Storage.Size << 5)); ImBitArrayClearBit(Storage.Data, n); }
+    void            Create(int sz)       IMGUI_NOEXCEPT        { Storage.resize((sz + 31) >> 5); memset(Storage.Data, 0, (size_t)Storage.Size * sizeof(Storage.Data[0])); }
+    void            Clear()              IMGUI_NOEXCEPT        { Storage.clear(); }
+    bool            TestBit(int n) const IMGUI_NOEXCEPT        { IM_ASSERT(n < (Storage.Size << 5)); return ImBitArrayTestBit(Storage.Data, n); }
+    void            SetBit(int n)        IMGUI_NOEXCEPT        { IM_ASSERT(n < (Storage.Size << 5)); ImBitArraySetBit(Storage.Data, n); }
+    void            ClearBit(int n)      IMGUI_NOEXCEPT        { IM_ASSERT(n < (Storage.Size << 5)); ImBitArrayClearBit(Storage.Data, n); }
 };
 
 // Helper: ImSpan<>
@@ -557,21 +557,21 @@ struct ImSpan
     T*                  DataEnd;
 
     // Constructors, destructor
-    inline ImSpan()                                 { Data = DataEnd = NULL; }
-    inline ImSpan(T* data, int size)                { Data = data; DataEnd = data + size; }
-    inline ImSpan(T* data, T* data_end)             { Data = data; DataEnd = data_end; }
-
-    inline void         set(T* data, int size)      { Data = data; DataEnd = data + size; }
-    inline void         set(T* data, T* data_end)   { Data = data; DataEnd = data_end; }
-    inline int          size() const                { return (int)(ptrdiff_t)(DataEnd - Data); }
-    inline int          size_in_bytes() const       { return (int)(ptrdiff_t)(DataEnd - Data) * (int)sizeof(T); }
-    inline T&           operator[](int i)           { T* p = Data + i; IM_ASSERT(p >= Data && p < DataEnd); return *p; }
-    inline const T&     operator[](int i) const     { const T* p = Data + i; IM_ASSERT(p >= Data && p < DataEnd); return *p; }
-
-    inline T*           begin()                     { return Data; }
-    inline const T*     begin() const               { return Data; }
-    inline T*           end()                       { return DataEnd; }
-    inline const T*     end() const                 { return DataEnd; }
+    inline ImSpan()                               IMGUI_NOEXCEPT   { Data = DataEnd = NULL; }
+    inline ImSpan(T* data, int size)              IMGUI_NOEXCEPT   { Data = data; DataEnd = data + size; }
+    inline ImSpan(T* data, T* data_end)           IMGUI_NOEXCEPT   { Data = data; DataEnd = data_end; }
+    
+    inline void         set(T* data, int size)    IMGUI_NOEXCEPT   { Data = data; DataEnd = data + size; }
+    inline void         set(T* data, T* data_end) IMGUI_NOEXCEPT   { Data = data; DataEnd = data_end; }
+    inline int          size() const              IMGUI_NOEXCEPT   { return (int)(ptrdiff_t)(DataEnd - Data); }
+    inline int          size_in_bytes() const     IMGUI_NOEXCEPT   { return (int)(ptrdiff_t)(DataEnd - Data) * (int)sizeof(T); }
+    inline T&           operator[](int i)         IMGUI_NOEXCEPT   { T* p = Data + i; IM_ASSERT(p >= Data && p < DataEnd); return *p; }
+    inline const T&     operator[](int i) const   IMGUI_NOEXCEPT   { const T* p = Data + i; IM_ASSERT(p >= Data && p < DataEnd); return *p; }
+    
+    inline T*           begin()                   IMGUI_NOEXCEPT   { return Data; }
+    inline const T*     begin() const             IMGUI_NOEXCEPT   { return Data; }
+    inline T*           end()                     IMGUI_NOEXCEPT   { return DataEnd; }
+    inline const T*     end() const               IMGUI_NOEXCEPT   { return DataEnd; }
 
     // Utilities
     inline int  index_from_ptr(const T* it) const   { IM_ASSERT(it >= Data && it < DataEnd); const ptrdiff_t off = it - Data; return (int)off; }
@@ -589,14 +589,14 @@ struct ImSpanAllocator
     int     Offsets[CHUNKS];
     int     Sizes[CHUNKS];
 
-    ImSpanAllocator()                               { memset(this, 0, sizeof(*this)); }
-    inline void  Reserve(int n, size_t sz, int a=4) { IM_ASSERT(n == CurrIdx && n < CHUNKS); CurrOff = IM_MEMALIGN(CurrOff, a); Offsets[n] = CurrOff; Sizes[n] = (int)sz; CurrIdx++; CurrOff += (int)sz; }
-    inline int   GetArenaSizeInBytes()              { return CurrOff; }
-    inline void  SetArenaBasePtr(void* base_ptr)    { BasePtr = (char*)base_ptr; }
-    inline void* GetSpanPtrBegin(int n)             { IM_ASSERT(n >= 0 && n < CHUNKS && CurrIdx == CHUNKS); return (void*)(BasePtr + Offsets[n]); }
-    inline void* GetSpanPtrEnd(int n)               { IM_ASSERT(n >= 0 && n < CHUNKS && CurrIdx == CHUNKS); return (void*)(BasePtr + Offsets[n] + Sizes[n]); }
+    ImSpanAllocator()                               IMGUI_NOEXCEPT { memset(this, 0, sizeof(*this)); }
+    inline void  Reserve(int n, size_t sz, int a=4) IMGUI_NOEXCEPT { IM_ASSERT(n == CurrIdx && n < CHUNKS); CurrOff = IM_MEMALIGN(CurrOff, a); Offsets[n] = CurrOff; Sizes[n] = (int)sz; CurrIdx++; CurrOff += (int)sz; }
+    inline int   GetArenaSizeInBytes()              IMGUI_NOEXCEPT { return CurrOff; }
+    inline void  SetArenaBasePtr(void* base_ptr)    IMGUI_NOEXCEPT { BasePtr = (char*)base_ptr; }
+    inline void* GetSpanPtrBegin(int n)             IMGUI_NOEXCEPT { IM_ASSERT(n >= 0 && n < CHUNKS && CurrIdx == CHUNKS); return (void*)(BasePtr + Offsets[n]); }
+    inline void* GetSpanPtrEnd(int n)               IMGUI_NOEXCEPT { IM_ASSERT(n >= 0 && n < CHUNKS && CurrIdx == CHUNKS); return (void*)(BasePtr + Offsets[n] + Sizes[n]); }
     template<typename T>
-    inline void  GetSpan(int n, ImSpan<T>* span)    { span->set((T*)GetSpanPtrBegin(n), (T*)GetSpanPtrEnd(n)); }
+    inline void  GetSpan(int n, ImSpan<T>* span)    IMGUI_NOEXCEPT { span->set((T*)GetSpanPtrBegin(n), (T*)GetSpanPtrEnd(n)); }
 };
 
 // Helper: ImPool<>
@@ -610,19 +610,19 @@ struct IMGUI_API ImPool
     ImGuiStorage    Map;        // ID->Index
     ImPoolIdx       FreeIdx;    // Next free idx to use
 
-    ImPool()    { FreeIdx = 0; }
-    ~ImPool()   { Clear(); }
-    T*          GetByKey(ImGuiID key)               { int idx = Map.GetInt(key, -1); return (idx != -1) ? &Buf[idx] : NULL; }
-    T*          GetByIndex(ImPoolIdx n)             { return &Buf[n]; }
-    ImPoolIdx   GetIndex(const T* p) const          { IM_ASSERT(p >= Buf.Data && p < Buf.Data + Buf.Size); return (ImPoolIdx)(p - Buf.Data); }
-    T*          GetOrAddByKey(ImGuiID key)          { int* p_idx = Map.GetIntRef(key, -1); if (*p_idx != -1) return &Buf[*p_idx]; *p_idx = FreeIdx; return Add(); }
-    bool        Contains(const T* p) const          { return (p >= Buf.Data && p < Buf.Data + Buf.Size); }
-    void        Clear()                             { for (int n = 0; n < Map.Data.Size; n++) { int idx = Map.Data[n].val_i; if (idx != -1) Buf[idx].~T(); } Map.Clear(); Buf.clear(); FreeIdx = 0; }
-    T*          Add()                               { int idx = FreeIdx; if (idx == Buf.Size) { Buf.resize(Buf.Size + 1); FreeIdx++; } else { FreeIdx = *(int*)&Buf[idx]; } IM_PLACEMENT_NEW(&Buf[idx]) T(); return &Buf[idx]; }
-    void        Remove(ImGuiID key, const T* p)     { Remove(key, GetIndex(p)); }
-    void        Remove(ImGuiID key, ImPoolIdx idx)  { Buf[idx].~T(); *(int*)&Buf[idx] = FreeIdx; FreeIdx = idx; Map.SetInt(key, -1); }
-    void        Reserve(int capacity)               { Buf.reserve(capacity); Map.Data.reserve(capacity); }
-    int         GetSize() const                     { return Buf.Size; }
+    ImPool()    IMGUI_NOEXCEPT { FreeIdx = 0; }
+    ~ImPool()   IMGUI_NOEXCEPT { Clear(); }
+    T*          GetByKey(ImGuiID key)              IMGUI_NOEXCEPT  { int idx = Map.GetInt(key, -1); return (idx != -1) ? &Buf[idx] : NULL; }
+    T*          GetByIndex(ImPoolIdx n)            IMGUI_NOEXCEPT  { return &Buf[n]; }
+    ImPoolIdx   GetIndex(const T* p) const         IMGUI_NOEXCEPT  { IM_ASSERT(p >= Buf.Data && p < Buf.Data + Buf.Size); return (ImPoolIdx)(p - Buf.Data); }
+    T*          GetOrAddByKey(ImGuiID key)         IMGUI_NOEXCEPT  { int* p_idx = Map.GetIntRef(key, -1); if (*p_idx != -1) return &Buf[*p_idx]; *p_idx = FreeIdx; return Add(); }
+    bool        Contains(const T* p) const         IMGUI_NOEXCEPT  { return (p >= Buf.Data && p < Buf.Data + Buf.Size); }
+    void        Clear()                            IMGUI_NOEXCEPT  { for (int n = 0; n < Map.Data.Size; n++) { int idx = Map.Data[n].val_i; if (idx != -1) Buf[idx].~T(); } Map.Clear(); Buf.clear(); FreeIdx = 0; }
+    T*          Add()                              IMGUI_NOEXCEPT  { int idx = FreeIdx; if (idx == Buf.Size) { Buf.resize(Buf.Size + 1); FreeIdx++; } else { FreeIdx = *(int*)&Buf[idx]; } IM_PLACEMENT_NEW(&Buf[idx]) T(); return &Buf[idx]; }
+    void        Remove(ImGuiID key, const T* p)    IMGUI_NOEXCEPT  { Remove(key, GetIndex(p)); }
+    void        Remove(ImGuiID key, ImPoolIdx idx) IMGUI_NOEXCEPT  { Buf[idx].~T(); *(int*)&Buf[idx] = FreeIdx; FreeIdx = idx; Map.SetInt(key, -1); }
+    void        Reserve(int capacity)              IMGUI_NOEXCEPT  { Buf.reserve(capacity); Map.Data.reserve(capacity); }
+    int         GetSize() const                    IMGUI_NOEXCEPT  { return Buf.Size; }
 };
 
 // Helper: ImChunkStream<>
@@ -635,17 +635,17 @@ struct IMGUI_API ImChunkStream
 {
     ImVector<char>  Buf;
 
-    void    clear()                     { Buf.clear(); }
-    bool    empty() const               { return Buf.Size == 0; }
-    int     size() const                { return Buf.Size; }
-    T*      alloc_chunk(size_t sz)      { size_t HDR_SZ = 4; sz = IM_MEMALIGN(HDR_SZ + sz, 4u); int off = Buf.Size; Buf.resize(off + (int)sz); ((int*)(void*)(Buf.Data + off))[0] = (int)sz; return (T*)(void*)(Buf.Data + off + (int)HDR_SZ); }
-    T*      begin()                     { size_t HDR_SZ = 4; if (!Buf.Data) return NULL; return (T*)(void*)(Buf.Data + HDR_SZ); }
-    T*      next_chunk(T* p)            { size_t HDR_SZ = 4; IM_ASSERT(p >= begin() && p < end()); p = (T*)(void*)((char*)(void*)p + chunk_size(p)); if (p == (T*)(void*)((char*)end() + HDR_SZ)) return (T*)0; IM_ASSERT(p < end()); return p; }
-    int     chunk_size(const T* p)      { return ((const int*)p)[-1]; }
-    T*      end()                       { return (T*)(void*)(Buf.Data + Buf.Size); }
-    int     offset_from_ptr(const T* p) { IM_ASSERT(p >= begin() && p < end()); const ptrdiff_t off = (const char*)p - Buf.Data; return (int)off; }
-    T*      ptr_from_offset(int off)    { IM_ASSERT(off >= 4 && off < Buf.Size); return (T*)(void*)(Buf.Data + off); }
-    void    swap(ImChunkStream<T>& rhs) { rhs.Buf.swap(Buf); }
+    void    clear()                     IMGUI_NOEXCEPT { Buf.clear(); }
+    bool    empty() const               IMGUI_NOEXCEPT { return Buf.Size == 0; }
+    int     size() const                IMGUI_NOEXCEPT { return Buf.Size; }
+    T*      alloc_chunk(size_t sz)      IMGUI_NOEXCEPT { size_t HDR_SZ = 4; sz = IM_MEMALIGN(HDR_SZ + sz, 4u); int off = Buf.Size; Buf.resize(off + (int)sz); ((int*)(void*)(Buf.Data + off))[0] = (int)sz; return (T*)(void*)(Buf.Data + off + (int)HDR_SZ); }
+    T*      begin()                     IMGUI_NOEXCEPT { size_t HDR_SZ = 4; if (!Buf.Data) return NULL; return (T*)(void*)(Buf.Data + HDR_SZ); }
+    T*      next_chunk(T* p)            IMGUI_NOEXCEPT { size_t HDR_SZ = 4; IM_ASSERT(p >= begin() && p < end()); p = (T*)(void*)((char*)(void*)p + chunk_size(p)); if (p == (T*)(void*)((char*)end() + HDR_SZ)) return (T*)0; IM_ASSERT(p < end()); return p; }
+    int     chunk_size(const T* p)      IMGUI_NOEXCEPT { return ((const int*)p)[-1]; }
+    T*      end()                       IMGUI_NOEXCEPT { return (T*)(void*)(Buf.Data + Buf.Size); }
+    int     offset_from_ptr(const T* p) IMGUI_NOEXCEPT { IM_ASSERT(p >= begin() && p < end()); const ptrdiff_t off = (const char*)p - Buf.Data; return (int)off; }
+    T*      ptr_from_offset(int off)    IMGUI_NOEXCEPT { IM_ASSERT(off >= 4 && off < Buf.Size); return (T*)(void*)(Buf.Data + off); }
+    void    swap(ImChunkStream<T>& rhs) IMGUI_NOEXCEPT { rhs.Buf.swap(Buf); }
 
 };
 
@@ -697,18 +697,18 @@ struct IMGUI_API ImDrawListSharedData
     ImU8            CircleSegmentCounts[64];    // Precomputed segment count for given radius before we calculate it dynamically (to avoid calculation overhead)
     const ImVec4*   TexUvLines;                 // UV of anti-aliased lines in the atlas
 
-    ImDrawListSharedData();
-    void SetCircleTessellationMaxError(float max_error);
+    ImDrawListSharedData() IMGUI_NOEXCEPT;
+    void SetCircleTessellationMaxError(float max_error) IMGUI_NOEXCEPT;
 };
 
 struct ImDrawDataBuilder
 {
     ImVector<ImDrawList*>   Layers[2];           // Global layers for: regular, tooltip
 
-    void Clear()                    { for (int n = 0; n < IM_ARRAYSIZE(Layers); n++) Layers[n].resize(0); }
-    void ClearFreeMemory()          { for (int n = 0; n < IM_ARRAYSIZE(Layers); n++) Layers[n].clear(); }
-    int  GetDrawListCount() const   { int count = 0; for (int n = 0; n < IM_ARRAYSIZE(Layers); n++) count += Layers[n].Size; return count; }
-    IMGUI_API void FlattenIntoSingleLayer();
+    void Clear()                  IMGUI_NOEXCEPT   { for (int n = 0; n < IM_ARRAYSIZE(Layers); n++) Layers[n].resize(0); }
+    void ClearFreeMemory()        IMGUI_NOEXCEPT   { for (int n = 0; n < IM_ARRAYSIZE(Layers); n++) Layers[n].clear(); }
+    int  GetDrawListCount() const IMGUI_NOEXCEPT   { int count = 0; for (int n = 0; n < IM_ARRAYSIZE(Layers); n++) count += Layers[n].Size; return count; }
+    IMGUI_API void FlattenIntoSingleLayer() IMGUI_NOEXCEPT;
 };
 
 //-----------------------------------------------------------------------------
@@ -978,9 +978,9 @@ struct ImGuiStyleMod
 {
     ImGuiStyleVar   VarIdx;
     union           { int BackupInt[2]; float BackupFloat[2]; };
-    ImGuiStyleMod(ImGuiStyleVar idx, int v)     { VarIdx = idx; BackupInt[0] = v; }
-    ImGuiStyleMod(ImGuiStyleVar idx, float v)   { VarIdx = idx; BackupFloat[0] = v; }
-    ImGuiStyleMod(ImGuiStyleVar idx, ImVec2 v)  { VarIdx = idx; BackupFloat[0] = v.x; BackupFloat[1] = v.y; }
+    ImGuiStyleMod(ImGuiStyleVar idx, int v)    IMGUI_NOEXCEPT  { VarIdx = idx; BackupInt[0] = v; }
+    ImGuiStyleMod(ImGuiStyleVar idx, float v)  IMGUI_NOEXCEPT  { VarIdx = idx; BackupFloat[0] = v; }
+    ImGuiStyleMod(ImGuiStyleVar idx, ImVec2 v) IMGUI_NOEXCEPT  { VarIdx = idx; BackupFloat[0] = v.x; BackupFloat[1] = v.y; }
 };
 
 // Stacked storage data for BeginGroup()/EndGroup()
@@ -1006,10 +1006,10 @@ struct IMGUI_API ImGuiMenuColumns
     float       Width, NextWidth;
     float       Pos[3], NextWidths[3];
 
-    ImGuiMenuColumns() { memset(this, 0, sizeof(*this)); }
-    void        Update(int count, float spacing, bool clear);
-    float       DeclColumns(float w0, float w1, float w2);
-    float       CalcExtraSpace(float avail_w) const;
+    ImGuiMenuColumns() IMGUI_NOEXCEPT { memset(this, 0, sizeof(*this)); }
+    void        Update(int count, float spacing, bool clear) IMGUI_NOEXCEPT;
+    float       DeclColumns(float w0, float w1, float w2) IMGUI_NOEXCEPT;
+    float       CalcExtraSpace(float avail_w) const IMGUI_NOEXCEPT;
 };
 
 // Internal state of the currently focused/edited text input box
@@ -1033,19 +1033,19 @@ struct IMGUI_API ImGuiInputTextState
     ImGuiInputTextCallback  UserCallback;           // "
     void*                   UserCallbackData;       // "
 
-    ImGuiInputTextState()                   { memset(this, 0, sizeof(*this)); }
-    void        ClearText()                 { CurLenW = CurLenA = 0; TextW[0] = 0; TextA[0] = 0; CursorClamp(); }
-    void        ClearFreeMemory()           { TextW.clear(); TextA.clear(); InitialTextA.clear(); }
-    int         GetUndoAvailCount() const   { return Stb.undostate.undo_point; }
-    int         GetRedoAvailCount() const   { return STB_TEXTEDIT_UNDOSTATECOUNT - Stb.undostate.redo_point; }
-    void        OnKeyPressed(int key);      // Cannot be inline because we call in code in stb_textedit.h implementation
+    ImGuiInputTextState()                 IMGUI_NOEXCEPT   { memset(this, 0, sizeof(*this)); }
+    void        ClearText()               IMGUI_NOEXCEPT   { CurLenW = CurLenA = 0; TextW[0] = 0; TextA[0] = 0; CursorClamp(); }
+    void        ClearFreeMemory()         IMGUI_NOEXCEPT   { TextW.clear(); TextA.clear(); InitialTextA.clear(); }
+    int         GetUndoAvailCount() const IMGUI_NOEXCEPT   { return Stb.undostate.undo_point; }
+    int         GetRedoAvailCount() const IMGUI_NOEXCEPT   { return STB_TEXTEDIT_UNDOSTATECOUNT - Stb.undostate.redo_point; }
+    void        OnKeyPressed(int key) IMGUI_NOEXCEPT;      // Cannot be inline because we call in code in stb_textedit.h implementation
 
     // Cursor & Selection
-    void        CursorAnimReset()           { CursorAnim = -0.30f; }                                   // After a user-input the cursor stays on for a while without blinking
-    void        CursorClamp()               { Stb.cursor = ImMin(Stb.cursor, CurLenW); Stb.select_start = ImMin(Stb.select_start, CurLenW); Stb.select_end = ImMin(Stb.select_end, CurLenW); }
-    bool        HasSelection() const        { return Stb.select_start != Stb.select_end; }
-    void        ClearSelection()            { Stb.select_start = Stb.select_end = Stb.cursor; }
-    void        SelectAll()                 { Stb.select_start = 0; Stb.cursor = Stb.select_end = CurLenW; Stb.has_preferred_x = 0; }
+    void        CursorAnimReset()         IMGUI_NOEXCEPT   { CursorAnim = -0.30f; }                                   // After a user-input the cursor stays on for a while without blinking
+    void        CursorClamp()             IMGUI_NOEXCEPT   { Stb.cursor = ImMin(Stb.cursor, CurLenW); Stb.select_start = ImMin(Stb.select_start, CurLenW); Stb.select_end = ImMin(Stb.select_end, CurLenW); }
+    bool        HasSelection() const      IMGUI_NOEXCEPT   { return Stb.select_start != Stb.select_end; }
+    void        ClearSelection()          IMGUI_NOEXCEPT   { Stb.select_start = Stb.select_end = Stb.cursor; }
+    void        SelectAll()               IMGUI_NOEXCEPT   { Stb.select_start = 0; Stb.cursor = Stb.select_end = CurLenW; Stb.has_preferred_x = 0; }
 };
 
 // Storage for current popup stack
@@ -1059,7 +1059,7 @@ struct ImGuiPopupData
     ImVec2              OpenPopupPos;   // Set on OpenPopup(), preferred popup position (typically == OpenMousePos when using mouse)
     ImVec2              OpenMousePos;   // Set on OpenPopup(), copy of mouse position at the time of opening popup
 
-    ImGuiPopupData()    { memset(this, 0, sizeof(*this)); OpenFrameCount = -1; }
+    ImGuiPopupData() IMGUI_NOEXCEPT    { memset(this, 0, sizeof(*this)); OpenFrameCount = -1; }
 };
 
 struct ImGuiNavItemData
@@ -1072,8 +1072,8 @@ struct ImGuiNavItemData
     float               DistCenter;     //      Move    // Best candidate center distance to current NavId
     float               DistAxial;      //      Move    // Best candidate axial distance to current NavId
 
-    ImGuiNavItemData()  { Clear(); }
-    void Clear()        { Window = NULL; ID = FocusScopeId = 0; RectRel = ImRect(); DistBox = DistCenter = DistAxial = FLT_MAX; }
+    ImGuiNavItemData() IMGUI_NOEXCEPT  { Clear(); }
+    void Clear()       IMGUI_NOEXCEPT  { Window = NULL; ID = FocusScopeId = 0; RectRel = ImRect(); DistBox = DistCenter = DistAxial = FLT_MAX; }
 };
 
 enum ImGuiNextWindowDataFlags_
@@ -1108,8 +1108,8 @@ struct ImGuiNextWindowData
     float                       BgAlphaVal;             // Override background alpha
     ImVec2                      MenuBarOffsetMinVal;    // *Always on* This is not exposed publicly, so we don't clear it.
 
-    ImGuiNextWindowData()       { memset(this, 0, sizeof(*this)); }
-    inline void ClearFlags()    { Flags = ImGuiNextWindowDataFlags_None; }
+    ImGuiNextWindowData()    IMGUI_NOEXCEPT    { memset(this, 0, sizeof(*this)); }
+    inline void ClearFlags() IMGUI_NOEXCEPT    { Flags = ImGuiNextWindowDataFlags_None; }
 };
 
 enum ImGuiNextItemDataFlags_
@@ -1127,8 +1127,8 @@ struct ImGuiNextItemData
     ImGuiCond                   OpenCond;
     bool                        OpenVal;        // Set by SetNextItemOpen()
 
-    ImGuiNextItemData()         { memset(this, 0, sizeof(*this)); }
-    inline void ClearFlags()    { Flags = ImGuiNextItemDataFlags_None; } // Also cleared manually by ItemAdd()!
+    ImGuiNextItemData()      IMGUI_NOEXCEPT    { memset(this, 0, sizeof(*this)); }
+    inline void ClearFlags() IMGUI_NOEXCEPT    { Flags = ImGuiNextItemDataFlags_None; } // Also cleared manually by ItemAdd()!
 };
 
 struct ImGuiShrinkWidthItem
@@ -1142,8 +1142,8 @@ struct ImGuiPtrOrIndex
     void*       Ptr;            // Either field can be set, not both. e.g. Dock node tab bars are loose while BeginTabBar() ones are in a pool.
     int         Index;          // Usually index in a main pool.
 
-    ImGuiPtrOrIndex(void* ptr)  { Ptr = ptr; Index = -1; }
-    ImGuiPtrOrIndex(int index)  { Ptr = NULL; Index = index; }
+    ImGuiPtrOrIndex(void* ptr) IMGUI_NOEXCEPT  { Ptr = ptr; Index = -1; }
+    ImGuiPtrOrIndex(int index) IMGUI_NOEXCEPT  { Ptr = NULL; Index = index; }
 };
 
 //-----------------------------------------------------------------------------
@@ -1178,7 +1178,7 @@ struct ImGuiOldColumnData
     ImGuiOldColumnFlags Flags;              // Not exposed
     ImRect              ClipRect;
 
-    ImGuiOldColumnData() { memset(this, 0, sizeof(*this)); }
+    ImGuiOldColumnData() IMGUI_NOEXCEPT { memset(this, 0, sizeof(*this)); }
 };
 
 struct ImGuiOldColumns
@@ -1199,7 +1199,7 @@ struct ImGuiOldColumns
     ImVector<ImGuiOldColumnData> Columns;
     ImDrawListSplitter  Splitter;
 
-    ImGuiOldColumns()   { memset(this, 0, sizeof(*this)); }
+    ImGuiOldColumns() IMGUI_NOEXCEPT   { memset(this, 0, sizeof(*this)); }
 };
 
 //-----------------------------------------------------------------------------
@@ -1236,18 +1236,18 @@ struct ImGuiViewportP : public ImGuiViewport
     ImVec2              BuildWorkOffsetMin;     // Work Area: Offset being built during current frame. Generally >= 0.0f.
     ImVec2              BuildWorkOffsetMax;     // Work Area: Offset being built during current frame. Generally <= 0.0f.
 
-    ImGuiViewportP()    { DrawListsLastFrame[0] = DrawListsLastFrame[1] = -1; DrawLists[0] = DrawLists[1] = NULL; }
-    ~ImGuiViewportP()   { if (DrawLists[0]) IM_DELETE(DrawLists[0]); if (DrawLists[1]) IM_DELETE(DrawLists[1]); }
+    ImGuiViewportP()  IMGUI_NOEXCEPT   { DrawListsLastFrame[0] = DrawListsLastFrame[1] = -1; DrawLists[0] = DrawLists[1] = NULL; }
+    ~ImGuiViewportP() IMGUI_NOEXCEPT   { if (DrawLists[0]) IM_DELETE(DrawLists[0]); if (DrawLists[1]) IM_DELETE(DrawLists[1]); }
 
     // Calculate work rect pos/size given a set of offset (we have 1 pair of offset for rect locked from last frame data, and 1 pair for currently building rect)
-    ImVec2  CalcWorkRectPos(const ImVec2& off_min) const                            { return ImVec2(Pos.x + off_min.x, Pos.y + off_min.y); }
-    ImVec2  CalcWorkRectSize(const ImVec2& off_min, const ImVec2& off_max) const    { return ImVec2(ImMax(0.0f, Size.x - off_min.x + off_max.x), ImMax(0.0f, Size.y - off_min.y + off_max.y)); }
-    void    UpdateWorkRect()            { WorkPos = CalcWorkRectPos(WorkOffsetMin); WorkSize = CalcWorkRectSize(WorkOffsetMin, WorkOffsetMax); } // Update public fields
+    ImVec2  CalcWorkRectPos(const ImVec2& off_min) const                         IMGUI_NOEXCEPT    { return ImVec2(Pos.x + off_min.x, Pos.y + off_min.y); }
+    ImVec2  CalcWorkRectSize(const ImVec2& off_min, const ImVec2& off_max) const IMGUI_NOEXCEPT    { return ImVec2(ImMax(0.0f, Size.x - off_min.x + off_max.x), ImMax(0.0f, Size.y - off_min.y + off_max.y)); }
+    void    UpdateWorkRect() IMGUI_NOEXCEPT            { WorkPos = CalcWorkRectPos(WorkOffsetMin); WorkSize = CalcWorkRectSize(WorkOffsetMin, WorkOffsetMax); } // Update public fields
 
     // Helpers to retrieve ImRect (we don't need to store BuildWorkRect as every access tend to change it, hence the code asymmetry)
-    ImRect  GetMainRect() const         { return ImRect(Pos.x, Pos.y, Pos.x + Size.x, Pos.y + Size.y); }
-    ImRect  GetWorkRect() const         { return ImRect(WorkPos.x, WorkPos.y, WorkPos.x + WorkSize.x, WorkPos.y + WorkSize.y); }
-    ImRect  GetBuildWorkRect() const    { ImVec2 pos = CalcWorkRectPos(BuildWorkOffsetMin); ImVec2 size = CalcWorkRectSize(BuildWorkOffsetMin, BuildWorkOffsetMax); return ImRect(pos.x, pos.y, pos.x + size.x, pos.y + size.y); }
+    ImRect  GetMainRect() const      IMGUI_NOEXCEPT    { return ImRect(Pos.x, Pos.y, Pos.x + Size.x, Pos.y + Size.y); }
+    ImRect  GetWorkRect() const      IMGUI_NOEXCEPT    { return ImRect(WorkPos.x, WorkPos.y, WorkPos.x + WorkSize.x, WorkPos.y + WorkSize.y); }
+    ImRect  GetBuildWorkRect() const IMGUI_NOEXCEPT    { ImVec2 pos = CalcWorkRectPos(BuildWorkOffsetMin); ImVec2 size = CalcWorkRectSize(BuildWorkOffsetMin, BuildWorkOffsetMax); return ImRect(pos.x, pos.y, pos.x + size.x, pos.y + size.y); }
 };
 
 //-----------------------------------------------------------------------------
@@ -1265,8 +1265,8 @@ struct ImGuiWindowSettings
     bool        Collapsed;
     bool        WantApply;      // Set when loaded from .ini data (to enable merging/loading .ini data into an already running context)
 
-    ImGuiWindowSettings()       { memset(this, 0, sizeof(*this)); }
-    char* GetName()             { return (char*)(this + 1); }
+    ImGuiWindowSettings() IMGUI_NOEXCEPT       { memset(this, 0, sizeof(*this)); }
+    char* GetName()       IMGUI_NOEXCEPT       { return (char*)(this + 1); }
 };
 
 struct ImGuiSettingsHandler
@@ -1276,12 +1276,12 @@ struct ImGuiSettingsHandler
     void        (*ClearAllFn)(ImGuiContext* ctx, ImGuiSettingsHandler* handler);                                // Clear all settings data
     void        (*ReadInitFn)(ImGuiContext* ctx, ImGuiSettingsHandler* handler);                                // Read: Called before reading (in registration order)
     void*       (*ReadOpenFn)(ImGuiContext* ctx, ImGuiSettingsHandler* handler, const char* name);              // Read: Called when entering into a new ini entry e.g. "[Window][Name]"
-    void        (*ReadLineFn)(ImGuiContext* ctx, ImGuiSettingsHandler* handler, void* entry, const char* line); // Read: Called for every line of text within an ini entry
+    void        (*ReadLineFn)(ImGuiContext* ctx, ImGuiSettingsHandler* handler, void* entry, const char* line) IMGUI_NOEXCEPT; // Read: Called for every line of text within an ini entry
     void        (*ApplyAllFn)(ImGuiContext* ctx, ImGuiSettingsHandler* handler);                                // Read: Called after reading (in registration order)
     void        (*WriteAllFn)(ImGuiContext* ctx, ImGuiSettingsHandler* handler, ImGuiTextBuffer* out_buf);      // Write: Output every entries into 'out_buf'
     void*       UserData;
 
-    ImGuiSettingsHandler() { memset(this, 0, sizeof(*this)); }
+    ImGuiSettingsHandler() IMGUI_NOEXCEPT { memset(this, 0, sizeof(*this)); }
 };
 
 //-----------------------------------------------------------------------------
@@ -1298,7 +1298,7 @@ struct ImGuiMetricsConfig
     int         ShowWindowsRectsType;
     int         ShowTablesRectsType;
 
-    ImGuiMetricsConfig()
+    ImGuiMetricsConfig() IMGUI_NOEXCEPT
     {
         ShowWindowsRects = false;
         ShowWindowsBeginOrder = false;
@@ -1320,9 +1320,9 @@ struct IMGUI_API ImGuiStackSizes
     short   SizeOfGroupStack;
     short   SizeOfBeginPopupStack;
 
-    ImGuiStackSizes() { memset(this, 0, sizeof(*this)); }
-    void SetToCurrentState();
-    void CompareWithCurrentState();
+    ImGuiStackSizes() IMGUI_NOEXCEPT { memset(this, 0, sizeof(*this)); }
+    void SetToCurrentState() IMGUI_NOEXCEPT;
+    void CompareWithCurrentState() IMGUI_NOEXCEPT;
 };
 
 //-----------------------------------------------------------------------------
@@ -1340,7 +1340,7 @@ struct ImGuiContextHook
     ImGuiContextHookCallback    Callback;
     void*                       UserData;
 
-    ImGuiContextHook()          { memset(this, 0, sizeof(*this)); }
+    ImGuiContextHook() IMGUI_NOEXCEPT { memset(this, 0, sizeof(*this)); }
 };
 
 //-----------------------------------------------------------------------------
@@ -1593,7 +1593,7 @@ struct ImGuiContext
     int                     WantTextInputNextFrame;
     char                    TempBuffer[1024 * 3 + 1];           // Temporary text buffer
 
-    ImGuiContext(ImFontAtlas* shared_font_atlas)
+    ImGuiContext(ImFontAtlas* shared_font_atlas) IMGUI_NOEXCEPT
     {
         Initialized = false;
         FontAtlasOwnedByContext = shared_font_atlas ? false : true;
@@ -1896,24 +1896,24 @@ struct IMGUI_API ImGuiWindow
     bool                    MemoryCompacted;                    // Set when window extraneous data have been garbage collected
 
 public:
-    ImGuiWindow(ImGuiContext* context, const char* name);
-    ~ImGuiWindow();
+    ImGuiWindow(ImGuiContext* context, const char* name) IMGUI_NOEXCEPT;
+    ~ImGuiWindow()                                       IMGUI_NOEXCEPT;
 
-    ImGuiID     GetID(const char* str, const char* str_end = NULL);
-    ImGuiID     GetID(const void* ptr);
-    ImGuiID     GetID(int n);
-    ImGuiID     GetIDNoKeepAlive(const char* str, const char* str_end = NULL);
-    ImGuiID     GetIDNoKeepAlive(const void* ptr);
-    ImGuiID     GetIDNoKeepAlive(int n);
-    ImGuiID     GetIDFromRectangle(const ImRect& r_abs);
+    ImGuiID     GetID(const char* str, const char* str_end = NULL) IMGUI_NOEXCEPT;
+    ImGuiID     GetID(const void* ptr)                             IMGUI_NOEXCEPT;
+    ImGuiID     GetID(int n)                                       IMGUI_NOEXCEPT;
+    ImGuiID     GetIDNoKeepAlive(const char* str, const char* str_end = NULL) IMGUI_NOEXCEPT;
+    ImGuiID     GetIDNoKeepAlive(const void* ptr)                  IMGUI_NOEXCEPT;
+    ImGuiID     GetIDNoKeepAlive(int n)                            IMGUI_NOEXCEPT;
+    ImGuiID     GetIDFromRectangle(const ImRect& r_abs)             IMGUI_NOEXCEPT;
 
     // We don't use g.FontSize because the window may be != g.CurrentWidow.
-    ImRect      Rect() const            { return ImRect(Pos.x, Pos.y, Pos.x + Size.x, Pos.y + Size.y); }
-    float       CalcFontSize() const    { ImGuiContext& g = *GImGui; float scale = g.FontBaseSize * FontWindowScale; if (ParentWindow) scale *= ParentWindow->FontWindowScale; return scale; }
-    float       TitleBarHeight() const  { ImGuiContext& g = *GImGui; return (Flags & ImGuiWindowFlags_NoTitleBar) ? 0.0f : CalcFontSize() + g.Style.FramePadding.y * 2.0f; }
-    ImRect      TitleBarRect() const    { return ImRect(Pos, ImVec2(Pos.x + SizeFull.x, Pos.y + TitleBarHeight())); }
-    float       MenuBarHeight() const   { ImGuiContext& g = *GImGui; return (Flags & ImGuiWindowFlags_MenuBar) ? DC.MenuBarOffset.y + CalcFontSize() + g.Style.FramePadding.y * 2.0f : 0.0f; }
-    ImRect      MenuBarRect() const     { float y1 = Pos.y + TitleBarHeight(); return ImRect(Pos.x, y1, Pos.x + SizeFull.x, y1 + MenuBarHeight()); }
+    ImRect      Rect() const           IMGUI_NOEXCEPT  { return ImRect(Pos.x, Pos.y, Pos.x + Size.x, Pos.y + Size.y); }
+    float       CalcFontSize() const   IMGUI_NOEXCEPT  { ImGuiContext& g = *GImGui; float scale = g.FontBaseSize * FontWindowScale; if (ParentWindow) scale *= ParentWindow->FontWindowScale; return scale; }
+    float       TitleBarHeight() const IMGUI_NOEXCEPT  { ImGuiContext& g = *GImGui; return (Flags & ImGuiWindowFlags_NoTitleBar) ? 0.0f : CalcFontSize() + g.Style.FramePadding.y * 2.0f; }
+    ImRect      TitleBarRect() const   IMGUI_NOEXCEPT  { return ImRect(Pos, ImVec2(Pos.x + SizeFull.x, Pos.y + TitleBarHeight())); }
+    float       MenuBarHeight() const  IMGUI_NOEXCEPT  { ImGuiContext& g = *GImGui; return (Flags & ImGuiWindowFlags_MenuBar) ? DC.MenuBarOffset.y + CalcFontSize() + g.Style.FramePadding.y * 2.0f : 0.0f; }
+    ImRect      MenuBarRect() const    IMGUI_NOEXCEPT  { float y1 = Pos.y + TitleBarHeight(); return ImRect(Pos.x, y1, Pos.x + SizeFull.x, y1 + MenuBarHeight()); }
 };
 
 // Backup and restore just enough data to be able to use IsItemHovered() on item A after another B in the same window has overwritten the data.
@@ -1924,9 +1924,9 @@ struct ImGuiLastItemDataBackup
     ImRect                  LastItemRect;
     ImRect                  LastItemDisplayRect;
 
-    ImGuiLastItemDataBackup() { Backup(); }
-    void Backup()           { ImGuiWindow* window = GImGui->CurrentWindow; LastItemId = window->DC.LastItemId; LastItemStatusFlags = window->DC.LastItemStatusFlags; LastItemRect = window->DC.LastItemRect; LastItemDisplayRect = window->DC.LastItemDisplayRect; }
-    void Restore() const    { ImGuiWindow* window = GImGui->CurrentWindow; window->DC.LastItemId = LastItemId; window->DC.LastItemStatusFlags = LastItemStatusFlags; window->DC.LastItemRect = LastItemRect; window->DC.LastItemDisplayRect = LastItemDisplayRect; }
+    ImGuiLastItemDataBackup() IMGUI_NOEXCEPT { Backup(); }
+    void Backup()             IMGUI_NOEXCEPT { ImGuiWindow* window = GImGui->CurrentWindow; LastItemId = window->DC.LastItemId; LastItemStatusFlags = window->DC.LastItemStatusFlags; LastItemRect = window->DC.LastItemRect; LastItemDisplayRect = window->DC.LastItemDisplayRect; }
+    void Restore() const      IMGUI_NOEXCEPT { ImGuiWindow* window = GImGui->CurrentWindow; window->DC.LastItemId = LastItemId; window->DC.LastItemStatusFlags = LastItemStatusFlags; window->DC.LastItemRect = LastItemRect; window->DC.LastItemDisplayRect = LastItemDisplayRect; }
 };
 
 //-----------------------------------------------------------------------------
@@ -1964,7 +1964,7 @@ struct ImGuiTabItem
     ImS16               IndexDuringLayout;      // Index only used during TabBarLayout()
     bool                WantClose;              // Marked as closed by SetTabItemClosed()
 
-    ImGuiTabItem()      { memset(this, 0, sizeof(*this)); LastFrameVisible = LastFrameSelected = -1; NameOffset = BeginOrder = IndexDuringLayout = -1; }
+    ImGuiTabItem() IMGUI_NOEXCEPT { memset(this, 0, sizeof(*this)); LastFrameVisible = LastFrameSelected = -1; NameOffset = BeginOrder = IndexDuringLayout = -1; }
 };
 
 // Storage for a tab bar (sizeof() 152 bytes)
@@ -2002,9 +2002,9 @@ struct ImGuiTabBar
     ImVec2              BackupCursorPos;
     ImGuiTextBuffer     TabsNames;              // For non-docking tab bar we re-append names in a contiguous buffer.
 
-    ImGuiTabBar();
-    int                 GetTabOrder(const ImGuiTabItem* tab) const  { return Tabs.index_from_ptr(tab); }
-    const char*         GetTabName(const ImGuiTabItem* tab) const
+    ImGuiTabBar() IMGUI_NOEXCEPT;
+    int                 GetTabOrder(const ImGuiTabItem* tab) const IMGUI_NOEXCEPT { return Tabs.index_from_ptr(tab); }
+    const char*         GetTabName(const ImGuiTabItem* tab) const  IMGUI_NOEXCEPT
     {
         IM_ASSERT(tab->NameOffset != -1 && (int)tab->NameOffset < TabsNames.Buf.Size);
         return TabsNames.Buf.Data + tab->NameOffset;
@@ -2072,7 +2072,7 @@ struct ImGuiTableColumn
     ImU8                    SortDirectionsAvailMask : 4;    // Mask of available sort directions (1-bit each)
     ImU8                    SortDirectionsAvailList;        // Ordered of available sort directions (2-bits each)
 
-    ImGuiTableColumn()
+    ImGuiTableColumn() IMGUI_NOEXCEPT
     {
         memset(this, 0, sizeof(*this));
         StretchWeight = WidthRequest = -1.0f;
@@ -2198,8 +2198,8 @@ struct ImGuiTable
     bool                        MemoryCompacted;
     bool                        HostSkipItems;              // Backup of InnerWindow->SkipItem at the end of BeginTable(), because we will overwrite InnerWindow->SkipItem on a per-column basis
 
-    IMGUI_API ImGuiTable()      { memset(this, 0, sizeof(*this)); LastFrameActive = -1; }
-    IMGUI_API ~ImGuiTable()     { IM_FREE(RawData); }
+    IMGUI_API ImGuiTable()  IMGUI_NOEXCEPT { memset(this, 0, sizeof(*this)); LastFrameActive = -1; }
+    IMGUI_API ~ImGuiTable() IMGUI_NOEXCEPT { IM_FREE(RawData); }
 };
 
 // Transient data that are only needed between BeginTable() and EndTable(), those buffers are shared (1 per level of stacked table).
@@ -2240,7 +2240,7 @@ struct ImGuiTableColumnSettings
     ImU8                    IsEnabled : 1; // "Visible" in ini file
     ImU8                    IsStretch : 1;
 
-    ImGuiTableColumnSettings()
+    ImGuiTableColumnSettings() IMGUI_NOEXCEPT
     {
         WidthOrWeight = 0.0f;
         UserID = 0;
@@ -2262,8 +2262,8 @@ struct ImGuiTableSettings
     ImGuiTableColumnIdx         ColumnsCountMax;        // Maximum number of columns this settings instance can store, we can recycle a settings instance with lower number of columns but not higher
     bool                        WantApply;              // Set when loaded from .ini data (to enable merging/loading .ini data into an already running context)
 
-    ImGuiTableSettings()        { memset(this, 0, sizeof(*this)); }
-    ImGuiTableColumnSettings*   GetColumnSettings()     { return (ImGuiTableColumnSettings*)(this + 1); }
+    ImGuiTableSettings()                          IMGUI_NOEXCEPT  { memset(this, 0, sizeof(*this)); }
+    ImGuiTableColumnSettings* GetColumnSettings() IMGUI_NOEXCEPT  { return (ImGuiTableColumnSettings*)(this + 1); }
 };
 
 #endif // #ifdef IMGUI_HAS_TABLE
@@ -2280,355 +2280,355 @@ namespace ImGui
     // If this ever crash because g.CurrentWindow is NULL it means that either
     // - ImGui::NewFrame() has never been called, which is illegal.
     // - You are calling ImGui functions after ImGui::EndFrame()/ImGui::Render() and before the next ImGui::NewFrame(), which is also illegal.
-    inline    ImGuiWindow*  GetCurrentWindowRead()      { ImGuiContext& g = *GImGui; return g.CurrentWindow; }
-    inline    ImGuiWindow*  GetCurrentWindow()          { ImGuiContext& g = *GImGui; g.CurrentWindow->WriteAccessed = true; return g.CurrentWindow; }
-    IMGUI_API ImGuiWindow*  FindWindowByID(ImGuiID id);
-    IMGUI_API ImGuiWindow*  FindWindowByName(const char* name);
-    IMGUI_API void          UpdateWindowParentAndRootLinks(ImGuiWindow* window, ImGuiWindowFlags flags, ImGuiWindow* parent_window);
-    IMGUI_API ImVec2        CalcWindowNextAutoFitSize(ImGuiWindow* window);
-    IMGUI_API bool          IsWindowChildOf(ImGuiWindow* window, ImGuiWindow* potential_parent);
-    IMGUI_API bool          IsWindowAbove(ImGuiWindow* potential_above, ImGuiWindow* potential_below);
-    IMGUI_API bool          IsWindowNavFocusable(ImGuiWindow* window);
-    IMGUI_API ImRect        GetWindowAllowedExtentRect(ImGuiWindow* window);
-    IMGUI_API void          SetWindowPos(ImGuiWindow* window, const ImVec2& pos, ImGuiCond cond = 0);
-    IMGUI_API void          SetWindowSize(ImGuiWindow* window, const ImVec2& size, ImGuiCond cond = 0);
-    IMGUI_API void          SetWindowCollapsed(ImGuiWindow* window, bool collapsed, ImGuiCond cond = 0);
-    IMGUI_API void          SetWindowHitTestHole(ImGuiWindow* window, const ImVec2& pos, const ImVec2& size);
+    inline    ImGuiWindow*  GetCurrentWindowRead()              IMGUI_NOEXCEPT { ImGuiContext& g = *GImGui; return g.CurrentWindow; }
+    inline    ImGuiWindow*  GetCurrentWindow()                  IMGUI_NOEXCEPT { ImGuiContext& g = *GImGui; g.CurrentWindow->WriteAccessed = true; return g.CurrentWindow; }
+    IMGUI_API ImGuiWindow*  FindWindowByID(ImGuiID id)          IMGUI_NOEXCEPT;
+    IMGUI_API ImGuiWindow*  FindWindowByName(const char* name)  IMGUI_NOEXCEPT;
+    IMGUI_API void          UpdateWindowParentAndRootLinks(ImGuiWindow* window, ImGuiWindowFlags flags, ImGuiWindow* parent_window) IMGUI_NOEXCEPT;
+    IMGUI_API ImVec2        CalcWindowNextAutoFitSize(ImGuiWindow* window) IMGUI_NOEXCEPT;
+    IMGUI_API bool          IsWindowChildOf(ImGuiWindow* window, ImGuiWindow* potential_parent) IMGUI_NOEXCEPT;
+    IMGUI_API bool          IsWindowAbove(ImGuiWindow* potential_above, ImGuiWindow* potential_below) IMGUI_NOEXCEPT;
+    IMGUI_API bool          IsWindowNavFocusable(ImGuiWindow* window) IMGUI_NOEXCEPT;
+    IMGUI_API ImRect        GetWindowAllowedExtentRect(ImGuiWindow* window) IMGUI_NOEXCEPT;
+    IMGUI_API void          SetWindowPos(ImGuiWindow* window, const ImVec2& pos, ImGuiCond cond = 0) IMGUI_NOEXCEPT;
+    IMGUI_API void          SetWindowSize(ImGuiWindow* window, const ImVec2& size, ImGuiCond cond = 0) IMGUI_NOEXCEPT;
+    IMGUI_API void          SetWindowCollapsed(ImGuiWindow* window, bool collapsed, ImGuiCond cond = 0) IMGUI_NOEXCEPT;
+    IMGUI_API void          SetWindowHitTestHole(ImGuiWindow* window, const ImVec2& pos, const ImVec2& size) IMGUI_NOEXCEPT;
 
     // Windows: Display Order and Focus Order
-    IMGUI_API void          FocusWindow(ImGuiWindow* window);
-    IMGUI_API void          FocusTopMostWindowUnderOne(ImGuiWindow* under_this_window, ImGuiWindow* ignore_window);
-    IMGUI_API void          BringWindowToFocusFront(ImGuiWindow* window);
-    IMGUI_API void          BringWindowToDisplayFront(ImGuiWindow* window);
-    IMGUI_API void          BringWindowToDisplayBack(ImGuiWindow* window);
+    IMGUI_API void          FocusWindow(ImGuiWindow* window)     IMGUI_NOEXCEPT;
+    IMGUI_API void          FocusTopMostWindowUnderOne(ImGuiWindow* under_this_window, ImGuiWindow* ignore_window) IMGUI_NOEXCEPT;
+    IMGUI_API void          BringWindowToFocusFront(ImGuiWindow* window) IMGUI_NOEXCEPT;
+    IMGUI_API void          BringWindowToDisplayFront(ImGuiWindow* window) IMGUI_NOEXCEPT;
+    IMGUI_API void          BringWindowToDisplayBack(ImGuiWindow* window) IMGUI_NOEXCEPT;
 
     // Fonts, drawing
-    IMGUI_API void          SetCurrentFont(ImFont* font);
-    inline ImFont*          GetDefaultFont() { ImGuiContext& g = *GImGui; return g.IO.FontDefault ? g.IO.FontDefault : g.IO.Fonts->Fonts[0]; }
-    inline ImDrawList*      GetForegroundDrawList(ImGuiWindow* window) { IM_UNUSED(window); return GetForegroundDrawList(); } // This seemingly unnecessary wrapper simplifies compatibility between the 'master' and 'docking' branches.
-    IMGUI_API ImDrawList*   GetBackgroundDrawList(ImGuiViewport* viewport);                     // get background draw list for the given viewport. this draw list will be the first rendering one. Useful to quickly draw shapes/text behind dear imgui contents.
-    IMGUI_API ImDrawList*   GetForegroundDrawList(ImGuiViewport* viewport);                     // get foreground draw list for the given viewport. this draw list will be the last rendered one. Useful to quickly draw shapes/text over dear imgui contents.
+    IMGUI_API void          SetCurrentFont(ImFont* font) IMGUI_NOEXCEPT;
+    inline ImFont*          GetDefaultFont() IMGUI_NOEXCEPT { ImGuiContext& g = *GImGui; return g.IO.FontDefault ? g.IO.FontDefault : g.IO.Fonts->Fonts[0]; }
+    inline ImDrawList*      GetForegroundDrawList(ImGuiWindow* window) IMGUI_NOEXCEPT { IM_UNUSED(window); return GetForegroundDrawList(); } // This seemingly unnecessary wrapper simplifies compatibility between the 'master' and 'docking' branches.
+    IMGUI_API ImDrawList*   GetBackgroundDrawList(ImGuiViewport* viewport) IMGUI_NOEXCEPT;   // get background draw list for the given viewport. this draw list will be the first rendering one. Useful to quickly draw shapes/text behind dear imgui contents.
+    IMGUI_API ImDrawList*   GetForegroundDrawList(ImGuiViewport* viewport) IMGUI_NOEXCEPT;   // get foreground draw list for the given viewport. this draw list will be the last rendered one. Useful to quickly draw shapes/text over dear imgui contents.
 
     // Init
-    IMGUI_API void          Initialize(ImGuiContext* context);
-    IMGUI_API void          Shutdown(ImGuiContext* context);    // Since 1.60 this is a _private_ function. You can call DestroyContext() to destroy the context created by CreateContext().
+    IMGUI_API void          Initialize(ImGuiContext* context) IMGUI_NOEXCEPT;
+    IMGUI_API void          Shutdown(ImGuiContext* context) IMGUI_NOEXCEPT;  // Since 1.60 this is a _private_ function. You can call DestroyContext() to destroy the context created by CreateContext().
 
     // NewFrame
-    IMGUI_API void          UpdateHoveredWindowAndCaptureFlags();
-    IMGUI_API void          StartMouseMovingWindow(ImGuiWindow* window);
-    IMGUI_API void          UpdateMouseMovingWindowNewFrame();
-    IMGUI_API void          UpdateMouseMovingWindowEndFrame();
+    IMGUI_API void          UpdateHoveredWindowAndCaptureFlags() IMGUI_NOEXCEPT;
+    IMGUI_API void          StartMouseMovingWindow(ImGuiWindow* window) IMGUI_NOEXCEPT;
+    IMGUI_API void          UpdateMouseMovingWindowNewFrame() IMGUI_NOEXCEPT;
+    IMGUI_API void          UpdateMouseMovingWindowEndFrame() IMGUI_NOEXCEPT;
 
     // Generic context hooks
-    IMGUI_API ImGuiID       AddContextHook(ImGuiContext* context, const ImGuiContextHook* hook);
-    IMGUI_API void          RemoveContextHook(ImGuiContext* context, ImGuiID hook_to_remove);
-    IMGUI_API void          CallContextHooks(ImGuiContext* context, ImGuiContextHookType type);
+    IMGUI_API ImGuiID       AddContextHook(ImGuiContext* context, const ImGuiContextHook* hook) IMGUI_NOEXCEPT;
+    IMGUI_API void          RemoveContextHook(ImGuiContext* context, ImGuiID hook_to_remove) IMGUI_NOEXCEPT;
+    IMGUI_API void          CallContextHooks(ImGuiContext* context, ImGuiContextHookType type) IMGUI_NOEXCEPT;
 
     // Settings
-    IMGUI_API void                  MarkIniSettingsDirty();
-    IMGUI_API void                  MarkIniSettingsDirty(ImGuiWindow* window);
-    IMGUI_API void                  ClearIniSettings();
-    IMGUI_API ImGuiWindowSettings*  CreateNewWindowSettings(const char* name);
-    IMGUI_API ImGuiWindowSettings*  FindWindowSettings(ImGuiID id);
-    IMGUI_API ImGuiWindowSettings*  FindOrCreateWindowSettings(const char* name);
-    IMGUI_API ImGuiSettingsHandler* FindSettingsHandler(const char* type_name);
+    IMGUI_API void                  MarkIniSettingsDirty() IMGUI_NOEXCEPT;
+    IMGUI_API void                  MarkIniSettingsDirty(ImGuiWindow* window) IMGUI_NOEXCEPT;
+    IMGUI_API void                  ClearIniSettings() IMGUI_NOEXCEPT;
+    IMGUI_API ImGuiWindowSettings*  CreateNewWindowSettings(const char* name) IMGUI_NOEXCEPT;
+    IMGUI_API ImGuiWindowSettings*  FindWindowSettings(ImGuiID id) IMGUI_NOEXCEPT;
+    IMGUI_API ImGuiWindowSettings*  FindOrCreateWindowSettings(const char* name) IMGUI_NOEXCEPT;
+    IMGUI_API ImGuiSettingsHandler* FindSettingsHandler(const char* type_name) IMGUI_NOEXCEPT;
 
     // Scrolling
-    IMGUI_API void          SetNextWindowScroll(const ImVec2& scroll); // Use -1.0f on one axis to leave as-is
-    IMGUI_API void          SetScrollX(ImGuiWindow* window, float scroll_x);
-    IMGUI_API void          SetScrollY(ImGuiWindow* window, float scroll_y);
-    IMGUI_API void          SetScrollFromPosX(ImGuiWindow* window, float local_x, float center_x_ratio);
-    IMGUI_API void          SetScrollFromPosY(ImGuiWindow* window, float local_y, float center_y_ratio);
-    IMGUI_API ImVec2        ScrollToBringRectIntoView(ImGuiWindow* window, const ImRect& item_rect);
+    IMGUI_API void          SetNextWindowScroll(const ImVec2& scroll)       IMGUI_NOEXCEPT; // Use -1.0f on one axis to leave as-is
+    IMGUI_API void          SetScrollX(ImGuiWindow* window, float scroll_x) IMGUI_NOEXCEPT;
+    IMGUI_API void          SetScrollY(ImGuiWindow* window, float scroll_y) IMGUI_NOEXCEPT;
+    IMGUI_API void          SetScrollFromPosX(ImGuiWindow* window, float local_x, float center_x_ratio) IMGUI_NOEXCEPT;
+    IMGUI_API void          SetScrollFromPosY(ImGuiWindow* window, float local_y, float center_y_ratio) IMGUI_NOEXCEPT;
+    IMGUI_API ImVec2        ScrollToBringRectIntoView(ImGuiWindow* window, const ImRect& item_rect) IMGUI_NOEXCEPT;
 
     // Basic Accessors
-    inline ImGuiID          GetItemID()     { ImGuiContext& g = *GImGui; return g.CurrentWindow->DC.LastItemId; }   // Get ID of last item (~~ often same ImGui::GetID(label) beforehand)
-    inline ImGuiItemStatusFlags GetItemStatusFlags() { ImGuiContext& g = *GImGui; return g.CurrentWindow->DC.LastItemStatusFlags; }
-    inline ImGuiID          GetActiveID()   { ImGuiContext& g = *GImGui; return g.ActiveId; }
-    inline ImGuiID          GetFocusID()    { ImGuiContext& g = *GImGui; return g.NavId; }
-    inline ImGuiItemFlags   GetItemFlags()  { ImGuiContext& g = *GImGui; return g.CurrentItemFlags; }
-    IMGUI_API void          SetActiveID(ImGuiID id, ImGuiWindow* window);
-    IMGUI_API void          SetFocusID(ImGuiID id, ImGuiWindow* window);
-    IMGUI_API void          ClearActiveID();
-    IMGUI_API ImGuiID       GetHoveredID();
-    IMGUI_API void          SetHoveredID(ImGuiID id);
-    IMGUI_API void          KeepAliveID(ImGuiID id);
-    IMGUI_API void          MarkItemEdited(ImGuiID id);     // Mark data associated to given item as "edited", used by IsItemDeactivatedAfterEdit() function.
-    IMGUI_API void          PushOverrideID(ImGuiID id);     // Push given value as-is at the top of the ID stack (whereas PushID combines old and new hashes)
-    IMGUI_API ImGuiID       GetIDWithSeed(const char* str_id_begin, const char* str_id_end, ImGuiID seed);
+    inline ImGuiID          GetItemID()    IMGUI_NOEXCEPT   { ImGuiContext& g = *GImGui; return g.CurrentWindow->DC.LastItemId; }   // Get ID of last item (~~ often same ImGui::GetID(label) beforehand)
+    inline ImGuiItemStatusFlags GetItemStatusFlags() IMGUI_NOEXCEPT { ImGuiContext& g = *GImGui; return g.CurrentWindow->DC.LastItemStatusFlags; }
+    inline ImGuiID          GetActiveID()  IMGUI_NOEXCEPT   { ImGuiContext& g = *GImGui; return g.ActiveId; }
+    inline ImGuiID          GetFocusID()   IMGUI_NOEXCEPT   { ImGuiContext& g = *GImGui; return g.NavId; }
+    inline ImGuiItemFlags   GetItemFlags() IMGUI_NOEXCEPT   { ImGuiContext& g = *GImGui; return g.CurrentItemFlags; }
+    IMGUI_API void          SetActiveID(ImGuiID id, ImGuiWindow* window) IMGUI_NOEXCEPT;
+    IMGUI_API void          SetFocusID(ImGuiID id, ImGuiWindow* window) IMGUI_NOEXCEPT;
+    IMGUI_API void          ClearActiveID() IMGUI_NOEXCEPT;
+    IMGUI_API ImGuiID       GetHoveredID()  IMGUI_NOEXCEPT;
+    IMGUI_API void          SetHoveredID(ImGuiID id) IMGUI_NOEXCEPT;
+    IMGUI_API void          KeepAliveID(ImGuiID id) IMGUI_NOEXCEPT;
+    IMGUI_API void          MarkItemEdited(ImGuiID id) IMGUI_NOEXCEPT;     // Mark data associated to given item as "edited", used by IsItemDeactivatedAfterEdit() function.
+    IMGUI_API void          PushOverrideID(ImGuiID id) IMGUI_NOEXCEPT;     // Push given value as-is at the top of the ID stack (whereas PushID combines old and new hashes)
+    IMGUI_API ImGuiID       GetIDWithSeed(const char* str_id_begin, const char* str_id_end, ImGuiID seed) IMGUI_NOEXCEPT;
 
     // Basic Helpers for widget code
-    IMGUI_API void          ItemSize(const ImVec2& size, float text_baseline_y = -1.0f);
-    IMGUI_API void          ItemSize(const ImRect& bb, float text_baseline_y = -1.0f);
-    IMGUI_API bool          ItemAdd(const ImRect& bb, ImGuiID id, const ImRect* nav_bb = NULL, ImGuiItemAddFlags flags = 0);
-    IMGUI_API bool          ItemHoverable(const ImRect& bb, ImGuiID id);
-    IMGUI_API void          ItemFocusable(ImGuiWindow* window, ImGuiID id);
-    IMGUI_API bool          IsClippedEx(const ImRect& bb, ImGuiID id, bool clip_even_when_logged);
-    IMGUI_API void          SetLastItemData(ImGuiWindow* window, ImGuiID item_id, ImGuiItemStatusFlags status_flags, const ImRect& item_rect);
-    IMGUI_API ImVec2        CalcItemSize(ImVec2 size, float default_w, float default_h);
-    IMGUI_API float         CalcWrapWidthForPos(const ImVec2& pos, float wrap_pos_x);
-    IMGUI_API void          PushMultiItemsWidths(int components, float width_full);
-    IMGUI_API void          PushItemFlag(ImGuiItemFlags option, bool enabled);
-    IMGUI_API void          PopItemFlag();
-    IMGUI_API bool          IsItemToggledSelection();                                   // Was the last item selection toggled? (after Selectable(), TreeNode() etc. We only returns toggle _event_ in order to handle clipping correctly)
-    IMGUI_API ImVec2        GetContentRegionMaxAbs();
-    IMGUI_API void          ShrinkWidths(ImGuiShrinkWidthItem* items, int count, float width_excess);
+    IMGUI_API void          ItemSize(const ImVec2& size, float text_baseline_y = -1.0f) IMGUI_NOEXCEPT;
+    IMGUI_API void          ItemSize(const ImRect& bb, float text_baseline_y = -1.0f) IMGUI_NOEXCEPT;
+    IMGUI_API bool          ItemAdd(const ImRect& bb, ImGuiID id, const ImRect* nav_bb = NULL, ImGuiItemAddFlags flags = 0) IMGUI_NOEXCEPT;
+    IMGUI_API bool          ItemHoverable(const ImRect& bb, ImGuiID id) IMGUI_NOEXCEPT;
+    IMGUI_API void          ItemFocusable(ImGuiWindow* window, ImGuiID id) IMGUI_NOEXCEPT;
+    IMGUI_API bool          IsClippedEx(const ImRect& bb, ImGuiID id, bool clip_even_when_logged) IMGUI_NOEXCEPT;
+    IMGUI_API void          SetLastItemData(ImGuiWindow* window, ImGuiID item_id, ImGuiItemStatusFlags status_flags, const ImRect& item_rect) IMGUI_NOEXCEPT;
+    IMGUI_API ImVec2        CalcItemSize(ImVec2 size, float default_w, float default_h) IMGUI_NOEXCEPT;
+    IMGUI_API float         CalcWrapWidthForPos(const ImVec2& pos, float wrap_pos_x) IMGUI_NOEXCEPT;
+    IMGUI_API void          PushMultiItemsWidths(int components, float width_full) IMGUI_NOEXCEPT;
+    IMGUI_API void          PushItemFlag(ImGuiItemFlags option, bool enabled) IMGUI_NOEXCEPT;
+    IMGUI_API void          PopItemFlag() IMGUI_NOEXCEPT;
+    IMGUI_API bool          IsItemToggledSelection() IMGUI_NOEXCEPT;                    // Was the last item selection toggled? (after Selectable(), TreeNode() etc. We only returns toggle _event_ in order to handle clipping correctly)
+    IMGUI_API ImVec2        GetContentRegionMaxAbs() IMGUI_NOEXCEPT;
+    IMGUI_API void          ShrinkWidths(ImGuiShrinkWidthItem* items, int count, float width_excess) IMGUI_NOEXCEPT;
 
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
     // If you have old/custom copy-and-pasted widgets that used FocusableItemRegister():
     //  (Old) IMGUI_VERSION_NUM  < 18209: using 'ItemAdd(....)'                              and 'bool focused = FocusableItemRegister(...)'
     //  (New) IMGUI_VERSION_NUM >= 18209: using 'ItemAdd(..., ImGuiItemAddFlags_Focusable)'  and 'bool focused = (GetItemStatusFlags() & ImGuiItemStatusFlags_Focused) != 0'
     // Widget code are simplified as there's no need to call FocusableItemUnregister() while managing the transition from regular widget to TempInputText()
-    inline bool FocusableItemRegister(ImGuiWindow* window, ImGuiID id)  { IM_ASSERT(0); IM_UNUSED(window); IM_UNUSED(id); return false; } // -> pass ImGuiItemAddFlags_Focusable flag to ItemAdd()
-    inline void FocusableItemUnregister(ImGuiWindow* window)            { IM_ASSERT(0); IM_UNUSED(window); }                              // -> unnecessary: TempInputText() uses ImGuiInputTextFlags_MergedItem
+    inline bool FocusableItemRegister(ImGuiWindow* window, ImGuiID id) IMGUI_NOEXCEPT  { IM_ASSERT(0); IM_UNUSED(window); IM_UNUSED(id); return false; } // -> pass ImGuiItemAddFlags_Focusable flag to ItemAdd()
+    inline void FocusableItemUnregister(ImGuiWindow* window)           IMGUI_NOEXCEPT  { IM_ASSERT(0); IM_UNUSED(window); }                              // -> unnecessary: TempInputText() uses ImGuiInputTextFlags_MergedItem
 #endif
 
     // Logging/Capture
-    IMGUI_API void          LogBegin(ImGuiLogType type, int auto_open_depth);           // -> BeginCapture() when we design v2 api, for now stay under the radar by using the old name.
-    IMGUI_API void          LogToBuffer(int auto_open_depth = -1);                      // Start logging/capturing to internal buffer
-    IMGUI_API void          LogRenderedText(const ImVec2* ref_pos, const char* text, const char* text_end = NULL);
-    IMGUI_API void          LogSetNextTextDecoration(const char* prefix, const char* suffix);
+    IMGUI_API void          LogBegin(ImGuiLogType type, int auto_open_depth) IMGUI_NOEXCEPT;           // -> BeginCapture() when we design v2 api, for now stay under the radar by using the old name.
+    IMGUI_API void          LogToBuffer(int auto_open_depth = -1)            IMGUI_NOEXCEPT;           // Start logging/capturing to internal buffer
+    IMGUI_API void          LogRenderedText(const ImVec2* ref_pos, const char* text, const char* text_end = NULL) IMGUI_NOEXCEPT;
+    IMGUI_API void          LogSetNextTextDecoration(const char* prefix, const char* suffix) IMGUI_NOEXCEPT;
 
     // Popups, Modals, Tooltips
-    IMGUI_API bool          BeginChildEx(const char* name, ImGuiID id, const ImVec2& size_arg, bool border, ImGuiWindowFlags flags);
-    IMGUI_API void          OpenPopupEx(ImGuiID id, ImGuiPopupFlags popup_flags = ImGuiPopupFlags_None);
-    IMGUI_API void          ClosePopupToLevel(int remaining, bool restore_focus_to_window_under_popup);
-    IMGUI_API void          ClosePopupsOverWindow(ImGuiWindow* ref_window, bool restore_focus_to_window_under_popup);
-    IMGUI_API bool          IsPopupOpen(ImGuiID id, ImGuiPopupFlags popup_flags);
-    IMGUI_API bool          BeginPopupEx(ImGuiID id, ImGuiWindowFlags extra_flags);
-    IMGUI_API void          BeginTooltipEx(ImGuiWindowFlags extra_flags, ImGuiTooltipFlags tooltip_flags);
-    IMGUI_API ImGuiWindow*  GetTopMostPopupModal();
-    IMGUI_API ImVec2        FindBestWindowPosForPopup(ImGuiWindow* window);
-    IMGUI_API ImVec2        FindBestWindowPosForPopupEx(const ImVec2& ref_pos, const ImVec2& size, ImGuiDir* last_dir, const ImRect& r_outer, const ImRect& r_avoid, ImGuiPopupPositionPolicy policy);
-    IMGUI_API bool          BeginViewportSideBar(const char* name, ImGuiViewport* viewport, ImGuiDir dir, float size, ImGuiWindowFlags window_flags);
+    IMGUI_API bool          BeginChildEx(const char* name, ImGuiID id, const ImVec2& size_arg, bool border, ImGuiWindowFlags flags) IMGUI_NOEXCEPT;
+    IMGUI_API void          OpenPopupEx(ImGuiID id, ImGuiPopupFlags popup_flags = ImGuiPopupFlags_None) IMGUI_NOEXCEPT;
+    IMGUI_API void          ClosePopupToLevel(int remaining, bool restore_focus_to_window_under_popup) IMGUI_NOEXCEPT;
+    IMGUI_API void          ClosePopupsOverWindow(ImGuiWindow* ref_window, bool restore_focus_to_window_under_popup) IMGUI_NOEXCEPT;
+    IMGUI_API bool          IsPopupOpen(ImGuiID id, ImGuiPopupFlags popup_flags) IMGUI_NOEXCEPT;
+    IMGUI_API bool          BeginPopupEx(ImGuiID id, ImGuiWindowFlags extra_flags) IMGUI_NOEXCEPT;
+    IMGUI_API void          BeginTooltipEx(ImGuiWindowFlags extra_flags, ImGuiTooltipFlags tooltip_flags) IMGUI_NOEXCEPT;
+    IMGUI_API ImGuiWindow*  GetTopMostPopupModal() IMGUI_NOEXCEPT;
+    IMGUI_API ImVec2        FindBestWindowPosForPopup(ImGuiWindow* window) IMGUI_NOEXCEPT;
+    IMGUI_API ImVec2        FindBestWindowPosForPopupEx(const ImVec2& ref_pos, const ImVec2& size, ImGuiDir* last_dir, const ImRect& r_outer, const ImRect& r_avoid, ImGuiPopupPositionPolicy policy) IMGUI_NOEXCEPT;
+    IMGUI_API bool          BeginViewportSideBar(const char* name, ImGuiViewport* viewport, ImGuiDir dir, float size, ImGuiWindowFlags window_flags) IMGUI_NOEXCEPT;
 
     // Gamepad/Keyboard Navigation
-    IMGUI_API void          NavInitWindow(ImGuiWindow* window, bool force_reinit);
-    IMGUI_API bool          NavMoveRequestButNoResultYet();
-    IMGUI_API void          NavMoveRequestCancel();
-    IMGUI_API void          NavMoveRequestForward(ImGuiDir move_dir, ImGuiDir clip_dir, const ImRect& bb_rel, ImGuiNavMoveFlags move_flags);
-    IMGUI_API void          NavMoveRequestTryWrapping(ImGuiWindow* window, ImGuiNavMoveFlags move_flags);
-    IMGUI_API float         GetNavInputAmount(ImGuiNavInput n, ImGuiInputReadMode mode);
-    IMGUI_API ImVec2        GetNavInputAmount2d(ImGuiNavDirSourceFlags dir_sources, ImGuiInputReadMode mode, float slow_factor = 0.0f, float fast_factor = 0.0f);
-    IMGUI_API int           CalcTypematicRepeatAmount(float t0, float t1, float repeat_delay, float repeat_rate);
-    IMGUI_API void          ActivateItem(ImGuiID id);   // Remotely activate a button, checkbox, tree node etc. given its unique ID. activation is queued and processed on the next frame when the item is encountered again.
-    IMGUI_API void          SetNavID(ImGuiID id, ImGuiNavLayer nav_layer, ImGuiID focus_scope_id, const ImRect& rect_rel);
+    IMGUI_API void          NavInitWindow(ImGuiWindow* window, bool force_reinit) IMGUI_NOEXCEPT;
+    IMGUI_API bool          NavMoveRequestButNoResultYet() IMGUI_NOEXCEPT;
+    IMGUI_API void          NavMoveRequestCancel() IMGUI_NOEXCEPT;
+    IMGUI_API void          NavMoveRequestForward(ImGuiDir move_dir, ImGuiDir clip_dir, const ImRect& bb_rel, ImGuiNavMoveFlags move_flags) IMGUI_NOEXCEPT;
+    IMGUI_API void          NavMoveRequestTryWrapping(ImGuiWindow* window, ImGuiNavMoveFlags move_flags) IMGUI_NOEXCEPT;
+    IMGUI_API float         GetNavInputAmount(ImGuiNavInput n, ImGuiInputReadMode mode) IMGUI_NOEXCEPT;
+    IMGUI_API ImVec2        GetNavInputAmount2d(ImGuiNavDirSourceFlags dir_sources, ImGuiInputReadMode mode, float slow_factor = 0.0f, float fast_factor = 0.0f) IMGUI_NOEXCEPT;
+    IMGUI_API int           CalcTypematicRepeatAmount(float t0, float t1, float repeat_delay, float repeat_rate) IMGUI_NOEXCEPT;
+    IMGUI_API void          ActivateItem(ImGuiID id) IMGUI_NOEXCEPT;   // Remotely activate a button, checkbox, tree node etc. given its unique ID. activation is queued and processed on the next frame when the item is encountered again.
+    IMGUI_API void          SetNavID(ImGuiID id, ImGuiNavLayer nav_layer, ImGuiID focus_scope_id, const ImRect& rect_rel) IMGUI_NOEXCEPT;
 
     // Focus Scope (WIP)
     // This is generally used to identify a selection set (multiple of which may be in the same window), as selection
     // patterns generally need to react (e.g. clear selection) when landing on an item of the set.
-    IMGUI_API void          PushFocusScope(ImGuiID id);
-    IMGUI_API void          PopFocusScope();
-    inline ImGuiID          GetFocusedFocusScope()          { ImGuiContext& g = *GImGui; return g.NavFocusScopeId; }                            // Focus scope which is actually active
-    inline ImGuiID          GetFocusScope()                 { ImGuiContext& g = *GImGui; return g.CurrentWindow->DC.NavFocusScopeIdCurrent; }   // Focus scope we are outputting into, set by PushFocusScope()
+    IMGUI_API void          PushFocusScope(ImGuiID id) IMGUI_NOEXCEPT;
+    IMGUI_API void          PopFocusScope() IMGUI_NOEXCEPT;
+    inline ImGuiID          GetFocusedFocusScope() IMGUI_NOEXCEPT { ImGuiContext& g = *GImGui; return g.NavFocusScopeId; }                            // Focus scope which is actually active
+    inline ImGuiID          GetFocusScope()        IMGUI_NOEXCEPT { ImGuiContext& g = *GImGui; return g.CurrentWindow->DC.NavFocusScopeIdCurrent; }   // Focus scope we are outputting into, set by PushFocusScope()
 
     // Inputs
     // FIXME: Eventually we should aim to move e.g. IsActiveIdUsingKey() into IsKeyXXX functions.
-    IMGUI_API void          SetItemUsingMouseWheel();
-    inline bool             IsActiveIdUsingNavDir(ImGuiDir dir)                         { ImGuiContext& g = *GImGui; return (g.ActiveIdUsingNavDirMask & (1 << dir)) != 0; }
-    inline bool             IsActiveIdUsingNavInput(ImGuiNavInput input)                { ImGuiContext& g = *GImGui; return (g.ActiveIdUsingNavInputMask & (1 << input)) != 0; }
-    inline bool             IsActiveIdUsingKey(ImGuiKey key)                            { ImGuiContext& g = *GImGui; IM_ASSERT(key < 64); return (g.ActiveIdUsingKeyInputMask & ((ImU64)1 << key)) != 0; }
-    IMGUI_API bool          IsMouseDragPastThreshold(ImGuiMouseButton button, float lock_threshold = -1.0f);
-    inline bool             IsKeyPressedMap(ImGuiKey key, bool repeat = true)           { ImGuiContext& g = *GImGui; const int key_index = g.IO.KeyMap[key]; return (key_index >= 0) ? IsKeyPressed(key_index, repeat) : false; }
-    inline bool             IsNavInputDown(ImGuiNavInput n)                             { ImGuiContext& g = *GImGui; return g.IO.NavInputs[n] > 0.0f; }
-    inline bool             IsNavInputTest(ImGuiNavInput n, ImGuiInputReadMode rm)      { return (GetNavInputAmount(n, rm) > 0.0f); }
-    IMGUI_API ImGuiKeyModFlags GetMergedKeyModFlags();
+    IMGUI_API void          SetItemUsingMouseWheel()                                IMGUI_NOEXCEPT;
+    inline bool             IsActiveIdUsingNavDir(ImGuiDir dir)                     IMGUI_NOEXCEPT { ImGuiContext& g = *GImGui; return (g.ActiveIdUsingNavDirMask & (1 << dir)) != 0; }
+    inline bool             IsActiveIdUsingNavInput(ImGuiNavInput input)            IMGUI_NOEXCEPT { ImGuiContext& g = *GImGui; return (g.ActiveIdUsingNavInputMask & (1 << input)) != 0; }
+    inline bool             IsActiveIdUsingKey(ImGuiKey key)                        IMGUI_NOEXCEPT { ImGuiContext& g = *GImGui; IM_ASSERT(key < 64); return (g.ActiveIdUsingKeyInputMask & ((ImU64)1 << key)) != 0; }
+    IMGUI_API bool          IsMouseDragPastThreshold(ImGuiMouseButton button, float lock_threshold = -1.0f) IMGUI_NOEXCEPT;
+    inline bool             IsKeyPressedMap(ImGuiKey key, bool repeat = true)       IMGUI_NOEXCEPT { ImGuiContext& g = *GImGui; const int key_index = g.IO.KeyMap[key]; return (key_index >= 0) ? IsKeyPressed(key_index, repeat) : false; }
+    inline bool             IsNavInputDown(ImGuiNavInput n)                         IMGUI_NOEXCEPT { ImGuiContext& g = *GImGui; return g.IO.NavInputs[n] > 0.0f; }
+    inline bool             IsNavInputTest(ImGuiNavInput n, ImGuiInputReadMode rm)  IMGUI_NOEXCEPT { return (GetNavInputAmount(n, rm) > 0.0f); }
+    IMGUI_API ImGuiKeyModFlags GetMergedKeyModFlags()                               IMGUI_NOEXCEPT;
 
     // Drag and Drop
-    IMGUI_API bool          BeginDragDropTargetCustom(const ImRect& bb, ImGuiID id);
-    IMGUI_API void          ClearDragDrop();
-    IMGUI_API bool          IsDragDropPayloadBeingAccepted();
+    IMGUI_API bool          BeginDragDropTargetCustom(const ImRect& bb, ImGuiID id) IMGUI_NOEXCEPT;
+    IMGUI_API void          ClearDragDrop()                                         IMGUI_NOEXCEPT;
+    IMGUI_API bool          IsDragDropPayloadBeingAccepted()                        IMGUI_NOEXCEPT;
 
     // Internal Columns API (this is not exposed because we will encourage transitioning to the Tables API)
-    IMGUI_API void          SetWindowClipRectBeforeSetChannel(ImGuiWindow* window, const ImRect& clip_rect);
-    IMGUI_API void          BeginColumns(const char* str_id, int count, ImGuiOldColumnFlags flags = 0); // setup number of columns. use an identifier to distinguish multiple column sets. close with EndColumns().
-    IMGUI_API void          EndColumns();                                                               // close columns
-    IMGUI_API void          PushColumnClipRect(int column_index);
-    IMGUI_API void          PushColumnsBackground();
-    IMGUI_API void          PopColumnsBackground();
-    IMGUI_API ImGuiID       GetColumnsID(const char* str_id, int count);
-    IMGUI_API ImGuiOldColumns* FindOrCreateColumns(ImGuiWindow* window, ImGuiID id);
-    IMGUI_API float         GetColumnOffsetFromNorm(const ImGuiOldColumns* columns, float offset_norm);
-    IMGUI_API float         GetColumnNormFromOffset(const ImGuiOldColumns* columns, float offset);
+    IMGUI_API void          SetWindowClipRectBeforeSetChannel(ImGuiWindow* window, const ImRect& clip_rect) IMGUI_NOEXCEPT;
+    IMGUI_API void          BeginColumns(const char* str_id, int count, ImGuiOldColumnFlags flags = 0) IMGUI_NOEXCEPT; // setup number of columns. use an identifier to distinguish multiple column sets. close with EndColumns().
+    IMGUI_API void          EndColumns() IMGUI_NOEXCEPT;                                                               // close columns
+    IMGUI_API void          PushColumnClipRect(int column_index) IMGUI_NOEXCEPT;
+    IMGUI_API void          PushColumnsBackground() IMGUI_NOEXCEPT;
+    IMGUI_API void          PopColumnsBackground() IMGUI_NOEXCEPT;
+    IMGUI_API ImGuiID       GetColumnsID(const char* str_id, int count) IMGUI_NOEXCEPT;
+    IMGUI_API ImGuiOldColumns* FindOrCreateColumns(ImGuiWindow* window, ImGuiID id) IMGUI_NOEXCEPT;
+    IMGUI_API float         GetColumnOffsetFromNorm(const ImGuiOldColumns* columns, float offset_norm) IMGUI_NOEXCEPT;
+    IMGUI_API float         GetColumnNormFromOffset(const ImGuiOldColumns* columns, float offset) IMGUI_NOEXCEPT;
 
     // Tables: Candidates for public API
-    IMGUI_API void          TableOpenContextMenu(int column_n = -1);
-    IMGUI_API void          TableSetColumnWidth(int column_n, float width);
-    IMGUI_API void          TableSetColumnSortDirection(int column_n, ImGuiSortDirection sort_direction, bool append_to_sort_specs);
-    IMGUI_API int           TableGetHoveredColumn(); // May use (TableGetColumnFlags() & ImGuiTableColumnFlags_IsHovered) instead. Return hovered column. return -1 when table is not hovered. return columns_count if the unused space at the right of visible columns is hovered.
-    IMGUI_API float         TableGetHeaderRowHeight();
-    IMGUI_API void          TablePushBackgroundChannel();
-    IMGUI_API void          TablePopBackgroundChannel();
+    IMGUI_API void          TableOpenContextMenu(int column_n = -1) IMGUI_NOEXCEPT;
+    IMGUI_API void          TableSetColumnWidth(int column_n, float width) IMGUI_NOEXCEPT;
+    IMGUI_API void          TableSetColumnSortDirection(int column_n, ImGuiSortDirection sort_direction, bool append_to_sort_specs) IMGUI_NOEXCEPT;
+    IMGUI_API int           TableGetHoveredColumn() IMGUI_NOEXCEPT; // May use (TableGetColumnFlags() & ImGuiTableColumnFlags_IsHovered) instead. Return hovered column. return -1 when table is not hovered. return columns_count if the unused space at the right of visible columns is hovered.
+    IMGUI_API float         TableGetHeaderRowHeight() IMGUI_NOEXCEPT;
+    IMGUI_API void          TablePushBackgroundChannel() IMGUI_NOEXCEPT;
+    IMGUI_API void          TablePopBackgroundChannel() IMGUI_NOEXCEPT;
 
     // Tables: Internals
-    inline    ImGuiTable*   GetCurrentTable() { ImGuiContext& g = *GImGui; return g.CurrentTable; }
-    IMGUI_API ImGuiTable*   TableFindByID(ImGuiID id);
-    IMGUI_API bool          BeginTableEx(const char* name, ImGuiID id, int columns_count, ImGuiTableFlags flags = 0, const ImVec2& outer_size = ImVec2(0, 0), float inner_width = 0.0f);
-    IMGUI_API void          TableBeginInitMemory(ImGuiTable* table, int columns_count);
-    IMGUI_API void          TableBeginApplyRequests(ImGuiTable* table);
-    IMGUI_API void          TableSetupDrawChannels(ImGuiTable* table);
-    IMGUI_API void          TableUpdateLayout(ImGuiTable* table);
-    IMGUI_API void          TableUpdateBorders(ImGuiTable* table);
-    IMGUI_API void          TableUpdateColumnsWeightFromWidth(ImGuiTable* table);
-    IMGUI_API void          TableDrawBorders(ImGuiTable* table);
-    IMGUI_API void          TableDrawContextMenu(ImGuiTable* table);
-    IMGUI_API void          TableMergeDrawChannels(ImGuiTable* table);
-    IMGUI_API void          TableSortSpecsSanitize(ImGuiTable* table);
-    IMGUI_API void          TableSortSpecsBuild(ImGuiTable* table);
-    IMGUI_API ImGuiSortDirection TableGetColumnNextSortDirection(ImGuiTableColumn* column);
-    IMGUI_API void          TableFixColumnSortDirection(ImGuiTable* table, ImGuiTableColumn* column);
-    IMGUI_API float         TableGetColumnWidthAuto(ImGuiTable* table, ImGuiTableColumn* column);
-    IMGUI_API void          TableBeginRow(ImGuiTable* table);
-    IMGUI_API void          TableEndRow(ImGuiTable* table);
-    IMGUI_API void          TableBeginCell(ImGuiTable* table, int column_n);
-    IMGUI_API void          TableEndCell(ImGuiTable* table);
-    IMGUI_API ImRect        TableGetCellBgRect(const ImGuiTable* table, int column_n);
-    IMGUI_API const char*   TableGetColumnName(const ImGuiTable* table, int column_n);
-    IMGUI_API ImGuiID       TableGetColumnResizeID(const ImGuiTable* table, int column_n, int instance_no = 0);
-    IMGUI_API float         TableGetMaxColumnWidth(const ImGuiTable* table, int column_n);
-    IMGUI_API void          TableSetColumnWidthAutoSingle(ImGuiTable* table, int column_n);
-    IMGUI_API void          TableSetColumnWidthAutoAll(ImGuiTable* table);
-    IMGUI_API void          TableRemove(ImGuiTable* table);
-    IMGUI_API void          TableGcCompactTransientBuffers(ImGuiTable* table);
-    IMGUI_API void          TableGcCompactTransientBuffers(ImGuiTableTempData* table);
-    IMGUI_API void          TableGcCompactSettings();
+    inline    ImGuiTable*   GetCurrentTable() IMGUI_NOEXCEPT { ImGuiContext& g = *GImGui; return g.CurrentTable; }
+    IMGUI_API ImGuiTable*   TableFindByID(ImGuiID id) IMGUI_NOEXCEPT;
+    IMGUI_API bool          BeginTableEx(const char* name, ImGuiID id, int columns_count, ImGuiTableFlags flags = 0, const ImVec2& outer_size = ImVec2(0, 0), float inner_width = 0.0f) IMGUI_NOEXCEPT;
+    IMGUI_API void          TableBeginInitMemory(ImGuiTable* table, int columns_count) IMGUI_NOEXCEPT;
+    IMGUI_API void          TableBeginApplyRequests(ImGuiTable* table) IMGUI_NOEXCEPT;
+    IMGUI_API void          TableSetupDrawChannels(ImGuiTable* table) IMGUI_NOEXCEPT;
+    IMGUI_API void          TableUpdateLayout(ImGuiTable* table) IMGUI_NOEXCEPT;
+    IMGUI_API void          TableUpdateBorders(ImGuiTable* table) IMGUI_NOEXCEPT;
+    IMGUI_API void          TableUpdateColumnsWeightFromWidth(ImGuiTable* table) IMGUI_NOEXCEPT;
+    IMGUI_API void          TableDrawBorders(ImGuiTable* table) IMGUI_NOEXCEPT;
+    IMGUI_API void          TableDrawContextMenu(ImGuiTable* table) IMGUI_NOEXCEPT;
+    IMGUI_API void          TableMergeDrawChannels(ImGuiTable* table) IMGUI_NOEXCEPT;
+    IMGUI_API void          TableSortSpecsSanitize(ImGuiTable* table) IMGUI_NOEXCEPT;
+    IMGUI_API void          TableSortSpecsBuild(ImGuiTable* table) IMGUI_NOEXCEPT;
+    IMGUI_API ImGuiSortDirection TableGetColumnNextSortDirection(ImGuiTableColumn* column) IMGUI_NOEXCEPT;
+    IMGUI_API void          TableFixColumnSortDirection(ImGuiTable* table, ImGuiTableColumn* column) IMGUI_NOEXCEPT;
+    IMGUI_API float         TableGetColumnWidthAuto(ImGuiTable* table, ImGuiTableColumn* column) IMGUI_NOEXCEPT;
+    IMGUI_API void          TableBeginRow(ImGuiTable* table) IMGUI_NOEXCEPT;
+    IMGUI_API void          TableEndRow(ImGuiTable* table) IMGUI_NOEXCEPT;
+    IMGUI_API void          TableBeginCell(ImGuiTable* table, int column_n) IMGUI_NOEXCEPT;
+    IMGUI_API void          TableEndCell(ImGuiTable* table) IMGUI_NOEXCEPT;
+    IMGUI_API ImRect        TableGetCellBgRect(const ImGuiTable* table, int column_n) IMGUI_NOEXCEPT;
+    IMGUI_API const char*   TableGetColumnName(const ImGuiTable* table, int column_n) IMGUI_NOEXCEPT;
+    IMGUI_API ImGuiID       TableGetColumnResizeID(const ImGuiTable* table, int column_n, int instance_no = 0) IMGUI_NOEXCEPT;
+    IMGUI_API float         TableGetMaxColumnWidth(const ImGuiTable* table, int column_n) IMGUI_NOEXCEPT;
+    IMGUI_API void          TableSetColumnWidthAutoSingle(ImGuiTable* table, int column_n) IMGUI_NOEXCEPT;
+    IMGUI_API void          TableSetColumnWidthAutoAll(ImGuiTable* table) IMGUI_NOEXCEPT;
+    IMGUI_API void          TableRemove(ImGuiTable* table) IMGUI_NOEXCEPT;
+    IMGUI_API void          TableGcCompactTransientBuffers(ImGuiTable* table) IMGUI_NOEXCEPT;
+    IMGUI_API void          TableGcCompactTransientBuffers(ImGuiTableTempData* table) IMGUI_NOEXCEPT;
+    IMGUI_API void          TableGcCompactSettings() IMGUI_NOEXCEPT;
 
     // Tables: Settings
-    IMGUI_API void                  TableLoadSettings(ImGuiTable* table);
-    IMGUI_API void                  TableSaveSettings(ImGuiTable* table);
-    IMGUI_API void                  TableResetSettings(ImGuiTable* table);
-    IMGUI_API ImGuiTableSettings*   TableGetBoundSettings(ImGuiTable* table);
-    IMGUI_API void                  TableSettingsInstallHandler(ImGuiContext* context);
-    IMGUI_API ImGuiTableSettings*   TableSettingsCreate(ImGuiID id, int columns_count);
-    IMGUI_API ImGuiTableSettings*   TableSettingsFindByID(ImGuiID id);
+    IMGUI_API void                  TableLoadSettings(ImGuiTable* table) IMGUI_NOEXCEPT;
+    IMGUI_API void                  TableSaveSettings(ImGuiTable* table) IMGUI_NOEXCEPT;
+    IMGUI_API void                  TableResetSettings(ImGuiTable* table) IMGUI_NOEXCEPT;
+    IMGUI_API ImGuiTableSettings*   TableGetBoundSettings(ImGuiTable* table) IMGUI_NOEXCEPT;
+    IMGUI_API void                  TableSettingsInstallHandler(ImGuiContext* context) IMGUI_NOEXCEPT;
+    IMGUI_API ImGuiTableSettings*   TableSettingsCreate(ImGuiID id, int columns_count) IMGUI_NOEXCEPT;
+    IMGUI_API ImGuiTableSettings*   TableSettingsFindByID(ImGuiID id) IMGUI_NOEXCEPT;
 
     // Tab Bars
-    IMGUI_API bool          BeginTabBarEx(ImGuiTabBar* tab_bar, const ImRect& bb, ImGuiTabBarFlags flags);
-    IMGUI_API ImGuiTabItem* TabBarFindTabByID(ImGuiTabBar* tab_bar, ImGuiID tab_id);
-    IMGUI_API void          TabBarRemoveTab(ImGuiTabBar* tab_bar, ImGuiID tab_id);
-    IMGUI_API void          TabBarCloseTab(ImGuiTabBar* tab_bar, ImGuiTabItem* tab);
-    IMGUI_API void          TabBarQueueReorder(ImGuiTabBar* tab_bar, const ImGuiTabItem* tab, int offset);
-    IMGUI_API void          TabBarQueueReorderFromMousePos(ImGuiTabBar* tab_bar, const ImGuiTabItem* tab, ImVec2 mouse_pos);
-    IMGUI_API bool          TabBarProcessReorder(ImGuiTabBar* tab_bar);
-    IMGUI_API bool          TabItemEx(ImGuiTabBar* tab_bar, const char* label, bool* p_open, ImGuiTabItemFlags flags);
-    IMGUI_API ImVec2        TabItemCalcSize(const char* label, bool has_close_button);
-    IMGUI_API void          TabItemBackground(ImDrawList* draw_list, const ImRect& bb, ImGuiTabItemFlags flags, ImU32 col);
-    IMGUI_API void          TabItemLabelAndCloseButton(ImDrawList* draw_list, const ImRect& bb, ImGuiTabItemFlags flags, ImVec2 frame_padding, const char* label, ImGuiID tab_id, ImGuiID close_button_id, bool is_contents_visible, bool* out_just_closed, bool* out_text_clipped);
+    IMGUI_API bool          BeginTabBarEx(ImGuiTabBar* tab_bar, const ImRect& bb, ImGuiTabBarFlags flags) IMGUI_NOEXCEPT;
+    IMGUI_API ImGuiTabItem* TabBarFindTabByID(ImGuiTabBar* tab_bar, ImGuiID tab_id) IMGUI_NOEXCEPT;
+    IMGUI_API void          TabBarRemoveTab(ImGuiTabBar* tab_bar, ImGuiID tab_id) IMGUI_NOEXCEPT;
+    IMGUI_API void          TabBarCloseTab(ImGuiTabBar* tab_bar, ImGuiTabItem* tab) IMGUI_NOEXCEPT;
+    IMGUI_API void          TabBarQueueReorder(ImGuiTabBar* tab_bar, const ImGuiTabItem* tab, int offset) IMGUI_NOEXCEPT;
+    IMGUI_API void          TabBarQueueReorderFromMousePos(ImGuiTabBar* tab_bar, const ImGuiTabItem* tab, ImVec2 mouse_pos) IMGUI_NOEXCEPT;
+    IMGUI_API bool          TabBarProcessReorder(ImGuiTabBar* tab_bar) IMGUI_NOEXCEPT;
+    IMGUI_API bool          TabItemEx(ImGuiTabBar* tab_bar, const char* label, bool* p_open, ImGuiTabItemFlags flags) IMGUI_NOEXCEPT;
+    IMGUI_API ImVec2        TabItemCalcSize(const char* label, bool has_close_button) IMGUI_NOEXCEPT;
+    IMGUI_API void          TabItemBackground(ImDrawList* draw_list, const ImRect& bb, ImGuiTabItemFlags flags, ImU32 col) IMGUI_NOEXCEPT;
+    IMGUI_API void          TabItemLabelAndCloseButton(ImDrawList* draw_list, const ImRect& bb, ImGuiTabItemFlags flags, ImVec2 frame_padding, const char* label, ImGuiID tab_id, ImGuiID close_button_id, bool is_contents_visible, bool* out_just_closed, bool* out_text_clipped) IMGUI_NOEXCEPT;
 
     // Render helpers
     // AVOID USING OUTSIDE OF IMGUI.CPP! NOT FOR PUBLIC CONSUMPTION. THOSE FUNCTIONS ARE A MESS. THEIR SIGNATURE AND BEHAVIOR WILL CHANGE, THEY NEED TO BE REFACTORED INTO SOMETHING DECENT.
     // NB: All position are in absolute pixels coordinates (we are never using window coordinates internally)
-    IMGUI_API void          RenderText(ImVec2 pos, const char* text, const char* text_end = NULL, bool hide_text_after_hash = true);
-    IMGUI_API void          RenderTextWrapped(ImVec2 pos, const char* text, const char* text_end, float wrap_width);
-    IMGUI_API void          RenderTextClipped(const ImVec2& pos_min, const ImVec2& pos_max, const char* text, const char* text_end, const ImVec2* text_size_if_known, const ImVec2& align = ImVec2(0, 0), const ImRect* clip_rect = NULL);
-    IMGUI_API void          RenderTextClippedEx(ImDrawList* draw_list, const ImVec2& pos_min, const ImVec2& pos_max, const char* text, const char* text_end, const ImVec2* text_size_if_known, const ImVec2& align = ImVec2(0, 0), const ImRect* clip_rect = NULL);
-    IMGUI_API void          RenderTextEllipsis(ImDrawList* draw_list, const ImVec2& pos_min, const ImVec2& pos_max, float clip_max_x, float ellipsis_max_x, const char* text, const char* text_end, const ImVec2* text_size_if_known);
-    IMGUI_API void          RenderFrame(ImVec2 p_min, ImVec2 p_max, ImU32 fill_col, bool border = true, float rounding = 0.0f);
-    IMGUI_API void          RenderFrameBorder(ImVec2 p_min, ImVec2 p_max, float rounding = 0.0f);
-    IMGUI_API void          RenderColorRectWithAlphaCheckerboard(ImDrawList* draw_list, ImVec2 p_min, ImVec2 p_max, ImU32 fill_col, float grid_step, ImVec2 grid_off, float rounding = 0.0f, ImDrawFlags flags = 0);
-    IMGUI_API void          RenderNavHighlight(const ImRect& bb, ImGuiID id, ImGuiNavHighlightFlags flags = ImGuiNavHighlightFlags_TypeDefault); // Navigation highlight
-    IMGUI_API const char*   FindRenderedTextEnd(const char* text, const char* text_end = NULL); // Find the optional ## from which we stop displaying text.
+    IMGUI_API void          RenderText(ImVec2 pos, const char* text, const char* text_end = NULL, bool hide_text_after_hash = true) IMGUI_NOEXCEPT;
+    IMGUI_API void          RenderTextWrapped(ImVec2 pos, const char* text, const char* text_end, float wrap_width) IMGUI_NOEXCEPT;
+    IMGUI_API void          RenderTextClipped(const ImVec2& pos_min, const ImVec2& pos_max, const char* text, const char* text_end, const ImVec2* text_size_if_known, const ImVec2& align = ImVec2(0, 0), const ImRect* clip_rect = NULL) IMGUI_NOEXCEPT;
+    IMGUI_API void          RenderTextClippedEx(ImDrawList* draw_list, const ImVec2& pos_min, const ImVec2& pos_max, const char* text, const char* text_end, const ImVec2* text_size_if_known, const ImVec2& align = ImVec2(0, 0), const ImRect* clip_rect = NULL) IMGUI_NOEXCEPT;
+    IMGUI_API void          RenderTextEllipsis(ImDrawList* draw_list, const ImVec2& pos_min, const ImVec2& pos_max, float clip_max_x, float ellipsis_max_x, const char* text, const char* text_end, const ImVec2* text_size_if_known) IMGUI_NOEXCEPT;
+    IMGUI_API void          RenderFrame(ImVec2 p_min, ImVec2 p_max, ImU32 fill_col, bool border = true, float rounding = 0.0f) IMGUI_NOEXCEPT;
+    IMGUI_API void          RenderFrameBorder(ImVec2 p_min, ImVec2 p_max, float rounding = 0.0f) IMGUI_NOEXCEPT;
+    IMGUI_API void          RenderColorRectWithAlphaCheckerboard(ImDrawList* draw_list, ImVec2 p_min, ImVec2 p_max, ImU32 fill_col, float grid_step, ImVec2 grid_off, float rounding = 0.0f, ImDrawFlags flags = 0) IMGUI_NOEXCEPT;
+    IMGUI_API void          RenderNavHighlight(const ImRect& bb, ImGuiID id, ImGuiNavHighlightFlags flags = ImGuiNavHighlightFlags_TypeDefault) IMGUI_NOEXCEPT; // Navigation highlight
+    IMGUI_API const char*   FindRenderedTextEnd(const char* text, const char* text_end = NULL) IMGUI_NOEXCEPT; // Find the optional ## from which we stop displaying text.
 
     // Render helpers (those functions don't access any ImGui state!)
-    IMGUI_API void          RenderArrow(ImDrawList* draw_list, ImVec2 pos, ImU32 col, ImGuiDir dir, float scale = 1.0f);
-    IMGUI_API void          RenderBullet(ImDrawList* draw_list, ImVec2 pos, ImU32 col);
-    IMGUI_API void          RenderCheckMark(ImDrawList* draw_list, ImVec2 pos, ImU32 col, float sz);
-    IMGUI_API void          RenderMouseCursor(ImDrawList* draw_list, ImVec2 pos, float scale, ImGuiMouseCursor mouse_cursor, ImU32 col_fill, ImU32 col_border, ImU32 col_shadow);
-    IMGUI_API void          RenderArrowPointingAt(ImDrawList* draw_list, ImVec2 pos, ImVec2 half_sz, ImGuiDir direction, ImU32 col);
-    IMGUI_API void          RenderRectFilledRangeH(ImDrawList* draw_list, const ImRect& rect, ImU32 col, float x_start_norm, float x_end_norm, float rounding);
-    IMGUI_API void          RenderRectFilledWithHole(ImDrawList* draw_list, ImRect outer, ImRect inner, ImU32 col, float rounding);
+    IMGUI_API void          RenderArrow(ImDrawList* draw_list, ImVec2 pos, ImU32 col, ImGuiDir dir, float scale = 1.0f) IMGUI_NOEXCEPT;
+    IMGUI_API void          RenderBullet(ImDrawList* draw_list, ImVec2 pos, ImU32 col) IMGUI_NOEXCEPT;
+    IMGUI_API void          RenderCheckMark(ImDrawList* draw_list, ImVec2 pos, ImU32 col, float sz) IMGUI_NOEXCEPT;
+    IMGUI_API void          RenderMouseCursor(ImDrawList* draw_list, ImVec2 pos, float scale, ImGuiMouseCursor mouse_cursor, ImU32 col_fill, ImU32 col_border, ImU32 col_shadow) IMGUI_NOEXCEPT;
+    IMGUI_API void          RenderArrowPointingAt(ImDrawList* draw_list, ImVec2 pos, ImVec2 half_sz, ImGuiDir direction, ImU32 col) IMGUI_NOEXCEPT;
+    IMGUI_API void          RenderRectFilledRangeH(ImDrawList* draw_list, const ImRect& rect, ImU32 col, float x_start_norm, float x_end_norm, float rounding) IMGUI_NOEXCEPT;
+    IMGUI_API void          RenderRectFilledWithHole(ImDrawList* draw_list, ImRect outer, ImRect inner, ImU32 col, float rounding) IMGUI_NOEXCEPT;
 
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
     // [1.71: 2019/06/07: Updating prototypes of some of the internal functions. Leaving those for reference for a short while]
-    inline void RenderArrow(ImVec2 pos, ImGuiDir dir, float scale=1.0f) { ImGuiWindow* window = GetCurrentWindow(); RenderArrow(window->DrawList, pos, GetColorU32(ImGuiCol_Text), dir, scale); }
-    inline void RenderBullet(ImVec2 pos)                                { ImGuiWindow* window = GetCurrentWindow(); RenderBullet(window->DrawList, pos, GetColorU32(ImGuiCol_Text)); }
+    inline void RenderArrow(ImVec2 pos, ImGuiDir dir, float scale=1.0f) IMGUI_NOEXCEPT { ImGuiWindow* window = GetCurrentWindow(); RenderArrow(window->DrawList, pos, GetColorU32(ImGuiCol_Text), dir, scale); }
+    inline void RenderBullet(ImVec2 pos)                                IMGUI_NOEXCEPT { ImGuiWindow* window = GetCurrentWindow(); RenderBullet(window->DrawList, pos, GetColorU32(ImGuiCol_Text)); }
 #endif
 
     // Widgets
-    IMGUI_API void          TextEx(const char* text, const char* text_end = NULL, ImGuiTextFlags flags = 0);
-    IMGUI_API bool          ButtonEx(const char* label, const ImVec2& size_arg = ImVec2(0, 0), ImGuiButtonFlags flags = 0);
-    IMGUI_API bool          CloseButton(ImGuiID id, const ImVec2& pos);
-    IMGUI_API bool          CollapseButton(ImGuiID id, const ImVec2& pos);
-    IMGUI_API bool          ArrowButtonEx(const char* str_id, ImGuiDir dir, ImVec2 size_arg, ImGuiButtonFlags flags = 0);
-    IMGUI_API void          Scrollbar(ImGuiAxis axis);
-    IMGUI_API bool          ScrollbarEx(const ImRect& bb, ImGuiID id, ImGuiAxis axis, float* p_scroll_v, float avail_v, float contents_v, ImDrawFlags flags);
-    IMGUI_API bool          ImageButtonEx(ImGuiID id, ImTextureID texture_id, const ImVec2& size, const ImVec2& uv0, const ImVec2& uv1, const ImVec2& padding, const ImVec4& bg_col, const ImVec4& tint_col);
-    IMGUI_API ImRect        GetWindowScrollbarRect(ImGuiWindow* window, ImGuiAxis axis);
-    IMGUI_API ImGuiID       GetWindowScrollbarID(ImGuiWindow* window, ImGuiAxis axis);
-    IMGUI_API ImGuiID       GetWindowResizeCornerID(ImGuiWindow* window, int n); // 0..3: corners
-    IMGUI_API ImGuiID       GetWindowResizeBorderID(ImGuiWindow* window, ImGuiDir dir);
-    IMGUI_API void          SeparatorEx(ImGuiSeparatorFlags flags);
-    IMGUI_API bool          CheckboxFlags(const char* label, ImS64* flags, ImS64 flags_value);
-    IMGUI_API bool          CheckboxFlags(const char* label, ImU64* flags, ImU64 flags_value);
+    IMGUI_API void          TextEx(const char* text, const char* text_end = NULL, ImGuiTextFlags flags = 0) IMGUI_NOEXCEPT;
+    IMGUI_API bool          ButtonEx(const char* label, const ImVec2& size_arg = ImVec2(0, 0), ImGuiButtonFlags flags = 0) IMGUI_NOEXCEPT;
+    IMGUI_API bool          CloseButton(ImGuiID id, const ImVec2& pos) IMGUI_NOEXCEPT;
+    IMGUI_API bool          CollapseButton(ImGuiID id, const ImVec2& pos) IMGUI_NOEXCEPT;
+    IMGUI_API bool          ArrowButtonEx(const char* str_id, ImGuiDir dir, ImVec2 size_arg, ImGuiButtonFlags flags = 0) IMGUI_NOEXCEPT;
+    IMGUI_API void          Scrollbar(ImGuiAxis axis) IMGUI_NOEXCEPT;
+    IMGUI_API bool          ScrollbarEx(const ImRect& bb, ImGuiID id, ImGuiAxis axis, float* p_scroll_v, float avail_v, float contents_v, ImDrawFlags flags) IMGUI_NOEXCEPT;
+    IMGUI_API bool          ImageButtonEx(ImGuiID id, ImTextureID texture_id, const ImVec2& size, const ImVec2& uv0, const ImVec2& uv1, const ImVec2& padding, const ImVec4& bg_col, const ImVec4& tint_col) IMGUI_NOEXCEPT;
+    IMGUI_API ImRect        GetWindowScrollbarRect(ImGuiWindow* window, ImGuiAxis axis) IMGUI_NOEXCEPT;
+    IMGUI_API ImGuiID       GetWindowScrollbarID(ImGuiWindow* window, ImGuiAxis axis) IMGUI_NOEXCEPT;
+    IMGUI_API ImGuiID       GetWindowResizeCornerID(ImGuiWindow* window, int n) IMGUI_NOEXCEPT; // 0..3: corners
+    IMGUI_API ImGuiID       GetWindowResizeBorderID(ImGuiWindow* window, ImGuiDir dir) IMGUI_NOEXCEPT;
+    IMGUI_API void          SeparatorEx(ImGuiSeparatorFlags flags) IMGUI_NOEXCEPT;
+    IMGUI_API bool          CheckboxFlags(const char* label, ImS64* flags, ImS64 flags_value) IMGUI_NOEXCEPT;
+    IMGUI_API bool          CheckboxFlags(const char* label, ImU64* flags, ImU64 flags_value) IMGUI_NOEXCEPT;
 
     // Widgets low-level behaviors
-    IMGUI_API bool          ButtonBehavior(const ImRect& bb, ImGuiID id, bool* out_hovered, bool* out_held, ImGuiButtonFlags flags = 0);
-    IMGUI_API bool          DragBehavior(ImGuiID id, ImGuiDataType data_type, void* p_v, float v_speed, const void* p_min, const void* p_max, const char* format, ImGuiSliderFlags flags);
-    IMGUI_API bool          SliderBehavior(const ImRect& bb, ImGuiID id, ImGuiDataType data_type, void* p_v, const void* p_min, const void* p_max, const char* format, ImGuiSliderFlags flags, ImRect* out_grab_bb);
-    IMGUI_API bool          SplitterBehavior(const ImRect& bb, ImGuiID id, ImGuiAxis axis, float* size1, float* size2, float min_size1, float min_size2, float hover_extend = 0.0f, float hover_visibility_delay = 0.0f);
-    IMGUI_API bool          TreeNodeBehavior(ImGuiID id, ImGuiTreeNodeFlags flags, const char* label, const char* label_end = NULL);
-    IMGUI_API bool          TreeNodeBehaviorIsOpen(ImGuiID id, ImGuiTreeNodeFlags flags = 0);                     // Consume previous SetNextItemOpen() data, if any. May return true when logging
-    IMGUI_API void          TreePushOverrideID(ImGuiID id);
+    IMGUI_API bool          ButtonBehavior(const ImRect& bb, ImGuiID id, bool* out_hovered, bool* out_held, ImGuiButtonFlags flags = 0) IMGUI_NOEXCEPT;
+    IMGUI_API bool          DragBehavior(ImGuiID id, ImGuiDataType data_type, void* p_v, float v_speed, const void* p_min, const void* p_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT;
+    IMGUI_API bool          SliderBehavior(const ImRect& bb, ImGuiID id, ImGuiDataType data_type, void* p_v, const void* p_min, const void* p_max, const char* format, ImGuiSliderFlags flags, ImRect* out_grab_bb) IMGUI_NOEXCEPT;
+    IMGUI_API bool          SplitterBehavior(const ImRect& bb, ImGuiID id, ImGuiAxis axis, float* size1, float* size2, float min_size1, float min_size2, float hover_extend = 0.0f, float hover_visibility_delay = 0.0f) IMGUI_NOEXCEPT;
+    IMGUI_API bool          TreeNodeBehavior(ImGuiID id, ImGuiTreeNodeFlags flags, const char* label, const char* label_end = NULL) IMGUI_NOEXCEPT;
+    IMGUI_API bool          TreeNodeBehaviorIsOpen(ImGuiID id, ImGuiTreeNodeFlags flags = 0) IMGUI_NOEXCEPT;                     // Consume previous SetNextItemOpen() data, if any. May return true when logging
+    IMGUI_API void          TreePushOverrideID(ImGuiID id) IMGUI_NOEXCEPT;
 
     // Template functions are instantiated in imgui_widgets.cpp for a finite number of types.
     // To use them externally (for custom widget) you may need an "extern template" statement in your code in order to link to existing instances and silence Clang warnings (see #2036).
     // e.g. " extern template IMGUI_API float RoundScalarWithFormatT<float, float>(const char* format, ImGuiDataType data_type, float v); "
-    template<typename T, typename SIGNED_T, typename FLOAT_T>   IMGUI_API float ScaleRatioFromValueT(ImGuiDataType data_type, T v, T v_min, T v_max, bool is_logarithmic, float logarithmic_zero_epsilon, float zero_deadzone_size);
-    template<typename T, typename SIGNED_T, typename FLOAT_T>   IMGUI_API T     ScaleValueFromRatioT(ImGuiDataType data_type, float t, T v_min, T v_max, bool is_logarithmic, float logarithmic_zero_epsilon, float zero_deadzone_size);
-    template<typename T, typename SIGNED_T, typename FLOAT_T>   IMGUI_API bool  DragBehaviorT(ImGuiDataType data_type, T* v, float v_speed, T v_min, T v_max, const char* format, ImGuiSliderFlags flags);
-    template<typename T, typename SIGNED_T, typename FLOAT_T>   IMGUI_API bool  SliderBehaviorT(const ImRect& bb, ImGuiID id, ImGuiDataType data_type, T* v, T v_min, T v_max, const char* format, ImGuiSliderFlags flags, ImRect* out_grab_bb);
-    template<typename T, typename SIGNED_T>                     IMGUI_API T     RoundScalarWithFormatT(const char* format, ImGuiDataType data_type, T v);
-    template<typename T>                                        IMGUI_API bool  CheckboxFlagsT(const char* label, T* flags, T flags_value);
+    template<typename T, typename SIGNED_T, typename FLOAT_T>   IMGUI_API float ScaleRatioFromValueT(ImGuiDataType data_type, T v, T v_min, T v_max, bool is_logarithmic, float logarithmic_zero_epsilon, float zero_deadzone_size) IMGUI_NOEXCEPT;
+    template<typename T, typename SIGNED_T, typename FLOAT_T>   IMGUI_API T     ScaleValueFromRatioT(ImGuiDataType data_type, float t, T v_min, T v_max, bool is_logarithmic, float logarithmic_zero_epsilon, float zero_deadzone_size) IMGUI_NOEXCEPT;
+    template<typename T, typename SIGNED_T, typename FLOAT_T>   IMGUI_API bool  DragBehaviorT(ImGuiDataType data_type, T* v, float v_speed, T v_min, T v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT;
+    template<typename T, typename SIGNED_T, typename FLOAT_T>   IMGUI_API bool  SliderBehaviorT(const ImRect& bb, ImGuiID id, ImGuiDataType data_type, T* v, T v_min, T v_max, const char* format, ImGuiSliderFlags flags, ImRect* out_grab_bb) IMGUI_NOEXCEPT;
+    template<typename T, typename SIGNED_T>                     IMGUI_API T     RoundScalarWithFormatT(const char* format, ImGuiDataType data_type, T v) IMGUI_NOEXCEPT;
+    template<typename T>                                        IMGUI_API bool  CheckboxFlagsT(const char* label, T* flags, T flags_value) IMGUI_NOEXCEPT;
 
     // Data type helpers
-    IMGUI_API const ImGuiDataTypeInfo*  DataTypeGetInfo(ImGuiDataType data_type);
-    IMGUI_API int           DataTypeFormatString(char* buf, int buf_size, ImGuiDataType data_type, const void* p_data, const char* format);
-    IMGUI_API void          DataTypeApplyOp(ImGuiDataType data_type, int op, void* output, const void* arg_1, const void* arg_2);
-    IMGUI_API bool          DataTypeApplyOpFromText(const char* buf, const char* initial_value_buf, ImGuiDataType data_type, void* p_data, const char* format);
-    IMGUI_API int           DataTypeCompare(ImGuiDataType data_type, const void* arg_1, const void* arg_2);
-    IMGUI_API bool          DataTypeClamp(ImGuiDataType data_type, void* p_data, const void* p_min, const void* p_max);
+    IMGUI_API const ImGuiDataTypeInfo*  DataTypeGetInfo(ImGuiDataType data_type) IMGUI_NOEXCEPT;
+    IMGUI_API int           DataTypeFormatString(char* buf, int buf_size, ImGuiDataType data_type, const void* p_data, const char* format) IMGUI_NOEXCEPT;
+    IMGUI_API void          DataTypeApplyOp(ImGuiDataType data_type, int op, void* output, const void* arg_1, const void* arg_2) IMGUI_NOEXCEPT;
+    IMGUI_API bool          DataTypeApplyOpFromText(const char* buf, const char* initial_value_buf, ImGuiDataType data_type, void* p_data, const char* format) IMGUI_NOEXCEPT;
+    IMGUI_API int           DataTypeCompare(ImGuiDataType data_type, const void* arg_1, const void* arg_2) IMGUI_NOEXCEPT;
+    IMGUI_API bool          DataTypeClamp(ImGuiDataType data_type, void* p_data, const void* p_min, const void* p_max) IMGUI_NOEXCEPT;
 
     // InputText
-    IMGUI_API bool          InputTextEx(const char* label, const char* hint, char* buf, int buf_size, const ImVec2& size_arg, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback = NULL, void* user_data = NULL);
-    IMGUI_API bool          TempInputText(const ImRect& bb, ImGuiID id, const char* label, char* buf, int buf_size, ImGuiInputTextFlags flags);
-    IMGUI_API bool          TempInputScalar(const ImRect& bb, ImGuiID id, const char* label, ImGuiDataType data_type, void* p_data, const char* format, const void* p_clamp_min = NULL, const void* p_clamp_max = NULL);
-    inline bool             TempInputIsActive(ImGuiID id)       { ImGuiContext& g = *GImGui; return (g.ActiveId == id && g.TempInputId == id); }
-    inline ImGuiInputTextState* GetInputTextState(ImGuiID id)   { ImGuiContext& g = *GImGui; return (g.InputTextState.ID == id) ? &g.InputTextState : NULL; } // Get input text state if active
+    IMGUI_API bool          InputTextEx(const char* label, const char* hint, char* buf, int buf_size, const ImVec2& size_arg, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback = NULL, void* user_data = NULL) IMGUI_NOEXCEPT;
+    IMGUI_API bool          TempInputText(const ImRect& bb, ImGuiID id, const char* label, char* buf, int buf_size, ImGuiInputTextFlags flags) IMGUI_NOEXCEPT;
+    IMGUI_API bool          TempInputScalar(const ImRect& bb, ImGuiID id, const char* label, ImGuiDataType data_type, void* p_data, const char* format, const void* p_clamp_min = NULL, const void* p_clamp_max = NULL) IMGUI_NOEXCEPT;
+    inline bool             TempInputIsActive(ImGuiID id)     IMGUI_NOEXCEPT   { ImGuiContext& g = *GImGui; return (g.ActiveId == id && g.TempInputId == id); }
+    inline ImGuiInputTextState* GetInputTextState(ImGuiID id) IMGUI_NOEXCEPT   { ImGuiContext& g = *GImGui; return (g.InputTextState.ID == id) ? &g.InputTextState : NULL; } // Get input text state if active
 
     // Color
-    IMGUI_API void          ColorTooltip(const char* text, const float* col, ImGuiColorEditFlags flags);
-    IMGUI_API void          ColorEditOptionsPopup(const float* col, ImGuiColorEditFlags flags);
-    IMGUI_API void          ColorPickerOptionsPopup(const float* ref_col, ImGuiColorEditFlags flags);
+    IMGUI_API void          ColorTooltip(const char* text, const float* col, ImGuiColorEditFlags flags) IMGUI_NOEXCEPT;
+    IMGUI_API void          ColorEditOptionsPopup(const float* col, ImGuiColorEditFlags flags) IMGUI_NOEXCEPT;
+    IMGUI_API void          ColorPickerOptionsPopup(const float* ref_col, ImGuiColorEditFlags flags) IMGUI_NOEXCEPT;
 
     // Plot
-    IMGUI_API int           PlotEx(ImGuiPlotType plot_type, const char* label, float (*values_getter)(void* data, int idx), void* data, int values_count, int values_offset, const char* overlay_text, float scale_min, float scale_max, ImVec2 frame_size);
+    IMGUI_API int           PlotEx(ImGuiPlotType plot_type, const char* label, float (*values_getter)(void* data, int idx), void* data, int values_count, int values_offset, const char* overlay_text, float scale_min, float scale_max, ImVec2 frame_size) IMGUI_NOEXCEPT;
 
     // Shade functions (write over already created vertices)
-    IMGUI_API void          ShadeVertsLinearColorGradientKeepAlpha(ImDrawList* draw_list, int vert_start_idx, int vert_end_idx, ImVec2 gradient_p0, ImVec2 gradient_p1, ImU32 col0, ImU32 col1);
-    IMGUI_API void          ShadeVertsLinearUV(ImDrawList* draw_list, int vert_start_idx, int vert_end_idx, const ImVec2& a, const ImVec2& b, const ImVec2& uv_a, const ImVec2& uv_b, bool clamp);
+    IMGUI_API void          ShadeVertsLinearColorGradientKeepAlpha(ImDrawList* draw_list, int vert_start_idx, int vert_end_idx, ImVec2 gradient_p0, ImVec2 gradient_p1, ImU32 col0, ImU32 col1) IMGUI_NOEXCEPT;
+    IMGUI_API void          ShadeVertsLinearUV(ImDrawList* draw_list, int vert_start_idx, int vert_end_idx, const ImVec2& a, const ImVec2& b, const ImVec2& uv_a, const ImVec2& uv_b, bool clamp) IMGUI_NOEXCEPT;
 
     // Garbage collection
-    IMGUI_API void          GcCompactTransientMiscBuffers();
-    IMGUI_API void          GcCompactTransientWindowBuffers(ImGuiWindow* window);
-    IMGUI_API void          GcAwakeTransientWindowBuffers(ImGuiWindow* window);
+    IMGUI_API void          GcCompactTransientMiscBuffers() IMGUI_NOEXCEPT;
+    IMGUI_API void          GcCompactTransientWindowBuffers(ImGuiWindow* window) IMGUI_NOEXCEPT;
+    IMGUI_API void          GcAwakeTransientWindowBuffers(ImGuiWindow* window) IMGUI_NOEXCEPT;
 
     // Debug Tools
-    IMGUI_API void          ErrorCheckEndFrameRecover(ImGuiErrorLogCallback log_callback, void* user_data = NULL);
-    inline void             DebugDrawItemRect(ImU32 col = IM_COL32(255,0,0,255))    { ImGuiContext& g = *GImGui; ImGuiWindow* window = g.CurrentWindow; GetForegroundDrawList(window)->AddRect(window->DC.LastItemRect.Min, window->DC.LastItemRect.Max, col); }
-    inline void             DebugStartItemPicker()                                  { ImGuiContext& g = *GImGui; g.DebugItemPickerActive = true; }
+    IMGUI_API void          ErrorCheckEndFrameRecover(ImGuiErrorLogCallback log_callback, void* user_data = NULL) IMGUI_NOEXCEPT;
+    inline void             DebugDrawItemRect(ImU32 col = IM_COL32(255,0,0,255)) IMGUI_NOEXCEPT    { ImGuiContext& g = *GImGui; ImGuiWindow* window = g.CurrentWindow; GetForegroundDrawList(window)->AddRect(window->DC.LastItemRect.Min, window->DC.LastItemRect.Max, col); }
+    inline void             DebugStartItemPicker()                               IMGUI_NOEXCEPT    { ImGuiContext& g = *GImGui; g.DebugItemPickerActive = true; }
 
-    IMGUI_API void          DebugNodeColumns(ImGuiOldColumns* columns);
-    IMGUI_API void          DebugNodeDrawList(ImGuiWindow* window, const ImDrawList* draw_list, const char* label);
-    IMGUI_API void          DebugNodeDrawCmdShowMeshAndBoundingBox(ImDrawList* out_draw_list, const ImDrawList* draw_list, const ImDrawCmd* draw_cmd, bool show_mesh, bool show_aabb);
-    IMGUI_API void          DebugNodeStorage(ImGuiStorage* storage, const char* label);
-    IMGUI_API void          DebugNodeTabBar(ImGuiTabBar* tab_bar, const char* label);
-    IMGUI_API void          DebugNodeTable(ImGuiTable* table);
-    IMGUI_API void          DebugNodeTableSettings(ImGuiTableSettings* settings);
-    IMGUI_API void          DebugNodeWindow(ImGuiWindow* window, const char* label);
-    IMGUI_API void          DebugNodeWindowSettings(ImGuiWindowSettings* settings);
-    IMGUI_API void          DebugNodeWindowsList(ImVector<ImGuiWindow*>* windows, const char* label);
-    IMGUI_API void          DebugNodeViewport(ImGuiViewportP* viewport);
-    IMGUI_API void          DebugRenderViewportThumbnail(ImDrawList* draw_list, ImGuiViewportP* viewport, const ImRect& bb);
+    IMGUI_API void          DebugNodeColumns(ImGuiOldColumns* columns) IMGUI_NOEXCEPT;
+    IMGUI_API void          DebugNodeDrawList(ImGuiWindow* window, const ImDrawList* draw_list, const char* label) IMGUI_NOEXCEPT;
+    IMGUI_API void          DebugNodeDrawCmdShowMeshAndBoundingBox(ImDrawList* out_draw_list, const ImDrawList* draw_list, const ImDrawCmd* draw_cmd, bool show_mesh, bool show_aabb) IMGUI_NOEXCEPT;
+    IMGUI_API void          DebugNodeStorage(ImGuiStorage* storage, const char* label) IMGUI_NOEXCEPT;
+    IMGUI_API void          DebugNodeTabBar(ImGuiTabBar* tab_bar, const char* label) IMGUI_NOEXCEPT;
+    IMGUI_API void          DebugNodeTable(ImGuiTable* table) IMGUI_NOEXCEPT;
+    IMGUI_API void          DebugNodeTableSettings(ImGuiTableSettings* settings) IMGUI_NOEXCEPT;
+    IMGUI_API void          DebugNodeWindow(ImGuiWindow* window, const char* label) IMGUI_NOEXCEPT;
+    IMGUI_API void          DebugNodeWindowSettings(ImGuiWindowSettings* settings) IMGUI_NOEXCEPT;
+    IMGUI_API void          DebugNodeWindowsList(ImVector<ImGuiWindow*>* windows, const char* label) IMGUI_NOEXCEPT;
+    IMGUI_API void          DebugNodeViewport(ImGuiViewportP* viewport) IMGUI_NOEXCEPT;
+    IMGUI_API void          DebugRenderViewportThumbnail(ImDrawList* draw_list, ImGuiViewportP* viewport, const ImRect& bb) IMGUI_NOEXCEPT;
 
 } // namespace ImGui
 
@@ -2640,30 +2640,30 @@ namespace ImGui
 // This structure is likely to evolve as we add support for incremental atlas updates
 struct ImFontBuilderIO
 {
-    bool    (*FontBuilder_Build)(ImFontAtlas* atlas);
+    bool    (*FontBuilder_Build)(ImFontAtlas* atlas) IMGUI_NOEXCEPT;
 };
 
 // Helper for font builder
-IMGUI_API const ImFontBuilderIO* ImFontAtlasGetBuilderForStbTruetype();
-IMGUI_API void      ImFontAtlasBuildInit(ImFontAtlas* atlas);
-IMGUI_API void      ImFontAtlasBuildSetupFont(ImFontAtlas* atlas, ImFont* font, ImFontConfig* font_config, float ascent, float descent);
-IMGUI_API void      ImFontAtlasBuildPackCustomRects(ImFontAtlas* atlas, void* stbrp_context_opaque);
-IMGUI_API void      ImFontAtlasBuildFinish(ImFontAtlas* atlas);
-IMGUI_API void      ImFontAtlasBuildRender8bppRectFromString(ImFontAtlas* atlas, int x, int y, int w, int h, const char* in_str, char in_marker_char, unsigned char in_marker_pixel_value);
-IMGUI_API void      ImFontAtlasBuildRender32bppRectFromString(ImFontAtlas* atlas, int x, int y, int w, int h, const char* in_str, char in_marker_char, unsigned int in_marker_pixel_value);
-IMGUI_API void      ImFontAtlasBuildMultiplyCalcLookupTable(unsigned char out_table[256], float in_multiply_factor);
-IMGUI_API void      ImFontAtlasBuildMultiplyRectAlpha8(const unsigned char table[256], unsigned char* pixels, int x, int y, int w, int h, int stride);
+IMGUI_API const ImFontBuilderIO* ImFontAtlasGetBuilderForStbTruetype() IMGUI_NOEXCEPT;
+IMGUI_API void      ImFontAtlasBuildInit(ImFontAtlas* atlas) IMGUI_NOEXCEPT;
+IMGUI_API void      ImFontAtlasBuildSetupFont(ImFontAtlas* atlas, ImFont* font, ImFontConfig* font_config, float ascent, float descent) IMGUI_NOEXCEPT;
+IMGUI_API void      ImFontAtlasBuildPackCustomRects(ImFontAtlas* atlas, void* stbrp_context_opaque) IMGUI_NOEXCEPT;
+IMGUI_API void      ImFontAtlasBuildFinish(ImFontAtlas* atlas) IMGUI_NOEXCEPT;
+IMGUI_API void      ImFontAtlasBuildRender8bppRectFromString(ImFontAtlas* atlas, int x, int y, int w, int h, const char* in_str, char in_marker_char, unsigned char in_marker_pixel_value) IMGUI_NOEXCEPT;
+IMGUI_API void      ImFontAtlasBuildRender32bppRectFromString(ImFontAtlas* atlas, int x, int y, int w, int h, const char* in_str, char in_marker_char, unsigned int in_marker_pixel_value) IMGUI_NOEXCEPT;
+IMGUI_API void      ImFontAtlasBuildMultiplyCalcLookupTable(unsigned char out_table[256], float in_multiply_factor) IMGUI_NOEXCEPT;
+IMGUI_API void      ImFontAtlasBuildMultiplyRectAlpha8(const unsigned char table[256], unsigned char* pixels, int x, int y, int w, int h, int stride) IMGUI_NOEXCEPT;
 
 //-----------------------------------------------------------------------------
 // [SECTION] Test Engine specific hooks (imgui_test_engine)
 //-----------------------------------------------------------------------------
 
 #ifdef IMGUI_ENABLE_TEST_ENGINE
-extern void         ImGuiTestEngineHook_ItemAdd(ImGuiContext* ctx, const ImRect& bb, ImGuiID id);
-extern void         ImGuiTestEngineHook_ItemInfo(ImGuiContext* ctx, ImGuiID id, const char* label, ImGuiItemStatusFlags flags);
-extern void         ImGuiTestEngineHook_IdInfo(ImGuiContext* ctx, ImGuiDataType data_type, ImGuiID id, const void* data_id);
-extern void         ImGuiTestEngineHook_IdInfo(ImGuiContext* ctx, ImGuiDataType data_type, ImGuiID id, const void* data_id, const void* data_id_end);
-extern void         ImGuiTestEngineHook_Log(ImGuiContext* ctx, const char* fmt, ...);
+extern void         ImGuiTestEngineHook_ItemAdd(ImGuiContext* ctx, const ImRect& bb, ImGuiID id) IMGUI_NOEXCEPT;
+extern void         ImGuiTestEngineHook_ItemInfo(ImGuiContext* ctx, ImGuiID id, const char* label, ImGuiItemStatusFlags flags) IMGUI_NOEXCEPT;
+extern void         ImGuiTestEngineHook_IdInfo(ImGuiContext* ctx, ImGuiDataType data_type, ImGuiID id, const void* data_id) IMGUI_NOEXCEPT;
+extern void         ImGuiTestEngineHook_IdInfo(ImGuiContext* ctx, ImGuiDataType data_type, ImGuiID id, const void* data_id, const void* data_id_end) IMGUI_NOEXCEPT;
+extern void         ImGuiTestEngineHook_Log(ImGuiContext* ctx, const char* fmt, ...) IMGUI_NOEXCEPT;
 #define IMGUI_TEST_ENGINE_ITEM_ADD(_BB,_ID)                 if (g.TestEngineHookItems) ImGuiTestEngineHook_ItemAdd(&g, _BB, _ID)               // Register item bounding box
 #define IMGUI_TEST_ENGINE_ITEM_INFO(_ID,_LABEL,_FLAGS)      if (g.TestEngineHookItems) ImGuiTestEngineHook_ItemInfo(&g, _ID, _LABEL, _FLAGS)   // Register item label and status flags (optional)
 #define IMGUI_TEST_ENGINE_LOG(_FMT,...)                     if (g.TestEngineHookItems) ImGuiTestEngineHook_Log(&g, _FMT, __VA_ARGS__)          // Custom log entry from user land into test log

--- a/imgui_tables.cpp
+++ b/imgui_tables.cpp
@@ -306,7 +306,7 @@ ImGuiTable* ImGui::TableFindByID(ImGuiID id)
 }
 
 // Read about "TABLE SIZING" at the top of this file.
-bool    ImGui::BeginTable(const char* str_id, int columns_count, ImGuiTableFlags flags, const ImVec2& outer_size, float inner_width)
+bool    ImGui::BeginTable(const char* str_id, int columns_count, ImGuiTableFlags flags, const ImVec2& outer_size, float inner_width) IMGUI_NOEXCEPT
 {
     ImGuiID id = GetID(str_id);
     return BeginTableEx(str_id, id, columns_count, flags, outer_size, inner_width);
@@ -1196,7 +1196,7 @@ void ImGui::TableUpdateBorders(ImGuiTable* table)
     }
 }
 
-void    ImGui::EndTable()
+void    ImGui::EndTable() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;

--- a/imgui_tables.cpp
+++ b/imgui_tables.cpp
@@ -261,7 +261,7 @@ static const float TABLE_RESIZE_SEPARATOR_HALF_THICKNESS = 4.0f;    // Extend ou
 static const float TABLE_RESIZE_SEPARATOR_FEEDBACK_TIMER = 0.06f;   // Delay/timer before making the hover feedback (color+cursor) visible because tables/columns tends to be more cramped.
 
 // Helper
-inline ImGuiTableFlags TableFixFlags(ImGuiTableFlags flags, ImGuiWindow* outer_window)
+inline ImGuiTableFlags TableFixFlags(ImGuiTableFlags flags, ImGuiWindow* outer_window) IMGUI_NOEXCEPT
 {
     // Adjust flags: set default sizing policy
     if ((flags & ImGuiTableFlags_SizingMask_) == 0)
@@ -299,7 +299,7 @@ inline ImGuiTableFlags TableFixFlags(ImGuiTableFlags flags, ImGuiWindow* outer_w
     return flags;
 }
 
-ImGuiTable* ImGui::TableFindByID(ImGuiID id)
+ImGuiTable* ImGui::TableFindByID(ImGuiID id) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return g.Tables.GetByKey(id);
@@ -312,7 +312,7 @@ bool    ImGui::BeginTable(const char* str_id, int columns_count, ImGuiTableFlags
     return BeginTableEx(str_id, id, columns_count, flags, outer_size, inner_width);
 }
 
-bool    ImGui::BeginTableEx(const char* name, ImGuiID id, int columns_count, ImGuiTableFlags flags, const ImVec2& outer_size, float inner_width)
+bool    ImGui::BeginTableEx(const char* name, ImGuiID id, int columns_count, ImGuiTableFlags flags, const ImVec2& outer_size, float inner_width) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* outer_window = GetCurrentWindow();
@@ -573,7 +573,7 @@ bool    ImGui::BeginTableEx(const char* name, ImGuiID id, int columns_count, ImG
 // + 2 * active_channels_count (for ImDrawCmd and ImDrawIdx buffers inside channels)
 // Where active_channels_count is variable but often == columns_count or columns_count + 1, see TableSetupDrawChannels() for details.
 // Unused channels don't perform their +2 allocations.
-void ImGui::TableBeginInitMemory(ImGuiTable* table, int columns_count)
+void ImGui::TableBeginInitMemory(ImGuiTable* table, int columns_count) IMGUI_NOEXCEPT
 {
     // Allocate single buffer for our arrays
     ImSpanAllocator<3> span_allocator;
@@ -589,7 +589,7 @@ void ImGui::TableBeginInitMemory(ImGuiTable* table, int columns_count)
 }
 
 // Apply queued resizing/reordering/hiding requests
-void ImGui::TableBeginApplyRequests(ImGuiTable* table)
+void ImGui::TableBeginApplyRequests(ImGuiTable* table) IMGUI_NOEXCEPT
 {
     // Handle resizing request
     // (We process this at the first TableBegin of the frame)
@@ -657,7 +657,7 @@ void ImGui::TableBeginApplyRequests(ImGuiTable* table)
 }
 
 // Adjust flags: default width mode + stretch columns are not allowed when auto extending
-static void TableSetupColumnFlags(ImGuiTable* table, ImGuiTableColumn* column, ImGuiTableColumnFlags flags_in)
+static void TableSetupColumnFlags(ImGuiTable* table, ImGuiTableColumn* column, ImGuiTableColumnFlags flags_in) IMGUI_NOEXCEPT
 {
     ImGuiTableColumnFlags flags = flags_in;
 
@@ -716,7 +716,7 @@ static void TableSetupColumnFlags(ImGuiTable* table, ImGuiTableColumn* column, I
 // Runs on the first call to TableNextRow(), to give a chance for TableSetupColumn() to be called first.
 // FIXME-TABLE: Our width (and therefore our WorkRect) will be minimal in the first frame for _WidthAuto columns.
 // Increase feedback side-effect with widgets relying on WorkRect.Max.x... Maybe provide a default distribution for _WidthAuto columns?
-void ImGui::TableUpdateLayout(ImGuiTable* table)
+void ImGui::TableUpdateLayout(ImGuiTable* table) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(table->IsLayoutLocked == false);
@@ -1135,7 +1135,7 @@ void ImGui::TableUpdateLayout(ImGuiTable* table)
 // - Set table->HoveredColumnBorder with a short delay/timer to reduce feedback noise
 // - Submit ahead of table contents and header, use ImGuiButtonFlags_AllowItemOverlap to prioritize widgets
 //   overlapping the same area.
-void ImGui::TableUpdateBorders(ImGuiTable* table)
+void ImGui::TableUpdateBorders(ImGuiTable* table) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(table->Flags & ImGuiTableFlags_Resizable);
@@ -1399,7 +1399,7 @@ void    ImGui::EndTable() IMGUI_NOEXCEPT
 
 // See "COLUMN SIZING POLICIES" comments at the top of this file
 // If (init_width_or_weight <= 0.0f) it is ignored
-void ImGui::TableSetupColumn(const char* label, ImGuiTableColumnFlags flags, float init_width_or_weight, ImGuiID user_id)
+void ImGui::TableSetupColumn(const char* label, ImGuiTableColumnFlags flags, float init_width_or_weight, ImGuiID user_id) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
@@ -1467,7 +1467,7 @@ void ImGui::TableSetupColumn(const char* label, ImGuiTableColumnFlags flags, flo
 }
 
 // [Public]
-void ImGui::TableSetupScrollFreeze(int columns, int rows)
+void ImGui::TableSetupScrollFreeze(int columns, int rows) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
@@ -1497,14 +1497,14 @@ void ImGui::TableSetupScrollFreeze(int columns, int rows)
 // - TableSetBgColor()
 //-----------------------------------------------------------------------------
 
-int ImGui::TableGetColumnCount()
+int ImGui::TableGetColumnCount() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
     return table ? table->ColumnsCount : 0;
 }
 
-const char* ImGui::TableGetColumnName(int column_n)
+const char* ImGui::TableGetColumnName(int column_n) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
@@ -1515,7 +1515,7 @@ const char* ImGui::TableGetColumnName(int column_n)
     return TableGetColumnName(table, column_n);
 }
 
-const char* ImGui::TableGetColumnName(const ImGuiTable* table, int column_n)
+const char* ImGui::TableGetColumnName(const ImGuiTable* table, int column_n) IMGUI_NOEXCEPT
 {
     if (table->IsLayoutLocked == false && column_n >= table->DeclColumnsCount)
         return ""; // NameOffset is invalid at this point
@@ -1529,7 +1529,7 @@ const char* ImGui::TableGetColumnName(const ImGuiTable* table, int column_n)
 // Note that end-user can use the context menu to change this themselves (right-click in headers, or right-click in columns body with ImGuiTableFlags_ContextMenuInBody)
 // Request will be applied during next layout, which happens on the first call to TableNextRow() after BeginTable()
 // For the getter you can use (TableGetColumnFlags() & ImGuiTableColumnFlags_IsEnabled)
-void ImGui::TableSetColumnEnabled(int column_n, bool enabled)
+void ImGui::TableSetColumnEnabled(int column_n, bool enabled) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
@@ -1544,7 +1544,7 @@ void ImGui::TableSetColumnEnabled(int column_n, bool enabled)
 }
 
 // We allow querying for an extra column in order to poll the IsHovered state of the right-most section
-ImGuiTableColumnFlags ImGui::TableGetColumnFlags(int column_n)
+ImGuiTableColumnFlags ImGui::TableGetColumnFlags(int column_n) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
@@ -1562,7 +1562,7 @@ ImGuiTableColumnFlags ImGui::TableGetColumnFlags(int column_n)
 //   The only case where this is correct is if we provided a min_row_height to TableNextRow() and don't go below it.
 // - Important: if ImGuiTableFlags_PadOuterX is set but ImGuiTableFlags_PadInnerX is not set, the outer-most left and right
 //   columns report a small offset so their CellBgRect can extend up to the outer border.
-ImRect ImGui::TableGetCellBgRect(const ImGuiTable* table, int column_n)
+ImRect ImGui::TableGetCellBgRect(const ImGuiTable* table, int column_n) IMGUI_NOEXCEPT
 {
     const ImGuiTableColumn* column = &table->Columns[column_n];
     float x1 = column->MinX;
@@ -1575,7 +1575,7 @@ ImRect ImGui::TableGetCellBgRect(const ImGuiTable* table, int column_n)
 }
 
 // Return the resizing ID for the right-side of the given column.
-ImGuiID ImGui::TableGetColumnResizeID(const ImGuiTable* table, int column_n, int instance_no)
+ImGuiID ImGui::TableGetColumnResizeID(const ImGuiTable* table, int column_n, int instance_no) IMGUI_NOEXCEPT
 {
     IM_ASSERT(column_n >= 0 && column_n < table->ColumnsCount);
     ImGuiID id = table->ID + 1 + (instance_no * table->ColumnsCount) + column_n;
@@ -1583,7 +1583,7 @@ ImGuiID ImGui::TableGetColumnResizeID(const ImGuiTable* table, int column_n, int
 }
 
 // Return -1 when table is not hovered. return columns_count if the unused space at the right of visible columns is hovered.
-int ImGui::TableGetHoveredColumn()
+int ImGui::TableGetHoveredColumn() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
@@ -1592,7 +1592,7 @@ int ImGui::TableGetHoveredColumn()
     return (int)table->HoveredColumnBody;
 }
 
-void ImGui::TableSetBgColor(ImGuiTableBgTarget target, ImU32 color, int column_n)
+void ImGui::TableSetBgColor(ImGuiTableBgTarget target, ImU32 color, int column_n) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
@@ -1644,7 +1644,7 @@ void ImGui::TableSetBgColor(ImGuiTableBgTarget target, ImU32 color, int column_n
 //-------------------------------------------------------------------------
 
 // [Public] Note: for row coloring we use ->RowBgColorCounter which is the same value without counting header rows
-int ImGui::TableGetRowIndex()
+int ImGui::TableGetRowIndex() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
@@ -1654,7 +1654,7 @@ int ImGui::TableGetRowIndex()
 }
 
 // [Public] Starts into the first cell of a new row
-void ImGui::TableNextRow(ImGuiTableRowFlags row_flags, float row_min_height)
+void ImGui::TableNextRow(ImGuiTableRowFlags row_flags, float row_min_height) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
@@ -1679,7 +1679,7 @@ void ImGui::TableNextRow(ImGuiTableRowFlags row_flags, float row_min_height)
 }
 
 // [Internal] Called by TableNextRow()
-void ImGui::TableBeginRow(ImGuiTable* table)
+void ImGui::TableBeginRow(ImGuiTable* table) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = table->InnerWindow;
     IM_ASSERT(!table->IsInsideRow);
@@ -1712,7 +1712,7 @@ void ImGui::TableBeginRow(ImGuiTable* table)
 }
 
 // [Internal] Called by TableNextRow()
-void ImGui::TableEndRow(ImGuiTable* table)
+void ImGui::TableEndRow(ImGuiTable* table) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -1856,7 +1856,7 @@ void ImGui::TableEndRow(ImGuiTable* table)
 // - TableEndCell() [Internal]
 //-------------------------------------------------------------------------
 
-int ImGui::TableGetColumnIndex()
+int ImGui::TableGetColumnIndex() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
@@ -1866,7 +1866,7 @@ int ImGui::TableGetColumnIndex()
 }
 
 // [Public] Append into a specific column
-bool ImGui::TableSetColumnIndex(int column_n)
+bool ImGui::TableSetColumnIndex(int column_n) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
@@ -1887,7 +1887,7 @@ bool ImGui::TableSetColumnIndex(int column_n)
 }
 
 // [Public] Append into the next column, wrap and create a new row when already on last column
-bool ImGui::TableNextColumn()
+bool ImGui::TableNextColumn() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
@@ -1916,7 +1916,7 @@ bool ImGui::TableNextColumn()
 // [Internal] Called by TableSetColumnIndex()/TableNextColumn()
 // This is called very frequently, so we need to be mindful of unnecessary overhead.
 // FIXME-TABLE FIXME-OPT: Could probably shortcut some things for non-active or clipped columns.
-void ImGui::TableBeginCell(ImGuiTable* table, int column_n)
+void ImGui::TableBeginCell(ImGuiTable* table, int column_n) IMGUI_NOEXCEPT
 {
     ImGuiTableColumn* column = &table->Columns[column_n];
     ImGuiWindow* window = table->InnerWindow;
@@ -1973,7 +1973,7 @@ void ImGui::TableBeginCell(ImGuiTable* table, int column_n)
 }
 
 // [Internal] Called by TableNextRow()/TableSetColumnIndex()/TableNextColumn()
-void ImGui::TableEndCell(ImGuiTable* table)
+void ImGui::TableEndCell(ImGuiTable* table) IMGUI_NOEXCEPT
 {
     ImGuiTableColumn* column = &table->Columns[table->CurrentColumn];
     ImGuiWindow* window = table->InnerWindow;
@@ -2005,7 +2005,7 @@ void ImGui::TableEndCell(ImGuiTable* table)
 //-------------------------------------------------------------------------
 
 // Maximum column content width given current layout. Use column->MinX so this value on a per-column basis.
-float ImGui::TableGetMaxColumnWidth(const ImGuiTable* table, int column_n)
+float ImGui::TableGetMaxColumnWidth(const ImGuiTable* table, int column_n) IMGUI_NOEXCEPT
 {
     const ImGuiTableColumn* column = &table->Columns[column_n];
     float max_width = FLT_MAX;
@@ -2036,7 +2036,7 @@ float ImGui::TableGetMaxColumnWidth(const ImGuiTable* table, int column_n)
 }
 
 // Note this is meant to be stored in column->WidthAuto, please generally use the WidthAuto field
-float ImGui::TableGetColumnWidthAuto(ImGuiTable* table, ImGuiTableColumn* column)
+float ImGui::TableGetColumnWidthAuto(ImGuiTable* table, ImGuiTableColumn* column) IMGUI_NOEXCEPT
 {
     const float content_width_body = ImMax(column->ContentMaxXFrozen, column->ContentMaxXUnfrozen) - column->WorkMinX;
     const float content_width_headers = column->ContentMaxXHeadersIdeal - column->WorkMinX;
@@ -2053,7 +2053,7 @@ float ImGui::TableGetColumnWidthAuto(ImGuiTable* table, ImGuiTableColumn* column
 }
 
 // 'width' = inner column width, without padding
-void ImGui::TableSetColumnWidth(int column_n, float width)
+void ImGui::TableSetColumnWidth(int column_n, float width) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
@@ -2136,7 +2136,7 @@ void ImGui::TableSetColumnWidth(int column_n, float width)
 
 // Disable clipping then auto-fit, will take 2 frames
 // (we don't take a shortcut for unclipped columns to reduce inconsistencies when e.g. resizing multiple columns)
-void ImGui::TableSetColumnWidthAutoSingle(ImGuiTable* table, int column_n)
+void ImGui::TableSetColumnWidthAutoSingle(ImGuiTable* table, int column_n) IMGUI_NOEXCEPT
 {
     // Single auto width uses auto-fit
     ImGuiTableColumn* column = &table->Columns[column_n];
@@ -2146,7 +2146,7 @@ void ImGui::TableSetColumnWidthAutoSingle(ImGuiTable* table, int column_n)
     table->AutoFitSingleColumn = (ImGuiTableColumnIdx)column_n;
 }
 
-void ImGui::TableSetColumnWidthAutoAll(ImGuiTable* table)
+void ImGui::TableSetColumnWidthAutoAll(ImGuiTable* table) IMGUI_NOEXCEPT
 {
     for (int column_n = 0; column_n < table->ColumnsCount; column_n++)
     {
@@ -2158,7 +2158,7 @@ void ImGui::TableSetColumnWidthAutoAll(ImGuiTable* table)
     }
 }
 
-void ImGui::TableUpdateColumnsWeightFromWidth(ImGuiTable* table)
+void ImGui::TableUpdateColumnsWeightFromWidth(ImGuiTable* table) IMGUI_NOEXCEPT
 {
     IM_ASSERT(table->LeftMostStretchedColumn != -1 && table->RightMostStretchedColumn != -1);
 
@@ -2199,7 +2199,7 @@ void ImGui::TableUpdateColumnsWeightFromWidth(ImGuiTable* table)
 
 // Bg2 is used by Selectable (and possibly other widgets) to render to the background.
 // Unlike our Bg0/1 channel which we uses for RowBg/CellBg/Borders and where we guarantee all shapes to be CPU-clipped, the Bg2 channel being widgets-facing will rely on regular ClipRect.
-void ImGui::TablePushBackgroundChannel()
+void ImGui::TablePushBackgroundChannel() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -2211,7 +2211,7 @@ void ImGui::TablePushBackgroundChannel()
     table->DrawSplitter->SetCurrentChannel(window->DrawList, table->Bg2DrawChannelCurrent);
 }
 
-void ImGui::TablePopBackgroundChannel()
+void ImGui::TablePopBackgroundChannel() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -2239,7 +2239,7 @@ void ImGui::TablePopBackgroundChannel()
 // - FreezeRows                   --> 2+D+N*2 (unless scrolling value is zero)
 // - FreezeRows || FreezeColunns  --> 3+D+N*2 (unless scrolling value is zero)
 // Where D is 1 if any column is clipped or hidden (dummy channel) otherwise 0.
-void ImGui::TableSetupDrawChannels(ImGuiTable* table)
+void ImGui::TableSetupDrawChannels(ImGuiTable* table) IMGUI_NOEXCEPT
 {
     const int freeze_row_multiplier = (table->FreezeRowsCount > 0) ? 2 : 1;
     const int channels_for_row = (table->Flags & ImGuiTableFlags_NoClip) ? 1 : table->ColumnsEnabledCount;
@@ -2307,7 +2307,7 @@ void ImGui::TableSetupDrawChannels(ImGuiTable* table)
 // Columns for which the draw channel(s) haven't been merged with other will use their own ImDrawCmd.
 //
 // This function is particularly tricky to understand.. take a breath.
-void ImGui::TableMergeDrawChannels(ImGuiTable* table)
+void ImGui::TableMergeDrawChannels(ImGuiTable* table) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImDrawListSplitter* splitter = table->DrawSplitter;
@@ -2474,7 +2474,7 @@ void ImGui::TableMergeDrawChannels(ImGuiTable* table)
 }
 
 // FIXME-TABLE: This is a mess, need to redesign how we render borders (as some are also done in TableEndRow)
-void ImGui::TableDrawBorders(ImGuiTable* table)
+void ImGui::TableDrawBorders(ImGuiTable* table) IMGUI_NOEXCEPT
 {
     ImGuiWindow* inner_window = table->InnerWindow;
     if (!table->OuterWindow->ClipRect.Overlaps(table->OuterRect))
@@ -2584,7 +2584,7 @@ void ImGui::TableDrawBorders(ImGuiTable* table)
 // You can sort your data again when 'SpecsChanged == true'. It will be true with sorting specs have changed since
 // last call, or the first time.
 // Lifetime: don't hold on this pointer over multiple frames or past any subsequent call to BeginTable()!
-ImGuiTableSortSpecs* ImGui::TableGetSortSpecs()
+ImGuiTableSortSpecs* ImGui::TableGetSortSpecs() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
@@ -2603,14 +2603,14 @@ ImGuiTableSortSpecs* ImGui::TableGetSortSpecs()
     return &table->SortSpecs;
 }
 
-static inline ImGuiSortDirection TableGetColumnAvailSortDirection(ImGuiTableColumn* column, int n)
+static inline ImGuiSortDirection TableGetColumnAvailSortDirection(ImGuiTableColumn* column, int n) IMGUI_NOEXCEPT
 {
     IM_ASSERT(n < column->SortDirectionsAvailCount);
     return (column->SortDirectionsAvailList >> (n << 1)) & 0x03;
 }
 
 // Fix sort direction if currently set on a value which is unavailable (e.g. activating NoSortAscending/NoSortDescending)
-void ImGui::TableFixColumnSortDirection(ImGuiTable* table, ImGuiTableColumn* column)
+void ImGui::TableFixColumnSortDirection(ImGuiTable* table, ImGuiTableColumn* column) IMGUI_NOEXCEPT
 {
     if (column->SortOrder == -1 || (column->SortDirectionsAvailMask & (1 << column->SortDirection)) != 0)
         return;
@@ -2622,7 +2622,7 @@ void ImGui::TableFixColumnSortDirection(ImGuiTable* table, ImGuiTableColumn* col
 // - If the PreferSortDescending flag is set, we will default to a Descending direction on the first click.
 // - Note that the PreferSortAscending flag is never checked, it is essentially the default and therefore a no-op.
 IM_STATIC_ASSERT(ImGuiSortDirection_None == 0 && ImGuiSortDirection_Ascending == 1 && ImGuiSortDirection_Descending == 2);
-ImGuiSortDirection ImGui::TableGetColumnNextSortDirection(ImGuiTableColumn* column)
+ImGuiSortDirection ImGui::TableGetColumnNextSortDirection(ImGuiTableColumn* column) IMGUI_NOEXCEPT
 {
     IM_ASSERT(column->SortDirectionsAvailCount > 0);
     if (column->SortOrder == -1)
@@ -2636,7 +2636,7 @@ ImGuiSortDirection ImGui::TableGetColumnNextSortDirection(ImGuiTableColumn* colu
 
 // Note that the NoSortAscending/NoSortDescending flags are processed in TableSortSpecsSanitize(), and they may change/revert
 // the value of SortDirection. We could technically also do it here but it would be unnecessary and duplicate code.
-void ImGui::TableSetColumnSortDirection(int column_n, ImGuiSortDirection sort_direction, bool append_to_sort_specs)
+void ImGui::TableSetColumnSortDirection(int column_n, ImGuiSortDirection sort_direction, bool append_to_sort_specs) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
@@ -2669,7 +2669,7 @@ void ImGui::TableSetColumnSortDirection(int column_n, ImGuiSortDirection sort_di
     table->IsSortSpecsDirty = true;
 }
 
-void ImGui::TableSortSpecsSanitize(ImGuiTable* table)
+void ImGui::TableSortSpecsSanitize(ImGuiTable* table) IMGUI_NOEXCEPT
 {
     IM_ASSERT(table->Flags & ImGuiTableFlags_Sortable);
 
@@ -2735,7 +2735,7 @@ void ImGui::TableSortSpecsSanitize(ImGuiTable* table)
     table->SortSpecsCount = (ImGuiTableColumnIdx)sort_order_count;
 }
 
-void ImGui::TableSortSpecsBuild(ImGuiTable* table)
+void ImGui::TableSortSpecsBuild(ImGuiTable* table) IMGUI_NOEXCEPT
 {
     IM_ASSERT(table->IsSortSpecsDirty);
     TableSortSpecsSanitize(table);
@@ -2771,7 +2771,7 @@ void ImGui::TableSortSpecsBuild(ImGuiTable* table)
 // - TableHeader()
 //-------------------------------------------------------------------------
 
-float ImGui::TableGetHeaderRowHeight()
+float ImGui::TableGetHeaderRowHeight() IMGUI_NOEXCEPT
 {
     // Caring for a minor edge case:
     // Calculate row height, for the unlikely case that some labels may be taller than others.
@@ -2792,7 +2792,7 @@ float ImGui::TableGetHeaderRowHeight()
 // See 'Demo->Tables->Custom headers' for a demonstration of implementing a custom version of this.
 // This code is constructed to not make much use of internal functions, as it is intended to be a template to copy.
 // FIXME-TABLE: TableOpenContextMenu() and TableGetHeaderRowHeight() are not public.
-void ImGui::TableHeadersRow()
+void ImGui::TableHeadersRow() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
@@ -2834,7 +2834,7 @@ void ImGui::TableHeadersRow()
 // Emit a column header (text + optional sort order)
 // We cpu-clip text here so that all columns headers can be merged into a same draw call.
 // Note that because of how we cpu-clip and display sorting indicators, you _cannot_ use SameLine() after a TableHeader()
-void ImGui::TableHeader(const char* label)
+void ImGui::TableHeader(const char* label) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -2981,7 +2981,7 @@ void ImGui::TableHeader(const char* label)
 //-------------------------------------------------------------------------
 
 // Use -1 to open menu not specific to a given column.
-void ImGui::TableOpenContextMenu(int column_n)
+void ImGui::TableOpenContextMenu(int column_n) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
@@ -3002,7 +3002,7 @@ void ImGui::TableOpenContextMenu(int column_n)
 
 // Output context menu into current window (generally a popup)
 // FIXME-TABLE: Ideally this should be writable by the user. Full programmatic access to that data?
-void ImGui::TableDrawContextMenu(ImGuiTable* table)
+void ImGui::TableDrawContextMenu(ImGuiTable* table) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -3115,7 +3115,7 @@ void ImGui::TableDrawContextMenu(ImGuiTable* table)
 //-------------------------------------------------------------------------
 
 // Clear and initialize empty settings instance
-static void TableSettingsInit(ImGuiTableSettings* settings, ImGuiID id, int columns_count, int columns_count_max)
+static void TableSettingsInit(ImGuiTableSettings* settings, ImGuiID id, int columns_count, int columns_count_max) IMGUI_NOEXCEPT
 {
     IM_PLACEMENT_NEW(settings) ImGuiTableSettings();
     ImGuiTableColumnSettings* settings_column = settings->GetColumnSettings();
@@ -3127,12 +3127,12 @@ static void TableSettingsInit(ImGuiTableSettings* settings, ImGuiID id, int colu
     settings->WantApply = true;
 }
 
-static size_t TableSettingsCalcChunkSize(int columns_count)
+static size_t TableSettingsCalcChunkSize(int columns_count) IMGUI_NOEXCEPT
 {
     return sizeof(ImGuiTableSettings) + (size_t)columns_count * sizeof(ImGuiTableColumnSettings);
 }
 
-ImGuiTableSettings* ImGui::TableSettingsCreate(ImGuiID id, int columns_count)
+ImGuiTableSettings* ImGui::TableSettingsCreate(ImGuiID id, int columns_count) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTableSettings* settings = g.SettingsTables.alloc_chunk(TableSettingsCalcChunkSize(columns_count));
@@ -3141,7 +3141,7 @@ ImGuiTableSettings* ImGui::TableSettingsCreate(ImGuiID id, int columns_count)
 }
 
 // Find existing settings
-ImGuiTableSettings* ImGui::TableSettingsFindByID(ImGuiID id)
+ImGuiTableSettings* ImGui::TableSettingsFindByID(ImGuiID id) IMGUI_NOEXCEPT
 {
     // FIXME-OPT: Might want to store a lookup map for this?
     ImGuiContext& g = *GImGui;
@@ -3152,7 +3152,7 @@ ImGuiTableSettings* ImGui::TableSettingsFindByID(ImGuiID id)
 }
 
 // Get settings for a given table, NULL if none
-ImGuiTableSettings* ImGui::TableGetBoundSettings(ImGuiTable* table)
+ImGuiTableSettings* ImGui::TableGetBoundSettings(ImGuiTable* table) IMGUI_NOEXCEPT
 {
     if (table->SettingsOffset != -1)
     {
@@ -3167,7 +3167,7 @@ ImGuiTableSettings* ImGui::TableGetBoundSettings(ImGuiTable* table)
 }
 
 // Restore initial state of table (with or without saved settings)
-void ImGui::TableResetSettings(ImGuiTable* table)
+void ImGui::TableResetSettings(ImGuiTable* table) IMGUI_NOEXCEPT
 {
     table->IsInitializing = table->IsSettingsDirty = true;
     table->IsResetAllRequest = false;
@@ -3175,7 +3175,7 @@ void ImGui::TableResetSettings(ImGuiTable* table)
     table->SettingsLoadedFlags = ImGuiTableFlags_None;      // Mark as nothing loaded so our initialized data becomes authoritative
 }
 
-void ImGui::TableSaveSettings(ImGuiTable* table)
+void ImGui::TableSaveSettings(ImGuiTable* table) IMGUI_NOEXCEPT
 {
     table->IsSettingsDirty = false;
     if (table->Flags & ImGuiTableFlags_NoSavedSettings)
@@ -3230,7 +3230,7 @@ void ImGui::TableSaveSettings(ImGuiTable* table)
     MarkIniSettingsDirty();
 }
 
-void ImGui::TableLoadSettings(ImGuiTable* table)
+void ImGui::TableLoadSettings(ImGuiTable* table) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     table->IsSettingsRequestLoad = false;
@@ -3295,7 +3295,7 @@ void ImGui::TableLoadSettings(ImGuiTable* table)
         table->DisplayOrderToIndex[table->Columns[column_n].DisplayOrder] = (ImGuiTableColumnIdx)column_n;
 }
 
-static void TableSettingsHandler_ClearAll(ImGuiContext* ctx, ImGuiSettingsHandler*)
+static void TableSettingsHandler_ClearAll(ImGuiContext* ctx, ImGuiSettingsHandler*) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *ctx;
     for (int i = 0; i != g.Tables.GetSize(); i++)
@@ -3304,7 +3304,7 @@ static void TableSettingsHandler_ClearAll(ImGuiContext* ctx, ImGuiSettingsHandle
 }
 
 // Apply to existing windows (if any)
-static void TableSettingsHandler_ApplyAll(ImGuiContext* ctx, ImGuiSettingsHandler*)
+static void TableSettingsHandler_ApplyAll(ImGuiContext* ctx, ImGuiSettingsHandler*) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *ctx;
     for (int i = 0; i != g.Tables.GetSize(); i++)
@@ -3315,7 +3315,7 @@ static void TableSettingsHandler_ApplyAll(ImGuiContext* ctx, ImGuiSettingsHandle
     }
 }
 
-static void* TableSettingsHandler_ReadOpen(ImGuiContext*, ImGuiSettingsHandler*, const char* name)
+static void* TableSettingsHandler_ReadOpen(ImGuiContext*, ImGuiSettingsHandler*, const char* name) IMGUI_NOEXCEPT
 {
     ImGuiID id = 0;
     int columns_count = 0;
@@ -3334,7 +3334,7 @@ static void* TableSettingsHandler_ReadOpen(ImGuiContext*, ImGuiSettingsHandler*,
     return ImGui::TableSettingsCreate(id, columns_count);
 }
 
-static void TableSettingsHandler_ReadLine(ImGuiContext*, ImGuiSettingsHandler*, void* entry, const char* line)
+static void TableSettingsHandler_ReadLine(ImGuiContext*, ImGuiSettingsHandler*, void* entry, const char* line) IMGUI_NOEXCEPT
 {
     // "Column 0  UserID=0x42AD2D21 Width=100 Visible=1 Order=0 Sort=0v"
     ImGuiTableSettings* settings = (ImGuiTableSettings*)entry;
@@ -3360,7 +3360,7 @@ static void TableSettingsHandler_ReadLine(ImGuiContext*, ImGuiSettingsHandler*, 
     }
 }
 
-static void TableSettingsHandler_WriteAll(ImGuiContext* ctx, ImGuiSettingsHandler* handler, ImGuiTextBuffer* buf)
+static void TableSettingsHandler_WriteAll(ImGuiContext* ctx, ImGuiSettingsHandler* handler, ImGuiTextBuffer* buf) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *ctx;
     for (ImGuiTableSettings* settings = g.SettingsTables.begin(); settings != NULL; settings = g.SettingsTables.next_chunk(settings))
@@ -3401,7 +3401,7 @@ static void TableSettingsHandler_WriteAll(ImGuiContext* ctx, ImGuiSettingsHandle
     }
 }
 
-void ImGui::TableSettingsInstallHandler(ImGuiContext* context)
+void ImGui::TableSettingsInstallHandler(ImGuiContext* context) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *context;
     ImGuiSettingsHandler ini_handler;
@@ -3424,7 +3424,7 @@ void ImGui::TableSettingsInstallHandler(ImGuiContext* context)
 //-------------------------------------------------------------------------
 
 // Remove Table (currently only used by TestEngine)
-void ImGui::TableRemove(ImGuiTable* table)
+void ImGui::TableRemove(ImGuiTable* table) IMGUI_NOEXCEPT
 {
     //IMGUI_DEBUG_LOG("TableRemove() id=0x%08X\n", table->ID);
     ImGuiContext& g = *GImGui;
@@ -3436,7 +3436,7 @@ void ImGui::TableRemove(ImGuiTable* table)
 }
 
 // Free up/compact internal Table buffers for when it gets unused
-void ImGui::TableGcCompactTransientBuffers(ImGuiTable* table)
+void ImGui::TableGcCompactTransientBuffers(ImGuiTable* table) IMGUI_NOEXCEPT
 {
     //IMGUI_DEBUG_LOG("TableGcCompactTransientBuffers() id=0x%08X\n", table->ID);
     ImGuiContext& g = *GImGui;
@@ -3458,7 +3458,7 @@ void ImGui::TableGcCompactTransientBuffers(ImGuiTableTempData* temp_data)
 }
 
 // Compact and remove unused settings data (currently only used by TestEngine)
-void ImGui::TableGcCompactSettings()
+void ImGui::TableGcCompactSettings() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     int required_memory = 0;
@@ -3484,7 +3484,7 @@ void ImGui::TableGcCompactSettings()
 
 #ifndef IMGUI_DISABLE_METRICS_WINDOW
 
-static const char* DebugNodeTableGetSizingPolicyDesc(ImGuiTableFlags sizing_policy)
+static const char* DebugNodeTableGetSizingPolicyDesc(ImGuiTableFlags sizing_policy) IMGUI_NOEXCEPT
 {
     sizing_policy &= ImGuiTableFlags_SizingMask_;
     if (sizing_policy == ImGuiTableFlags_SizingFixedFit)    { return "FixedFit"; }
@@ -3494,7 +3494,7 @@ static const char* DebugNodeTableGetSizingPolicyDesc(ImGuiTableFlags sizing_poli
     return "N/A";
 }
 
-void ImGui::DebugNodeTable(ImGuiTable* table)
+void ImGui::DebugNodeTable(ImGuiTable* table) IMGUI_NOEXCEPT
 {
     char buf[512];
     char* p = buf;
@@ -3556,7 +3556,7 @@ void ImGui::DebugNodeTable(ImGuiTable* table)
     TreePop();
 }
 
-void ImGui::DebugNodeTableSettings(ImGuiTableSettings* settings)
+void ImGui::DebugNodeTableSettings(ImGuiTableSettings* settings) IMGUI_NOEXCEPT
 {
     if (!TreeNode((void*)(intptr_t)settings->ID, "Settings 0x%08X (%d columns)", settings->ID, settings->ColumnsCount))
         return;
@@ -3576,8 +3576,8 @@ void ImGui::DebugNodeTableSettings(ImGuiTableSettings* settings)
 
 #else // #ifndef IMGUI_DISABLE_METRICS_WINDOW
 
-void ImGui::DebugNodeTable(ImGuiTable*) {}
-void ImGui::DebugNodeTableSettings(ImGuiTableSettings*) {}
+void ImGui::DebugNodeTable(ImGuiTable*) IMGUI_NOEXCEPT {}
+void ImGui::DebugNodeTableSettings(ImGuiTableSettings*) IMGUI_NOEXCEPT {}
 
 #endif
 
@@ -3610,7 +3610,7 @@ void ImGui::DebugNodeTableSettings(ImGuiTableSettings*) {}
 // they would meddle many times with the underlying ImDrawCmd.
 // Instead, we do a preemptive overwrite of clipping rectangle _without_ altering the command-buffer and let
 // the subsequent single call to SetCurrentChannel() does it things once.
-void ImGui::SetWindowClipRectBeforeSetChannel(ImGuiWindow* window, const ImRect& clip_rect)
+void ImGui::SetWindowClipRectBeforeSetChannel(ImGuiWindow* window, const ImRect& clip_rect) IMGUI_NOEXCEPT
 {
     ImVec4 clip_rect_vec4 = clip_rect.ToVec4();
     window->ClipRect = clip_rect;
@@ -3618,31 +3618,31 @@ void ImGui::SetWindowClipRectBeforeSetChannel(ImGuiWindow* window, const ImRect&
     window->DrawList->_ClipRectStack.Data[window->DrawList->_ClipRectStack.Size - 1] = clip_rect_vec4;
 }
 
-int ImGui::GetColumnIndex()
+int ImGui::GetColumnIndex() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     return window->DC.CurrentColumns ? window->DC.CurrentColumns->Current : 0;
 }
 
-int ImGui::GetColumnsCount()
+int ImGui::GetColumnsCount() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     return window->DC.CurrentColumns ? window->DC.CurrentColumns->Count : 1;
 }
 
-float ImGui::GetColumnOffsetFromNorm(const ImGuiOldColumns* columns, float offset_norm)
+float ImGui::GetColumnOffsetFromNorm(const ImGuiOldColumns* columns, float offset_norm) IMGUI_NOEXCEPT
 {
     return offset_norm * (columns->OffMaxX - columns->OffMinX);
 }
 
-float ImGui::GetColumnNormFromOffset(const ImGuiOldColumns* columns, float offset)
+float ImGui::GetColumnNormFromOffset(const ImGuiOldColumns* columns, float offset) IMGUI_NOEXCEPT
 {
     return offset / (columns->OffMaxX - columns->OffMinX);
 }
 
 static const float COLUMNS_HIT_RECT_HALF_WIDTH = 4.0f;
 
-static float GetDraggedColumnOffset(ImGuiOldColumns* columns, int column_index)
+static float GetDraggedColumnOffset(ImGuiOldColumns* columns, int column_index) IMGUI_NOEXCEPT
 {
     // Active (dragged) column always follow mouse. The reason we need this is that dragging a column to the right edge of an auto-resizing
     // window creates a feedback loop because we store normalized positions. So while dragging we enforce absolute positioning.
@@ -3659,7 +3659,7 @@ static float GetDraggedColumnOffset(ImGuiOldColumns* columns, int column_index)
     return x;
 }
 
-float ImGui::GetColumnOffset(int column_index)
+float ImGui::GetColumnOffset(int column_index) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     ImGuiOldColumns* columns = window->DC.CurrentColumns;
@@ -3675,7 +3675,7 @@ float ImGui::GetColumnOffset(int column_index)
     return x_offset;
 }
 
-static float GetColumnWidthEx(ImGuiOldColumns* columns, int column_index, bool before_resize = false)
+static float GetColumnWidthEx(ImGuiOldColumns* columns, int column_index, bool before_resize = false) IMGUI_NOEXCEPT
 {
     if (column_index < 0)
         column_index = columns->Current;
@@ -3688,7 +3688,7 @@ static float GetColumnWidthEx(ImGuiOldColumns* columns, int column_index, bool b
     return ImGui::GetColumnOffsetFromNorm(columns, offset_norm);
 }
 
-float ImGui::GetColumnWidth(int column_index)
+float ImGui::GetColumnWidth(int column_index) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -3701,7 +3701,7 @@ float ImGui::GetColumnWidth(int column_index)
     return GetColumnOffsetFromNorm(columns, columns->Columns[column_index + 1].OffsetNorm - columns->Columns[column_index].OffsetNorm);
 }
 
-void ImGui::SetColumnOffset(int column_index, float offset)
+void ImGui::SetColumnOffset(int column_index, float offset) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -3723,7 +3723,7 @@ void ImGui::SetColumnOffset(int column_index, float offset)
         SetColumnOffset(column_index + 1, offset + ImMax(g.Style.ColumnsMinSpacing, width));
 }
 
-void ImGui::SetColumnWidth(int column_index, float width)
+void ImGui::SetColumnWidth(int column_index, float width) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     ImGuiOldColumns* columns = window->DC.CurrentColumns;
@@ -3734,7 +3734,7 @@ void ImGui::SetColumnWidth(int column_index, float width)
     SetColumnOffset(column_index + 1, GetColumnOffset(column_index) + width);
 }
 
-void ImGui::PushColumnClipRect(int column_index)
+void ImGui::PushColumnClipRect(int column_index) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     ImGuiOldColumns* columns = window->DC.CurrentColumns;
@@ -3746,7 +3746,7 @@ void ImGui::PushColumnClipRect(int column_index)
 }
 
 // Get into the columns background draw command (which is generally the same draw command as before we called BeginColumns)
-void ImGui::PushColumnsBackground()
+void ImGui::PushColumnsBackground() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     ImGuiOldColumns* columns = window->DC.CurrentColumns;
@@ -3759,7 +3759,7 @@ void ImGui::PushColumnsBackground()
     columns->Splitter.SetCurrentChannel(window->DrawList, 0);
 }
 
-void ImGui::PopColumnsBackground()
+void ImGui::PopColumnsBackground() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     ImGuiOldColumns* columns = window->DC.CurrentColumns;
@@ -3771,7 +3771,7 @@ void ImGui::PopColumnsBackground()
     columns->Splitter.SetCurrentChannel(window->DrawList, columns->Current + 1);
 }
 
-ImGuiOldColumns* ImGui::FindOrCreateColumns(ImGuiWindow* window, ImGuiID id)
+ImGuiOldColumns* ImGui::FindOrCreateColumns(ImGuiWindow* window, ImGuiID id) IMGUI_NOEXCEPT
 {
     // We have few columns per window so for now we don't need bother much with turning this into a faster lookup.
     for (int n = 0; n < window->ColumnsStorage.Size; n++)
@@ -3784,7 +3784,7 @@ ImGuiOldColumns* ImGui::FindOrCreateColumns(ImGuiWindow* window, ImGuiID id)
     return columns;
 }
 
-ImGuiID ImGui::GetColumnsID(const char* str_id, int columns_count)
+ImGuiID ImGui::GetColumnsID(const char* str_id, int columns_count) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
 
@@ -3797,7 +3797,7 @@ ImGuiID ImGui::GetColumnsID(const char* str_id, int columns_count)
     return id;
 }
 
-void ImGui::BeginColumns(const char* str_id, int columns_count, ImGuiOldColumnFlags flags)
+void ImGui::BeginColumns(const char* str_id, int columns_count, ImGuiOldColumnFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = GetCurrentWindow();
@@ -3874,7 +3874,7 @@ void ImGui::BeginColumns(const char* str_id, int columns_count, ImGuiOldColumnFl
     window->WorkRect.Max.x = window->Pos.x + offset_1 - column_padding;
 }
 
-void ImGui::NextColumn()
+void ImGui::NextColumn() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems || window->DC.CurrentColumns == NULL)
@@ -3929,7 +3929,7 @@ void ImGui::NextColumn()
     window->WorkRect.Max.x = window->Pos.x + offset_1 - column_padding;
 }
 
-void ImGui::EndColumns()
+void ImGui::EndColumns() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = GetCurrentWindow();
@@ -4005,7 +4005,7 @@ void ImGui::EndColumns()
     window->DC.CursorPos.x = IM_FLOOR(window->Pos.x + window->DC.Indent.x + window->DC.ColumnsOffset.x);
 }
 
-void ImGui::Columns(int columns_count, const char* id, bool border)
+void ImGui::Columns(int columns_count, const char* id, bool border) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     IM_ASSERT(columns_count >= 1);

--- a/imgui_tables.cpp
+++ b/imgui_tables.cpp
@@ -261,7 +261,7 @@ static const float TABLE_RESIZE_SEPARATOR_HALF_THICKNESS = 4.0f;    // Extend ou
 static const float TABLE_RESIZE_SEPARATOR_FEEDBACK_TIMER = 0.06f;   // Delay/timer before making the hover feedback (color+cursor) visible because tables/columns tends to be more cramped.
 
 // Helper
-inline ImGuiTableFlags TableFixFlags(ImGuiTableFlags flags, ImGuiWindow* outer_window) IMGUI_NOEXCEPT
+inline ImGuiTableFlags TableFixFlags(ImGuiTableFlags flags, ImGuiWindow* outer_window) IM_NOEXCEPT
 {
     // Adjust flags: set default sizing policy
     if ((flags & ImGuiTableFlags_SizingMask_) == 0)
@@ -299,20 +299,20 @@ inline ImGuiTableFlags TableFixFlags(ImGuiTableFlags flags, ImGuiWindow* outer_w
     return flags;
 }
 
-ImGuiTable* ImGui::TableFindByID(ImGuiID id) IMGUI_NOEXCEPT
+ImGuiTable* ImGui::TableFindByID(ImGuiID id) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return g.Tables.GetByKey(id);
 }
 
 // Read about "TABLE SIZING" at the top of this file.
-bool    ImGui::BeginTable(const char* str_id, int columns_count, ImGuiTableFlags flags, const ImVec2& outer_size, float inner_width) IMGUI_NOEXCEPT
+bool    ImGui::BeginTable(const char* str_id, int columns_count, ImGuiTableFlags flags, const ImVec2& outer_size, float inner_width) IM_NOEXCEPT
 {
     ImGuiID id = GetID(str_id);
     return BeginTableEx(str_id, id, columns_count, flags, outer_size, inner_width);
 }
 
-bool    ImGui::BeginTableEx(const char* name, ImGuiID id, int columns_count, ImGuiTableFlags flags, const ImVec2& outer_size, float inner_width) IMGUI_NOEXCEPT
+bool    ImGui::BeginTableEx(const char* name, ImGuiID id, int columns_count, ImGuiTableFlags flags, const ImVec2& outer_size, float inner_width) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* outer_window = GetCurrentWindow();
@@ -573,7 +573,7 @@ bool    ImGui::BeginTableEx(const char* name, ImGuiID id, int columns_count, ImG
 // + 2 * active_channels_count (for ImDrawCmd and ImDrawIdx buffers inside channels)
 // Where active_channels_count is variable but often == columns_count or columns_count + 1, see TableSetupDrawChannels() for details.
 // Unused channels don't perform their +2 allocations.
-void ImGui::TableBeginInitMemory(ImGuiTable* table, int columns_count) IMGUI_NOEXCEPT
+void ImGui::TableBeginInitMemory(ImGuiTable* table, int columns_count) IM_NOEXCEPT
 {
     // Allocate single buffer for our arrays
     ImSpanAllocator<3> span_allocator;
@@ -589,7 +589,7 @@ void ImGui::TableBeginInitMemory(ImGuiTable* table, int columns_count) IMGUI_NOE
 }
 
 // Apply queued resizing/reordering/hiding requests
-void ImGui::TableBeginApplyRequests(ImGuiTable* table) IMGUI_NOEXCEPT
+void ImGui::TableBeginApplyRequests(ImGuiTable* table) IM_NOEXCEPT
 {
     // Handle resizing request
     // (We process this at the first TableBegin of the frame)
@@ -657,7 +657,7 @@ void ImGui::TableBeginApplyRequests(ImGuiTable* table) IMGUI_NOEXCEPT
 }
 
 // Adjust flags: default width mode + stretch columns are not allowed when auto extending
-static void TableSetupColumnFlags(ImGuiTable* table, ImGuiTableColumn* column, ImGuiTableColumnFlags flags_in) IMGUI_NOEXCEPT
+static void TableSetupColumnFlags(ImGuiTable* table, ImGuiTableColumn* column, ImGuiTableColumnFlags flags_in) IM_NOEXCEPT
 {
     ImGuiTableColumnFlags flags = flags_in;
 
@@ -716,7 +716,7 @@ static void TableSetupColumnFlags(ImGuiTable* table, ImGuiTableColumn* column, I
 // Runs on the first call to TableNextRow(), to give a chance for TableSetupColumn() to be called first.
 // FIXME-TABLE: Our width (and therefore our WorkRect) will be minimal in the first frame for _WidthAuto columns.
 // Increase feedback side-effect with widgets relying on WorkRect.Max.x... Maybe provide a default distribution for _WidthAuto columns?
-void ImGui::TableUpdateLayout(ImGuiTable* table) IMGUI_NOEXCEPT
+void ImGui::TableUpdateLayout(ImGuiTable* table) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(table->IsLayoutLocked == false);
@@ -1135,7 +1135,7 @@ void ImGui::TableUpdateLayout(ImGuiTable* table) IMGUI_NOEXCEPT
 // - Set table->HoveredColumnBorder with a short delay/timer to reduce feedback noise
 // - Submit ahead of table contents and header, use ImGuiButtonFlags_AllowItemOverlap to prioritize widgets
 //   overlapping the same area.
-void ImGui::TableUpdateBorders(ImGuiTable* table) IMGUI_NOEXCEPT
+void ImGui::TableUpdateBorders(ImGuiTable* table) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(table->Flags & ImGuiTableFlags_Resizable);
@@ -1196,7 +1196,7 @@ void ImGui::TableUpdateBorders(ImGuiTable* table) IMGUI_NOEXCEPT
     }
 }
 
-void    ImGui::EndTable() IMGUI_NOEXCEPT
+void    ImGui::EndTable() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
@@ -1399,7 +1399,7 @@ void    ImGui::EndTable() IMGUI_NOEXCEPT
 
 // See "COLUMN SIZING POLICIES" comments at the top of this file
 // If (init_width_or_weight <= 0.0f) it is ignored
-void ImGui::TableSetupColumn(const char* label, ImGuiTableColumnFlags flags, float init_width_or_weight, ImGuiID user_id) IMGUI_NOEXCEPT
+void ImGui::TableSetupColumn(const char* label, ImGuiTableColumnFlags flags, float init_width_or_weight, ImGuiID user_id) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
@@ -1467,7 +1467,7 @@ void ImGui::TableSetupColumn(const char* label, ImGuiTableColumnFlags flags, flo
 }
 
 // [Public]
-void ImGui::TableSetupScrollFreeze(int columns, int rows) IMGUI_NOEXCEPT
+void ImGui::TableSetupScrollFreeze(int columns, int rows) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
@@ -1497,14 +1497,14 @@ void ImGui::TableSetupScrollFreeze(int columns, int rows) IMGUI_NOEXCEPT
 // - TableSetBgColor()
 //-----------------------------------------------------------------------------
 
-int ImGui::TableGetColumnCount() IMGUI_NOEXCEPT
+int ImGui::TableGetColumnCount() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
     return table ? table->ColumnsCount : 0;
 }
 
-const char* ImGui::TableGetColumnName(int column_n) IMGUI_NOEXCEPT
+const char* ImGui::TableGetColumnName(int column_n) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
@@ -1515,7 +1515,7 @@ const char* ImGui::TableGetColumnName(int column_n) IMGUI_NOEXCEPT
     return TableGetColumnName(table, column_n);
 }
 
-const char* ImGui::TableGetColumnName(const ImGuiTable* table, int column_n) IMGUI_NOEXCEPT
+const char* ImGui::TableGetColumnName(const ImGuiTable* table, int column_n) IM_NOEXCEPT
 {
     if (table->IsLayoutLocked == false && column_n >= table->DeclColumnsCount)
         return ""; // NameOffset is invalid at this point
@@ -1529,7 +1529,7 @@ const char* ImGui::TableGetColumnName(const ImGuiTable* table, int column_n) IMG
 // Note that end-user can use the context menu to change this themselves (right-click in headers, or right-click in columns body with ImGuiTableFlags_ContextMenuInBody)
 // Request will be applied during next layout, which happens on the first call to TableNextRow() after BeginTable()
 // For the getter you can use (TableGetColumnFlags() & ImGuiTableColumnFlags_IsEnabled)
-void ImGui::TableSetColumnEnabled(int column_n, bool enabled) IMGUI_NOEXCEPT
+void ImGui::TableSetColumnEnabled(int column_n, bool enabled) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
@@ -1544,7 +1544,7 @@ void ImGui::TableSetColumnEnabled(int column_n, bool enabled) IMGUI_NOEXCEPT
 }
 
 // We allow querying for an extra column in order to poll the IsHovered state of the right-most section
-ImGuiTableColumnFlags ImGui::TableGetColumnFlags(int column_n) IMGUI_NOEXCEPT
+ImGuiTableColumnFlags ImGui::TableGetColumnFlags(int column_n) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
@@ -1562,7 +1562,7 @@ ImGuiTableColumnFlags ImGui::TableGetColumnFlags(int column_n) IMGUI_NOEXCEPT
 //   The only case where this is correct is if we provided a min_row_height to TableNextRow() and don't go below it.
 // - Important: if ImGuiTableFlags_PadOuterX is set but ImGuiTableFlags_PadInnerX is not set, the outer-most left and right
 //   columns report a small offset so their CellBgRect can extend up to the outer border.
-ImRect ImGui::TableGetCellBgRect(const ImGuiTable* table, int column_n) IMGUI_NOEXCEPT
+ImRect ImGui::TableGetCellBgRect(const ImGuiTable* table, int column_n) IM_NOEXCEPT
 {
     const ImGuiTableColumn* column = &table->Columns[column_n];
     float x1 = column->MinX;
@@ -1575,7 +1575,7 @@ ImRect ImGui::TableGetCellBgRect(const ImGuiTable* table, int column_n) IMGUI_NO
 }
 
 // Return the resizing ID for the right-side of the given column.
-ImGuiID ImGui::TableGetColumnResizeID(const ImGuiTable* table, int column_n, int instance_no) IMGUI_NOEXCEPT
+ImGuiID ImGui::TableGetColumnResizeID(const ImGuiTable* table, int column_n, int instance_no) IM_NOEXCEPT
 {
     IM_ASSERT(column_n >= 0 && column_n < table->ColumnsCount);
     ImGuiID id = table->ID + 1 + (instance_no * table->ColumnsCount) + column_n;
@@ -1583,7 +1583,7 @@ ImGuiID ImGui::TableGetColumnResizeID(const ImGuiTable* table, int column_n, int
 }
 
 // Return -1 when table is not hovered. return columns_count if the unused space at the right of visible columns is hovered.
-int ImGui::TableGetHoveredColumn() IMGUI_NOEXCEPT
+int ImGui::TableGetHoveredColumn() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
@@ -1592,7 +1592,7 @@ int ImGui::TableGetHoveredColumn() IMGUI_NOEXCEPT
     return (int)table->HoveredColumnBody;
 }
 
-void ImGui::TableSetBgColor(ImGuiTableBgTarget target, ImU32 color, int column_n) IMGUI_NOEXCEPT
+void ImGui::TableSetBgColor(ImGuiTableBgTarget target, ImU32 color, int column_n) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
@@ -1644,7 +1644,7 @@ void ImGui::TableSetBgColor(ImGuiTableBgTarget target, ImU32 color, int column_n
 //-------------------------------------------------------------------------
 
 // [Public] Note: for row coloring we use ->RowBgColorCounter which is the same value without counting header rows
-int ImGui::TableGetRowIndex() IMGUI_NOEXCEPT
+int ImGui::TableGetRowIndex() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
@@ -1654,7 +1654,7 @@ int ImGui::TableGetRowIndex() IMGUI_NOEXCEPT
 }
 
 // [Public] Starts into the first cell of a new row
-void ImGui::TableNextRow(ImGuiTableRowFlags row_flags, float row_min_height) IMGUI_NOEXCEPT
+void ImGui::TableNextRow(ImGuiTableRowFlags row_flags, float row_min_height) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
@@ -1679,7 +1679,7 @@ void ImGui::TableNextRow(ImGuiTableRowFlags row_flags, float row_min_height) IMG
 }
 
 // [Internal] Called by TableNextRow()
-void ImGui::TableBeginRow(ImGuiTable* table) IMGUI_NOEXCEPT
+void ImGui::TableBeginRow(ImGuiTable* table) IM_NOEXCEPT
 {
     ImGuiWindow* window = table->InnerWindow;
     IM_ASSERT(!table->IsInsideRow);
@@ -1712,7 +1712,7 @@ void ImGui::TableBeginRow(ImGuiTable* table) IMGUI_NOEXCEPT
 }
 
 // [Internal] Called by TableNextRow()
-void ImGui::TableEndRow(ImGuiTable* table) IMGUI_NOEXCEPT
+void ImGui::TableEndRow(ImGuiTable* table) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -1856,7 +1856,7 @@ void ImGui::TableEndRow(ImGuiTable* table) IMGUI_NOEXCEPT
 // - TableEndCell() [Internal]
 //-------------------------------------------------------------------------
 
-int ImGui::TableGetColumnIndex() IMGUI_NOEXCEPT
+int ImGui::TableGetColumnIndex() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
@@ -1866,7 +1866,7 @@ int ImGui::TableGetColumnIndex() IMGUI_NOEXCEPT
 }
 
 // [Public] Append into a specific column
-bool ImGui::TableSetColumnIndex(int column_n) IMGUI_NOEXCEPT
+bool ImGui::TableSetColumnIndex(int column_n) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
@@ -1887,7 +1887,7 @@ bool ImGui::TableSetColumnIndex(int column_n) IMGUI_NOEXCEPT
 }
 
 // [Public] Append into the next column, wrap and create a new row when already on last column
-bool ImGui::TableNextColumn() IMGUI_NOEXCEPT
+bool ImGui::TableNextColumn() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
@@ -1916,7 +1916,7 @@ bool ImGui::TableNextColumn() IMGUI_NOEXCEPT
 // [Internal] Called by TableSetColumnIndex()/TableNextColumn()
 // This is called very frequently, so we need to be mindful of unnecessary overhead.
 // FIXME-TABLE FIXME-OPT: Could probably shortcut some things for non-active or clipped columns.
-void ImGui::TableBeginCell(ImGuiTable* table, int column_n) IMGUI_NOEXCEPT
+void ImGui::TableBeginCell(ImGuiTable* table, int column_n) IM_NOEXCEPT
 {
     ImGuiTableColumn* column = &table->Columns[column_n];
     ImGuiWindow* window = table->InnerWindow;
@@ -1973,7 +1973,7 @@ void ImGui::TableBeginCell(ImGuiTable* table, int column_n) IMGUI_NOEXCEPT
 }
 
 // [Internal] Called by TableNextRow()/TableSetColumnIndex()/TableNextColumn()
-void ImGui::TableEndCell(ImGuiTable* table) IMGUI_NOEXCEPT
+void ImGui::TableEndCell(ImGuiTable* table) IM_NOEXCEPT
 {
     ImGuiTableColumn* column = &table->Columns[table->CurrentColumn];
     ImGuiWindow* window = table->InnerWindow;
@@ -2005,7 +2005,7 @@ void ImGui::TableEndCell(ImGuiTable* table) IMGUI_NOEXCEPT
 //-------------------------------------------------------------------------
 
 // Maximum column content width given current layout. Use column->MinX so this value on a per-column basis.
-float ImGui::TableGetMaxColumnWidth(const ImGuiTable* table, int column_n) IMGUI_NOEXCEPT
+float ImGui::TableGetMaxColumnWidth(const ImGuiTable* table, int column_n) IM_NOEXCEPT
 {
     const ImGuiTableColumn* column = &table->Columns[column_n];
     float max_width = FLT_MAX;
@@ -2036,7 +2036,7 @@ float ImGui::TableGetMaxColumnWidth(const ImGuiTable* table, int column_n) IMGUI
 }
 
 // Note this is meant to be stored in column->WidthAuto, please generally use the WidthAuto field
-float ImGui::TableGetColumnWidthAuto(ImGuiTable* table, ImGuiTableColumn* column) IMGUI_NOEXCEPT
+float ImGui::TableGetColumnWidthAuto(ImGuiTable* table, ImGuiTableColumn* column) IM_NOEXCEPT
 {
     const float content_width_body = ImMax(column->ContentMaxXFrozen, column->ContentMaxXUnfrozen) - column->WorkMinX;
     const float content_width_headers = column->ContentMaxXHeadersIdeal - column->WorkMinX;
@@ -2053,7 +2053,7 @@ float ImGui::TableGetColumnWidthAuto(ImGuiTable* table, ImGuiTableColumn* column
 }
 
 // 'width' = inner column width, without padding
-void ImGui::TableSetColumnWidth(int column_n, float width) IMGUI_NOEXCEPT
+void ImGui::TableSetColumnWidth(int column_n, float width) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
@@ -2136,7 +2136,7 @@ void ImGui::TableSetColumnWidth(int column_n, float width) IMGUI_NOEXCEPT
 
 // Disable clipping then auto-fit, will take 2 frames
 // (we don't take a shortcut for unclipped columns to reduce inconsistencies when e.g. resizing multiple columns)
-void ImGui::TableSetColumnWidthAutoSingle(ImGuiTable* table, int column_n) IMGUI_NOEXCEPT
+void ImGui::TableSetColumnWidthAutoSingle(ImGuiTable* table, int column_n) IM_NOEXCEPT
 {
     // Single auto width uses auto-fit
     ImGuiTableColumn* column = &table->Columns[column_n];
@@ -2146,7 +2146,7 @@ void ImGui::TableSetColumnWidthAutoSingle(ImGuiTable* table, int column_n) IMGUI
     table->AutoFitSingleColumn = (ImGuiTableColumnIdx)column_n;
 }
 
-void ImGui::TableSetColumnWidthAutoAll(ImGuiTable* table) IMGUI_NOEXCEPT
+void ImGui::TableSetColumnWidthAutoAll(ImGuiTable* table) IM_NOEXCEPT
 {
     for (int column_n = 0; column_n < table->ColumnsCount; column_n++)
     {
@@ -2158,7 +2158,7 @@ void ImGui::TableSetColumnWidthAutoAll(ImGuiTable* table) IMGUI_NOEXCEPT
     }
 }
 
-void ImGui::TableUpdateColumnsWeightFromWidth(ImGuiTable* table) IMGUI_NOEXCEPT
+void ImGui::TableUpdateColumnsWeightFromWidth(ImGuiTable* table) IM_NOEXCEPT
 {
     IM_ASSERT(table->LeftMostStretchedColumn != -1 && table->RightMostStretchedColumn != -1);
 
@@ -2199,7 +2199,7 @@ void ImGui::TableUpdateColumnsWeightFromWidth(ImGuiTable* table) IMGUI_NOEXCEPT
 
 // Bg2 is used by Selectable (and possibly other widgets) to render to the background.
 // Unlike our Bg0/1 channel which we uses for RowBg/CellBg/Borders and where we guarantee all shapes to be CPU-clipped, the Bg2 channel being widgets-facing will rely on regular ClipRect.
-void ImGui::TablePushBackgroundChannel() IMGUI_NOEXCEPT
+void ImGui::TablePushBackgroundChannel() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -2211,7 +2211,7 @@ void ImGui::TablePushBackgroundChannel() IMGUI_NOEXCEPT
     table->DrawSplitter->SetCurrentChannel(window->DrawList, table->Bg2DrawChannelCurrent);
 }
 
-void ImGui::TablePopBackgroundChannel() IMGUI_NOEXCEPT
+void ImGui::TablePopBackgroundChannel() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -2239,7 +2239,7 @@ void ImGui::TablePopBackgroundChannel() IMGUI_NOEXCEPT
 // - FreezeRows                   --> 2+D+N*2 (unless scrolling value is zero)
 // - FreezeRows || FreezeColunns  --> 3+D+N*2 (unless scrolling value is zero)
 // Where D is 1 if any column is clipped or hidden (dummy channel) otherwise 0.
-void ImGui::TableSetupDrawChannels(ImGuiTable* table) IMGUI_NOEXCEPT
+void ImGui::TableSetupDrawChannels(ImGuiTable* table) IM_NOEXCEPT
 {
     const int freeze_row_multiplier = (table->FreezeRowsCount > 0) ? 2 : 1;
     const int channels_for_row = (table->Flags & ImGuiTableFlags_NoClip) ? 1 : table->ColumnsEnabledCount;
@@ -2307,7 +2307,7 @@ void ImGui::TableSetupDrawChannels(ImGuiTable* table) IMGUI_NOEXCEPT
 // Columns for which the draw channel(s) haven't been merged with other will use their own ImDrawCmd.
 //
 // This function is particularly tricky to understand.. take a breath.
-void ImGui::TableMergeDrawChannels(ImGuiTable* table) IMGUI_NOEXCEPT
+void ImGui::TableMergeDrawChannels(ImGuiTable* table) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImDrawListSplitter* splitter = table->DrawSplitter;
@@ -2474,7 +2474,7 @@ void ImGui::TableMergeDrawChannels(ImGuiTable* table) IMGUI_NOEXCEPT
 }
 
 // FIXME-TABLE: This is a mess, need to redesign how we render borders (as some are also done in TableEndRow)
-void ImGui::TableDrawBorders(ImGuiTable* table) IMGUI_NOEXCEPT
+void ImGui::TableDrawBorders(ImGuiTable* table) IM_NOEXCEPT
 {
     ImGuiWindow* inner_window = table->InnerWindow;
     if (!table->OuterWindow->ClipRect.Overlaps(table->OuterRect))
@@ -2584,7 +2584,7 @@ void ImGui::TableDrawBorders(ImGuiTable* table) IMGUI_NOEXCEPT
 // You can sort your data again when 'SpecsChanged == true'. It will be true with sorting specs have changed since
 // last call, or the first time.
 // Lifetime: don't hold on this pointer over multiple frames or past any subsequent call to BeginTable()!
-ImGuiTableSortSpecs* ImGui::TableGetSortSpecs() IMGUI_NOEXCEPT
+ImGuiTableSortSpecs* ImGui::TableGetSortSpecs() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
@@ -2603,14 +2603,14 @@ ImGuiTableSortSpecs* ImGui::TableGetSortSpecs() IMGUI_NOEXCEPT
     return &table->SortSpecs;
 }
 
-static inline ImGuiSortDirection TableGetColumnAvailSortDirection(ImGuiTableColumn* column, int n) IMGUI_NOEXCEPT
+static inline ImGuiSortDirection TableGetColumnAvailSortDirection(ImGuiTableColumn* column, int n) IM_NOEXCEPT
 {
     IM_ASSERT(n < column->SortDirectionsAvailCount);
     return (column->SortDirectionsAvailList >> (n << 1)) & 0x03;
 }
 
 // Fix sort direction if currently set on a value which is unavailable (e.g. activating NoSortAscending/NoSortDescending)
-void ImGui::TableFixColumnSortDirection(ImGuiTable* table, ImGuiTableColumn* column) IMGUI_NOEXCEPT
+void ImGui::TableFixColumnSortDirection(ImGuiTable* table, ImGuiTableColumn* column) IM_NOEXCEPT
 {
     if (column->SortOrder == -1 || (column->SortDirectionsAvailMask & (1 << column->SortDirection)) != 0)
         return;
@@ -2622,7 +2622,7 @@ void ImGui::TableFixColumnSortDirection(ImGuiTable* table, ImGuiTableColumn* col
 // - If the PreferSortDescending flag is set, we will default to a Descending direction on the first click.
 // - Note that the PreferSortAscending flag is never checked, it is essentially the default and therefore a no-op.
 IM_STATIC_ASSERT(ImGuiSortDirection_None == 0 && ImGuiSortDirection_Ascending == 1 && ImGuiSortDirection_Descending == 2);
-ImGuiSortDirection ImGui::TableGetColumnNextSortDirection(ImGuiTableColumn* column) IMGUI_NOEXCEPT
+ImGuiSortDirection ImGui::TableGetColumnNextSortDirection(ImGuiTableColumn* column) IM_NOEXCEPT
 {
     IM_ASSERT(column->SortDirectionsAvailCount > 0);
     if (column->SortOrder == -1)
@@ -2636,7 +2636,7 @@ ImGuiSortDirection ImGui::TableGetColumnNextSortDirection(ImGuiTableColumn* colu
 
 // Note that the NoSortAscending/NoSortDescending flags are processed in TableSortSpecsSanitize(), and they may change/revert
 // the value of SortDirection. We could technically also do it here but it would be unnecessary and duplicate code.
-void ImGui::TableSetColumnSortDirection(int column_n, ImGuiSortDirection sort_direction, bool append_to_sort_specs) IMGUI_NOEXCEPT
+void ImGui::TableSetColumnSortDirection(int column_n, ImGuiSortDirection sort_direction, bool append_to_sort_specs) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
@@ -2669,7 +2669,7 @@ void ImGui::TableSetColumnSortDirection(int column_n, ImGuiSortDirection sort_di
     table->IsSortSpecsDirty = true;
 }
 
-void ImGui::TableSortSpecsSanitize(ImGuiTable* table) IMGUI_NOEXCEPT
+void ImGui::TableSortSpecsSanitize(ImGuiTable* table) IM_NOEXCEPT
 {
     IM_ASSERT(table->Flags & ImGuiTableFlags_Sortable);
 
@@ -2735,7 +2735,7 @@ void ImGui::TableSortSpecsSanitize(ImGuiTable* table) IMGUI_NOEXCEPT
     table->SortSpecsCount = (ImGuiTableColumnIdx)sort_order_count;
 }
 
-void ImGui::TableSortSpecsBuild(ImGuiTable* table) IMGUI_NOEXCEPT
+void ImGui::TableSortSpecsBuild(ImGuiTable* table) IM_NOEXCEPT
 {
     IM_ASSERT(table->IsSortSpecsDirty);
     TableSortSpecsSanitize(table);
@@ -2771,7 +2771,7 @@ void ImGui::TableSortSpecsBuild(ImGuiTable* table) IMGUI_NOEXCEPT
 // - TableHeader()
 //-------------------------------------------------------------------------
 
-float ImGui::TableGetHeaderRowHeight() IMGUI_NOEXCEPT
+float ImGui::TableGetHeaderRowHeight() IM_NOEXCEPT
 {
     // Caring for a minor edge case:
     // Calculate row height, for the unlikely case that some labels may be taller than others.
@@ -2792,7 +2792,7 @@ float ImGui::TableGetHeaderRowHeight() IMGUI_NOEXCEPT
 // See 'Demo->Tables->Custom headers' for a demonstration of implementing a custom version of this.
 // This code is constructed to not make much use of internal functions, as it is intended to be a template to copy.
 // FIXME-TABLE: TableOpenContextMenu() and TableGetHeaderRowHeight() are not public.
-void ImGui::TableHeadersRow() IMGUI_NOEXCEPT
+void ImGui::TableHeadersRow() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
@@ -2834,7 +2834,7 @@ void ImGui::TableHeadersRow() IMGUI_NOEXCEPT
 // Emit a column header (text + optional sort order)
 // We cpu-clip text here so that all columns headers can be merged into a same draw call.
 // Note that because of how we cpu-clip and display sorting indicators, you _cannot_ use SameLine() after a TableHeader()
-void ImGui::TableHeader(const char* label) IMGUI_NOEXCEPT
+void ImGui::TableHeader(const char* label) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -2981,7 +2981,7 @@ void ImGui::TableHeader(const char* label) IMGUI_NOEXCEPT
 //-------------------------------------------------------------------------
 
 // Use -1 to open menu not specific to a given column.
-void ImGui::TableOpenContextMenu(int column_n) IMGUI_NOEXCEPT
+void ImGui::TableOpenContextMenu(int column_n) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
@@ -3002,7 +3002,7 @@ void ImGui::TableOpenContextMenu(int column_n) IMGUI_NOEXCEPT
 
 // Output context menu into current window (generally a popup)
 // FIXME-TABLE: Ideally this should be writable by the user. Full programmatic access to that data?
-void ImGui::TableDrawContextMenu(ImGuiTable* table) IMGUI_NOEXCEPT
+void ImGui::TableDrawContextMenu(ImGuiTable* table) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -3115,7 +3115,7 @@ void ImGui::TableDrawContextMenu(ImGuiTable* table) IMGUI_NOEXCEPT
 //-------------------------------------------------------------------------
 
 // Clear and initialize empty settings instance
-static void TableSettingsInit(ImGuiTableSettings* settings, ImGuiID id, int columns_count, int columns_count_max) IMGUI_NOEXCEPT
+static void TableSettingsInit(ImGuiTableSettings* settings, ImGuiID id, int columns_count, int columns_count_max) IM_NOEXCEPT
 {
     IM_PLACEMENT_NEW(settings) ImGuiTableSettings();
     ImGuiTableColumnSettings* settings_column = settings->GetColumnSettings();
@@ -3127,12 +3127,12 @@ static void TableSettingsInit(ImGuiTableSettings* settings, ImGuiID id, int colu
     settings->WantApply = true;
 }
 
-static size_t TableSettingsCalcChunkSize(int columns_count) IMGUI_NOEXCEPT
+static size_t TableSettingsCalcChunkSize(int columns_count) IM_NOEXCEPT
 {
     return sizeof(ImGuiTableSettings) + (size_t)columns_count * sizeof(ImGuiTableColumnSettings);
 }
 
-ImGuiTableSettings* ImGui::TableSettingsCreate(ImGuiID id, int columns_count) IMGUI_NOEXCEPT
+ImGuiTableSettings* ImGui::TableSettingsCreate(ImGuiID id, int columns_count) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiTableSettings* settings = g.SettingsTables.alloc_chunk(TableSettingsCalcChunkSize(columns_count));
@@ -3141,7 +3141,7 @@ ImGuiTableSettings* ImGui::TableSettingsCreate(ImGuiID id, int columns_count) IM
 }
 
 // Find existing settings
-ImGuiTableSettings* ImGui::TableSettingsFindByID(ImGuiID id) IMGUI_NOEXCEPT
+ImGuiTableSettings* ImGui::TableSettingsFindByID(ImGuiID id) IM_NOEXCEPT
 {
     // FIXME-OPT: Might want to store a lookup map for this?
     ImGuiContext& g = *GImGui;
@@ -3152,7 +3152,7 @@ ImGuiTableSettings* ImGui::TableSettingsFindByID(ImGuiID id) IMGUI_NOEXCEPT
 }
 
 // Get settings for a given table, NULL if none
-ImGuiTableSettings* ImGui::TableGetBoundSettings(ImGuiTable* table) IMGUI_NOEXCEPT
+ImGuiTableSettings* ImGui::TableGetBoundSettings(ImGuiTable* table) IM_NOEXCEPT
 {
     if (table->SettingsOffset != -1)
     {
@@ -3167,7 +3167,7 @@ ImGuiTableSettings* ImGui::TableGetBoundSettings(ImGuiTable* table) IMGUI_NOEXCE
 }
 
 // Restore initial state of table (with or without saved settings)
-void ImGui::TableResetSettings(ImGuiTable* table) IMGUI_NOEXCEPT
+void ImGui::TableResetSettings(ImGuiTable* table) IM_NOEXCEPT
 {
     table->IsInitializing = table->IsSettingsDirty = true;
     table->IsResetAllRequest = false;
@@ -3175,7 +3175,7 @@ void ImGui::TableResetSettings(ImGuiTable* table) IMGUI_NOEXCEPT
     table->SettingsLoadedFlags = ImGuiTableFlags_None;      // Mark as nothing loaded so our initialized data becomes authoritative
 }
 
-void ImGui::TableSaveSettings(ImGuiTable* table) IMGUI_NOEXCEPT
+void ImGui::TableSaveSettings(ImGuiTable* table) IM_NOEXCEPT
 {
     table->IsSettingsDirty = false;
     if (table->Flags & ImGuiTableFlags_NoSavedSettings)
@@ -3230,7 +3230,7 @@ void ImGui::TableSaveSettings(ImGuiTable* table) IMGUI_NOEXCEPT
     MarkIniSettingsDirty();
 }
 
-void ImGui::TableLoadSettings(ImGuiTable* table) IMGUI_NOEXCEPT
+void ImGui::TableLoadSettings(ImGuiTable* table) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     table->IsSettingsRequestLoad = false;
@@ -3295,7 +3295,7 @@ void ImGui::TableLoadSettings(ImGuiTable* table) IMGUI_NOEXCEPT
         table->DisplayOrderToIndex[table->Columns[column_n].DisplayOrder] = (ImGuiTableColumnIdx)column_n;
 }
 
-static void TableSettingsHandler_ClearAll(ImGuiContext* ctx, ImGuiSettingsHandler*) IMGUI_NOEXCEPT
+static void TableSettingsHandler_ClearAll(ImGuiContext* ctx, ImGuiSettingsHandler*) IM_NOEXCEPT
 {
     ImGuiContext& g = *ctx;
     for (int i = 0; i != g.Tables.GetSize(); i++)
@@ -3304,7 +3304,7 @@ static void TableSettingsHandler_ClearAll(ImGuiContext* ctx, ImGuiSettingsHandle
 }
 
 // Apply to existing windows (if any)
-static void TableSettingsHandler_ApplyAll(ImGuiContext* ctx, ImGuiSettingsHandler*) IMGUI_NOEXCEPT
+static void TableSettingsHandler_ApplyAll(ImGuiContext* ctx, ImGuiSettingsHandler*) IM_NOEXCEPT
 {
     ImGuiContext& g = *ctx;
     for (int i = 0; i != g.Tables.GetSize(); i++)
@@ -3315,7 +3315,7 @@ static void TableSettingsHandler_ApplyAll(ImGuiContext* ctx, ImGuiSettingsHandle
     }
 }
 
-static void* TableSettingsHandler_ReadOpen(ImGuiContext*, ImGuiSettingsHandler*, const char* name) IMGUI_NOEXCEPT
+static void* TableSettingsHandler_ReadOpen(ImGuiContext*, ImGuiSettingsHandler*, const char* name) IM_NOEXCEPT
 {
     ImGuiID id = 0;
     int columns_count = 0;
@@ -3334,7 +3334,7 @@ static void* TableSettingsHandler_ReadOpen(ImGuiContext*, ImGuiSettingsHandler*,
     return ImGui::TableSettingsCreate(id, columns_count);
 }
 
-static void TableSettingsHandler_ReadLine(ImGuiContext*, ImGuiSettingsHandler*, void* entry, const char* line) IMGUI_NOEXCEPT
+static void TableSettingsHandler_ReadLine(ImGuiContext*, ImGuiSettingsHandler*, void* entry, const char* line) IM_NOEXCEPT
 {
     // "Column 0  UserID=0x42AD2D21 Width=100 Visible=1 Order=0 Sort=0v"
     ImGuiTableSettings* settings = (ImGuiTableSettings*)entry;
@@ -3360,7 +3360,7 @@ static void TableSettingsHandler_ReadLine(ImGuiContext*, ImGuiSettingsHandler*, 
     }
 }
 
-static void TableSettingsHandler_WriteAll(ImGuiContext* ctx, ImGuiSettingsHandler* handler, ImGuiTextBuffer* buf) IMGUI_NOEXCEPT
+static void TableSettingsHandler_WriteAll(ImGuiContext* ctx, ImGuiSettingsHandler* handler, ImGuiTextBuffer* buf) IM_NOEXCEPT
 {
     ImGuiContext& g = *ctx;
     for (ImGuiTableSettings* settings = g.SettingsTables.begin(); settings != NULL; settings = g.SettingsTables.next_chunk(settings))
@@ -3401,7 +3401,7 @@ static void TableSettingsHandler_WriteAll(ImGuiContext* ctx, ImGuiSettingsHandle
     }
 }
 
-void ImGui::TableSettingsInstallHandler(ImGuiContext* context) IMGUI_NOEXCEPT
+void ImGui::TableSettingsInstallHandler(ImGuiContext* context) IM_NOEXCEPT
 {
     ImGuiContext& g = *context;
     ImGuiSettingsHandler ini_handler;
@@ -3424,7 +3424,7 @@ void ImGui::TableSettingsInstallHandler(ImGuiContext* context) IMGUI_NOEXCEPT
 //-------------------------------------------------------------------------
 
 // Remove Table (currently only used by TestEngine)
-void ImGui::TableRemove(ImGuiTable* table) IMGUI_NOEXCEPT
+void ImGui::TableRemove(ImGuiTable* table) IM_NOEXCEPT
 {
     //IMGUI_DEBUG_LOG("TableRemove() id=0x%08X\n", table->ID);
     ImGuiContext& g = *GImGui;
@@ -3436,7 +3436,7 @@ void ImGui::TableRemove(ImGuiTable* table) IMGUI_NOEXCEPT
 }
 
 // Free up/compact internal Table buffers for when it gets unused
-void ImGui::TableGcCompactTransientBuffers(ImGuiTable* table) IMGUI_NOEXCEPT
+void ImGui::TableGcCompactTransientBuffers(ImGuiTable* table) IM_NOEXCEPT
 {
     //IMGUI_DEBUG_LOG("TableGcCompactTransientBuffers() id=0x%08X\n", table->ID);
     ImGuiContext& g = *GImGui;
@@ -3458,7 +3458,7 @@ void ImGui::TableGcCompactTransientBuffers(ImGuiTableTempData* temp_data)
 }
 
 // Compact and remove unused settings data (currently only used by TestEngine)
-void ImGui::TableGcCompactSettings() IMGUI_NOEXCEPT
+void ImGui::TableGcCompactSettings() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     int required_memory = 0;
@@ -3484,7 +3484,7 @@ void ImGui::TableGcCompactSettings() IMGUI_NOEXCEPT
 
 #ifndef IMGUI_DISABLE_METRICS_WINDOW
 
-static const char* DebugNodeTableGetSizingPolicyDesc(ImGuiTableFlags sizing_policy) IMGUI_NOEXCEPT
+static const char* DebugNodeTableGetSizingPolicyDesc(ImGuiTableFlags sizing_policy) IM_NOEXCEPT
 {
     sizing_policy &= ImGuiTableFlags_SizingMask_;
     if (sizing_policy == ImGuiTableFlags_SizingFixedFit)    { return "FixedFit"; }
@@ -3494,7 +3494,7 @@ static const char* DebugNodeTableGetSizingPolicyDesc(ImGuiTableFlags sizing_poli
     return "N/A";
 }
 
-void ImGui::DebugNodeTable(ImGuiTable* table) IMGUI_NOEXCEPT
+void ImGui::DebugNodeTable(ImGuiTable* table) IM_NOEXCEPT
 {
     char buf[512];
     char* p = buf;
@@ -3556,7 +3556,7 @@ void ImGui::DebugNodeTable(ImGuiTable* table) IMGUI_NOEXCEPT
     TreePop();
 }
 
-void ImGui::DebugNodeTableSettings(ImGuiTableSettings* settings) IMGUI_NOEXCEPT
+void ImGui::DebugNodeTableSettings(ImGuiTableSettings* settings) IM_NOEXCEPT
 {
     if (!TreeNode((void*)(intptr_t)settings->ID, "Settings 0x%08X (%d columns)", settings->ID, settings->ColumnsCount))
         return;
@@ -3576,8 +3576,8 @@ void ImGui::DebugNodeTableSettings(ImGuiTableSettings* settings) IMGUI_NOEXCEPT
 
 #else // #ifndef IMGUI_DISABLE_METRICS_WINDOW
 
-void ImGui::DebugNodeTable(ImGuiTable*) IMGUI_NOEXCEPT {}
-void ImGui::DebugNodeTableSettings(ImGuiTableSettings*) IMGUI_NOEXCEPT {}
+void ImGui::DebugNodeTable(ImGuiTable*) IM_NOEXCEPT {}
+void ImGui::DebugNodeTableSettings(ImGuiTableSettings*) IM_NOEXCEPT {}
 
 #endif
 
@@ -3610,7 +3610,7 @@ void ImGui::DebugNodeTableSettings(ImGuiTableSettings*) IMGUI_NOEXCEPT {}
 // they would meddle many times with the underlying ImDrawCmd.
 // Instead, we do a preemptive overwrite of clipping rectangle _without_ altering the command-buffer and let
 // the subsequent single call to SetCurrentChannel() does it things once.
-void ImGui::SetWindowClipRectBeforeSetChannel(ImGuiWindow* window, const ImRect& clip_rect) IMGUI_NOEXCEPT
+void ImGui::SetWindowClipRectBeforeSetChannel(ImGuiWindow* window, const ImRect& clip_rect) IM_NOEXCEPT
 {
     ImVec4 clip_rect_vec4 = clip_rect.ToVec4();
     window->ClipRect = clip_rect;
@@ -3618,31 +3618,31 @@ void ImGui::SetWindowClipRectBeforeSetChannel(ImGuiWindow* window, const ImRect&
     window->DrawList->_ClipRectStack.Data[window->DrawList->_ClipRectStack.Size - 1] = clip_rect_vec4;
 }
 
-int ImGui::GetColumnIndex() IMGUI_NOEXCEPT
+int ImGui::GetColumnIndex() IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     return window->DC.CurrentColumns ? window->DC.CurrentColumns->Current : 0;
 }
 
-int ImGui::GetColumnsCount() IMGUI_NOEXCEPT
+int ImGui::GetColumnsCount() IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     return window->DC.CurrentColumns ? window->DC.CurrentColumns->Count : 1;
 }
 
-float ImGui::GetColumnOffsetFromNorm(const ImGuiOldColumns* columns, float offset_norm) IMGUI_NOEXCEPT
+float ImGui::GetColumnOffsetFromNorm(const ImGuiOldColumns* columns, float offset_norm) IM_NOEXCEPT
 {
     return offset_norm * (columns->OffMaxX - columns->OffMinX);
 }
 
-float ImGui::GetColumnNormFromOffset(const ImGuiOldColumns* columns, float offset) IMGUI_NOEXCEPT
+float ImGui::GetColumnNormFromOffset(const ImGuiOldColumns* columns, float offset) IM_NOEXCEPT
 {
     return offset / (columns->OffMaxX - columns->OffMinX);
 }
 
 static const float COLUMNS_HIT_RECT_HALF_WIDTH = 4.0f;
 
-static float GetDraggedColumnOffset(ImGuiOldColumns* columns, int column_index) IMGUI_NOEXCEPT
+static float GetDraggedColumnOffset(ImGuiOldColumns* columns, int column_index) IM_NOEXCEPT
 {
     // Active (dragged) column always follow mouse. The reason we need this is that dragging a column to the right edge of an auto-resizing
     // window creates a feedback loop because we store normalized positions. So while dragging we enforce absolute positioning.
@@ -3659,7 +3659,7 @@ static float GetDraggedColumnOffset(ImGuiOldColumns* columns, int column_index) 
     return x;
 }
 
-float ImGui::GetColumnOffset(int column_index) IMGUI_NOEXCEPT
+float ImGui::GetColumnOffset(int column_index) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     ImGuiOldColumns* columns = window->DC.CurrentColumns;
@@ -3675,7 +3675,7 @@ float ImGui::GetColumnOffset(int column_index) IMGUI_NOEXCEPT
     return x_offset;
 }
 
-static float GetColumnWidthEx(ImGuiOldColumns* columns, int column_index, bool before_resize = false) IMGUI_NOEXCEPT
+static float GetColumnWidthEx(ImGuiOldColumns* columns, int column_index, bool before_resize = false) IM_NOEXCEPT
 {
     if (column_index < 0)
         column_index = columns->Current;
@@ -3688,7 +3688,7 @@ static float GetColumnWidthEx(ImGuiOldColumns* columns, int column_index, bool b
     return ImGui::GetColumnOffsetFromNorm(columns, offset_norm);
 }
 
-float ImGui::GetColumnWidth(int column_index) IMGUI_NOEXCEPT
+float ImGui::GetColumnWidth(int column_index) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -3701,7 +3701,7 @@ float ImGui::GetColumnWidth(int column_index) IMGUI_NOEXCEPT
     return GetColumnOffsetFromNorm(columns, columns->Columns[column_index + 1].OffsetNorm - columns->Columns[column_index].OffsetNorm);
 }
 
-void ImGui::SetColumnOffset(int column_index, float offset) IMGUI_NOEXCEPT
+void ImGui::SetColumnOffset(int column_index, float offset) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -3723,7 +3723,7 @@ void ImGui::SetColumnOffset(int column_index, float offset) IMGUI_NOEXCEPT
         SetColumnOffset(column_index + 1, offset + ImMax(g.Style.ColumnsMinSpacing, width));
 }
 
-void ImGui::SetColumnWidth(int column_index, float width) IMGUI_NOEXCEPT
+void ImGui::SetColumnWidth(int column_index, float width) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     ImGuiOldColumns* columns = window->DC.CurrentColumns;
@@ -3734,7 +3734,7 @@ void ImGui::SetColumnWidth(int column_index, float width) IMGUI_NOEXCEPT
     SetColumnOffset(column_index + 1, GetColumnOffset(column_index) + width);
 }
 
-void ImGui::PushColumnClipRect(int column_index) IMGUI_NOEXCEPT
+void ImGui::PushColumnClipRect(int column_index) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     ImGuiOldColumns* columns = window->DC.CurrentColumns;
@@ -3746,7 +3746,7 @@ void ImGui::PushColumnClipRect(int column_index) IMGUI_NOEXCEPT
 }
 
 // Get into the columns background draw command (which is generally the same draw command as before we called BeginColumns)
-void ImGui::PushColumnsBackground() IMGUI_NOEXCEPT
+void ImGui::PushColumnsBackground() IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     ImGuiOldColumns* columns = window->DC.CurrentColumns;
@@ -3759,7 +3759,7 @@ void ImGui::PushColumnsBackground() IMGUI_NOEXCEPT
     columns->Splitter.SetCurrentChannel(window->DrawList, 0);
 }
 
-void ImGui::PopColumnsBackground() IMGUI_NOEXCEPT
+void ImGui::PopColumnsBackground() IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindowRead();
     ImGuiOldColumns* columns = window->DC.CurrentColumns;
@@ -3771,7 +3771,7 @@ void ImGui::PopColumnsBackground() IMGUI_NOEXCEPT
     columns->Splitter.SetCurrentChannel(window->DrawList, columns->Current + 1);
 }
 
-ImGuiOldColumns* ImGui::FindOrCreateColumns(ImGuiWindow* window, ImGuiID id) IMGUI_NOEXCEPT
+ImGuiOldColumns* ImGui::FindOrCreateColumns(ImGuiWindow* window, ImGuiID id) IM_NOEXCEPT
 {
     // We have few columns per window so for now we don't need bother much with turning this into a faster lookup.
     for (int n = 0; n < window->ColumnsStorage.Size; n++)
@@ -3784,7 +3784,7 @@ ImGuiOldColumns* ImGui::FindOrCreateColumns(ImGuiWindow* window, ImGuiID id) IMG
     return columns;
 }
 
-ImGuiID ImGui::GetColumnsID(const char* str_id, int columns_count) IMGUI_NOEXCEPT
+ImGuiID ImGui::GetColumnsID(const char* str_id, int columns_count) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
 
@@ -3797,7 +3797,7 @@ ImGuiID ImGui::GetColumnsID(const char* str_id, int columns_count) IMGUI_NOEXCEP
     return id;
 }
 
-void ImGui::BeginColumns(const char* str_id, int columns_count, ImGuiOldColumnFlags flags) IMGUI_NOEXCEPT
+void ImGui::BeginColumns(const char* str_id, int columns_count, ImGuiOldColumnFlags flags) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = GetCurrentWindow();
@@ -3874,7 +3874,7 @@ void ImGui::BeginColumns(const char* str_id, int columns_count, ImGuiOldColumnFl
     window->WorkRect.Max.x = window->Pos.x + offset_1 - column_padding;
 }
 
-void ImGui::NextColumn() IMGUI_NOEXCEPT
+void ImGui::NextColumn() IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems || window->DC.CurrentColumns == NULL)
@@ -3929,7 +3929,7 @@ void ImGui::NextColumn() IMGUI_NOEXCEPT
     window->WorkRect.Max.x = window->Pos.x + offset_1 - column_padding;
 }
 
-void ImGui::EndColumns() IMGUI_NOEXCEPT
+void ImGui::EndColumns() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = GetCurrentWindow();
@@ -4005,7 +4005,7 @@ void ImGui::EndColumns() IMGUI_NOEXCEPT
     window->DC.CursorPos.x = IM_FLOOR(window->Pos.x + window->DC.Indent.x + window->DC.ColumnsOffset.x);
 }
 
-void ImGui::Columns(int columns_count, const char* id, bool border) IMGUI_NOEXCEPT
+void ImGui::Columns(int columns_count, const char* id, bool border) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     IM_ASSERT(columns_count >= 1);

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -1550,7 +1550,7 @@ static float CalcMaxPopupHeightFromItemCount(int items_count)
     return (g.FontSize + g.Style.ItemSpacing.y) * items_count - g.Style.ItemSpacing.y + (g.Style.WindowPadding.y * 2);
 }
 
-bool ImGui::BeginCombo(const char* label, const char* preview_value, ImGuiComboFlags flags)
+bool ImGui::BeginCombo(const char* label, const char* preview_value, ImGuiComboFlags flags) IMGUI_NOEXCEPT
 {
     // Always consume the SetNextWindowSizeConstraint() call in our early return paths
     ImGuiContext& g = *GImGui;
@@ -1667,7 +1667,7 @@ bool ImGui::BeginCombo(const char* label, const char* preview_value, ImGuiComboF
     return true;
 }
 
-void ImGui::EndCombo()
+void ImGui::EndCombo() IMGUI_NOEXCEPT
 {
     EndPopup();
 }
@@ -6173,7 +6173,7 @@ bool ImGui::Selectable(const char* label, bool* p_selected, ImGuiSelectableFlags
 
 // Tip: To have a list filling the entire window width, use size.x = -FLT_MIN and pass an non-visible label e.g. "##empty"
 // Tip: If your vertical size is calculated from an item count (e.g. 10 * item_height) consider adding a fractional part to facilitate seeing scrolling boundaries (e.g. 10.25 * item_height).
-bool ImGui::BeginListBox(const char* label, const ImVec2& size_arg)
+bool ImGui::BeginListBox(const char* label, const ImVec2& size_arg) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = GetCurrentWindow();
@@ -6226,7 +6226,7 @@ bool ImGui::ListBoxHeader(const char* label, int items_count, int height_in_item
 }
 #endif
 
-void ImGui::EndListBox()
+void ImGui::EndListBox() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -6544,7 +6544,7 @@ float ImGuiMenuColumns::CalcExtraSpace(float avail_w) const
 // Currently the main responsibility of this function being to setup clip-rect + horizontal layout + menu navigation layer.
 // Ideally we also want this to be responsible for claiming space out of the main window scrolling rectangle, in which case ImGuiWindowFlags_MenuBar will become unnecessary.
 // Then later the same system could be used for multiple menu-bars, scrollbars, side-bars.
-bool ImGui::BeginMenuBar()
+bool ImGui::BeginMenuBar() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -6572,7 +6572,7 @@ bool ImGui::BeginMenuBar()
     return true;
 }
 
-void ImGui::EndMenuBar()
+void ImGui::EndMenuBar() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -6651,7 +6651,7 @@ bool ImGui::BeginViewportSideBar(const char* name, ImGuiViewport* viewport_p, Im
     return is_open;
 }
 
-bool ImGui::BeginMainMenuBar()
+bool ImGui::BeginMainMenuBar() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiViewportP* viewport = (ImGuiViewportP*)(void*)GetMainViewport();
@@ -6672,7 +6672,7 @@ bool ImGui::BeginMainMenuBar()
     return is_open;
 }
 
-void ImGui::EndMainMenuBar()
+void ImGui::EndMainMenuBar() IMGUI_NOEXCEPT
 {
     EndMenuBar();
 
@@ -6685,7 +6685,7 @@ void ImGui::EndMainMenuBar()
     End();
 }
 
-bool ImGui::BeginMenu(const char* label, bool enabled)
+bool ImGui::BeginMenu(const char* label, bool enabled) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -6849,7 +6849,7 @@ bool ImGui::BeginMenu(const char* label, bool enabled)
     return menu_is_open;
 }
 
-void ImGui::EndMenu()
+void ImGui::EndMenu() IMGUI_NOEXCEPT
 {
     // Nav: When a left move request _within our child menu_ failed, close ourselves (the _parent_ menu).
     // A menu doesn't close itself because EndMenuBar() wants the catch the last Left<>Right inputs.
@@ -7008,7 +7008,7 @@ static ImGuiPtrOrIndex GetTabBarRefFromTabBar(ImGuiTabBar* tab_bar)
     return ImGuiPtrOrIndex(tab_bar);
 }
 
-bool    ImGui::BeginTabBar(const char* str_id, ImGuiTabBarFlags flags)
+bool    ImGui::BeginTabBar(const char* str_id, ImGuiTabBarFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7081,7 +7081,7 @@ bool    ImGui::BeginTabBarEx(ImGuiTabBar* tab_bar, const ImRect& tab_bar_bb, ImG
     return true;
 }
 
-void    ImGui::EndTabBar()
+void    ImGui::EndTabBar() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7643,7 +7643,7 @@ static ImGuiTabItem* ImGui::TabBarTabListPopupButton(ImGuiTabBar* tab_bar)
 // - TabItemLabelAndCloseButton() [Internal]
 //-------------------------------------------------------------------------
 
-bool    ImGui::BeginTabItem(const char* label, bool* p_open, ImGuiTabItemFlags flags)
+bool    ImGui::BeginTabItem(const char* label, bool* p_open, ImGuiTabItemFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7667,7 +7667,7 @@ bool    ImGui::BeginTabItem(const char* label, bool* p_open, ImGuiTabItemFlags f
     return ret;
 }
 
-void    ImGui::EndTabItem()
+void    ImGui::EndTabItem() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -124,9 +124,9 @@ static const ImU64          IM_U64_MAX = (2ULL * 9223372036854775807LL + 1);
 //-------------------------------------------------------------------------
 
 // For InputTextEx()
-static bool             InputTextFilterCharacter(unsigned int* p_char, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback, void* user_data, ImGuiInputSource input_source);
-static int              InputTextCalcTextLenAndLineCount(const char* text_begin, const char** out_text_end);
-static ImVec2           InputTextCalcTextSizeW(const ImWchar* text_begin, const ImWchar* text_end, const ImWchar** remaining = NULL, ImVec2* out_offset = NULL, bool stop_on_new_line = false);
+static bool             InputTextFilterCharacter(unsigned int* p_char, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback, void* user_data, ImGuiInputSource input_source) IMGUI_NOEXCEPT;
+static int              InputTextCalcTextLenAndLineCount(const char* text_begin, const char** out_text_end) IMGUI_NOEXCEPT;
+static ImVec2           InputTextCalcTextSizeW(const ImWchar* text_begin, const ImWchar* text_end, const ImWchar** remaining = NULL, ImVec2* out_offset = NULL, bool stop_on_new_line = false) IMGUI_NOEXCEPT;
 
 //-------------------------------------------------------------------------
 // [SECTION] Widgets: Text, etc.
@@ -147,7 +147,7 @@ static ImVec2           InputTextCalcTextSizeW(const ImWchar* text_begin, const 
 // - BulletTextV()
 //-------------------------------------------------------------------------
 
-void ImGui::TextEx(const char* text, const char* text_end, ImGuiTextFlags flags)
+void ImGui::TextEx(const char* text, const char* text_end, ImGuiTextFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -250,12 +250,12 @@ void ImGui::TextEx(const char* text, const char* text_end, ImGuiTextFlags flags)
     }
 }
 
-void ImGui::TextUnformatted(const char* text, const char* text_end)
+void ImGui::TextUnformatted(const char* text, const char* text_end) IMGUI_NOEXCEPT
 {
     TextEx(text, text_end, ImGuiTextFlags_NoWidthForLargeClippedText);
 }
 
-void ImGui::Text(const char* fmt, ...)
+void ImGui::Text(const char* fmt, ...) IMGUI_NOEXCEPT
 {
     va_list args;
     va_start(args, fmt);
@@ -263,7 +263,7 @@ void ImGui::Text(const char* fmt, ...)
     va_end(args);
 }
 
-void ImGui::TextV(const char* fmt, va_list args)
+void ImGui::TextV(const char* fmt, va_list args) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -274,7 +274,7 @@ void ImGui::TextV(const char* fmt, va_list args)
     TextEx(g.TempBuffer, text_end, ImGuiTextFlags_NoWidthForLargeClippedText);
 }
 
-void ImGui::TextColored(const ImVec4& col, const char* fmt, ...)
+void ImGui::TextColored(const ImVec4& col, const char* fmt, ...) IMGUI_NOEXCEPT
 {
     va_list args;
     va_start(args, fmt);
@@ -282,7 +282,7 @@ void ImGui::TextColored(const ImVec4& col, const char* fmt, ...)
     va_end(args);
 }
 
-void ImGui::TextColoredV(const ImVec4& col, const char* fmt, va_list args)
+void ImGui::TextColoredV(const ImVec4& col, const char* fmt, va_list args) IMGUI_NOEXCEPT
 {
     PushStyleColor(ImGuiCol_Text, col);
     if (fmt[0] == '%' && fmt[1] == 's' && fmt[2] == 0)
@@ -292,7 +292,7 @@ void ImGui::TextColoredV(const ImVec4& col, const char* fmt, va_list args)
     PopStyleColor();
 }
 
-void ImGui::TextDisabled(const char* fmt, ...)
+void ImGui::TextDisabled(const char* fmt, ...) IMGUI_NOEXCEPT
 {
     va_list args;
     va_start(args, fmt);
@@ -300,7 +300,7 @@ void ImGui::TextDisabled(const char* fmt, ...)
     va_end(args);
 }
 
-void ImGui::TextDisabledV(const char* fmt, va_list args)
+void ImGui::TextDisabledV(const char* fmt, va_list args) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     PushStyleColor(ImGuiCol_Text, g.Style.Colors[ImGuiCol_TextDisabled]);
@@ -311,7 +311,7 @@ void ImGui::TextDisabledV(const char* fmt, va_list args)
     PopStyleColor();
 }
 
-void ImGui::TextWrapped(const char* fmt, ...)
+void ImGui::TextWrapped(const char* fmt, ...) IMGUI_NOEXCEPT
 {
     va_list args;
     va_start(args, fmt);
@@ -319,7 +319,7 @@ void ImGui::TextWrapped(const char* fmt, ...)
     va_end(args);
 }
 
-void ImGui::TextWrappedV(const char* fmt, va_list args)
+void ImGui::TextWrappedV(const char* fmt, va_list args) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     bool need_backup = (g.CurrentWindow->DC.TextWrapPos < 0.0f);  // Keep existing wrap position if one is already set
@@ -333,7 +333,7 @@ void ImGui::TextWrappedV(const char* fmt, va_list args)
         PopTextWrapPos();
 }
 
-void ImGui::LabelText(const char* label, const char* fmt, ...)
+void ImGui::LabelText(const char* label, const char* fmt, ...) IMGUI_NOEXCEPT
 {
     va_list args;
     va_start(args, fmt);
@@ -342,7 +342,7 @@ void ImGui::LabelText(const char* label, const char* fmt, ...)
 }
 
 // Add a label+text combo aligned to other label+value widgets
-void ImGui::LabelTextV(const char* label, const char* fmt, va_list args)
+void ImGui::LabelTextV(const char* label, const char* fmt, va_list args) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -370,7 +370,7 @@ void ImGui::LabelTextV(const char* label, const char* fmt, va_list args)
         RenderText(ImVec2(value_bb.Max.x + style.ItemInnerSpacing.x, value_bb.Min.y + style.FramePadding.y), label);
 }
 
-void ImGui::BulletText(const char* fmt, ...)
+void ImGui::BulletText(const char* fmt, ...) IMGUI_NOEXCEPT
 {
     va_list args;
     va_start(args, fmt);
@@ -379,7 +379,7 @@ void ImGui::BulletText(const char* fmt, ...)
 }
 
 // Text with a little bullet aligned to the typical tree node.
-void ImGui::BulletTextV(const char* fmt, va_list args)
+void ImGui::BulletTextV(const char* fmt, va_list args) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -483,7 +483,7 @@ void ImGui::BulletTextV(const char* fmt, va_list args)
 //   Frame N + RepeatDelay + RepeatRate*N   true                     true              -                   true
 //-------------------------------------------------------------------------------------------------------------------------------------------------
 
-bool ImGui::ButtonBehavior(const ImRect& bb, ImGuiID id, bool* out_hovered, bool* out_held, ImGuiButtonFlags flags)
+bool ImGui::ButtonBehavior(const ImRect& bb, ImGuiID id, bool* out_hovered, bool* out_held, ImGuiButtonFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = GetCurrentWindow();
@@ -667,7 +667,7 @@ bool ImGui::ButtonBehavior(const ImRect& bb, ImGuiID id, bool* out_hovered, bool
     return pressed;
 }
 
-bool ImGui::ButtonEx(const char* label, const ImVec2& size_arg, ImGuiButtonFlags flags)
+bool ImGui::ButtonEx(const char* label, const ImVec2& size_arg, ImGuiButtonFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -710,13 +710,13 @@ bool ImGui::ButtonEx(const char* label, const ImVec2& size_arg, ImGuiButtonFlags
     return pressed;
 }
 
-bool ImGui::Button(const char* label, const ImVec2& size_arg)
+bool ImGui::Button(const char* label, const ImVec2& size_arg) IMGUI_NOEXCEPT
 {
     return ButtonEx(label, size_arg, ImGuiButtonFlags_None);
 }
 
 // Small buttons fits within text without additional vertical spacing.
-bool ImGui::SmallButton(const char* label)
+bool ImGui::SmallButton(const char* label) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     float backup_padding_y = g.Style.FramePadding.y;
@@ -728,7 +728,7 @@ bool ImGui::SmallButton(const char* label)
 
 // Tip: use ImGui::PushID()/PopID() to push indices or pointers in the ID stack.
 // Then you can keep 'str_id' empty or the same for all your buttons (instead of creating a string based on a non-string id)
-bool ImGui::InvisibleButton(const char* str_id, const ImVec2& size_arg, ImGuiButtonFlags flags)
+bool ImGui::InvisibleButton(const char* str_id, const ImVec2& size_arg, ImGuiButtonFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -750,7 +750,7 @@ bool ImGui::InvisibleButton(const char* str_id, const ImVec2& size_arg, ImGuiBut
     return pressed;
 }
 
-bool ImGui::ArrowButtonEx(const char* str_id, ImGuiDir dir, ImVec2 size, ImGuiButtonFlags flags)
+bool ImGui::ArrowButtonEx(const char* str_id, ImGuiDir dir, ImVec2 size, ImGuiButtonFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -780,14 +780,14 @@ bool ImGui::ArrowButtonEx(const char* str_id, ImGuiDir dir, ImVec2 size, ImGuiBu
     return pressed;
 }
 
-bool ImGui::ArrowButton(const char* str_id, ImGuiDir dir)
+bool ImGui::ArrowButton(const char* str_id, ImGuiDir dir) IMGUI_NOEXCEPT
 {
     float sz = GetFrameHeight();
     return ArrowButtonEx(str_id, dir, ImVec2(sz, sz), ImGuiButtonFlags_None);
 }
 
 // Button to close a window
-bool ImGui::CloseButton(ImGuiID id, const ImVec2& pos)
+bool ImGui::CloseButton(ImGuiID id, const ImVec2& pos) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -825,7 +825,7 @@ bool ImGui::CloseButton(ImGuiID id, const ImVec2& pos)
     return pressed;
 }
 
-bool ImGui::CollapseButton(ImGuiID id, const ImVec2& pos)
+bool ImGui::CollapseButton(ImGuiID id, const ImVec2& pos) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -850,13 +850,13 @@ bool ImGui::CollapseButton(ImGuiID id, const ImVec2& pos)
     return pressed;
 }
 
-ImGuiID ImGui::GetWindowScrollbarID(ImGuiWindow* window, ImGuiAxis axis)
+ImGuiID ImGui::GetWindowScrollbarID(ImGuiWindow* window, ImGuiAxis axis) IMGUI_NOEXCEPT
 {
     return window->GetIDNoKeepAlive(axis == ImGuiAxis_X ? "#SCROLLX" : "#SCROLLY");
 }
 
 // Return scrollbar rectangle, must only be called for corresponding axis if window->ScrollbarX/Y is set.
-ImRect ImGui::GetWindowScrollbarRect(ImGuiWindow* window, ImGuiAxis axis)
+ImRect ImGui::GetWindowScrollbarRect(ImGuiWindow* window, ImGuiAxis axis) IMGUI_NOEXCEPT
 {
     const ImRect outer_rect = window->Rect();
     const ImRect inner_rect = window->InnerRect;
@@ -869,7 +869,7 @@ ImRect ImGui::GetWindowScrollbarRect(ImGuiWindow* window, ImGuiAxis axis)
         return ImRect(ImMax(outer_rect.Min.x, outer_rect.Max.x - border_size - scrollbar_size), inner_rect.Min.y, outer_rect.Max.x, inner_rect.Max.y);
 }
 
-void ImGui::Scrollbar(ImGuiAxis axis)
+void ImGui::Scrollbar(ImGuiAxis axis) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -904,7 +904,7 @@ void ImGui::Scrollbar(ImGuiAxis axis)
 // - We store values as normalized ratio and in a form that allows the window content to change while we are holding on a scrollbar
 // - We handle both horizontal and vertical scrollbars, which makes the terminology not ideal.
 // Still, the code should probably be made simpler..
-bool ImGui::ScrollbarEx(const ImRect& bb_frame, ImGuiID id, ImGuiAxis axis, float* p_scroll_v, float size_avail_v, float size_contents_v, ImDrawFlags flags)
+bool ImGui::ScrollbarEx(const ImRect& bb_frame, ImGuiID id, ImGuiAxis axis, float* p_scroll_v, float size_avail_v, float size_contents_v, ImDrawFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -995,7 +995,7 @@ bool ImGui::ScrollbarEx(const ImRect& bb_frame, ImGuiID id, ImGuiAxis axis, floa
     return held;
 }
 
-void ImGui::Image(ImTextureID user_texture_id, const ImVec2& size, const ImVec2& uv0, const ImVec2& uv1, const ImVec4& tint_col, const ImVec4& border_col)
+void ImGui::Image(ImTextureID user_texture_id, const ImVec2& size, const ImVec2& uv0, const ImVec2& uv1, const ImVec4& tint_col, const ImVec4& border_col) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -1021,7 +1021,7 @@ void ImGui::Image(ImTextureID user_texture_id, const ImVec2& size, const ImVec2&
 
 // ImageButton() is flawed as 'id' is always derived from 'texture_id' (see #2464 #1390)
 // We provide this internal helper to write your own variant while we figure out how to redesign the public ImageButton() API.
-bool ImGui::ImageButtonEx(ImGuiID id, ImTextureID texture_id, const ImVec2& size, const ImVec2& uv0, const ImVec2& uv1, const ImVec2& padding, const ImVec4& bg_col, const ImVec4& tint_col)
+bool ImGui::ImageButtonEx(ImGuiID id, ImTextureID texture_id, const ImVec2& size, const ImVec2& uv0, const ImVec2& uv1, const ImVec2& padding, const ImVec4& bg_col, const ImVec4& tint_col) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = GetCurrentWindow();
@@ -1050,7 +1050,7 @@ bool ImGui::ImageButtonEx(ImGuiID id, ImTextureID texture_id, const ImVec2& size
 // frame_padding < 0: uses FramePadding from style (default)
 // frame_padding = 0: no framing
 // frame_padding > 0: set framing size
-bool ImGui::ImageButton(ImTextureID user_texture_id, const ImVec2& size, const ImVec2& uv0, const ImVec2& uv1, int frame_padding, const ImVec4& bg_col, const ImVec4& tint_col)
+bool ImGui::ImageButton(ImTextureID user_texture_id, const ImVec2& size, const ImVec2& uv0, const ImVec2& uv1, int frame_padding, const ImVec4& bg_col, const ImVec4& tint_col) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -1066,7 +1066,7 @@ bool ImGui::ImageButton(ImTextureID user_texture_id, const ImVec2& size, const I
     return ImageButtonEx(id, user_texture_id, size, uv0, uv1, padding, bg_col, tint_col);
 }
 
-bool ImGui::Checkbox(const char* label, bool* v)
+bool ImGui::Checkbox(const char* label, bool* v) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -1124,7 +1124,7 @@ bool ImGui::Checkbox(const char* label, bool* v)
 }
 
 template<typename T>
-bool ImGui::CheckboxFlagsT(const char* label, T* flags, T flags_value)
+bool ImGui::CheckboxFlagsT(const char* label, T* flags, T flags_value) IMGUI_NOEXCEPT
 {
     bool all_on = (*flags & flags_value) == flags_value;
     bool any_on = (*flags & flags_value) != 0;
@@ -1152,27 +1152,27 @@ bool ImGui::CheckboxFlagsT(const char* label, T* flags, T flags_value)
     return pressed;
 }
 
-bool ImGui::CheckboxFlags(const char* label, int* flags, int flags_value)
+bool ImGui::CheckboxFlags(const char* label, int* flags, int flags_value) IMGUI_NOEXCEPT
 {
     return CheckboxFlagsT(label, flags, flags_value);
 }
 
-bool ImGui::CheckboxFlags(const char* label, unsigned int* flags, unsigned int flags_value)
+bool ImGui::CheckboxFlags(const char* label, unsigned int* flags, unsigned int flags_value) IMGUI_NOEXCEPT
 {
     return CheckboxFlagsT(label, flags, flags_value);
 }
 
-bool ImGui::CheckboxFlags(const char* label, ImS64* flags, ImS64 flags_value)
+bool ImGui::CheckboxFlags(const char* label, ImS64* flags, ImS64 flags_value) IMGUI_NOEXCEPT
 {
     return CheckboxFlagsT(label, flags, flags_value);
 }
 
-bool ImGui::CheckboxFlags(const char* label, ImU64* flags, ImU64 flags_value)
+bool ImGui::CheckboxFlags(const char* label, ImU64* flags, ImU64 flags_value) IMGUI_NOEXCEPT
 {
     return CheckboxFlagsT(label, flags, flags_value);
 }
 
-bool ImGui::RadioButton(const char* label, bool active)
+bool ImGui::RadioButton(const char* label, bool active) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -1226,7 +1226,7 @@ bool ImGui::RadioButton(const char* label, bool active)
 }
 
 // FIXME: This would work nicely if it was a public template, e.g. 'template<T> RadioButton(const char* label, T* v, T v_button)', but I'm not sure how we would expose it..
-bool ImGui::RadioButton(const char* label, int* v, int v_button)
+bool ImGui::RadioButton(const char* label, int* v, int v_button) IMGUI_NOEXCEPT
 {
     const bool pressed = RadioButton(label, *v == v_button);
     if (pressed)
@@ -1235,7 +1235,7 @@ bool ImGui::RadioButton(const char* label, int* v, int v_button)
 }
 
 // size_arg (for each axis) < 0.0f: align to end, 0.0f: auto, > 0.0f: specified size
-void ImGui::ProgressBar(float fraction, const ImVec2& size_arg, const char* overlay)
+void ImGui::ProgressBar(float fraction, const ImVec2& size_arg, const char* overlay) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -1271,7 +1271,7 @@ void ImGui::ProgressBar(float fraction, const ImVec2& size_arg, const char* over
         RenderTextClipped(ImVec2(ImClamp(fill_br.x + style.ItemSpacing.x, bb.Min.x, bb.Max.x - overlay_size.x - style.ItemInnerSpacing.x), bb.Min.y), bb.Max, overlay, NULL, &overlay_size, ImVec2(0.0f, 0.5f), &bb);
 }
 
-void ImGui::Bullet()
+void ImGui::Bullet() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -1307,7 +1307,7 @@ void ImGui::Bullet()
 // - ShrinkWidths() [Internal]
 //-------------------------------------------------------------------------
 
-void ImGui::Spacing()
+void ImGui::Spacing() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -1315,7 +1315,7 @@ void ImGui::Spacing()
     ItemSize(ImVec2(0, 0));
 }
 
-void ImGui::Dummy(const ImVec2& size)
+void ImGui::Dummy(const ImVec2& size) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -1326,7 +1326,7 @@ void ImGui::Dummy(const ImVec2& size)
     ItemAdd(bb, 0);
 }
 
-void ImGui::NewLine()
+void ImGui::NewLine() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -1342,7 +1342,7 @@ void ImGui::NewLine()
     window->DC.LayoutType = backup_layout_type;
 }
 
-void ImGui::AlignTextToFramePadding()
+void ImGui::AlignTextToFramePadding() IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -1354,7 +1354,7 @@ void ImGui::AlignTextToFramePadding()
 }
 
 // Horizontal/vertical separating line
-void ImGui::SeparatorEx(ImGuiSeparatorFlags flags)
+void ImGui::SeparatorEx(ImGuiSeparatorFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -1414,7 +1414,7 @@ void ImGui::SeparatorEx(ImGuiSeparatorFlags flags)
     }
 }
 
-void ImGui::Separator()
+void ImGui::Separator() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -1428,7 +1428,7 @@ void ImGui::Separator()
 }
 
 // Using 'hover_visibility_delay' allows us to hide the highlight and mouse cursor for a short time, which can be convenient to reduce visual noise.
-bool ImGui::SplitterBehavior(const ImRect& bb, ImGuiID id, ImGuiAxis axis, float* size1, float* size2, float min_size1, float min_size2, float hover_extend, float hover_visibility_delay)
+bool ImGui::SplitterBehavior(const ImRect& bb, ImGuiID id, ImGuiAxis axis, float* size1, float* size2, float min_size1, float min_size2, float hover_extend, float hover_visibility_delay) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -1496,7 +1496,7 @@ static int IMGUI_CDECL ShrinkWidthItemComparer(const void* lhs, const void* rhs)
 
 // Shrink excess width from a set of item, by removing width from the larger items first.
 // Set items Width to -1.0f to disable shrinking this item.
-void ImGui::ShrinkWidths(ImGuiShrinkWidthItem* items, int count, float width_excess)
+void ImGui::ShrinkWidths(ImGuiShrinkWidthItem* items, int count, float width_excess) IMGUI_NOEXCEPT
 {
     if (count == 1)
     {
@@ -1542,7 +1542,7 @@ void ImGui::ShrinkWidths(ImGuiShrinkWidthItem* items, int count, float width_exc
 // - Combo()
 //-------------------------------------------------------------------------
 
-static float CalcMaxPopupHeightFromItemCount(int items_count)
+static float CalcMaxPopupHeightFromItemCount(int items_count) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (items_count <= 0)
@@ -1673,7 +1673,7 @@ void ImGui::EndCombo() IMGUI_NOEXCEPT
 }
 
 // Getter for the old Combo() API: const char*[]
-static bool Items_ArrayGetter(void* data, int idx, const char** out_text)
+static bool Items_ArrayGetter(void* data, int idx, const char** out_text) IMGUI_NOEXCEPT
 {
     const char* const* items = (const char* const*)data;
     if (out_text)
@@ -1682,7 +1682,7 @@ static bool Items_ArrayGetter(void* data, int idx, const char** out_text)
 }
 
 // Getter for the old Combo() API: "item1\0item2\0item3\0"
-static bool Items_SingleStringGetter(void* data, int idx, const char** out_text)
+static bool Items_SingleStringGetter(void* data, int idx, const char** out_text) IMGUI_NOEXCEPT
 {
     // FIXME-OPT: we could pre-compute the indices to fasten this. But only 1 active combo means the waste is limited.
     const char* items_separated_by_zeros = (const char*)data;
@@ -1703,7 +1703,7 @@ static bool Items_SingleStringGetter(void* data, int idx, const char** out_text)
 }
 
 // Old API, prefer using BeginCombo() nowadays if you can.
-bool ImGui::Combo(const char* label, int* current_item, bool (*items_getter)(void*, int, const char**), void* data, int items_count, int popup_max_height_in_items)
+bool ImGui::Combo(const char* label, int* current_item, bool (*items_getter)(void*, int, const char**), void* data, int items_count, int popup_max_height_in_items) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -1747,14 +1747,14 @@ bool ImGui::Combo(const char* label, int* current_item, bool (*items_getter)(voi
 }
 
 // Combo box helper allowing to pass an array of strings.
-bool ImGui::Combo(const char* label, int* current_item, const char* const items[], int items_count, int height_in_items)
+bool ImGui::Combo(const char* label, int* current_item, const char* const items[], int items_count, int height_in_items) IMGUI_NOEXCEPT
 {
     const bool value_changed = Combo(label, current_item, Items_ArrayGetter, (void*)items, items_count, height_in_items);
     return value_changed;
 }
 
 // Combo box helper allowing to pass all items in a single string literal holding multiple zero-terminated items "item1\0item2\0"
-bool ImGui::Combo(const char* label, int* current_item, const char* items_separated_by_zeros, int height_in_items)
+bool ImGui::Combo(const char* label, int* current_item, const char* items_separated_by_zeros, int height_in_items) IMGUI_NOEXCEPT
 {
     int items_count = 0;
     const char* p = items_separated_by_zeros;       // FIXME-OPT: Avoid computing this, or at least only when combo is open
@@ -1803,7 +1803,7 @@ IM_STATIC_ASSERT(IM_ARRAYSIZE(GDataTypeInfo) == ImGuiDataType_COUNT);
 // FIXME-LEGACY: Prior to 1.61 our DragInt() function internally used floats and because of this the compile-time default value for format was "%.0f".
 // Even though we changed the compile-time default, we expect users to have carried %f around, which would break the display of DragInt() calls.
 // To honor backward compatibility we are rewriting the format string, unless IMGUI_DISABLE_OBSOLETE_FUNCTIONS is enabled. What could possibly go wrong?!
-static const char* PatchFormatStringFloatToInt(const char* fmt)
+static const char* PatchFormatStringFloatToInt(const char* fmt) IMGUI_NOEXCEPT
 {
     if (fmt[0] == '%' && fmt[1] == '.' && fmt[2] == '0' && fmt[3] == 'f' && fmt[4] == 0) // Fast legacy path for "%.0f" which is expected to be the most common case.
         return "%d";
@@ -1824,13 +1824,13 @@ static const char* PatchFormatStringFloatToInt(const char* fmt)
     return fmt;
 }
 
-const ImGuiDataTypeInfo* ImGui::DataTypeGetInfo(ImGuiDataType data_type)
+const ImGuiDataTypeInfo* ImGui::DataTypeGetInfo(ImGuiDataType data_type) IMGUI_NOEXCEPT
 {
     IM_ASSERT(data_type >= 0 && data_type < ImGuiDataType_COUNT);
     return &GDataTypeInfo[data_type];
 }
 
-int ImGui::DataTypeFormatString(char* buf, int buf_size, ImGuiDataType data_type, const void* p_data, const char* format)
+int ImGui::DataTypeFormatString(char* buf, int buf_size, ImGuiDataType data_type, const void* p_data, const char* format) IMGUI_NOEXCEPT
 {
     // Signedness doesn't matter when pushing integer arguments
     if (data_type == ImGuiDataType_S32 || data_type == ImGuiDataType_U32)
@@ -1853,7 +1853,7 @@ int ImGui::DataTypeFormatString(char* buf, int buf_size, ImGuiDataType data_type
     return 0;
 }
 
-void ImGui::DataTypeApplyOp(ImGuiDataType data_type, int op, void* output, const void* arg1, const void* arg2)
+void ImGui::DataTypeApplyOp(ImGuiDataType data_type, int op, void* output, const void* arg1, const void* arg2) IMGUI_NOEXCEPT
 {
     IM_ASSERT(op == '+' || op == '-');
     switch (data_type)
@@ -1905,7 +1905,7 @@ void ImGui::DataTypeApplyOp(ImGuiDataType data_type, int op, void* output, const
 
 // User can input math operators (e.g. +100) to edit a numerical values.
 // NB: This is _not_ a full expression evaluator. We should probably add one and replace this dumb mess..
-bool ImGui::DataTypeApplyOpFromText(const char* buf, const char* initial_value_buf, ImGuiDataType data_type, void* p_data, const char* format)
+bool ImGui::DataTypeApplyOpFromText(const char* buf, const char* initial_value_buf, ImGuiDataType data_type, void* p_data, const char* format) IMGUI_NOEXCEPT
 {
     while (ImCharIsBlankA(*buf))
         buf++;
@@ -2007,14 +2007,14 @@ bool ImGui::DataTypeApplyOpFromText(const char* buf, const char* initial_value_b
 }
 
 template<typename T>
-static int DataTypeCompareT(const T* lhs, const T* rhs)
+static int DataTypeCompareT(const T* lhs, const T* rhs) IMGUI_NOEXCEPT
 {
     if (*lhs < *rhs) return -1;
     if (*lhs > *rhs) return +1;
     return 0;
 }
 
-int ImGui::DataTypeCompare(ImGuiDataType data_type, const void* arg_1, const void* arg_2)
+int ImGui::DataTypeCompare(ImGuiDataType data_type, const void* arg_1, const void* arg_2) IMGUI_NOEXCEPT
 {
     switch (data_type)
     {
@@ -2035,7 +2035,7 @@ int ImGui::DataTypeCompare(ImGuiDataType data_type, const void* arg_1, const voi
 }
 
 template<typename T>
-static bool DataTypeClampT(T* v, const T* v_min, const T* v_max)
+static bool DataTypeClampT(T* v, const T* v_min, const T* v_max) IMGUI_NOEXCEPT
 {
     // Clamp, both sides are optional, return true if modified
     if (v_min && *v < *v_min) { *v = *v_min; return true; }
@@ -2043,7 +2043,7 @@ static bool DataTypeClampT(T* v, const T* v_min, const T* v_max)
     return false;
 }
 
-bool ImGui::DataTypeClamp(ImGuiDataType data_type, void* p_data, const void* p_min, const void* p_max)
+bool ImGui::DataTypeClamp(ImGuiDataType data_type, void* p_data, const void* p_min, const void* p_max) IMGUI_NOEXCEPT
 {
     switch (data_type)
     {
@@ -2063,7 +2063,7 @@ bool ImGui::DataTypeClamp(ImGuiDataType data_type, void* p_data, const void* p_m
     return false;
 }
 
-static float GetMinimumStepAtDecimalPrecision(int decimal_precision)
+static float GetMinimumStepAtDecimalPrecision(int decimal_precision) IMGUI_NOEXCEPT
 {
     static const float min_steps[10] = { 1.0f, 0.1f, 0.01f, 0.001f, 0.0001f, 0.00001f, 0.000001f, 0.0000001f, 0.00000001f, 0.000000001f };
     if (decimal_precision < 0)
@@ -2072,7 +2072,7 @@ static float GetMinimumStepAtDecimalPrecision(int decimal_precision)
 }
 
 template<typename TYPE>
-static const char* ImAtoi(const char* src, TYPE* output)
+static const char* ImAtoi(const char* src, TYPE* output) IMGUI_NOEXCEPT
 {
     int negative = 0;
     if (*src == '-') { negative = 1; src++; }
@@ -2087,7 +2087,7 @@ static const char* ImAtoi(const char* src, TYPE* output)
 // Sanitize format
 // - Zero terminate so extra characters after format (e.g. "%f123") don't confuse atof/atoi
 // - stb_sprintf.h supports several new modifiers which format numbers in a way that also makes them incompatible atof/atoi.
-static void SanitizeFormatString(const char* fmt, char* fmt_out, size_t fmt_out_size)
+static void SanitizeFormatString(const char* fmt, char* fmt_out, size_t fmt_out_size) IMGUI_NOEXCEPT
 {
     IM_UNUSED(fmt_out_size);
     const char* fmt_end = ImParseFormatFindEnd(fmt);
@@ -2102,7 +2102,7 @@ static void SanitizeFormatString(const char* fmt, char* fmt_out, size_t fmt_out_
 }
 
 template<typename TYPE, typename SIGNEDTYPE>
-TYPE ImGui::RoundScalarWithFormatT(const char* format, ImGuiDataType data_type, TYPE v)
+TYPE ImGui::RoundScalarWithFormatT(const char* format, ImGuiDataType data_type, TYPE v) IMGUI_NOEXCEPT
 {
     const char* fmt_start = ImParseFormatFindStart(format);
     if (fmt_start[0] != '%' || fmt_start[1] == '%') // Don't apply if the value is not visible in the format string
@@ -2147,7 +2147,7 @@ TYPE ImGui::RoundScalarWithFormatT(const char* format, ImGuiDataType data_type, 
 
 // This is called by DragBehavior() when the widget is active (held by mouse or being manipulated with Nav controls)
 template<typename TYPE, typename SIGNEDTYPE, typename FLOATTYPE>
-bool ImGui::DragBehaviorT(ImGuiDataType data_type, TYPE* v, float v_speed, const TYPE v_min, const TYPE v_max, const char* format, ImGuiSliderFlags flags)
+bool ImGui::DragBehaviorT(ImGuiDataType data_type, TYPE* v, float v_speed, const TYPE v_min, const TYPE v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     const ImGuiAxis axis = (flags & ImGuiSliderFlags_Vertical) ? ImGuiAxis_Y : ImGuiAxis_X;
@@ -2262,7 +2262,7 @@ bool ImGui::DragBehaviorT(ImGuiDataType data_type, TYPE* v, float v_speed, const
     return true;
 }
 
-bool ImGui::DragBehavior(ImGuiID id, ImGuiDataType data_type, void* p_v, float v_speed, const void* p_min, const void* p_max, const char* format, ImGuiSliderFlags flags)
+bool ImGui::DragBehavior(ImGuiID id, ImGuiDataType data_type, void* p_v, float v_speed, const void* p_min, const void* p_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
 {
     // Read imgui.cpp "API BREAKING CHANGES" section for 1.78 if you hit this assert.
     IM_ASSERT((flags == 1 || (flags & ImGuiSliderFlags_InvalidMask_) == 0) && "Invalid ImGuiSliderFlags flags! Has the 'float power' argument been mistakenly cast to flags? Call function with ImGuiSliderFlags_Logarithmic flags instead.");
@@ -2300,7 +2300,7 @@ bool ImGui::DragBehavior(ImGuiID id, ImGuiDataType data_type, void* p_v, float v
 
 // Note: p_data, p_min and p_max are _pointers_ to a memory address holding the data. For a Drag widget, p_min and p_max are optional.
 // Read code of e.g. DragFloat(), DragInt() etc. or examples in 'Demo->Widgets->Data Types' to understand how to use this function directly.
-bool ImGui::DragScalar(const char* label, ImGuiDataType data_type, void* p_data, float v_speed, const void* p_min, const void* p_max, const char* format, ImGuiSliderFlags flags)
+bool ImGui::DragScalar(const char* label, ImGuiDataType data_type, void* p_data, float v_speed, const void* p_min, const void* p_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -2384,7 +2384,7 @@ bool ImGui::DragScalar(const char* label, ImGuiDataType data_type, void* p_data,
     return value_changed;
 }
 
-bool ImGui::DragScalarN(const char* label, ImGuiDataType data_type, void* p_data, int components, float v_speed, const void* p_min, const void* p_max, const char* format, ImGuiSliderFlags flags)
+bool ImGui::DragScalarN(const char* label, ImGuiDataType data_type, void* p_data, int components, float v_speed, const void* p_min, const void* p_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -2419,28 +2419,28 @@ bool ImGui::DragScalarN(const char* label, ImGuiDataType data_type, void* p_data
     return value_changed;
 }
 
-bool ImGui::DragFloat(const char* label, float* v, float v_speed, float v_min, float v_max, const char* format, ImGuiSliderFlags flags)
+bool ImGui::DragFloat(const char* label, float* v, float v_speed, float v_min, float v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
 {
     return DragScalar(label, ImGuiDataType_Float, v, v_speed, &v_min, &v_max, format, flags);
 }
 
-bool ImGui::DragFloat2(const char* label, float v[2], float v_speed, float v_min, float v_max, const char* format, ImGuiSliderFlags flags)
+bool ImGui::DragFloat2(const char* label, float v[2], float v_speed, float v_min, float v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
 {
     return DragScalarN(label, ImGuiDataType_Float, v, 2, v_speed, &v_min, &v_max, format, flags);
 }
 
-bool ImGui::DragFloat3(const char* label, float v[3], float v_speed, float v_min, float v_max, const char* format, ImGuiSliderFlags flags)
+bool ImGui::DragFloat3(const char* label, float v[3], float v_speed, float v_min, float v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
 {
     return DragScalarN(label, ImGuiDataType_Float, v, 3, v_speed, &v_min, &v_max, format, flags);
 }
 
-bool ImGui::DragFloat4(const char* label, float v[4], float v_speed, float v_min, float v_max, const char* format, ImGuiSliderFlags flags)
+bool ImGui::DragFloat4(const char* label, float v[4], float v_speed, float v_min, float v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
 {
     return DragScalarN(label, ImGuiDataType_Float, v, 4, v_speed, &v_min, &v_max, format, flags);
 }
 
 // NB: You likely want to specify the ImGuiSliderFlags_AlwaysClamp when using this.
-bool ImGui::DragFloatRange2(const char* label, float* v_current_min, float* v_current_max, float v_speed, float v_min, float v_max, const char* format, const char* format_max, ImGuiSliderFlags flags)
+bool ImGui::DragFloatRange2(const char* label, float* v_current_min, float* v_current_max, float v_speed, float v_min, float v_max, const char* format, const char* format_max, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -2472,28 +2472,28 @@ bool ImGui::DragFloatRange2(const char* label, float* v_current_min, float* v_cu
 }
 
 // NB: v_speed is float to allow adjusting the drag speed with more precision
-bool ImGui::DragInt(const char* label, int* v, float v_speed, int v_min, int v_max, const char* format, ImGuiSliderFlags flags)
+bool ImGui::DragInt(const char* label, int* v, float v_speed, int v_min, int v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
 {
     return DragScalar(label, ImGuiDataType_S32, v, v_speed, &v_min, &v_max, format, flags);
 }
 
-bool ImGui::DragInt2(const char* label, int v[2], float v_speed, int v_min, int v_max, const char* format, ImGuiSliderFlags flags)
+bool ImGui::DragInt2(const char* label, int v[2], float v_speed, int v_min, int v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
 {
     return DragScalarN(label, ImGuiDataType_S32, v, 2, v_speed, &v_min, &v_max, format, flags);
 }
 
-bool ImGui::DragInt3(const char* label, int v[3], float v_speed, int v_min, int v_max, const char* format, ImGuiSliderFlags flags)
+bool ImGui::DragInt3(const char* label, int v[3], float v_speed, int v_min, int v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
 {
     return DragScalarN(label, ImGuiDataType_S32, v, 3, v_speed, &v_min, &v_max, format, flags);
 }
 
-bool ImGui::DragInt4(const char* label, int v[4], float v_speed, int v_min, int v_max, const char* format, ImGuiSliderFlags flags)
+bool ImGui::DragInt4(const char* label, int v[4], float v_speed, int v_min, int v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
 {
     return DragScalarN(label, ImGuiDataType_S32, v, 4, v_speed, &v_min, &v_max, format, flags);
 }
 
 // NB: You likely want to specify the ImGuiSliderFlags_AlwaysClamp when using this.
-bool ImGui::DragIntRange2(const char* label, int* v_current_min, int* v_current_max, float v_speed, int v_min, int v_max, const char* format, const char* format_max, ImGuiSliderFlags flags)
+bool ImGui::DragIntRange2(const char* label, int* v_current_min, int* v_current_max, float v_speed, int v_min, int v_max, const char* format, const char* format_max, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -2528,7 +2528,7 @@ bool ImGui::DragIntRange2(const char* label, int* v_current_min, int* v_current_
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
 
 // Obsolete versions with power parameter. See https://github.com/ocornut/imgui/issues/3361 for details.
-bool ImGui::DragScalar(const char* label, ImGuiDataType data_type, void* p_data, float v_speed, const void* p_min, const void* p_max, const char* format, float power)
+bool ImGui::DragScalar(const char* label, ImGuiDataType data_type, void* p_data, float v_speed, const void* p_min, const void* p_max, const char* format, float power) IMGUI_NOEXCEPT
 {
     ImGuiSliderFlags drag_flags = ImGuiSliderFlags_None;
     if (power != 1.0f)
@@ -2540,7 +2540,7 @@ bool ImGui::DragScalar(const char* label, ImGuiDataType data_type, void* p_data,
     return DragScalar(label, data_type, p_data, v_speed, p_min, p_max, format, drag_flags);
 }
 
-bool ImGui::DragScalarN(const char* label, ImGuiDataType data_type, void* p_data, int components, float v_speed, const void* p_min, const void* p_max, const char* format, float power)
+bool ImGui::DragScalarN(const char* label, ImGuiDataType data_type, void* p_data, int components, float v_speed, const void* p_min, const void* p_max, const char* format, float power) IMGUI_NOEXCEPT
 {
     ImGuiSliderFlags drag_flags = ImGuiSliderFlags_None;
     if (power != 1.0f)
@@ -2579,7 +2579,7 @@ bool ImGui::DragScalarN(const char* label, ImGuiDataType data_type, void* p_data
 
 // Convert a value v in the output space of a slider into a parametric position on the slider itself (the logical opposite of ScaleValueFromRatioT)
 template<typename TYPE, typename SIGNEDTYPE, typename FLOATTYPE>
-float ImGui::ScaleRatioFromValueT(ImGuiDataType data_type, TYPE v, TYPE v_min, TYPE v_max, bool is_logarithmic, float logarithmic_zero_epsilon, float zero_deadzone_halfsize)
+float ImGui::ScaleRatioFromValueT(ImGuiDataType data_type, TYPE v, TYPE v_min, TYPE v_max, bool is_logarithmic, float logarithmic_zero_epsilon, float zero_deadzone_halfsize) IMGUI_NOEXCEPT
 {
     if (v_min == v_max)
         return 0.0f;
@@ -2635,7 +2635,7 @@ float ImGui::ScaleRatioFromValueT(ImGuiDataType data_type, TYPE v, TYPE v_min, T
 
 // Convert a parametric position on a slider into a value v in the output space (the logical opposite of ScaleRatioFromValueT)
 template<typename TYPE, typename SIGNEDTYPE, typename FLOATTYPE>
-TYPE ImGui::ScaleValueFromRatioT(ImGuiDataType data_type, float t, TYPE v_min, TYPE v_max, bool is_logarithmic, float logarithmic_zero_epsilon, float zero_deadzone_halfsize)
+TYPE ImGui::ScaleValueFromRatioT(ImGuiDataType data_type, float t, TYPE v_min, TYPE v_max, bool is_logarithmic, float logarithmic_zero_epsilon, float zero_deadzone_halfsize) IMGUI_NOEXCEPT
 {
     if (v_min == v_max)
         return v_min;
@@ -2714,7 +2714,7 @@ TYPE ImGui::ScaleValueFromRatioT(ImGuiDataType data_type, float t, TYPE v_min, T
 
 // FIXME: Move more of the code into SliderBehavior()
 template<typename TYPE, typename SIGNEDTYPE, typename FLOATTYPE>
-bool ImGui::SliderBehaviorT(const ImRect& bb, ImGuiID id, ImGuiDataType data_type, TYPE* v, const TYPE v_min, const TYPE v_max, const char* format, ImGuiSliderFlags flags, ImRect* out_grab_bb)
+bool ImGui::SliderBehaviorT(const ImRect& bb, ImGuiID id, ImGuiDataType data_type, TYPE* v, const TYPE v_min, const TYPE v_max, const char* format, ImGuiSliderFlags flags, ImRect* out_grab_bb) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     const ImGuiStyle& style = g.Style;
@@ -2874,7 +2874,7 @@ bool ImGui::SliderBehaviorT(const ImRect& bb, ImGuiID id, ImGuiDataType data_typ
 // For 32-bit and larger types, slider bounds are limited to half the natural type range.
 // So e.g. an integer Slider between INT_MAX-10 and INT_MAX will fail, but an integer Slider between INT_MAX/2-10 and INT_MAX/2 will be ok.
 // It would be possible to lift that limitation with some work but it doesn't seem to be worth it for sliders.
-bool ImGui::SliderBehavior(const ImRect& bb, ImGuiID id, ImGuiDataType data_type, void* p_v, const void* p_min, const void* p_max, const char* format, ImGuiSliderFlags flags, ImRect* out_grab_bb)
+bool ImGui::SliderBehavior(const ImRect& bb, ImGuiID id, ImGuiDataType data_type, void* p_v, const void* p_min, const void* p_max, const char* format, ImGuiSliderFlags flags, ImRect* out_grab_bb) IMGUI_NOEXCEPT
 {
     // Read imgui.cpp "API BREAKING CHANGES" section for 1.78 if you hit this assert.
     IM_ASSERT((flags == 1 || (flags & ImGuiSliderFlags_InvalidMask_) == 0) && "Invalid ImGuiSliderFlags flag!  Has the 'float power' argument been mistakenly cast to flags? Call function with ImGuiSliderFlags_Logarithmic flags instead.");
@@ -2915,7 +2915,7 @@ bool ImGui::SliderBehavior(const ImRect& bb, ImGuiID id, ImGuiDataType data_type
 
 // Note: p_data, p_min and p_max are _pointers_ to a memory address holding the data. For a slider, they are all required.
 // Read code of e.g. SliderFloat(), SliderInt() etc. or examples in 'Demo->Widgets->Data Types' to understand how to use this function directly.
-bool ImGui::SliderScalar(const char* label, ImGuiDataType data_type, void* p_data, const void* p_min, const void* p_max, const char* format, ImGuiSliderFlags flags)
+bool ImGui::SliderScalar(const char* label, ImGuiDataType data_type, void* p_data, const void* p_min, const void* p_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -2996,7 +2996,7 @@ bool ImGui::SliderScalar(const char* label, ImGuiDataType data_type, void* p_dat
 }
 
 // Add multiple sliders on 1 line for compact edition of multiple components
-bool ImGui::SliderScalarN(const char* label, ImGuiDataType data_type, void* v, int components, const void* v_min, const void* v_max, const char* format, ImGuiSliderFlags flags)
+bool ImGui::SliderScalarN(const char* label, ImGuiDataType data_type, void* v, int components, const void* v_min, const void* v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -3031,27 +3031,27 @@ bool ImGui::SliderScalarN(const char* label, ImGuiDataType data_type, void* v, i
     return value_changed;
 }
 
-bool ImGui::SliderFloat(const char* label, float* v, float v_min, float v_max, const char* format, ImGuiSliderFlags flags)
+bool ImGui::SliderFloat(const char* label, float* v, float v_min, float v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
 {
     return SliderScalar(label, ImGuiDataType_Float, v, &v_min, &v_max, format, flags);
 }
 
-bool ImGui::SliderFloat2(const char* label, float v[2], float v_min, float v_max, const char* format, ImGuiSliderFlags flags)
+bool ImGui::SliderFloat2(const char* label, float v[2], float v_min, float v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
 {
     return SliderScalarN(label, ImGuiDataType_Float, v, 2, &v_min, &v_max, format, flags);
 }
 
-bool ImGui::SliderFloat3(const char* label, float v[3], float v_min, float v_max, const char* format, ImGuiSliderFlags flags)
+bool ImGui::SliderFloat3(const char* label, float v[3], float v_min, float v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
 {
     return SliderScalarN(label, ImGuiDataType_Float, v, 3, &v_min, &v_max, format, flags);
 }
 
-bool ImGui::SliderFloat4(const char* label, float v[4], float v_min, float v_max, const char* format, ImGuiSliderFlags flags)
+bool ImGui::SliderFloat4(const char* label, float v[4], float v_min, float v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
 {
     return SliderScalarN(label, ImGuiDataType_Float, v, 4, &v_min, &v_max, format, flags);
 }
 
-bool ImGui::SliderAngle(const char* label, float* v_rad, float v_degrees_min, float v_degrees_max, const char* format, ImGuiSliderFlags flags)
+bool ImGui::SliderAngle(const char* label, float* v_rad, float v_degrees_min, float v_degrees_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
 {
     if (format == NULL)
         format = "%.0f deg";
@@ -3061,27 +3061,27 @@ bool ImGui::SliderAngle(const char* label, float* v_rad, float v_degrees_min, fl
     return value_changed;
 }
 
-bool ImGui::SliderInt(const char* label, int* v, int v_min, int v_max, const char* format, ImGuiSliderFlags flags)
+bool ImGui::SliderInt(const char* label, int* v, int v_min, int v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
 {
     return SliderScalar(label, ImGuiDataType_S32, v, &v_min, &v_max, format, flags);
 }
 
-bool ImGui::SliderInt2(const char* label, int v[2], int v_min, int v_max, const char* format, ImGuiSliderFlags flags)
+bool ImGui::SliderInt2(const char* label, int v[2], int v_min, int v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
 {
     return SliderScalarN(label, ImGuiDataType_S32, v, 2, &v_min, &v_max, format, flags);
 }
 
-bool ImGui::SliderInt3(const char* label, int v[3], int v_min, int v_max, const char* format, ImGuiSliderFlags flags)
+bool ImGui::SliderInt3(const char* label, int v[3], int v_min, int v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
 {
     return SliderScalarN(label, ImGuiDataType_S32, v, 3, &v_min, &v_max, format, flags);
 }
 
-bool ImGui::SliderInt4(const char* label, int v[4], int v_min, int v_max, const char* format, ImGuiSliderFlags flags)
+bool ImGui::SliderInt4(const char* label, int v[4], int v_min, int v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
 {
     return SliderScalarN(label, ImGuiDataType_S32, v, 4, &v_min, &v_max, format, flags);
 }
 
-bool ImGui::VSliderScalar(const char* label, const ImVec2& size, ImGuiDataType data_type, void* p_data, const void* p_min, const void* p_max, const char* format, ImGuiSliderFlags flags)
+bool ImGui::VSliderScalar(const char* label, const ImVec2& size, ImGuiDataType data_type, void* p_data, const void* p_min, const void* p_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -3140,12 +3140,12 @@ bool ImGui::VSliderScalar(const char* label, const ImVec2& size, ImGuiDataType d
     return value_changed;
 }
 
-bool ImGui::VSliderFloat(const char* label, const ImVec2& size, float* v, float v_min, float v_max, const char* format, ImGuiSliderFlags flags)
+bool ImGui::VSliderFloat(const char* label, const ImVec2& size, float* v, float v_min, float v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
 {
     return VSliderScalar(label, size, ImGuiDataType_Float, v, &v_min, &v_max, format, flags);
 }
 
-bool ImGui::VSliderInt(const char* label, const ImVec2& size, int* v, int v_min, int v_max, const char* format, ImGuiSliderFlags flags)
+bool ImGui::VSliderInt(const char* label, const ImVec2& size, int* v, int v_min, int v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
 {
     return VSliderScalar(label, size, ImGuiDataType_S32, v, &v_min, &v_max, format, flags);
 }
@@ -3153,7 +3153,7 @@ bool ImGui::VSliderInt(const char* label, const ImVec2& size, int* v, int v_min,
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
 
 // Obsolete versions with power parameter. See https://github.com/ocornut/imgui/issues/3361 for details.
-bool ImGui::SliderScalar(const char* label, ImGuiDataType data_type, void* p_data, const void* p_min, const void* p_max, const char* format, float power)
+bool ImGui::SliderScalar(const char* label, ImGuiDataType data_type, void* p_data, const void* p_min, const void* p_max, const char* format, float power) IMGUI_NOEXCEPT
 {
     ImGuiSliderFlags slider_flags = ImGuiSliderFlags_None;
     if (power != 1.0f)
@@ -3164,7 +3164,7 @@ bool ImGui::SliderScalar(const char* label, ImGuiDataType data_type, void* p_dat
     return SliderScalar(label, data_type, p_data, p_min, p_max, format, slider_flags);
 }
 
-bool ImGui::SliderScalarN(const char* label, ImGuiDataType data_type, void* v, int components, const void* v_min, const void* v_max, const char* format, float power)
+bool ImGui::SliderScalarN(const char* label, ImGuiDataType data_type, void* v, int components, const void* v_min, const void* v_max, const char* format, float power) IMGUI_NOEXCEPT
 {
     ImGuiSliderFlags slider_flags = ImGuiSliderFlags_None;
     if (power != 1.0f)
@@ -3199,7 +3199,7 @@ bool ImGui::SliderScalarN(const char* label, ImGuiDataType data_type, void* v, i
 //-------------------------------------------------------------------------
 
 // We don't use strchr() because our strings are usually very short and often start with '%'
-const char* ImParseFormatFindStart(const char* fmt)
+const char* ImParseFormatFindStart(const char* fmt) IMGUI_NOEXCEPT
 {
     while (char c = fmt[0])
     {
@@ -3212,7 +3212,7 @@ const char* ImParseFormatFindStart(const char* fmt)
     return fmt;
 }
 
-const char* ImParseFormatFindEnd(const char* fmt)
+const char* ImParseFormatFindEnd(const char* fmt) IMGUI_NOEXCEPT
 {
     // Printf/scanf types modifiers: I/L/h/j/l/t/w/z. Other uppercase letters qualify as types aka end of the format.
     if (fmt[0] != '%')
@@ -3234,7 +3234,7 @@ const char* ImParseFormatFindEnd(const char* fmt)
 //  fmt = "%.3f"       -> return fmt
 //  fmt = "hello %.3f" -> return fmt + 6
 //  fmt = "%.3f hello" -> return buf written with "%.3f"
-const char* ImParseFormatTrimDecorations(const char* fmt, char* buf, size_t buf_size)
+const char* ImParseFormatTrimDecorations(const char* fmt, char* buf, size_t buf_size) IMGUI_NOEXCEPT
 {
     const char* fmt_start = ImParseFormatFindStart(fmt);
     if (fmt_start[0] != '%')
@@ -3248,7 +3248,7 @@ const char* ImParseFormatTrimDecorations(const char* fmt, char* buf, size_t buf_
 
 // Parse display precision back from the display format string
 // FIXME: This is still used by some navigation code path to infer a minimum tweak step, but we should aim to rework widgets so it isn't needed.
-int ImParseFormatPrecision(const char* fmt, int default_precision)
+int ImParseFormatPrecision(const char* fmt, int default_precision) IMGUI_NOEXCEPT
 {
     fmt = ImParseFormatFindStart(fmt);
     if (fmt[0] != '%')
@@ -3272,7 +3272,7 @@ int ImParseFormatPrecision(const char* fmt, int default_precision)
 
 // Create text input in place of another active widget (e.g. used when doing a CTRL+Click on drag/slider widgets)
 // FIXME: Facilitate using this in variety of other situations.
-bool ImGui::TempInputText(const ImRect& bb, ImGuiID id, const char* label, char* buf, int buf_size, ImGuiInputTextFlags flags)
+bool ImGui::TempInputText(const ImRect& bb, ImGuiID id, const char* label, char* buf, int buf_size, ImGuiInputTextFlags flags) IMGUI_NOEXCEPT
 {
     // On the first frame, g.TempInputTextId == 0, then on subsequent frames it becomes == id.
     // We clear ActiveID on the first frame to allow the InputText() taking it back.
@@ -3295,7 +3295,7 @@ bool ImGui::TempInputText(const ImRect& bb, ImGuiID id, const char* label, char*
 // Note that Drag/Slider functions are only forwarding the min/max values clamping values if the ImGuiSliderFlags_AlwaysClamp flag is set!
 // This is intended: this way we allow CTRL+Click manual input to set a value out of bounds, for maximum flexibility.
 // However this may not be ideal for all uses, as some user code may break on out of bound values.
-bool ImGui::TempInputScalar(const ImRect& bb, ImGuiID id, const char* label, ImGuiDataType data_type, void* p_data, const char* format, const void* p_clamp_min, const void* p_clamp_max)
+bool ImGui::TempInputScalar(const ImRect& bb, ImGuiID id, const char* label, ImGuiDataType data_type, void* p_data, const char* format, const void* p_clamp_min, const void* p_clamp_max) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -3334,7 +3334,7 @@ bool ImGui::TempInputScalar(const ImRect& bb, ImGuiID id, const char* label, ImG
 
 // Note: p_data, p_step, p_step_fast are _pointers_ to a memory address holding the data. For an Input widget, p_step and p_step_fast are optional.
 // Read code of e.g. InputFloat(), InputInt() etc. or examples in 'Demo->Widgets->Data Types' to understand how to use this function directly.
-bool ImGui::InputScalar(const char* label, ImGuiDataType data_type, void* p_data, const void* p_step, const void* p_step_fast, const char* format, ImGuiInputTextFlags flags)
+bool ImGui::InputScalar(const char* label, ImGuiDataType data_type, void* p_data, const void* p_step, const void* p_step_fast, const char* format, ImGuiInputTextFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -3406,7 +3406,7 @@ bool ImGui::InputScalar(const char* label, ImGuiDataType data_type, void* p_data
     return value_changed;
 }
 
-bool ImGui::InputScalarN(const char* label, ImGuiDataType data_type, void* p_data, int components, const void* p_step, const void* p_step_fast, const char* format, ImGuiInputTextFlags flags)
+bool ImGui::InputScalarN(const char* label, ImGuiDataType data_type, void* p_data, int components, const void* p_step, const void* p_step_fast, const char* format, ImGuiInputTextFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -3441,50 +3441,50 @@ bool ImGui::InputScalarN(const char* label, ImGuiDataType data_type, void* p_dat
     return value_changed;
 }
 
-bool ImGui::InputFloat(const char* label, float* v, float step, float step_fast, const char* format, ImGuiInputTextFlags flags)
+bool ImGui::InputFloat(const char* label, float* v, float step, float step_fast, const char* format, ImGuiInputTextFlags flags) IMGUI_NOEXCEPT
 {
     flags |= ImGuiInputTextFlags_CharsScientific;
     return InputScalar(label, ImGuiDataType_Float, (void*)v, (void*)(step > 0.0f ? &step : NULL), (void*)(step_fast > 0.0f ? &step_fast : NULL), format, flags);
 }
 
-bool ImGui::InputFloat2(const char* label, float v[2], const char* format, ImGuiInputTextFlags flags)
+bool ImGui::InputFloat2(const char* label, float v[2], const char* format, ImGuiInputTextFlags flags) IMGUI_NOEXCEPT
 {
     return InputScalarN(label, ImGuiDataType_Float, v, 2, NULL, NULL, format, flags);
 }
 
-bool ImGui::InputFloat3(const char* label, float v[3], const char* format, ImGuiInputTextFlags flags)
+bool ImGui::InputFloat3(const char* label, float v[3], const char* format, ImGuiInputTextFlags flags) IMGUI_NOEXCEPT
 {
     return InputScalarN(label, ImGuiDataType_Float, v, 3, NULL, NULL, format, flags);
 }
 
-bool ImGui::InputFloat4(const char* label, float v[4], const char* format, ImGuiInputTextFlags flags)
+bool ImGui::InputFloat4(const char* label, float v[4], const char* format, ImGuiInputTextFlags flags) IMGUI_NOEXCEPT
 {
     return InputScalarN(label, ImGuiDataType_Float, v, 4, NULL, NULL, format, flags);
 }
 
-bool ImGui::InputInt(const char* label, int* v, int step, int step_fast, ImGuiInputTextFlags flags)
+bool ImGui::InputInt(const char* label, int* v, int step, int step_fast, ImGuiInputTextFlags flags) IMGUI_NOEXCEPT
 {
     // Hexadecimal input provided as a convenience but the flag name is awkward. Typically you'd use InputText() to parse your own data, if you want to handle prefixes.
     const char* format = (flags & ImGuiInputTextFlags_CharsHexadecimal) ? "%08X" : "%d";
     return InputScalar(label, ImGuiDataType_S32, (void*)v, (void*)(step > 0 ? &step : NULL), (void*)(step_fast > 0 ? &step_fast : NULL), format, flags);
 }
 
-bool ImGui::InputInt2(const char* label, int v[2], ImGuiInputTextFlags flags)
+bool ImGui::InputInt2(const char* label, int v[2], ImGuiInputTextFlags flags) IMGUI_NOEXCEPT
 {
     return InputScalarN(label, ImGuiDataType_S32, v, 2, NULL, NULL, "%d", flags);
 }
 
-bool ImGui::InputInt3(const char* label, int v[3], ImGuiInputTextFlags flags)
+bool ImGui::InputInt3(const char* label, int v[3], ImGuiInputTextFlags flags) IMGUI_NOEXCEPT
 {
     return InputScalarN(label, ImGuiDataType_S32, v, 3, NULL, NULL, "%d", flags);
 }
 
-bool ImGui::InputInt4(const char* label, int v[4], ImGuiInputTextFlags flags)
+bool ImGui::InputInt4(const char* label, int v[4], ImGuiInputTextFlags flags) IMGUI_NOEXCEPT
 {
     return InputScalarN(label, ImGuiDataType_S32, v, 4, NULL, NULL, "%d", flags);
 }
 
-bool ImGui::InputDouble(const char* label, double* v, double step, double step_fast, const char* format, ImGuiInputTextFlags flags)
+bool ImGui::InputDouble(const char* label, double* v, double step, double step_fast, const char* format, ImGuiInputTextFlags flags) IMGUI_NOEXCEPT
 {
     flags |= ImGuiInputTextFlags_CharsScientific;
     return InputScalar(label, ImGuiDataType_Double, (void*)v, (void*)(step > 0.0 ? &step : NULL), (void*)(step_fast > 0.0 ? &step_fast : NULL), format, flags);
@@ -3499,24 +3499,24 @@ bool ImGui::InputDouble(const char* label, double* v, double step, double step_f
 // - InputTextEx() [Internal]
 //-------------------------------------------------------------------------
 
-bool ImGui::InputText(const char* label, char* buf, size_t buf_size, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback, void* user_data)
+bool ImGui::InputText(const char* label, char* buf, size_t buf_size, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback, void* user_data) IMGUI_NOEXCEPT
 {
     IM_ASSERT(!(flags & ImGuiInputTextFlags_Multiline)); // call InputTextMultiline()
     return InputTextEx(label, NULL, buf, (int)buf_size, ImVec2(0, 0), flags, callback, user_data);
 }
 
-bool ImGui::InputTextMultiline(const char* label, char* buf, size_t buf_size, const ImVec2& size, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback, void* user_data)
+bool ImGui::InputTextMultiline(const char* label, char* buf, size_t buf_size, const ImVec2& size, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback, void* user_data) IMGUI_NOEXCEPT
 {
     return InputTextEx(label, NULL, buf, (int)buf_size, size, flags | ImGuiInputTextFlags_Multiline, callback, user_data);
 }
 
-bool ImGui::InputTextWithHint(const char* label, const char* hint, char* buf, size_t buf_size, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback, void* user_data)
+bool ImGui::InputTextWithHint(const char* label, const char* hint, char* buf, size_t buf_size, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback, void* user_data) IMGUI_NOEXCEPT
 {
     IM_ASSERT(!(flags & ImGuiInputTextFlags_Multiline)); // call InputTextMultiline()
     return InputTextEx(label, hint, buf, (int)buf_size, ImVec2(0, 0), flags, callback, user_data);
 }
 
-static int InputTextCalcTextLenAndLineCount(const char* text_begin, const char** out_text_end)
+static int InputTextCalcTextLenAndLineCount(const char* text_begin, const char** out_text_end) IMGUI_NOEXCEPT
 {
     int line_count = 0;
     const char* s = text_begin;
@@ -3530,7 +3530,7 @@ static int InputTextCalcTextLenAndLineCount(const char* text_begin, const char**
     return line_count;
 }
 
-static ImVec2 InputTextCalcTextSizeW(const ImWchar* text_begin, const ImWchar* text_end, const ImWchar** remaining, ImVec2* out_offset, bool stop_on_new_line)
+static ImVec2 InputTextCalcTextSizeW(const ImWchar* text_begin, const ImWchar* text_end, const ImWchar** remaining, ImVec2* out_offset, bool stop_on_new_line) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImFont* font = g.Font;
@@ -3579,12 +3579,12 @@ static ImVec2 InputTextCalcTextSizeW(const ImWchar* text_begin, const ImWchar* t
 namespace ImStb
 {
 
-static int     STB_TEXTEDIT_STRINGLEN(const ImGuiInputTextState* obj)                             { return obj->CurLenW; }
-static ImWchar STB_TEXTEDIT_GETCHAR(const ImGuiInputTextState* obj, int idx)                      { return obj->TextW[idx]; }
-static float   STB_TEXTEDIT_GETWIDTH(ImGuiInputTextState* obj, int line_start_idx, int char_idx)  { ImWchar c = obj->TextW[line_start_idx + char_idx]; if (c == '\n') return STB_TEXTEDIT_GETWIDTH_NEWLINE; ImGuiContext& g = *GImGui; return g.Font->GetCharAdvance(c) * (g.FontSize / g.Font->FontSize); }
-static int     STB_TEXTEDIT_KEYTOTEXT(int key)                                                    { return key >= 0x200000 ? 0 : key; }
+static int     STB_TEXTEDIT_STRINGLEN(const ImGuiInputTextState* obj)                            IMGUI_NOEXCEPT { return obj->CurLenW; }
+static ImWchar STB_TEXTEDIT_GETCHAR(const ImGuiInputTextState* obj, int idx)                     IMGUI_NOEXCEPT { return obj->TextW[idx]; }
+static float   STB_TEXTEDIT_GETWIDTH(ImGuiInputTextState* obj, int line_start_idx, int char_idx) IMGUI_NOEXCEPT { ImWchar c = obj->TextW[line_start_idx + char_idx]; if (c == '\n') return STB_TEXTEDIT_GETWIDTH_NEWLINE; ImGuiContext& g = *GImGui; return g.Font->GetCharAdvance(c) * (g.FontSize / g.Font->FontSize); }
+static int     STB_TEXTEDIT_KEYTOTEXT(int key)                                                   IMGUI_NOEXCEPT { return key >= 0x200000 ? 0 : key; }
 static ImWchar STB_TEXTEDIT_NEWLINE = '\n';
-static void    STB_TEXTEDIT_LAYOUTROW(StbTexteditRow* r, ImGuiInputTextState* obj, int line_start_idx)
+static void    STB_TEXTEDIT_LAYOUTROW(StbTexteditRow* r, ImGuiInputTextState* obj, int line_start_idx) IMGUI_NOEXCEPT
 {
     const ImWchar* text = obj->TextW.Data;
     const ImWchar* text_remaining = NULL;
@@ -3598,19 +3598,19 @@ static void    STB_TEXTEDIT_LAYOUTROW(StbTexteditRow* r, ImGuiInputTextState* ob
 }
 
 // When ImGuiInputTextFlags_Password is set, we don't want actions such as CTRL+Arrow to leak the fact that underlying data are blanks or separators.
-static bool is_separator(unsigned int c)                                        { return ImCharIsBlankW(c) || c==',' || c==';' || c=='(' || c==')' || c=='{' || c=='}' || c=='[' || c==']' || c=='|'; }
-static int  is_word_boundary_from_right(ImGuiInputTextState* obj, int idx)      { if (obj->Flags & ImGuiInputTextFlags_Password) return 0; return idx > 0 ? (is_separator(obj->TextW[idx - 1]) && !is_separator(obj->TextW[idx]) ) : 1; }
-static int  STB_TEXTEDIT_MOVEWORDLEFT_IMPL(ImGuiInputTextState* obj, int idx)   { idx--; while (idx >= 0 && !is_word_boundary_from_right(obj, idx)) idx--; return idx < 0 ? 0 : idx; }
+static bool is_separator(unsigned int c)                                       IMGUI_NOEXCEPT { return ImCharIsBlankW(c) || c==',' || c==';' || c=='(' || c==')' || c=='{' || c=='}' || c=='[' || c==']' || c=='|'; }
+static int  is_word_boundary_from_right(ImGuiInputTextState* obj, int idx)     IMGUI_NOEXCEPT { if (obj->Flags & ImGuiInputTextFlags_Password) return 0; return idx > 0 ? (is_separator(obj->TextW[idx - 1]) && !is_separator(obj->TextW[idx]) ) : 1; }
+static int  STB_TEXTEDIT_MOVEWORDLEFT_IMPL(ImGuiInputTextState* obj, int idx)  IMGUI_NOEXCEPT { idx--; while (idx >= 0 && !is_word_boundary_from_right(obj, idx)) idx--; return idx < 0 ? 0 : idx; }
 #ifdef __APPLE__    // FIXME: Move setting to IO structure
-static int  is_word_boundary_from_left(ImGuiInputTextState* obj, int idx)       { if (obj->Flags & ImGuiInputTextFlags_Password) return 0; return idx > 0 ? (!is_separator(obj->TextW[idx - 1]) && is_separator(obj->TextW[idx]) ) : 1; }
-static int  STB_TEXTEDIT_MOVEWORDRIGHT_IMPL(ImGuiInputTextState* obj, int idx)  { idx++; int len = obj->CurLenW; while (idx < len && !is_word_boundary_from_left(obj, idx)) idx++; return idx > len ? len : idx; }
+static int  is_word_boundary_from_left(ImGuiInputTextState* obj, int idx)      IMGUI_NOEXCEPT { if (obj->Flags & ImGuiInputTextFlags_Password) return 0; return idx > 0 ? (!is_separator(obj->TextW[idx - 1]) && is_separator(obj->TextW[idx]) ) : 1; }
+static int  STB_TEXTEDIT_MOVEWORDRIGHT_IMPL(ImGuiInputTextState* obj, int idx) IMGUI_NOEXCEPT { idx++; int len = obj->CurLenW; while (idx < len && !is_word_boundary_from_left(obj, idx)) idx++; return idx > len ? len : idx; }
 #else
-static int  STB_TEXTEDIT_MOVEWORDRIGHT_IMPL(ImGuiInputTextState* obj, int idx)  { idx++; int len = obj->CurLenW; while (idx < len && !is_word_boundary_from_right(obj, idx)) idx++; return idx > len ? len : idx; }
+static int  STB_TEXTEDIT_MOVEWORDRIGHT_IMPL(ImGuiInputTextState* obj, int idx) IMGUI_NOEXCEPT { idx++; int len = obj->CurLenW; while (idx < len && !is_word_boundary_from_right(obj, idx)) idx++; return idx > len ? len : idx; }
 #endif
 #define STB_TEXTEDIT_MOVEWORDLEFT   STB_TEXTEDIT_MOVEWORDLEFT_IMPL    // They need to be #define for stb_textedit.h
 #define STB_TEXTEDIT_MOVEWORDRIGHT  STB_TEXTEDIT_MOVEWORDRIGHT_IMPL
 
-static void STB_TEXTEDIT_DELETECHARS(ImGuiInputTextState* obj, int pos, int n)
+static void STB_TEXTEDIT_DELETECHARS(ImGuiInputTextState* obj, int pos, int n) IMGUI_NOEXCEPT
 {
     ImWchar* dst = obj->TextW.Data + pos;
 
@@ -3626,7 +3626,7 @@ static void STB_TEXTEDIT_DELETECHARS(ImGuiInputTextState* obj, int pos, int n)
     *dst = '\0';
 }
 
-static bool STB_TEXTEDIT_INSERTCHARS(ImGuiInputTextState* obj, int pos, const ImWchar* new_text, int new_text_len)
+static bool STB_TEXTEDIT_INSERTCHARS(ImGuiInputTextState* obj, int pos, const ImWchar* new_text, int new_text_len) IMGUI_NOEXCEPT
 {
     const bool is_resizable = (obj->Flags & ImGuiInputTextFlags_CallbackResize) != 0;
     const int text_len = obj->CurLenW;
@@ -3682,7 +3682,7 @@ static bool STB_TEXTEDIT_INSERTCHARS(ImGuiInputTextState* obj, int pos, const Im
 
 // stb_textedit internally allows for a single undo record to do addition and deletion, but somehow, calling
 // the stb_textedit_paste() function creates two separate records, so we perform it manually. (FIXME: Report to nothings/stb?)
-static void stb_textedit_replace(ImGuiInputTextState* str, STB_TexteditState* state, const STB_TEXTEDIT_CHARTYPE* text, int text_len)
+static void stb_textedit_replace(STB_TEXTEDIT_STRING* str, STB_TexteditState* state, const STB_TEXTEDIT_CHARTYPE* text, int text_len) IMGUI_NOEXCEPT
 {
     stb_text_makeundo_replace(str, state, 0, str->CurLenW, text_len);
     ImStb::STB_TEXTEDIT_DELETECHARS(str, 0, str->CurLenW);
@@ -3699,14 +3699,14 @@ static void stb_textedit_replace(ImGuiInputTextState* str, STB_TexteditState* st
 
 } // namespace ImStb
 
-void ImGuiInputTextState::OnKeyPressed(int key)
+void ImGuiInputTextState::OnKeyPressed(int key) IMGUI_NOEXCEPT
 {
     stb_textedit_key(this, &Stb, key);
     CursorFollow = true;
     CursorAnimReset();
 }
 
-ImGuiInputTextCallbackData::ImGuiInputTextCallbackData()
+ImGuiInputTextCallbackData::ImGuiInputTextCallbackData() IMGUI_NOEXCEPT
 {
     memset(this, 0, sizeof(*this));
 }
@@ -3714,7 +3714,7 @@ ImGuiInputTextCallbackData::ImGuiInputTextCallbackData()
 // Public API to manipulate UTF-8 text
 // We expose UTF-8 to the user (unlike the STB_TEXTEDIT_* functions which are manipulating wchar)
 // FIXME: The existence of this rarely exercised code path is a bit of a nuisance.
-void ImGuiInputTextCallbackData::DeleteChars(int pos, int bytes_count)
+void ImGuiInputTextCallbackData::DeleteChars(int pos, int bytes_count) IMGUI_NOEXCEPT
 {
     IM_ASSERT(pos + bytes_count <= BufTextLen);
     char* dst = Buf + pos;
@@ -3732,7 +3732,7 @@ void ImGuiInputTextCallbackData::DeleteChars(int pos, int bytes_count)
     BufTextLen -= bytes_count;
 }
 
-void ImGuiInputTextCallbackData::InsertChars(int pos, const char* new_text, const char* new_text_end)
+void ImGuiInputTextCallbackData::InsertChars(int pos, const char* new_text, const char* new_text_end) IMGUI_NOEXCEPT
 {
     const bool is_resizable = (Flags & ImGuiInputTextFlags_CallbackResize) != 0;
     const int new_text_len = new_text_end ? (int)(new_text_end - new_text) : (int)strlen(new_text);
@@ -3765,7 +3765,7 @@ void ImGuiInputTextCallbackData::InsertChars(int pos, const char* new_text, cons
 }
 
 // Return false to discard a character.
-static bool InputTextFilterCharacter(unsigned int* p_char, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback, void* user_data, ImGuiInputSource input_source)
+static bool InputTextFilterCharacter(unsigned int* p_char, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback, void* user_data, ImGuiInputSource input_source) IMGUI_NOEXCEPT
 {
     IM_ASSERT(input_source == ImGuiInputSource_Keyboard || input_source == ImGuiInputSource_Clipboard);
     unsigned int c = *p_char;
@@ -3858,7 +3858,7 @@ static bool InputTextFilterCharacter(unsigned int* p_char, ImGuiInputTextFlags f
 // - If you want to use ImGui::InputText() with std::string, see misc/cpp/imgui_stdlib.h
 // (FIXME: Rather confusing and messy function, among the worse part of our codebase, expecting to rewrite a V2 at some point.. Partly because we are
 //  doing UTF8 > U16 > UTF8 conversions on the go to easily interface with stb_textedit. Ideally should stay in UTF-8 all the time. See https://github.com/nothings/stb/issues/188)
-bool ImGui::InputTextEx(const char* label, const char* hint, char* buf, int buf_size, const ImVec2& size_arg, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback, void* callback_user_data)
+bool ImGui::InputTextEx(const char* label, const char* hint, char* buf, int buf_size, const ImVec2& size_arg, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback, void* callback_user_data) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -4677,7 +4677,7 @@ bool ImGui::InputTextEx(const char* label, const char* hint, char* buf, int buf_
 // - ColorPickerOptionsPopup() [Internal]
 //-------------------------------------------------------------------------
 
-bool ImGui::ColorEdit3(const char* label, float col[3], ImGuiColorEditFlags flags)
+bool ImGui::ColorEdit3(const char* label, float col[3], ImGuiColorEditFlags flags) IMGUI_NOEXCEPT
 {
     return ColorEdit4(label, col, flags | ImGuiColorEditFlags_NoAlpha);
 }
@@ -4685,7 +4685,7 @@ bool ImGui::ColorEdit3(const char* label, float col[3], ImGuiColorEditFlags flag
 // Edit colors components (each component in 0.0f..1.0f range).
 // See enum ImGuiColorEditFlags_ for available options. e.g. Only access 3 floats if ImGuiColorEditFlags_NoAlpha flag is set.
 // With typical options: Left-click on color square to open color picker. Right-click to open option menu. CTRL-Click over input fields to edit them and TAB to go to next item.
-bool ImGui::ColorEdit4(const char* label, float col[4], ImGuiColorEditFlags flags)
+bool ImGui::ColorEdit4(const char* label, float col[4], ImGuiColorEditFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -4925,7 +4925,7 @@ bool ImGui::ColorEdit4(const char* label, float col[4], ImGuiColorEditFlags flag
     return value_changed;
 }
 
-bool ImGui::ColorPicker3(const char* label, float col[3], ImGuiColorEditFlags flags)
+bool ImGui::ColorPicker3(const char* label, float col[3], ImGuiColorEditFlags flags) IMGUI_NOEXCEPT
 {
     float col4[4] = { col[0], col[1], col[2], 1.0f };
     if (!ColorPicker4(label, col4, flags | ImGuiColorEditFlags_NoAlpha))
@@ -4935,7 +4935,7 @@ bool ImGui::ColorPicker3(const char* label, float col[3], ImGuiColorEditFlags fl
 }
 
 // Helper for ColorPicker4()
-static void RenderArrowsForVerticalBar(ImDrawList* draw_list, ImVec2 pos, ImVec2 half_sz, float bar_w, float alpha)
+static void RenderArrowsForVerticalBar(ImDrawList* draw_list, ImVec2 pos, ImVec2 half_sz, float bar_w, float alpha) IMGUI_NOEXCEPT
 {
     ImU32 alpha8 = IM_F32_TO_INT8_SAT(alpha);
     ImGui::RenderArrowPointingAt(draw_list, ImVec2(pos.x + half_sz.x + 1,         pos.y), ImVec2(half_sz.x + 2, half_sz.y + 1), ImGuiDir_Right, IM_COL32(0,0,0,alpha8));
@@ -4948,7 +4948,7 @@ static void RenderArrowsForVerticalBar(ImDrawList* draw_list, ImVec2 pos, ImVec2
 // (In C++ the 'float col[4]' notation for a function argument is equivalent to 'float* col', we only specify a size to facilitate understanding of the code.)
 // FIXME: we adjust the big color square height based on item width, which may cause a flickering feedback loop (if automatic height makes a vertical scrollbar appears, affecting automatic width..)
 // FIXME: this is trying to be aware of style.Alpha but not fully correct. Also, the color wheel will have overlapping glitches with (style.Alpha < 1.0)
-bool ImGui::ColorPicker4(const char* label, float col[4], ImGuiColorEditFlags flags, const float* ref_col)
+bool ImGui::ColorPicker4(const char* label, float col[4], ImGuiColorEditFlags flags, const float* ref_col) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = GetCurrentWindow();
@@ -5327,7 +5327,7 @@ bool ImGui::ColorPicker4(const char* label, float col[4], ImGuiColorEditFlags fl
 // FIXME: May want to display/ignore the alpha component in the color display? Yet show it in the tooltip.
 // 'desc_id' is not called 'label' because we don't display it next to the button, but only in the tooltip.
 // Note that 'col' may be encoded in HSV if ImGuiColorEditFlags_InputHSV is set.
-bool ImGui::ColorButton(const char* desc_id, const ImVec4& col, ImGuiColorEditFlags flags, ImVec2 size)
+bool ImGui::ColorButton(const char* desc_id, const ImVec4& col, ImGuiColorEditFlags flags, ImVec2 size) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -5411,7 +5411,7 @@ bool ImGui::ColorButton(const char* desc_id, const ImVec4& col, ImGuiColorEditFl
 }
 
 // Initialize/override default color options
-void ImGui::SetColorEditOptions(ImGuiColorEditFlags flags)
+void ImGui::SetColorEditOptions(ImGuiColorEditFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if ((flags & ImGuiColorEditFlags__DisplayMask) == 0)
@@ -5430,7 +5430,7 @@ void ImGui::SetColorEditOptions(ImGuiColorEditFlags flags)
 }
 
 // Note: only access 3 floats if ImGuiColorEditFlags_NoAlpha flag is set.
-void ImGui::ColorTooltip(const char* text, const float* col, ImGuiColorEditFlags flags)
+void ImGui::ColorTooltip(const char* text, const float* col, ImGuiColorEditFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -5464,7 +5464,7 @@ void ImGui::ColorTooltip(const char* text, const float* col, ImGuiColorEditFlags
     EndTooltip();
 }
 
-void ImGui::ColorEditOptionsPopup(const float* col, ImGuiColorEditFlags flags)
+void ImGui::ColorEditOptionsPopup(const float* col, ImGuiColorEditFlags flags) IMGUI_NOEXCEPT
 {
     bool allow_opt_inputs = !(flags & ImGuiColorEditFlags__DisplayMask);
     bool allow_opt_datatype = !(flags & ImGuiColorEditFlags__DataTypeMask);
@@ -5515,7 +5515,7 @@ void ImGui::ColorEditOptionsPopup(const float* col, ImGuiColorEditFlags flags)
     EndPopup();
 }
 
-void ImGui::ColorPickerOptionsPopup(const float* ref_col, ImGuiColorEditFlags flags)
+void ImGui::ColorPickerOptionsPopup(const float* ref_col, ImGuiColorEditFlags flags) IMGUI_NOEXCEPT
 {
     bool allow_opt_picker = !(flags & ImGuiColorEditFlags__PickerMask);
     bool allow_opt_alpha_bar = !(flags & ImGuiColorEditFlags_NoAlpha) && !(flags & ImGuiColorEditFlags_AlphaBar);
@@ -5568,7 +5568,7 @@ void ImGui::ColorPickerOptionsPopup(const float* ref_col, ImGuiColorEditFlags fl
 // - CollapsingHeader()
 //-------------------------------------------------------------------------
 
-bool ImGui::TreeNode(const char* str_id, const char* fmt, ...)
+bool ImGui::TreeNode(const char* str_id, const char* fmt, ...) IMGUI_NOEXCEPT
 {
     va_list args;
     va_start(args, fmt);
@@ -5577,7 +5577,7 @@ bool ImGui::TreeNode(const char* str_id, const char* fmt, ...)
     return is_open;
 }
 
-bool ImGui::TreeNode(const void* ptr_id, const char* fmt, ...)
+bool ImGui::TreeNode(const void* ptr_id, const char* fmt, ...) IMGUI_NOEXCEPT
 {
     va_list args;
     va_start(args, fmt);
@@ -5586,7 +5586,7 @@ bool ImGui::TreeNode(const void* ptr_id, const char* fmt, ...)
     return is_open;
 }
 
-bool ImGui::TreeNode(const char* label)
+bool ImGui::TreeNode(const char* label) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -5594,17 +5594,17 @@ bool ImGui::TreeNode(const char* label)
     return TreeNodeBehavior(window->GetID(label), 0, label, NULL);
 }
 
-bool ImGui::TreeNodeV(const char* str_id, const char* fmt, va_list args)
+bool ImGui::TreeNodeV(const char* str_id, const char* fmt, va_list args) IMGUI_NOEXCEPT
 {
     return TreeNodeExV(str_id, 0, fmt, args);
 }
 
-bool ImGui::TreeNodeV(const void* ptr_id, const char* fmt, va_list args)
+bool ImGui::TreeNodeV(const void* ptr_id, const char* fmt, va_list args) IMGUI_NOEXCEPT
 {
     return TreeNodeExV(ptr_id, 0, fmt, args);
 }
 
-bool ImGui::TreeNodeEx(const char* label, ImGuiTreeNodeFlags flags)
+bool ImGui::TreeNodeEx(const char* label, ImGuiTreeNodeFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -5613,7 +5613,7 @@ bool ImGui::TreeNodeEx(const char* label, ImGuiTreeNodeFlags flags)
     return TreeNodeBehavior(window->GetID(label), flags, label, NULL);
 }
 
-bool ImGui::TreeNodeEx(const char* str_id, ImGuiTreeNodeFlags flags, const char* fmt, ...)
+bool ImGui::TreeNodeEx(const char* str_id, ImGuiTreeNodeFlags flags, const char* fmt, ...) IMGUI_NOEXCEPT
 {
     va_list args;
     va_start(args, fmt);
@@ -5622,7 +5622,7 @@ bool ImGui::TreeNodeEx(const char* str_id, ImGuiTreeNodeFlags flags, const char*
     return is_open;
 }
 
-bool ImGui::TreeNodeEx(const void* ptr_id, ImGuiTreeNodeFlags flags, const char* fmt, ...)
+bool ImGui::TreeNodeEx(const void* ptr_id, ImGuiTreeNodeFlags flags, const char* fmt, ...) IMGUI_NOEXCEPT
 {
     va_list args;
     va_start(args, fmt);
@@ -5631,7 +5631,7 @@ bool ImGui::TreeNodeEx(const void* ptr_id, ImGuiTreeNodeFlags flags, const char*
     return is_open;
 }
 
-bool ImGui::TreeNodeExV(const char* str_id, ImGuiTreeNodeFlags flags, const char* fmt, va_list args)
+bool ImGui::TreeNodeExV(const char* str_id, ImGuiTreeNodeFlags flags, const char* fmt, va_list args) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -5642,7 +5642,7 @@ bool ImGui::TreeNodeExV(const char* str_id, ImGuiTreeNodeFlags flags, const char
     return TreeNodeBehavior(window->GetID(str_id), flags, g.TempBuffer, label_end);
 }
 
-bool ImGui::TreeNodeExV(const void* ptr_id, ImGuiTreeNodeFlags flags, const char* fmt, va_list args)
+bool ImGui::TreeNodeExV(const void* ptr_id, ImGuiTreeNodeFlags flags, const char* fmt, va_list args) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -5653,7 +5653,7 @@ bool ImGui::TreeNodeExV(const void* ptr_id, ImGuiTreeNodeFlags flags, const char
     return TreeNodeBehavior(window->GetID(ptr_id), flags, g.TempBuffer, label_end);
 }
 
-bool ImGui::TreeNodeBehaviorIsOpen(ImGuiID id, ImGuiTreeNodeFlags flags)
+bool ImGui::TreeNodeBehaviorIsOpen(ImGuiID id, ImGuiTreeNodeFlags flags) IMGUI_NOEXCEPT
 {
     if (flags & ImGuiTreeNodeFlags_Leaf)
         return true;
@@ -5699,7 +5699,7 @@ bool ImGui::TreeNodeBehaviorIsOpen(ImGuiID id, ImGuiTreeNodeFlags flags)
     return is_open;
 }
 
-bool ImGui::TreeNodeBehavior(ImGuiID id, ImGuiTreeNodeFlags flags, const char* label, const char* label_end)
+bool ImGui::TreeNodeBehavior(ImGuiID id, ImGuiTreeNodeFlags flags, const char* label, const char* label_end) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -5886,7 +5886,7 @@ bool ImGui::TreeNodeBehavior(ImGuiID id, ImGuiTreeNodeFlags flags, const char* l
     return is_open;
 }
 
-void ImGui::TreePush(const char* str_id)
+void ImGui::TreePush(const char* str_id) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     Indent();
@@ -5894,7 +5894,7 @@ void ImGui::TreePush(const char* str_id)
     PushID(str_id ? str_id : "#TreePush");
 }
 
-void ImGui::TreePush(const void* ptr_id)
+void ImGui::TreePush(const void* ptr_id) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     Indent();
@@ -5902,7 +5902,7 @@ void ImGui::TreePush(const void* ptr_id)
     PushID(ptr_id ? ptr_id : (const void*)"#TreePush");
 }
 
-void ImGui::TreePushOverrideID(ImGuiID id)
+void ImGui::TreePushOverrideID(ImGuiID id) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -5911,7 +5911,7 @@ void ImGui::TreePushOverrideID(ImGuiID id)
     window->IDStack.push_back(id);
 }
 
-void ImGui::TreePop()
+void ImGui::TreePop() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -5934,14 +5934,14 @@ void ImGui::TreePop()
 }
 
 // Horizontal distance preceding label when using TreeNode() or Bullet()
-float ImGui::GetTreeNodeToLabelSpacing()
+float ImGui::GetTreeNodeToLabelSpacing() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return g.FontSize + (g.Style.FramePadding.x * 2.0f);
 }
 
 // Set next TreeNode/CollapsingHeader open state.
-void ImGui::SetNextItemOpen(bool is_open, ImGuiCond cond)
+void ImGui::SetNextItemOpen(bool is_open, ImGuiCond cond) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.CurrentWindow->SkipItems)
@@ -5953,7 +5953,7 @@ void ImGui::SetNextItemOpen(bool is_open, ImGuiCond cond)
 
 // CollapsingHeader returns true when opened but do not indent nor push into the ID stack (because of the ImGuiTreeNodeFlags_NoTreePushOnOpen flag).
 // This is basically the same as calling TreeNodeEx(label, ImGuiTreeNodeFlags_CollapsingHeader). You can remove the _NoTreePushOnOpen flag if you want behavior closer to normal TreeNode().
-bool ImGui::CollapsingHeader(const char* label, ImGuiTreeNodeFlags flags)
+bool ImGui::CollapsingHeader(const char* label, ImGuiTreeNodeFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -5966,7 +5966,7 @@ bool ImGui::CollapsingHeader(const char* label, ImGuiTreeNodeFlags flags)
 // p_visible != NULL && *p_visible == true  : show a small close button on the corner of the header, clicking the button will set *p_visible = false
 // p_visible != NULL && *p_visible == false : do not show the header at all
 // Do not mistake this with the Open state of the header itself, which you can adjust with SetNextItemOpen() or ImGuiTreeNodeFlags_DefaultOpen.
-bool ImGui::CollapsingHeader(const char* label, bool* p_visible, ImGuiTreeNodeFlags flags)
+bool ImGui::CollapsingHeader(const char* label, bool* p_visible, ImGuiTreeNodeFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -6009,7 +6009,7 @@ bool ImGui::CollapsingHeader(const char* label, bool* p_visible, ImGuiTreeNodeFl
 // But you need to make sure the ID is unique, e.g. enclose calls in PushID/PopID or use ##unique_id.
 // With this scheme, ImGuiSelectableFlags_SpanAllColumns and ImGuiSelectableFlags_AllowItemOverlap are also frequently used flags.
 // FIXME: Selectable() with (size.x == 0.0f) and (SelectableTextAlign.x > 0.0f) followed by SameLine() is currently not supported.
-bool ImGui::Selectable(const char* label, bool selected, ImGuiSelectableFlags flags, const ImVec2& size_arg)
+bool ImGui::Selectable(const char* label, bool selected, ImGuiSelectableFlags flags, const ImVec2& size_arg) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -6153,7 +6153,7 @@ bool ImGui::Selectable(const char* label, bool selected, ImGuiSelectableFlags fl
     return pressed;
 }
 
-bool ImGui::Selectable(const char* label, bool* p_selected, ImGuiSelectableFlags flags, const ImVec2& size_arg)
+bool ImGui::Selectable(const char* label, bool* p_selected, ImGuiSelectableFlags flags, const ImVec2& size_arg) IMGUI_NOEXCEPT
 {
     if (Selectable(label, *p_selected, flags, size_arg))
     {
@@ -6214,7 +6214,7 @@ bool ImGui::BeginListBox(const char* label, const ImVec2& size_arg) IMGUI_NOEXCE
 
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
 // OBSOLETED in 1.81 (from February 2021)
-bool ImGui::ListBoxHeader(const char* label, int items_count, int height_in_items)
+bool ImGui::ListBoxHeader(const char* label, int items_count, int height_in_items) IMGUI_NOEXCEPT
 {
     // If height_in_items == -1, default height is maximum 7.
     ImGuiContext& g = *GImGui;
@@ -6237,7 +6237,7 @@ void ImGui::EndListBox() IMGUI_NOEXCEPT
     EndGroup(); // This is only required to be able to do IsItemXXX query on the whole ListBox including label
 }
 
-bool ImGui::ListBox(const char* label, int* current_item, const char* const items[], int items_count, int height_items)
+bool ImGui::ListBox(const char* label, int* current_item, const char* const items[], int items_count, int height_items) IMGUI_NOEXCEPT
 {
     const bool value_changed = ListBox(label, current_item, Items_ArrayGetter, (void*)items, items_count, height_items);
     return value_changed;
@@ -6245,7 +6245,7 @@ bool ImGui::ListBox(const char* label, int* current_item, const char* const item
 
 // This is merely a helper around BeginListBox(), EndListBox().
 // Considering using those directly to submit custom data or store selection differently.
-bool ImGui::ListBox(const char* label, int* current_item, bool (*items_getter)(void*, int, const char**), void* data, int items_count, int height_in_items)
+bool ImGui::ListBox(const char* label, int* current_item, bool (*items_getter)(void*, int, const char**), void* data, int items_count, int height_in_items) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -6301,7 +6301,7 @@ bool ImGui::ListBox(const char* label, int* current_item, bool (*items_getter)(v
 // - others https://github.com/ocornut/imgui/wiki/Useful-Widgets
 //-------------------------------------------------------------------------
 
-int ImGui::PlotEx(ImGuiPlotType plot_type, const char* label, float (*values_getter)(void* data, int idx), void* data, int values_count, int values_offset, const char* overlay_text, float scale_min, float scale_max, ImVec2 frame_size)
+int ImGui::PlotEx(ImGuiPlotType plot_type, const char* label, float (*values_getter)(void* data, int idx), void* data, int values_count, int values_offset, const char* overlay_text, float scale_min, float scale_max, ImVec2 frame_size) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = GetCurrentWindow();
@@ -6424,34 +6424,34 @@ struct ImGuiPlotArrayGetterData
     const float* Values;
     int Stride;
 
-    ImGuiPlotArrayGetterData(const float* values, int stride) { Values = values; Stride = stride; }
+    ImGuiPlotArrayGetterData(const float* values, int stride) IMGUI_NOEXCEPT { Values = values; Stride = stride; }
 };
 
-static float Plot_ArrayGetter(void* data, int idx)
+static float Plot_ArrayGetter(void* data, int idx) IMGUI_NOEXCEPT
 {
     ImGuiPlotArrayGetterData* plot_data = (ImGuiPlotArrayGetterData*)data;
     const float v = *(const float*)(const void*)((const unsigned char*)plot_data->Values + (size_t)idx * plot_data->Stride);
     return v;
 }
 
-void ImGui::PlotLines(const char* label, const float* values, int values_count, int values_offset, const char* overlay_text, float scale_min, float scale_max, ImVec2 graph_size, int stride)
+void ImGui::PlotLines(const char* label, const float* values, int values_count, int values_offset, const char* overlay_text, float scale_min, float scale_max, ImVec2 graph_size, int stride) IMGUI_NOEXCEPT
 {
     ImGuiPlotArrayGetterData data(values, stride);
     PlotEx(ImGuiPlotType_Lines, label, &Plot_ArrayGetter, (void*)&data, values_count, values_offset, overlay_text, scale_min, scale_max, graph_size);
 }
 
-void ImGui::PlotLines(const char* label, float (*values_getter)(void* data, int idx), void* data, int values_count, int values_offset, const char* overlay_text, float scale_min, float scale_max, ImVec2 graph_size)
+void ImGui::PlotLines(const char* label, float (*values_getter)(void* data, int idx), void* data, int values_count, int values_offset, const char* overlay_text, float scale_min, float scale_max, ImVec2 graph_size) IMGUI_NOEXCEPT
 {
     PlotEx(ImGuiPlotType_Lines, label, values_getter, data, values_count, values_offset, overlay_text, scale_min, scale_max, graph_size);
 }
 
-void ImGui::PlotHistogram(const char* label, const float* values, int values_count, int values_offset, const char* overlay_text, float scale_min, float scale_max, ImVec2 graph_size, int stride)
+void ImGui::PlotHistogram(const char* label, const float* values, int values_count, int values_offset, const char* overlay_text, float scale_min, float scale_max, ImVec2 graph_size, int stride) IMGUI_NOEXCEPT
 {
     ImGuiPlotArrayGetterData data(values, stride);
     PlotEx(ImGuiPlotType_Histogram, label, &Plot_ArrayGetter, (void*)&data, values_count, values_offset, overlay_text, scale_min, scale_max, graph_size);
 }
 
-void ImGui::PlotHistogram(const char* label, float (*values_getter)(void* data, int idx), void* data, int values_count, int values_offset, const char* overlay_text, float scale_min, float scale_max, ImVec2 graph_size)
+void ImGui::PlotHistogram(const char* label, float (*values_getter)(void* data, int idx), void* data, int values_count, int values_offset, const char* overlay_text, float scale_min, float scale_max, ImVec2 graph_size) IMGUI_NOEXCEPT
 {
     PlotEx(ImGuiPlotType_Histogram, label, values_getter, data, values_count, values_offset, overlay_text, scale_min, scale_max, graph_size);
 }
@@ -6463,22 +6463,22 @@ void ImGui::PlotHistogram(const char* label, float (*values_getter)(void* data, 
 // - Value()
 //-------------------------------------------------------------------------
 
-void ImGui::Value(const char* prefix, bool b)
+void ImGui::Value(const char* prefix, bool b) IMGUI_NOEXCEPT
 {
     Text("%s: %s", prefix, (b ? "true" : "false"));
 }
 
-void ImGui::Value(const char* prefix, int v)
+void ImGui::Value(const char* prefix, int v) IMGUI_NOEXCEPT
 {
     Text("%s: %d", prefix, v);
 }
 
-void ImGui::Value(const char* prefix, unsigned int v)
+void ImGui::Value(const char* prefix, unsigned int v) IMGUI_NOEXCEPT
 {
     Text("%s: %d", prefix, v);
 }
 
-void ImGui::Value(const char* prefix, float v, const char* float_format)
+void ImGui::Value(const char* prefix, float v, const char* float_format) IMGUI_NOEXCEPT
 {
     if (float_format)
     {
@@ -6506,7 +6506,7 @@ void ImGui::Value(const char* prefix, float v, const char* float_format)
 //-------------------------------------------------------------------------
 
 // Helpers for internal use
-void ImGuiMenuColumns::Update(int count, float spacing, bool clear)
+void ImGuiMenuColumns::Update(int count, float spacing, bool clear) IMGUI_NOEXCEPT
 {
     IM_ASSERT(count == IM_ARRAYSIZE(Pos));
     IM_UNUSED(count);
@@ -6524,7 +6524,7 @@ void ImGuiMenuColumns::Update(int count, float spacing, bool clear)
     }
 }
 
-float ImGuiMenuColumns::DeclColumns(float w0, float w1, float w2) // not using va_arg because they promote float to double
+float ImGuiMenuColumns::DeclColumns(float w0, float w1, float w2) IMGUI_NOEXCEPT  // not using va_arg because they promote float to double
 {
     NextWidth = 0.0f;
     NextWidths[0] = ImMax(NextWidths[0], w0);
@@ -6535,7 +6535,7 @@ float ImGuiMenuColumns::DeclColumns(float w0, float w1, float w2) // not using v
     return ImMax(Width, NextWidth);
 }
 
-float ImGuiMenuColumns::CalcExtraSpace(float avail_w) const
+float ImGuiMenuColumns::CalcExtraSpace(float avail_w) const IMGUI_NOEXCEPT
 {
     return ImMax(0.0f, avail_w - Width);
 }
@@ -6616,7 +6616,7 @@ void ImGui::EndMenuBar() IMGUI_NOEXCEPT
 // Important: calling order matters!
 // FIXME: Somehow overlapping with docking tech.
 // FIXME: The "rect-cut" aspect of this could be formalized into a lower-level helper (rect-cut: https://halt.software/dead-simple-layouts)
-bool ImGui::BeginViewportSideBar(const char* name, ImGuiViewport* viewport_p, ImGuiDir dir, float axis_size, ImGuiWindowFlags window_flags)
+bool ImGui::BeginViewportSideBar(const char* name, ImGuiViewport* viewport_p, ImGuiDir dir, float axis_size, ImGuiWindowFlags window_flags) IMGUI_NOEXCEPT
 {
     IM_ASSERT(dir != ImGuiDir_None);
 
@@ -6865,7 +6865,7 @@ void ImGui::EndMenu() IMGUI_NOEXCEPT
     EndPopup();
 }
 
-bool ImGui::MenuItem(const char* label, const char* shortcut, bool selected, bool enabled)
+bool ImGui::MenuItem(const char* label, const char* shortcut, bool selected, bool enabled) IMGUI_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -6914,7 +6914,7 @@ bool ImGui::MenuItem(const char* label, const char* shortcut, bool selected, boo
     return pressed;
 }
 
-bool ImGui::MenuItem(const char* label, const char* shortcut, bool* p_selected, bool enabled)
+bool ImGui::MenuItem(const char* label, const char* shortcut, bool* p_selected, bool enabled) IMGUI_NOEXCEPT
 {
     if (MenuItem(label, shortcut, p_selected ? *p_selected : false, enabled))
     {
@@ -6950,33 +6950,33 @@ struct ImGuiTabBarSection
     float               Width;                  // Sum of width of tabs in this section (after shrinking down)
     float               Spacing;                // Horizontal spacing at the end of the section.
 
-    ImGuiTabBarSection() { memset(this, 0, sizeof(*this)); }
+    ImGuiTabBarSection() IMGUI_NOEXCEPT { memset(this, 0, sizeof(*this)); }
 };
 
 namespace ImGui
 {
-    static void             TabBarLayout(ImGuiTabBar* tab_bar);
-    static ImU32            TabBarCalcTabID(ImGuiTabBar* tab_bar, const char* label);
-    static float            TabBarCalcMaxTabWidth();
-    static float            TabBarScrollClamp(ImGuiTabBar* tab_bar, float scrolling);
-    static void             TabBarScrollToTab(ImGuiTabBar* tab_bar, ImGuiID tab_id, ImGuiTabBarSection* sections);
-    static ImGuiTabItem*    TabBarScrollingButtons(ImGuiTabBar* tab_bar);
-    static ImGuiTabItem*    TabBarTabListPopupButton(ImGuiTabBar* tab_bar);
+    static void             TabBarLayout(ImGuiTabBar* tab_bar) IMGUI_NOEXCEPT;
+    static ImU32            TabBarCalcTabID(ImGuiTabBar* tab_bar, const char* label) IMGUI_NOEXCEPT;
+    static float            TabBarCalcMaxTabWidth() IMGUI_NOEXCEPT;
+    static float            TabBarScrollClamp(ImGuiTabBar* tab_bar, float scrolling) IMGUI_NOEXCEPT;
+    static void             TabBarScrollToTab(ImGuiTabBar* tab_bar, ImGuiID tab_id, ImGuiTabBarSection* sections) IMGUI_NOEXCEPT;
+    static ImGuiTabItem*    TabBarScrollingButtons(ImGuiTabBar* tab_bar) IMGUI_NOEXCEPT;
+    static ImGuiTabItem*    TabBarTabListPopupButton(ImGuiTabBar* tab_bar) IMGUI_NOEXCEPT;
 }
 
-ImGuiTabBar::ImGuiTabBar()
+ImGuiTabBar::ImGuiTabBar() IMGUI_NOEXCEPT
 {
     memset(this, 0, sizeof(*this));
     CurrFrameVisible = PrevFrameVisible = -1;
     LastTabItemIdx = -1;
 }
 
-static inline int TabItemGetSectionIdx(const ImGuiTabItem* tab)
+static inline int TabItemGetSectionIdx(const ImGuiTabItem* tab) IMGUI_NOEXCEPT
 {
     return (tab->Flags & ImGuiTabItemFlags_Leading) ? 0 : (tab->Flags & ImGuiTabItemFlags_Trailing) ? 2 : 1;
 }
 
-static int IMGUI_CDECL TabItemComparerBySection(const void* lhs, const void* rhs)
+static int IMGUI_CDECL TabItemComparerBySection(const void* lhs, const void* rhs) IMGUI_NOEXCEPT
 {
     const ImGuiTabItem* a = (const ImGuiTabItem*)lhs;
     const ImGuiTabItem* b = (const ImGuiTabItem*)rhs;
@@ -6987,20 +6987,20 @@ static int IMGUI_CDECL TabItemComparerBySection(const void* lhs, const void* rhs
     return (int)(a->IndexDuringLayout - b->IndexDuringLayout);
 }
 
-static int IMGUI_CDECL TabItemComparerByBeginOrder(const void* lhs, const void* rhs)
+static int IMGUI_CDECL TabItemComparerByBeginOrder(const void* lhs, const void* rhs) IMGUI_NOEXCEPT
 {
     const ImGuiTabItem* a = (const ImGuiTabItem*)lhs;
     const ImGuiTabItem* b = (const ImGuiTabItem*)rhs;
     return (int)(a->BeginOrder - b->BeginOrder);
 }
 
-static ImGuiTabBar* GetTabBarFromTabBarRef(const ImGuiPtrOrIndex& ref)
+static ImGuiTabBar* GetTabBarFromTabBarRef(const ImGuiPtrOrIndex& ref) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return ref.Ptr ? (ImGuiTabBar*)ref.Ptr : g.TabBars.GetByIndex(ref.Index);
 }
 
-static ImGuiPtrOrIndex GetTabBarRefFromTabBar(ImGuiTabBar* tab_bar)
+static ImGuiPtrOrIndex GetTabBarRefFromTabBar(ImGuiTabBar* tab_bar) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.TabBars.Contains(tab_bar))
@@ -7022,7 +7022,7 @@ bool    ImGui::BeginTabBar(const char* str_id, ImGuiTabBarFlags flags) IMGUI_NOE
     return BeginTabBarEx(tab_bar, tab_bar_bb, flags | ImGuiTabBarFlags_IsFocused);
 }
 
-bool    ImGui::BeginTabBarEx(ImGuiTabBar* tab_bar, const ImRect& tab_bar_bb, ImGuiTabBarFlags flags)
+bool    ImGui::BeginTabBarEx(ImGuiTabBar* tab_bar, const ImRect& tab_bar_bb, ImGuiTabBarFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7122,7 +7122,7 @@ void    ImGui::EndTabBar() IMGUI_NOEXCEPT
 
 // This is called only once a frame before by the first call to ItemTab()
 // The reason we're not calling it in BeginTabBar() is to leave a chance to the user to call the SetTabItemClosed() functions.
-static void ImGui::TabBarLayout(ImGuiTabBar* tab_bar)
+static void ImGui::TabBarLayout(ImGuiTabBar* tab_bar) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     tab_bar->WantLayout = false;
@@ -7352,7 +7352,7 @@ static void ImGui::TabBarLayout(ImGuiTabBar* tab_bar)
 }
 
 // Dockables uses Name/ID in the global namespace. Non-dockable items use the ID stack.
-static ImU32   ImGui::TabBarCalcTabID(ImGuiTabBar* tab_bar, const char* label)
+static ImU32   ImGui::TabBarCalcTabID(ImGuiTabBar* tab_bar, const char* label) IMGUI_NOEXCEPT
 {
     if (tab_bar->Flags & ImGuiTabBarFlags_DockNode)
     {
@@ -7367,13 +7367,13 @@ static ImU32   ImGui::TabBarCalcTabID(ImGuiTabBar* tab_bar, const char* label)
     }
 }
 
-static float ImGui::TabBarCalcMaxTabWidth()
+static float ImGui::TabBarCalcMaxTabWidth() IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return g.FontSize * 20.0f;
 }
 
-ImGuiTabItem* ImGui::TabBarFindTabByID(ImGuiTabBar* tab_bar, ImGuiID tab_id)
+ImGuiTabItem* ImGui::TabBarFindTabByID(ImGuiTabBar* tab_bar, ImGuiID tab_id) IMGUI_NOEXCEPT
 {
     if (tab_id != 0)
         for (int n = 0; n < tab_bar->Tabs.Size; n++)
@@ -7383,7 +7383,7 @@ ImGuiTabItem* ImGui::TabBarFindTabByID(ImGuiTabBar* tab_bar, ImGuiID tab_id)
 }
 
 // The *TabId fields be already set by the docking system _before_ the actual TabItem was created, so we clear them regardless.
-void ImGui::TabBarRemoveTab(ImGuiTabBar* tab_bar, ImGuiID tab_id)
+void ImGui::TabBarRemoveTab(ImGuiTabBar* tab_bar, ImGuiID tab_id) IMGUI_NOEXCEPT
 {
     if (ImGuiTabItem* tab = TabBarFindTabByID(tab_bar, tab_id))
         tab_bar->Tabs.erase(tab);
@@ -7393,7 +7393,7 @@ void ImGui::TabBarRemoveTab(ImGuiTabBar* tab_bar, ImGuiID tab_id)
 }
 
 // Called on manual closure attempt
-void ImGui::TabBarCloseTab(ImGuiTabBar* tab_bar, ImGuiTabItem* tab)
+void ImGui::TabBarCloseTab(ImGuiTabBar* tab_bar, ImGuiTabItem* tab) IMGUI_NOEXCEPT
 {
     IM_ASSERT(!(tab->Flags & ImGuiTabItemFlags_Button));
     if (!(tab->Flags & ImGuiTabItemFlags_UnsavedDocument))
@@ -7415,14 +7415,14 @@ void ImGui::TabBarCloseTab(ImGuiTabBar* tab_bar, ImGuiTabItem* tab)
     }
 }
 
-static float ImGui::TabBarScrollClamp(ImGuiTabBar* tab_bar, float scrolling)
+static float ImGui::TabBarScrollClamp(ImGuiTabBar* tab_bar, float scrolling) IMGUI_NOEXCEPT
 {
     scrolling = ImMin(scrolling, tab_bar->WidthAllTabs - tab_bar->BarRect.GetWidth());
     return ImMax(scrolling, 0.0f);
 }
 
 // Note: we may scroll to tab that are not selected! e.g. using keyboard arrow keys
-static void ImGui::TabBarScrollToTab(ImGuiTabBar* tab_bar, ImGuiID tab_id, ImGuiTabBarSection* sections)
+static void ImGui::TabBarScrollToTab(ImGuiTabBar* tab_bar, ImGuiID tab_id, ImGuiTabBarSection* sections) IMGUI_NOEXCEPT
 {
     ImGuiTabItem* tab = TabBarFindTabByID(tab_bar, tab_id);
     if (tab == NULL)
@@ -7456,7 +7456,7 @@ static void ImGui::TabBarScrollToTab(ImGuiTabBar* tab_bar, ImGuiID tab_id, ImGui
     }
 }
 
-void ImGui::TabBarQueueReorder(ImGuiTabBar* tab_bar, const ImGuiTabItem* tab, int offset)
+void ImGui::TabBarQueueReorder(ImGuiTabBar* tab_bar, const ImGuiTabItem* tab, int offset) IMGUI_NOEXCEPT
 {
     IM_ASSERT(offset != 0);
     IM_ASSERT(tab_bar->ReorderRequestTabId == 0);
@@ -7464,7 +7464,7 @@ void ImGui::TabBarQueueReorder(ImGuiTabBar* tab_bar, const ImGuiTabItem* tab, in
     tab_bar->ReorderRequestOffset = (ImS16)offset;
 }
 
-void ImGui::TabBarQueueReorderFromMousePos(ImGuiTabBar* tab_bar, const ImGuiTabItem* src_tab, ImVec2 mouse_pos)
+void ImGui::TabBarQueueReorderFromMousePos(ImGuiTabBar* tab_bar, const ImGuiTabItem* src_tab, ImVec2 mouse_pos) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(tab_bar->ReorderRequestTabId == 0);
@@ -7500,7 +7500,7 @@ void ImGui::TabBarQueueReorderFromMousePos(ImGuiTabBar* tab_bar, const ImGuiTabI
         TabBarQueueReorder(tab_bar, src_tab, dst_idx - src_idx);
 }
 
-bool ImGui::TabBarProcessReorder(ImGuiTabBar* tab_bar)
+bool ImGui::TabBarProcessReorder(ImGuiTabBar* tab_bar) IMGUI_NOEXCEPT
 {
     ImGuiTabItem* tab1 = TabBarFindTabByID(tab_bar, tab_bar->ReorderRequestTabId);
     if (tab1 == NULL || (tab1->Flags & ImGuiTabItemFlags_NoReorder))
@@ -7531,7 +7531,7 @@ bool ImGui::TabBarProcessReorder(ImGuiTabBar* tab_bar)
     return true;
 }
 
-static ImGuiTabItem* ImGui::TabBarScrollingButtons(ImGuiTabBar* tab_bar)
+static ImGuiTabItem* ImGui::TabBarScrollingButtons(ImGuiTabBar* tab_bar) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7592,7 +7592,7 @@ static ImGuiTabItem* ImGui::TabBarScrollingButtons(ImGuiTabBar* tab_bar)
     return tab_to_scroll_to;
 }
 
-static ImGuiTabItem* ImGui::TabBarTabListPopupButton(ImGuiTabBar* tab_bar)
+static ImGuiTabItem* ImGui::TabBarTabListPopupButton(ImGuiTabBar* tab_bar) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7686,7 +7686,7 @@ void    ImGui::EndTabItem() IMGUI_NOEXCEPT
         PopID();
 }
 
-bool    ImGui::TabItemButton(const char* label, ImGuiTabItemFlags flags)
+bool    ImGui::TabItemButton(const char* label, ImGuiTabItemFlags flags) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7702,7 +7702,7 @@ bool    ImGui::TabItemButton(const char* label, ImGuiTabItemFlags flags)
     return TabItemEx(tab_bar, label, NULL, flags | ImGuiTabItemFlags_Button | ImGuiTabItemFlags_NoReorder);
 }
 
-bool    ImGui::TabItemEx(ImGuiTabBar* tab_bar, const char* label, bool* p_open, ImGuiTabItemFlags flags)
+bool    ImGui::TabItemEx(ImGuiTabBar* tab_bar, const char* label, bool* p_open, ImGuiTabItemFlags flags) IMGUI_NOEXCEPT
 {
     // Layout whole tab bar if not already done
     if (tab_bar->WantLayout)
@@ -7918,7 +7918,7 @@ bool    ImGui::TabItemEx(ImGuiTabBar* tab_bar, const char* label, bool* p_open, 
 // [Public] This is call is 100% optional but it allows to remove some one-frame glitches when a tab has been unexpectedly removed.
 // To use it to need to call the function SetTabItemClosed() between BeginTabBar() and EndTabBar().
 // Tabs closed by the close button will automatically be flagged to avoid this issue.
-void    ImGui::SetTabItemClosed(const char* label)
+void    ImGui::SetTabItemClosed(const char* label) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     bool is_within_manual_tab_bar = g.CurrentTabBar && !(g.CurrentTabBar->Flags & ImGuiTabBarFlags_DockNode);
@@ -7931,7 +7931,7 @@ void    ImGui::SetTabItemClosed(const char* label)
     }
 }
 
-ImVec2 ImGui::TabItemCalcSize(const char* label, bool has_close_button)
+ImVec2 ImGui::TabItemCalcSize(const char* label, bool has_close_button) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImVec2 label_size = CalcTextSize(label, NULL, true);
@@ -7943,7 +7943,7 @@ ImVec2 ImGui::TabItemCalcSize(const char* label, bool has_close_button)
     return ImVec2(ImMin(size.x, TabBarCalcMaxTabWidth()), size.y);
 }
 
-void ImGui::TabItemBackground(ImDrawList* draw_list, const ImRect& bb, ImGuiTabItemFlags flags, ImU32 col)
+void ImGui::TabItemBackground(ImDrawList* draw_list, const ImRect& bb, ImGuiTabItemFlags flags, ImU32 col) IMGUI_NOEXCEPT
 {
     // While rendering tabs, we trim 1 pixel off the top of our bounding box so they can fit within a regular frame height while looking "detached" from it.
     ImGuiContext& g = *GImGui;
@@ -7970,7 +7970,7 @@ void ImGui::TabItemBackground(ImDrawList* draw_list, const ImRect& bb, ImGuiTabI
 
 // Render text label (with custom clipping) + Unsaved Document marker + Close Button logic
 // We tend to lock style.FramePadding for a given tab-bar, hence the 'frame_padding' parameter.
-void ImGui::TabItemLabelAndCloseButton(ImDrawList* draw_list, const ImRect& bb, ImGuiTabItemFlags flags, ImVec2 frame_padding, const char* label, ImGuiID tab_id, ImGuiID close_button_id, bool is_contents_visible, bool* out_just_closed, bool* out_text_clipped)
+void ImGui::TabItemLabelAndCloseButton(ImDrawList* draw_list, const ImRect& bb, ImGuiTabItemFlags flags, ImVec2 frame_padding, const char* label, ImGuiID tab_id, ImGuiID close_button_id, bool is_contents_visible, bool* out_just_closed, bool* out_text_clipped) IMGUI_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImVec2 label_size = CalcTextSize(label, NULL, true);

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -124,9 +124,9 @@ static const ImU64          IM_U64_MAX = (2ULL * 9223372036854775807LL + 1);
 //-------------------------------------------------------------------------
 
 // For InputTextEx()
-static bool             InputTextFilterCharacter(unsigned int* p_char, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback, void* user_data, ImGuiInputSource input_source) IMGUI_NOEXCEPT;
-static int              InputTextCalcTextLenAndLineCount(const char* text_begin, const char** out_text_end) IMGUI_NOEXCEPT;
-static ImVec2           InputTextCalcTextSizeW(const ImWchar* text_begin, const ImWchar* text_end, const ImWchar** remaining = NULL, ImVec2* out_offset = NULL, bool stop_on_new_line = false) IMGUI_NOEXCEPT;
+static bool             InputTextFilterCharacter(unsigned int* p_char, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback, void* user_data, ImGuiInputSource input_source) IM_NOEXCEPT;
+static int              InputTextCalcTextLenAndLineCount(const char* text_begin, const char** out_text_end) IM_NOEXCEPT;
+static ImVec2           InputTextCalcTextSizeW(const ImWchar* text_begin, const ImWchar* text_end, const ImWchar** remaining = NULL, ImVec2* out_offset = NULL, bool stop_on_new_line = false) IM_NOEXCEPT;
 
 //-------------------------------------------------------------------------
 // [SECTION] Widgets: Text, etc.
@@ -147,7 +147,7 @@ static ImVec2           InputTextCalcTextSizeW(const ImWchar* text_begin, const 
 // - BulletTextV()
 //-------------------------------------------------------------------------
 
-void ImGui::TextEx(const char* text, const char* text_end, ImGuiTextFlags flags) IMGUI_NOEXCEPT
+void ImGui::TextEx(const char* text, const char* text_end, ImGuiTextFlags flags) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -250,12 +250,12 @@ void ImGui::TextEx(const char* text, const char* text_end, ImGuiTextFlags flags)
     }
 }
 
-void ImGui::TextUnformatted(const char* text, const char* text_end) IMGUI_NOEXCEPT
+void ImGui::TextUnformatted(const char* text, const char* text_end) IM_NOEXCEPT
 {
     TextEx(text, text_end, ImGuiTextFlags_NoWidthForLargeClippedText);
 }
 
-void ImGui::Text(const char* fmt, ...) IMGUI_NOEXCEPT
+void ImGui::Text(const char* fmt, ...) IM_NOEXCEPT
 {
     va_list args;
     va_start(args, fmt);
@@ -263,7 +263,7 @@ void ImGui::Text(const char* fmt, ...) IMGUI_NOEXCEPT
     va_end(args);
 }
 
-void ImGui::TextV(const char* fmt, va_list args) IMGUI_NOEXCEPT
+void ImGui::TextV(const char* fmt, va_list args) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -274,7 +274,7 @@ void ImGui::TextV(const char* fmt, va_list args) IMGUI_NOEXCEPT
     TextEx(g.TempBuffer, text_end, ImGuiTextFlags_NoWidthForLargeClippedText);
 }
 
-void ImGui::TextColored(const ImVec4& col, const char* fmt, ...) IMGUI_NOEXCEPT
+void ImGui::TextColored(const ImVec4& col, const char* fmt, ...) IM_NOEXCEPT
 {
     va_list args;
     va_start(args, fmt);
@@ -282,7 +282,7 @@ void ImGui::TextColored(const ImVec4& col, const char* fmt, ...) IMGUI_NOEXCEPT
     va_end(args);
 }
 
-void ImGui::TextColoredV(const ImVec4& col, const char* fmt, va_list args) IMGUI_NOEXCEPT
+void ImGui::TextColoredV(const ImVec4& col, const char* fmt, va_list args) IM_NOEXCEPT
 {
     PushStyleColor(ImGuiCol_Text, col);
     if (fmt[0] == '%' && fmt[1] == 's' && fmt[2] == 0)
@@ -292,7 +292,7 @@ void ImGui::TextColoredV(const ImVec4& col, const char* fmt, va_list args) IMGUI
     PopStyleColor();
 }
 
-void ImGui::TextDisabled(const char* fmt, ...) IMGUI_NOEXCEPT
+void ImGui::TextDisabled(const char* fmt, ...) IM_NOEXCEPT
 {
     va_list args;
     va_start(args, fmt);
@@ -300,7 +300,7 @@ void ImGui::TextDisabled(const char* fmt, ...) IMGUI_NOEXCEPT
     va_end(args);
 }
 
-void ImGui::TextDisabledV(const char* fmt, va_list args) IMGUI_NOEXCEPT
+void ImGui::TextDisabledV(const char* fmt, va_list args) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     PushStyleColor(ImGuiCol_Text, g.Style.Colors[ImGuiCol_TextDisabled]);
@@ -311,7 +311,7 @@ void ImGui::TextDisabledV(const char* fmt, va_list args) IMGUI_NOEXCEPT
     PopStyleColor();
 }
 
-void ImGui::TextWrapped(const char* fmt, ...) IMGUI_NOEXCEPT
+void ImGui::TextWrapped(const char* fmt, ...) IM_NOEXCEPT
 {
     va_list args;
     va_start(args, fmt);
@@ -319,7 +319,7 @@ void ImGui::TextWrapped(const char* fmt, ...) IMGUI_NOEXCEPT
     va_end(args);
 }
 
-void ImGui::TextWrappedV(const char* fmt, va_list args) IMGUI_NOEXCEPT
+void ImGui::TextWrappedV(const char* fmt, va_list args) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     bool need_backup = (g.CurrentWindow->DC.TextWrapPos < 0.0f);  // Keep existing wrap position if one is already set
@@ -333,7 +333,7 @@ void ImGui::TextWrappedV(const char* fmt, va_list args) IMGUI_NOEXCEPT
         PopTextWrapPos();
 }
 
-void ImGui::LabelText(const char* label, const char* fmt, ...) IMGUI_NOEXCEPT
+void ImGui::LabelText(const char* label, const char* fmt, ...) IM_NOEXCEPT
 {
     va_list args;
     va_start(args, fmt);
@@ -342,7 +342,7 @@ void ImGui::LabelText(const char* label, const char* fmt, ...) IMGUI_NOEXCEPT
 }
 
 // Add a label+text combo aligned to other label+value widgets
-void ImGui::LabelTextV(const char* label, const char* fmt, va_list args) IMGUI_NOEXCEPT
+void ImGui::LabelTextV(const char* label, const char* fmt, va_list args) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -370,7 +370,7 @@ void ImGui::LabelTextV(const char* label, const char* fmt, va_list args) IMGUI_N
         RenderText(ImVec2(value_bb.Max.x + style.ItemInnerSpacing.x, value_bb.Min.y + style.FramePadding.y), label);
 }
 
-void ImGui::BulletText(const char* fmt, ...) IMGUI_NOEXCEPT
+void ImGui::BulletText(const char* fmt, ...) IM_NOEXCEPT
 {
     va_list args;
     va_start(args, fmt);
@@ -379,7 +379,7 @@ void ImGui::BulletText(const char* fmt, ...) IMGUI_NOEXCEPT
 }
 
 // Text with a little bullet aligned to the typical tree node.
-void ImGui::BulletTextV(const char* fmt, va_list args) IMGUI_NOEXCEPT
+void ImGui::BulletTextV(const char* fmt, va_list args) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -483,7 +483,7 @@ void ImGui::BulletTextV(const char* fmt, va_list args) IMGUI_NOEXCEPT
 //   Frame N + RepeatDelay + RepeatRate*N   true                     true              -                   true
 //-------------------------------------------------------------------------------------------------------------------------------------------------
 
-bool ImGui::ButtonBehavior(const ImRect& bb, ImGuiID id, bool* out_hovered, bool* out_held, ImGuiButtonFlags flags) IMGUI_NOEXCEPT
+bool ImGui::ButtonBehavior(const ImRect& bb, ImGuiID id, bool* out_hovered, bool* out_held, ImGuiButtonFlags flags) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = GetCurrentWindow();
@@ -667,7 +667,7 @@ bool ImGui::ButtonBehavior(const ImRect& bb, ImGuiID id, bool* out_hovered, bool
     return pressed;
 }
 
-bool ImGui::ButtonEx(const char* label, const ImVec2& size_arg, ImGuiButtonFlags flags) IMGUI_NOEXCEPT
+bool ImGui::ButtonEx(const char* label, const ImVec2& size_arg, ImGuiButtonFlags flags) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -710,13 +710,13 @@ bool ImGui::ButtonEx(const char* label, const ImVec2& size_arg, ImGuiButtonFlags
     return pressed;
 }
 
-bool ImGui::Button(const char* label, const ImVec2& size_arg) IMGUI_NOEXCEPT
+bool ImGui::Button(const char* label, const ImVec2& size_arg) IM_NOEXCEPT
 {
     return ButtonEx(label, size_arg, ImGuiButtonFlags_None);
 }
 
 // Small buttons fits within text without additional vertical spacing.
-bool ImGui::SmallButton(const char* label) IMGUI_NOEXCEPT
+bool ImGui::SmallButton(const char* label) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     float backup_padding_y = g.Style.FramePadding.y;
@@ -728,7 +728,7 @@ bool ImGui::SmallButton(const char* label) IMGUI_NOEXCEPT
 
 // Tip: use ImGui::PushID()/PopID() to push indices or pointers in the ID stack.
 // Then you can keep 'str_id' empty or the same for all your buttons (instead of creating a string based on a non-string id)
-bool ImGui::InvisibleButton(const char* str_id, const ImVec2& size_arg, ImGuiButtonFlags flags) IMGUI_NOEXCEPT
+bool ImGui::InvisibleButton(const char* str_id, const ImVec2& size_arg, ImGuiButtonFlags flags) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -750,7 +750,7 @@ bool ImGui::InvisibleButton(const char* str_id, const ImVec2& size_arg, ImGuiBut
     return pressed;
 }
 
-bool ImGui::ArrowButtonEx(const char* str_id, ImGuiDir dir, ImVec2 size, ImGuiButtonFlags flags) IMGUI_NOEXCEPT
+bool ImGui::ArrowButtonEx(const char* str_id, ImGuiDir dir, ImVec2 size, ImGuiButtonFlags flags) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -780,14 +780,14 @@ bool ImGui::ArrowButtonEx(const char* str_id, ImGuiDir dir, ImVec2 size, ImGuiBu
     return pressed;
 }
 
-bool ImGui::ArrowButton(const char* str_id, ImGuiDir dir) IMGUI_NOEXCEPT
+bool ImGui::ArrowButton(const char* str_id, ImGuiDir dir) IM_NOEXCEPT
 {
     float sz = GetFrameHeight();
     return ArrowButtonEx(str_id, dir, ImVec2(sz, sz), ImGuiButtonFlags_None);
 }
 
 // Button to close a window
-bool ImGui::CloseButton(ImGuiID id, const ImVec2& pos) IMGUI_NOEXCEPT
+bool ImGui::CloseButton(ImGuiID id, const ImVec2& pos) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -825,7 +825,7 @@ bool ImGui::CloseButton(ImGuiID id, const ImVec2& pos) IMGUI_NOEXCEPT
     return pressed;
 }
 
-bool ImGui::CollapseButton(ImGuiID id, const ImVec2& pos) IMGUI_NOEXCEPT
+bool ImGui::CollapseButton(ImGuiID id, const ImVec2& pos) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -850,13 +850,13 @@ bool ImGui::CollapseButton(ImGuiID id, const ImVec2& pos) IMGUI_NOEXCEPT
     return pressed;
 }
 
-ImGuiID ImGui::GetWindowScrollbarID(ImGuiWindow* window, ImGuiAxis axis) IMGUI_NOEXCEPT
+ImGuiID ImGui::GetWindowScrollbarID(ImGuiWindow* window, ImGuiAxis axis) IM_NOEXCEPT
 {
     return window->GetIDNoKeepAlive(axis == ImGuiAxis_X ? "#SCROLLX" : "#SCROLLY");
 }
 
 // Return scrollbar rectangle, must only be called for corresponding axis if window->ScrollbarX/Y is set.
-ImRect ImGui::GetWindowScrollbarRect(ImGuiWindow* window, ImGuiAxis axis) IMGUI_NOEXCEPT
+ImRect ImGui::GetWindowScrollbarRect(ImGuiWindow* window, ImGuiAxis axis) IM_NOEXCEPT
 {
     const ImRect outer_rect = window->Rect();
     const ImRect inner_rect = window->InnerRect;
@@ -869,7 +869,7 @@ ImRect ImGui::GetWindowScrollbarRect(ImGuiWindow* window, ImGuiAxis axis) IMGUI_
         return ImRect(ImMax(outer_rect.Min.x, outer_rect.Max.x - border_size - scrollbar_size), inner_rect.Min.y, outer_rect.Max.x, inner_rect.Max.y);
 }
 
-void ImGui::Scrollbar(ImGuiAxis axis) IMGUI_NOEXCEPT
+void ImGui::Scrollbar(ImGuiAxis axis) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -904,7 +904,7 @@ void ImGui::Scrollbar(ImGuiAxis axis) IMGUI_NOEXCEPT
 // - We store values as normalized ratio and in a form that allows the window content to change while we are holding on a scrollbar
 // - We handle both horizontal and vertical scrollbars, which makes the terminology not ideal.
 // Still, the code should probably be made simpler..
-bool ImGui::ScrollbarEx(const ImRect& bb_frame, ImGuiID id, ImGuiAxis axis, float* p_scroll_v, float size_avail_v, float size_contents_v, ImDrawFlags flags) IMGUI_NOEXCEPT
+bool ImGui::ScrollbarEx(const ImRect& bb_frame, ImGuiID id, ImGuiAxis axis, float* p_scroll_v, float size_avail_v, float size_contents_v, ImDrawFlags flags) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -995,7 +995,7 @@ bool ImGui::ScrollbarEx(const ImRect& bb_frame, ImGuiID id, ImGuiAxis axis, floa
     return held;
 }
 
-void ImGui::Image(ImTextureID user_texture_id, const ImVec2& size, const ImVec2& uv0, const ImVec2& uv1, const ImVec4& tint_col, const ImVec4& border_col) IMGUI_NOEXCEPT
+void ImGui::Image(ImTextureID user_texture_id, const ImVec2& size, const ImVec2& uv0, const ImVec2& uv1, const ImVec4& tint_col, const ImVec4& border_col) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -1021,7 +1021,7 @@ void ImGui::Image(ImTextureID user_texture_id, const ImVec2& size, const ImVec2&
 
 // ImageButton() is flawed as 'id' is always derived from 'texture_id' (see #2464 #1390)
 // We provide this internal helper to write your own variant while we figure out how to redesign the public ImageButton() API.
-bool ImGui::ImageButtonEx(ImGuiID id, ImTextureID texture_id, const ImVec2& size, const ImVec2& uv0, const ImVec2& uv1, const ImVec2& padding, const ImVec4& bg_col, const ImVec4& tint_col) IMGUI_NOEXCEPT
+bool ImGui::ImageButtonEx(ImGuiID id, ImTextureID texture_id, const ImVec2& size, const ImVec2& uv0, const ImVec2& uv1, const ImVec2& padding, const ImVec4& bg_col, const ImVec4& tint_col) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = GetCurrentWindow();
@@ -1050,7 +1050,7 @@ bool ImGui::ImageButtonEx(ImGuiID id, ImTextureID texture_id, const ImVec2& size
 // frame_padding < 0: uses FramePadding from style (default)
 // frame_padding = 0: no framing
 // frame_padding > 0: set framing size
-bool ImGui::ImageButton(ImTextureID user_texture_id, const ImVec2& size, const ImVec2& uv0, const ImVec2& uv1, int frame_padding, const ImVec4& bg_col, const ImVec4& tint_col) IMGUI_NOEXCEPT
+bool ImGui::ImageButton(ImTextureID user_texture_id, const ImVec2& size, const ImVec2& uv0, const ImVec2& uv1, int frame_padding, const ImVec4& bg_col, const ImVec4& tint_col) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -1066,7 +1066,7 @@ bool ImGui::ImageButton(ImTextureID user_texture_id, const ImVec2& size, const I
     return ImageButtonEx(id, user_texture_id, size, uv0, uv1, padding, bg_col, tint_col);
 }
 
-bool ImGui::Checkbox(const char* label, bool* v) IMGUI_NOEXCEPT
+bool ImGui::Checkbox(const char* label, bool* v) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -1124,7 +1124,7 @@ bool ImGui::Checkbox(const char* label, bool* v) IMGUI_NOEXCEPT
 }
 
 template<typename T>
-bool ImGui::CheckboxFlagsT(const char* label, T* flags, T flags_value) IMGUI_NOEXCEPT
+bool ImGui::CheckboxFlagsT(const char* label, T* flags, T flags_value) IM_NOEXCEPT
 {
     bool all_on = (*flags & flags_value) == flags_value;
     bool any_on = (*flags & flags_value) != 0;
@@ -1152,27 +1152,27 @@ bool ImGui::CheckboxFlagsT(const char* label, T* flags, T flags_value) IMGUI_NOE
     return pressed;
 }
 
-bool ImGui::CheckboxFlags(const char* label, int* flags, int flags_value) IMGUI_NOEXCEPT
+bool ImGui::CheckboxFlags(const char* label, int* flags, int flags_value) IM_NOEXCEPT
 {
     return CheckboxFlagsT(label, flags, flags_value);
 }
 
-bool ImGui::CheckboxFlags(const char* label, unsigned int* flags, unsigned int flags_value) IMGUI_NOEXCEPT
+bool ImGui::CheckboxFlags(const char* label, unsigned int* flags, unsigned int flags_value) IM_NOEXCEPT
 {
     return CheckboxFlagsT(label, flags, flags_value);
 }
 
-bool ImGui::CheckboxFlags(const char* label, ImS64* flags, ImS64 flags_value) IMGUI_NOEXCEPT
+bool ImGui::CheckboxFlags(const char* label, ImS64* flags, ImS64 flags_value) IM_NOEXCEPT
 {
     return CheckboxFlagsT(label, flags, flags_value);
 }
 
-bool ImGui::CheckboxFlags(const char* label, ImU64* flags, ImU64 flags_value) IMGUI_NOEXCEPT
+bool ImGui::CheckboxFlags(const char* label, ImU64* flags, ImU64 flags_value) IM_NOEXCEPT
 {
     return CheckboxFlagsT(label, flags, flags_value);
 }
 
-bool ImGui::RadioButton(const char* label, bool active) IMGUI_NOEXCEPT
+bool ImGui::RadioButton(const char* label, bool active) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -1226,7 +1226,7 @@ bool ImGui::RadioButton(const char* label, bool active) IMGUI_NOEXCEPT
 }
 
 // FIXME: This would work nicely if it was a public template, e.g. 'template<T> RadioButton(const char* label, T* v, T v_button)', but I'm not sure how we would expose it..
-bool ImGui::RadioButton(const char* label, int* v, int v_button) IMGUI_NOEXCEPT
+bool ImGui::RadioButton(const char* label, int* v, int v_button) IM_NOEXCEPT
 {
     const bool pressed = RadioButton(label, *v == v_button);
     if (pressed)
@@ -1235,7 +1235,7 @@ bool ImGui::RadioButton(const char* label, int* v, int v_button) IMGUI_NOEXCEPT
 }
 
 // size_arg (for each axis) < 0.0f: align to end, 0.0f: auto, > 0.0f: specified size
-void ImGui::ProgressBar(float fraction, const ImVec2& size_arg, const char* overlay) IMGUI_NOEXCEPT
+void ImGui::ProgressBar(float fraction, const ImVec2& size_arg, const char* overlay) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -1271,7 +1271,7 @@ void ImGui::ProgressBar(float fraction, const ImVec2& size_arg, const char* over
         RenderTextClipped(ImVec2(ImClamp(fill_br.x + style.ItemSpacing.x, bb.Min.x, bb.Max.x - overlay_size.x - style.ItemInnerSpacing.x), bb.Min.y), bb.Max, overlay, NULL, &overlay_size, ImVec2(0.0f, 0.5f), &bb);
 }
 
-void ImGui::Bullet() IMGUI_NOEXCEPT
+void ImGui::Bullet() IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -1307,7 +1307,7 @@ void ImGui::Bullet() IMGUI_NOEXCEPT
 // - ShrinkWidths() [Internal]
 //-------------------------------------------------------------------------
 
-void ImGui::Spacing() IMGUI_NOEXCEPT
+void ImGui::Spacing() IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -1315,7 +1315,7 @@ void ImGui::Spacing() IMGUI_NOEXCEPT
     ItemSize(ImVec2(0, 0));
 }
 
-void ImGui::Dummy(const ImVec2& size) IMGUI_NOEXCEPT
+void ImGui::Dummy(const ImVec2& size) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -1326,7 +1326,7 @@ void ImGui::Dummy(const ImVec2& size) IMGUI_NOEXCEPT
     ItemAdd(bb, 0);
 }
 
-void ImGui::NewLine() IMGUI_NOEXCEPT
+void ImGui::NewLine() IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -1342,7 +1342,7 @@ void ImGui::NewLine() IMGUI_NOEXCEPT
     window->DC.LayoutType = backup_layout_type;
 }
 
-void ImGui::AlignTextToFramePadding() IMGUI_NOEXCEPT
+void ImGui::AlignTextToFramePadding() IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -1354,7 +1354,7 @@ void ImGui::AlignTextToFramePadding() IMGUI_NOEXCEPT
 }
 
 // Horizontal/vertical separating line
-void ImGui::SeparatorEx(ImGuiSeparatorFlags flags) IMGUI_NOEXCEPT
+void ImGui::SeparatorEx(ImGuiSeparatorFlags flags) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -1414,7 +1414,7 @@ void ImGui::SeparatorEx(ImGuiSeparatorFlags flags) IMGUI_NOEXCEPT
     }
 }
 
-void ImGui::Separator() IMGUI_NOEXCEPT
+void ImGui::Separator() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -1428,7 +1428,7 @@ void ImGui::Separator() IMGUI_NOEXCEPT
 }
 
 // Using 'hover_visibility_delay' allows us to hide the highlight and mouse cursor for a short time, which can be convenient to reduce visual noise.
-bool ImGui::SplitterBehavior(const ImRect& bb, ImGuiID id, ImGuiAxis axis, float* size1, float* size2, float min_size1, float min_size2, float hover_extend, float hover_visibility_delay) IMGUI_NOEXCEPT
+bool ImGui::SplitterBehavior(const ImRect& bb, ImGuiID id, ImGuiAxis axis, float* size1, float* size2, float min_size1, float min_size2, float hover_extend, float hover_visibility_delay) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -1496,7 +1496,7 @@ static int IMGUI_CDECL ShrinkWidthItemComparer(const void* lhs, const void* rhs)
 
 // Shrink excess width from a set of item, by removing width from the larger items first.
 // Set items Width to -1.0f to disable shrinking this item.
-void ImGui::ShrinkWidths(ImGuiShrinkWidthItem* items, int count, float width_excess) IMGUI_NOEXCEPT
+void ImGui::ShrinkWidths(ImGuiShrinkWidthItem* items, int count, float width_excess) IM_NOEXCEPT
 {
     if (count == 1)
     {
@@ -1542,7 +1542,7 @@ void ImGui::ShrinkWidths(ImGuiShrinkWidthItem* items, int count, float width_exc
 // - Combo()
 //-------------------------------------------------------------------------
 
-static float CalcMaxPopupHeightFromItemCount(int items_count) IMGUI_NOEXCEPT
+static float CalcMaxPopupHeightFromItemCount(int items_count) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (items_count <= 0)
@@ -1550,7 +1550,7 @@ static float CalcMaxPopupHeightFromItemCount(int items_count) IMGUI_NOEXCEPT
     return (g.FontSize + g.Style.ItemSpacing.y) * items_count - g.Style.ItemSpacing.y + (g.Style.WindowPadding.y * 2);
 }
 
-bool ImGui::BeginCombo(const char* label, const char* preview_value, ImGuiComboFlags flags) IMGUI_NOEXCEPT
+bool ImGui::BeginCombo(const char* label, const char* preview_value, ImGuiComboFlags flags) IM_NOEXCEPT
 {
     // Always consume the SetNextWindowSizeConstraint() call in our early return paths
     ImGuiContext& g = *GImGui;
@@ -1667,13 +1667,13 @@ bool ImGui::BeginCombo(const char* label, const char* preview_value, ImGuiComboF
     return true;
 }
 
-void ImGui::EndCombo() IMGUI_NOEXCEPT
+void ImGui::EndCombo() IM_NOEXCEPT
 {
     EndPopup();
 }
 
 // Getter for the old Combo() API: const char*[]
-static bool Items_ArrayGetter(void* data, int idx, const char** out_text) IMGUI_NOEXCEPT
+static bool Items_ArrayGetter(void* data, int idx, const char** out_text) IM_NOEXCEPT
 {
     const char* const* items = (const char* const*)data;
     if (out_text)
@@ -1682,7 +1682,7 @@ static bool Items_ArrayGetter(void* data, int idx, const char** out_text) IMGUI_
 }
 
 // Getter for the old Combo() API: "item1\0item2\0item3\0"
-static bool Items_SingleStringGetter(void* data, int idx, const char** out_text) IMGUI_NOEXCEPT
+static bool Items_SingleStringGetter(void* data, int idx, const char** out_text) IM_NOEXCEPT
 {
     // FIXME-OPT: we could pre-compute the indices to fasten this. But only 1 active combo means the waste is limited.
     const char* items_separated_by_zeros = (const char*)data;
@@ -1703,7 +1703,7 @@ static bool Items_SingleStringGetter(void* data, int idx, const char** out_text)
 }
 
 // Old API, prefer using BeginCombo() nowadays if you can.
-bool ImGui::Combo(const char* label, int* current_item, bool (*items_getter)(void*, int, const char**), void* data, int items_count, int popup_max_height_in_items) IMGUI_NOEXCEPT
+bool ImGui::Combo(const char* label, int* current_item, bool (*items_getter)(void*, int, const char**), void* data, int items_count, int popup_max_height_in_items) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -1747,14 +1747,14 @@ bool ImGui::Combo(const char* label, int* current_item, bool (*items_getter)(voi
 }
 
 // Combo box helper allowing to pass an array of strings.
-bool ImGui::Combo(const char* label, int* current_item, const char* const items[], int items_count, int height_in_items) IMGUI_NOEXCEPT
+bool ImGui::Combo(const char* label, int* current_item, const char* const items[], int items_count, int height_in_items) IM_NOEXCEPT
 {
     const bool value_changed = Combo(label, current_item, Items_ArrayGetter, (void*)items, items_count, height_in_items);
     return value_changed;
 }
 
 // Combo box helper allowing to pass all items in a single string literal holding multiple zero-terminated items "item1\0item2\0"
-bool ImGui::Combo(const char* label, int* current_item, const char* items_separated_by_zeros, int height_in_items) IMGUI_NOEXCEPT
+bool ImGui::Combo(const char* label, int* current_item, const char* items_separated_by_zeros, int height_in_items) IM_NOEXCEPT
 {
     int items_count = 0;
     const char* p = items_separated_by_zeros;       // FIXME-OPT: Avoid computing this, or at least only when combo is open
@@ -1803,7 +1803,7 @@ IM_STATIC_ASSERT(IM_ARRAYSIZE(GDataTypeInfo) == ImGuiDataType_COUNT);
 // FIXME-LEGACY: Prior to 1.61 our DragInt() function internally used floats and because of this the compile-time default value for format was "%.0f".
 // Even though we changed the compile-time default, we expect users to have carried %f around, which would break the display of DragInt() calls.
 // To honor backward compatibility we are rewriting the format string, unless IMGUI_DISABLE_OBSOLETE_FUNCTIONS is enabled. What could possibly go wrong?!
-static const char* PatchFormatStringFloatToInt(const char* fmt) IMGUI_NOEXCEPT
+static const char* PatchFormatStringFloatToInt(const char* fmt) IM_NOEXCEPT
 {
     if (fmt[0] == '%' && fmt[1] == '.' && fmt[2] == '0' && fmt[3] == 'f' && fmt[4] == 0) // Fast legacy path for "%.0f" which is expected to be the most common case.
         return "%d";
@@ -1824,13 +1824,13 @@ static const char* PatchFormatStringFloatToInt(const char* fmt) IMGUI_NOEXCEPT
     return fmt;
 }
 
-const ImGuiDataTypeInfo* ImGui::DataTypeGetInfo(ImGuiDataType data_type) IMGUI_NOEXCEPT
+const ImGuiDataTypeInfo* ImGui::DataTypeGetInfo(ImGuiDataType data_type) IM_NOEXCEPT
 {
     IM_ASSERT(data_type >= 0 && data_type < ImGuiDataType_COUNT);
     return &GDataTypeInfo[data_type];
 }
 
-int ImGui::DataTypeFormatString(char* buf, int buf_size, ImGuiDataType data_type, const void* p_data, const char* format) IMGUI_NOEXCEPT
+int ImGui::DataTypeFormatString(char* buf, int buf_size, ImGuiDataType data_type, const void* p_data, const char* format) IM_NOEXCEPT
 {
     // Signedness doesn't matter when pushing integer arguments
     if (data_type == ImGuiDataType_S32 || data_type == ImGuiDataType_U32)
@@ -1853,7 +1853,7 @@ int ImGui::DataTypeFormatString(char* buf, int buf_size, ImGuiDataType data_type
     return 0;
 }
 
-void ImGui::DataTypeApplyOp(ImGuiDataType data_type, int op, void* output, const void* arg1, const void* arg2) IMGUI_NOEXCEPT
+void ImGui::DataTypeApplyOp(ImGuiDataType data_type, int op, void* output, const void* arg1, const void* arg2) IM_NOEXCEPT
 {
     IM_ASSERT(op == '+' || op == '-');
     switch (data_type)
@@ -1905,7 +1905,7 @@ void ImGui::DataTypeApplyOp(ImGuiDataType data_type, int op, void* output, const
 
 // User can input math operators (e.g. +100) to edit a numerical values.
 // NB: This is _not_ a full expression evaluator. We should probably add one and replace this dumb mess..
-bool ImGui::DataTypeApplyOpFromText(const char* buf, const char* initial_value_buf, ImGuiDataType data_type, void* p_data, const char* format) IMGUI_NOEXCEPT
+bool ImGui::DataTypeApplyOpFromText(const char* buf, const char* initial_value_buf, ImGuiDataType data_type, void* p_data, const char* format) IM_NOEXCEPT
 {
     while (ImCharIsBlankA(*buf))
         buf++;
@@ -2007,14 +2007,14 @@ bool ImGui::DataTypeApplyOpFromText(const char* buf, const char* initial_value_b
 }
 
 template<typename T>
-static int DataTypeCompareT(const T* lhs, const T* rhs) IMGUI_NOEXCEPT
+static int DataTypeCompareT(const T* lhs, const T* rhs) IM_NOEXCEPT
 {
     if (*lhs < *rhs) return -1;
     if (*lhs > *rhs) return +1;
     return 0;
 }
 
-int ImGui::DataTypeCompare(ImGuiDataType data_type, const void* arg_1, const void* arg_2) IMGUI_NOEXCEPT
+int ImGui::DataTypeCompare(ImGuiDataType data_type, const void* arg_1, const void* arg_2) IM_NOEXCEPT
 {
     switch (data_type)
     {
@@ -2035,7 +2035,7 @@ int ImGui::DataTypeCompare(ImGuiDataType data_type, const void* arg_1, const voi
 }
 
 template<typename T>
-static bool DataTypeClampT(T* v, const T* v_min, const T* v_max) IMGUI_NOEXCEPT
+static bool DataTypeClampT(T* v, const T* v_min, const T* v_max) IM_NOEXCEPT
 {
     // Clamp, both sides are optional, return true if modified
     if (v_min && *v < *v_min) { *v = *v_min; return true; }
@@ -2043,7 +2043,7 @@ static bool DataTypeClampT(T* v, const T* v_min, const T* v_max) IMGUI_NOEXCEPT
     return false;
 }
 
-bool ImGui::DataTypeClamp(ImGuiDataType data_type, void* p_data, const void* p_min, const void* p_max) IMGUI_NOEXCEPT
+bool ImGui::DataTypeClamp(ImGuiDataType data_type, void* p_data, const void* p_min, const void* p_max) IM_NOEXCEPT
 {
     switch (data_type)
     {
@@ -2063,7 +2063,7 @@ bool ImGui::DataTypeClamp(ImGuiDataType data_type, void* p_data, const void* p_m
     return false;
 }
 
-static float GetMinimumStepAtDecimalPrecision(int decimal_precision) IMGUI_NOEXCEPT
+static float GetMinimumStepAtDecimalPrecision(int decimal_precision) IM_NOEXCEPT
 {
     static const float min_steps[10] = { 1.0f, 0.1f, 0.01f, 0.001f, 0.0001f, 0.00001f, 0.000001f, 0.0000001f, 0.00000001f, 0.000000001f };
     if (decimal_precision < 0)
@@ -2072,7 +2072,7 @@ static float GetMinimumStepAtDecimalPrecision(int decimal_precision) IMGUI_NOEXC
 }
 
 template<typename TYPE>
-static const char* ImAtoi(const char* src, TYPE* output) IMGUI_NOEXCEPT
+static const char* ImAtoi(const char* src, TYPE* output) IM_NOEXCEPT
 {
     int negative = 0;
     if (*src == '-') { negative = 1; src++; }
@@ -2087,7 +2087,7 @@ static const char* ImAtoi(const char* src, TYPE* output) IMGUI_NOEXCEPT
 // Sanitize format
 // - Zero terminate so extra characters after format (e.g. "%f123") don't confuse atof/atoi
 // - stb_sprintf.h supports several new modifiers which format numbers in a way that also makes them incompatible atof/atoi.
-static void SanitizeFormatString(const char* fmt, char* fmt_out, size_t fmt_out_size) IMGUI_NOEXCEPT
+static void SanitizeFormatString(const char* fmt, char* fmt_out, size_t fmt_out_size) IM_NOEXCEPT
 {
     IM_UNUSED(fmt_out_size);
     const char* fmt_end = ImParseFormatFindEnd(fmt);
@@ -2102,7 +2102,7 @@ static void SanitizeFormatString(const char* fmt, char* fmt_out, size_t fmt_out_
 }
 
 template<typename TYPE, typename SIGNEDTYPE>
-TYPE ImGui::RoundScalarWithFormatT(const char* format, ImGuiDataType data_type, TYPE v) IMGUI_NOEXCEPT
+TYPE ImGui::RoundScalarWithFormatT(const char* format, ImGuiDataType data_type, TYPE v) IM_NOEXCEPT
 {
     const char* fmt_start = ImParseFormatFindStart(format);
     if (fmt_start[0] != '%' || fmt_start[1] == '%') // Don't apply if the value is not visible in the format string
@@ -2147,7 +2147,7 @@ TYPE ImGui::RoundScalarWithFormatT(const char* format, ImGuiDataType data_type, 
 
 // This is called by DragBehavior() when the widget is active (held by mouse or being manipulated with Nav controls)
 template<typename TYPE, typename SIGNEDTYPE, typename FLOATTYPE>
-bool ImGui::DragBehaviorT(ImGuiDataType data_type, TYPE* v, float v_speed, const TYPE v_min, const TYPE v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
+bool ImGui::DragBehaviorT(ImGuiDataType data_type, TYPE* v, float v_speed, const TYPE v_min, const TYPE v_max, const char* format, ImGuiSliderFlags flags) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     const ImGuiAxis axis = (flags & ImGuiSliderFlags_Vertical) ? ImGuiAxis_Y : ImGuiAxis_X;
@@ -2262,7 +2262,7 @@ bool ImGui::DragBehaviorT(ImGuiDataType data_type, TYPE* v, float v_speed, const
     return true;
 }
 
-bool ImGui::DragBehavior(ImGuiID id, ImGuiDataType data_type, void* p_v, float v_speed, const void* p_min, const void* p_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
+bool ImGui::DragBehavior(ImGuiID id, ImGuiDataType data_type, void* p_v, float v_speed, const void* p_min, const void* p_max, const char* format, ImGuiSliderFlags flags) IM_NOEXCEPT
 {
     // Read imgui.cpp "API BREAKING CHANGES" section for 1.78 if you hit this assert.
     IM_ASSERT((flags == 1 || (flags & ImGuiSliderFlags_InvalidMask_) == 0) && "Invalid ImGuiSliderFlags flags! Has the 'float power' argument been mistakenly cast to flags? Call function with ImGuiSliderFlags_Logarithmic flags instead.");
@@ -2300,7 +2300,7 @@ bool ImGui::DragBehavior(ImGuiID id, ImGuiDataType data_type, void* p_v, float v
 
 // Note: p_data, p_min and p_max are _pointers_ to a memory address holding the data. For a Drag widget, p_min and p_max are optional.
 // Read code of e.g. DragFloat(), DragInt() etc. or examples in 'Demo->Widgets->Data Types' to understand how to use this function directly.
-bool ImGui::DragScalar(const char* label, ImGuiDataType data_type, void* p_data, float v_speed, const void* p_min, const void* p_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
+bool ImGui::DragScalar(const char* label, ImGuiDataType data_type, void* p_data, float v_speed, const void* p_min, const void* p_max, const char* format, ImGuiSliderFlags flags) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -2384,7 +2384,7 @@ bool ImGui::DragScalar(const char* label, ImGuiDataType data_type, void* p_data,
     return value_changed;
 }
 
-bool ImGui::DragScalarN(const char* label, ImGuiDataType data_type, void* p_data, int components, float v_speed, const void* p_min, const void* p_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
+bool ImGui::DragScalarN(const char* label, ImGuiDataType data_type, void* p_data, int components, float v_speed, const void* p_min, const void* p_max, const char* format, ImGuiSliderFlags flags) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -2419,28 +2419,28 @@ bool ImGui::DragScalarN(const char* label, ImGuiDataType data_type, void* p_data
     return value_changed;
 }
 
-bool ImGui::DragFloat(const char* label, float* v, float v_speed, float v_min, float v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
+bool ImGui::DragFloat(const char* label, float* v, float v_speed, float v_min, float v_max, const char* format, ImGuiSliderFlags flags) IM_NOEXCEPT
 {
     return DragScalar(label, ImGuiDataType_Float, v, v_speed, &v_min, &v_max, format, flags);
 }
 
-bool ImGui::DragFloat2(const char* label, float v[2], float v_speed, float v_min, float v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
+bool ImGui::DragFloat2(const char* label, float v[2], float v_speed, float v_min, float v_max, const char* format, ImGuiSliderFlags flags) IM_NOEXCEPT
 {
     return DragScalarN(label, ImGuiDataType_Float, v, 2, v_speed, &v_min, &v_max, format, flags);
 }
 
-bool ImGui::DragFloat3(const char* label, float v[3], float v_speed, float v_min, float v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
+bool ImGui::DragFloat3(const char* label, float v[3], float v_speed, float v_min, float v_max, const char* format, ImGuiSliderFlags flags) IM_NOEXCEPT
 {
     return DragScalarN(label, ImGuiDataType_Float, v, 3, v_speed, &v_min, &v_max, format, flags);
 }
 
-bool ImGui::DragFloat4(const char* label, float v[4], float v_speed, float v_min, float v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
+bool ImGui::DragFloat4(const char* label, float v[4], float v_speed, float v_min, float v_max, const char* format, ImGuiSliderFlags flags) IM_NOEXCEPT
 {
     return DragScalarN(label, ImGuiDataType_Float, v, 4, v_speed, &v_min, &v_max, format, flags);
 }
 
 // NB: You likely want to specify the ImGuiSliderFlags_AlwaysClamp when using this.
-bool ImGui::DragFloatRange2(const char* label, float* v_current_min, float* v_current_max, float v_speed, float v_min, float v_max, const char* format, const char* format_max, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
+bool ImGui::DragFloatRange2(const char* label, float* v_current_min, float* v_current_max, float v_speed, float v_min, float v_max, const char* format, const char* format_max, ImGuiSliderFlags flags) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -2472,28 +2472,28 @@ bool ImGui::DragFloatRange2(const char* label, float* v_current_min, float* v_cu
 }
 
 // NB: v_speed is float to allow adjusting the drag speed with more precision
-bool ImGui::DragInt(const char* label, int* v, float v_speed, int v_min, int v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
+bool ImGui::DragInt(const char* label, int* v, float v_speed, int v_min, int v_max, const char* format, ImGuiSliderFlags flags) IM_NOEXCEPT
 {
     return DragScalar(label, ImGuiDataType_S32, v, v_speed, &v_min, &v_max, format, flags);
 }
 
-bool ImGui::DragInt2(const char* label, int v[2], float v_speed, int v_min, int v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
+bool ImGui::DragInt2(const char* label, int v[2], float v_speed, int v_min, int v_max, const char* format, ImGuiSliderFlags flags) IM_NOEXCEPT
 {
     return DragScalarN(label, ImGuiDataType_S32, v, 2, v_speed, &v_min, &v_max, format, flags);
 }
 
-bool ImGui::DragInt3(const char* label, int v[3], float v_speed, int v_min, int v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
+bool ImGui::DragInt3(const char* label, int v[3], float v_speed, int v_min, int v_max, const char* format, ImGuiSliderFlags flags) IM_NOEXCEPT
 {
     return DragScalarN(label, ImGuiDataType_S32, v, 3, v_speed, &v_min, &v_max, format, flags);
 }
 
-bool ImGui::DragInt4(const char* label, int v[4], float v_speed, int v_min, int v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
+bool ImGui::DragInt4(const char* label, int v[4], float v_speed, int v_min, int v_max, const char* format, ImGuiSliderFlags flags) IM_NOEXCEPT
 {
     return DragScalarN(label, ImGuiDataType_S32, v, 4, v_speed, &v_min, &v_max, format, flags);
 }
 
 // NB: You likely want to specify the ImGuiSliderFlags_AlwaysClamp when using this.
-bool ImGui::DragIntRange2(const char* label, int* v_current_min, int* v_current_max, float v_speed, int v_min, int v_max, const char* format, const char* format_max, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
+bool ImGui::DragIntRange2(const char* label, int* v_current_min, int* v_current_max, float v_speed, int v_min, int v_max, const char* format, const char* format_max, ImGuiSliderFlags flags) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -2528,7 +2528,7 @@ bool ImGui::DragIntRange2(const char* label, int* v_current_min, int* v_current_
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
 
 // Obsolete versions with power parameter. See https://github.com/ocornut/imgui/issues/3361 for details.
-bool ImGui::DragScalar(const char* label, ImGuiDataType data_type, void* p_data, float v_speed, const void* p_min, const void* p_max, const char* format, float power) IMGUI_NOEXCEPT
+bool ImGui::DragScalar(const char* label, ImGuiDataType data_type, void* p_data, float v_speed, const void* p_min, const void* p_max, const char* format, float power) IM_NOEXCEPT
 {
     ImGuiSliderFlags drag_flags = ImGuiSliderFlags_None;
     if (power != 1.0f)
@@ -2540,7 +2540,7 @@ bool ImGui::DragScalar(const char* label, ImGuiDataType data_type, void* p_data,
     return DragScalar(label, data_type, p_data, v_speed, p_min, p_max, format, drag_flags);
 }
 
-bool ImGui::DragScalarN(const char* label, ImGuiDataType data_type, void* p_data, int components, float v_speed, const void* p_min, const void* p_max, const char* format, float power) IMGUI_NOEXCEPT
+bool ImGui::DragScalarN(const char* label, ImGuiDataType data_type, void* p_data, int components, float v_speed, const void* p_min, const void* p_max, const char* format, float power) IM_NOEXCEPT
 {
     ImGuiSliderFlags drag_flags = ImGuiSliderFlags_None;
     if (power != 1.0f)
@@ -2579,7 +2579,7 @@ bool ImGui::DragScalarN(const char* label, ImGuiDataType data_type, void* p_data
 
 // Convert a value v in the output space of a slider into a parametric position on the slider itself (the logical opposite of ScaleValueFromRatioT)
 template<typename TYPE, typename SIGNEDTYPE, typename FLOATTYPE>
-float ImGui::ScaleRatioFromValueT(ImGuiDataType data_type, TYPE v, TYPE v_min, TYPE v_max, bool is_logarithmic, float logarithmic_zero_epsilon, float zero_deadzone_halfsize) IMGUI_NOEXCEPT
+float ImGui::ScaleRatioFromValueT(ImGuiDataType data_type, TYPE v, TYPE v_min, TYPE v_max, bool is_logarithmic, float logarithmic_zero_epsilon, float zero_deadzone_halfsize) IM_NOEXCEPT
 {
     if (v_min == v_max)
         return 0.0f;
@@ -2635,7 +2635,7 @@ float ImGui::ScaleRatioFromValueT(ImGuiDataType data_type, TYPE v, TYPE v_min, T
 
 // Convert a parametric position on a slider into a value v in the output space (the logical opposite of ScaleRatioFromValueT)
 template<typename TYPE, typename SIGNEDTYPE, typename FLOATTYPE>
-TYPE ImGui::ScaleValueFromRatioT(ImGuiDataType data_type, float t, TYPE v_min, TYPE v_max, bool is_logarithmic, float logarithmic_zero_epsilon, float zero_deadzone_halfsize) IMGUI_NOEXCEPT
+TYPE ImGui::ScaleValueFromRatioT(ImGuiDataType data_type, float t, TYPE v_min, TYPE v_max, bool is_logarithmic, float logarithmic_zero_epsilon, float zero_deadzone_halfsize) IM_NOEXCEPT
 {
     if (v_min == v_max)
         return v_min;
@@ -2714,7 +2714,7 @@ TYPE ImGui::ScaleValueFromRatioT(ImGuiDataType data_type, float t, TYPE v_min, T
 
 // FIXME: Move more of the code into SliderBehavior()
 template<typename TYPE, typename SIGNEDTYPE, typename FLOATTYPE>
-bool ImGui::SliderBehaviorT(const ImRect& bb, ImGuiID id, ImGuiDataType data_type, TYPE* v, const TYPE v_min, const TYPE v_max, const char* format, ImGuiSliderFlags flags, ImRect* out_grab_bb) IMGUI_NOEXCEPT
+bool ImGui::SliderBehaviorT(const ImRect& bb, ImGuiID id, ImGuiDataType data_type, TYPE* v, const TYPE v_min, const TYPE v_max, const char* format, ImGuiSliderFlags flags, ImRect* out_grab_bb) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     const ImGuiStyle& style = g.Style;
@@ -2874,7 +2874,7 @@ bool ImGui::SliderBehaviorT(const ImRect& bb, ImGuiID id, ImGuiDataType data_typ
 // For 32-bit and larger types, slider bounds are limited to half the natural type range.
 // So e.g. an integer Slider between INT_MAX-10 and INT_MAX will fail, but an integer Slider between INT_MAX/2-10 and INT_MAX/2 will be ok.
 // It would be possible to lift that limitation with some work but it doesn't seem to be worth it for sliders.
-bool ImGui::SliderBehavior(const ImRect& bb, ImGuiID id, ImGuiDataType data_type, void* p_v, const void* p_min, const void* p_max, const char* format, ImGuiSliderFlags flags, ImRect* out_grab_bb) IMGUI_NOEXCEPT
+bool ImGui::SliderBehavior(const ImRect& bb, ImGuiID id, ImGuiDataType data_type, void* p_v, const void* p_min, const void* p_max, const char* format, ImGuiSliderFlags flags, ImRect* out_grab_bb) IM_NOEXCEPT
 {
     // Read imgui.cpp "API BREAKING CHANGES" section for 1.78 if you hit this assert.
     IM_ASSERT((flags == 1 || (flags & ImGuiSliderFlags_InvalidMask_) == 0) && "Invalid ImGuiSliderFlags flag!  Has the 'float power' argument been mistakenly cast to flags? Call function with ImGuiSliderFlags_Logarithmic flags instead.");
@@ -2915,7 +2915,7 @@ bool ImGui::SliderBehavior(const ImRect& bb, ImGuiID id, ImGuiDataType data_type
 
 // Note: p_data, p_min and p_max are _pointers_ to a memory address holding the data. For a slider, they are all required.
 // Read code of e.g. SliderFloat(), SliderInt() etc. or examples in 'Demo->Widgets->Data Types' to understand how to use this function directly.
-bool ImGui::SliderScalar(const char* label, ImGuiDataType data_type, void* p_data, const void* p_min, const void* p_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
+bool ImGui::SliderScalar(const char* label, ImGuiDataType data_type, void* p_data, const void* p_min, const void* p_max, const char* format, ImGuiSliderFlags flags) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -2996,7 +2996,7 @@ bool ImGui::SliderScalar(const char* label, ImGuiDataType data_type, void* p_dat
 }
 
 // Add multiple sliders on 1 line for compact edition of multiple components
-bool ImGui::SliderScalarN(const char* label, ImGuiDataType data_type, void* v, int components, const void* v_min, const void* v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
+bool ImGui::SliderScalarN(const char* label, ImGuiDataType data_type, void* v, int components, const void* v_min, const void* v_max, const char* format, ImGuiSliderFlags flags) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -3031,27 +3031,27 @@ bool ImGui::SliderScalarN(const char* label, ImGuiDataType data_type, void* v, i
     return value_changed;
 }
 
-bool ImGui::SliderFloat(const char* label, float* v, float v_min, float v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
+bool ImGui::SliderFloat(const char* label, float* v, float v_min, float v_max, const char* format, ImGuiSliderFlags flags) IM_NOEXCEPT
 {
     return SliderScalar(label, ImGuiDataType_Float, v, &v_min, &v_max, format, flags);
 }
 
-bool ImGui::SliderFloat2(const char* label, float v[2], float v_min, float v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
+bool ImGui::SliderFloat2(const char* label, float v[2], float v_min, float v_max, const char* format, ImGuiSliderFlags flags) IM_NOEXCEPT
 {
     return SliderScalarN(label, ImGuiDataType_Float, v, 2, &v_min, &v_max, format, flags);
 }
 
-bool ImGui::SliderFloat3(const char* label, float v[3], float v_min, float v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
+bool ImGui::SliderFloat3(const char* label, float v[3], float v_min, float v_max, const char* format, ImGuiSliderFlags flags) IM_NOEXCEPT
 {
     return SliderScalarN(label, ImGuiDataType_Float, v, 3, &v_min, &v_max, format, flags);
 }
 
-bool ImGui::SliderFloat4(const char* label, float v[4], float v_min, float v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
+bool ImGui::SliderFloat4(const char* label, float v[4], float v_min, float v_max, const char* format, ImGuiSliderFlags flags) IM_NOEXCEPT
 {
     return SliderScalarN(label, ImGuiDataType_Float, v, 4, &v_min, &v_max, format, flags);
 }
 
-bool ImGui::SliderAngle(const char* label, float* v_rad, float v_degrees_min, float v_degrees_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
+bool ImGui::SliderAngle(const char* label, float* v_rad, float v_degrees_min, float v_degrees_max, const char* format, ImGuiSliderFlags flags) IM_NOEXCEPT
 {
     if (format == NULL)
         format = "%.0f deg";
@@ -3061,27 +3061,27 @@ bool ImGui::SliderAngle(const char* label, float* v_rad, float v_degrees_min, fl
     return value_changed;
 }
 
-bool ImGui::SliderInt(const char* label, int* v, int v_min, int v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
+bool ImGui::SliderInt(const char* label, int* v, int v_min, int v_max, const char* format, ImGuiSliderFlags flags) IM_NOEXCEPT
 {
     return SliderScalar(label, ImGuiDataType_S32, v, &v_min, &v_max, format, flags);
 }
 
-bool ImGui::SliderInt2(const char* label, int v[2], int v_min, int v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
+bool ImGui::SliderInt2(const char* label, int v[2], int v_min, int v_max, const char* format, ImGuiSliderFlags flags) IM_NOEXCEPT
 {
     return SliderScalarN(label, ImGuiDataType_S32, v, 2, &v_min, &v_max, format, flags);
 }
 
-bool ImGui::SliderInt3(const char* label, int v[3], int v_min, int v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
+bool ImGui::SliderInt3(const char* label, int v[3], int v_min, int v_max, const char* format, ImGuiSliderFlags flags) IM_NOEXCEPT
 {
     return SliderScalarN(label, ImGuiDataType_S32, v, 3, &v_min, &v_max, format, flags);
 }
 
-bool ImGui::SliderInt4(const char* label, int v[4], int v_min, int v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
+bool ImGui::SliderInt4(const char* label, int v[4], int v_min, int v_max, const char* format, ImGuiSliderFlags flags) IM_NOEXCEPT
 {
     return SliderScalarN(label, ImGuiDataType_S32, v, 4, &v_min, &v_max, format, flags);
 }
 
-bool ImGui::VSliderScalar(const char* label, const ImVec2& size, ImGuiDataType data_type, void* p_data, const void* p_min, const void* p_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
+bool ImGui::VSliderScalar(const char* label, const ImVec2& size, ImGuiDataType data_type, void* p_data, const void* p_min, const void* p_max, const char* format, ImGuiSliderFlags flags) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -3140,12 +3140,12 @@ bool ImGui::VSliderScalar(const char* label, const ImVec2& size, ImGuiDataType d
     return value_changed;
 }
 
-bool ImGui::VSliderFloat(const char* label, const ImVec2& size, float* v, float v_min, float v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
+bool ImGui::VSliderFloat(const char* label, const ImVec2& size, float* v, float v_min, float v_max, const char* format, ImGuiSliderFlags flags) IM_NOEXCEPT
 {
     return VSliderScalar(label, size, ImGuiDataType_Float, v, &v_min, &v_max, format, flags);
 }
 
-bool ImGui::VSliderInt(const char* label, const ImVec2& size, int* v, int v_min, int v_max, const char* format, ImGuiSliderFlags flags) IMGUI_NOEXCEPT
+bool ImGui::VSliderInt(const char* label, const ImVec2& size, int* v, int v_min, int v_max, const char* format, ImGuiSliderFlags flags) IM_NOEXCEPT
 {
     return VSliderScalar(label, size, ImGuiDataType_S32, v, &v_min, &v_max, format, flags);
 }
@@ -3153,7 +3153,7 @@ bool ImGui::VSliderInt(const char* label, const ImVec2& size, int* v, int v_min,
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
 
 // Obsolete versions with power parameter. See https://github.com/ocornut/imgui/issues/3361 for details.
-bool ImGui::SliderScalar(const char* label, ImGuiDataType data_type, void* p_data, const void* p_min, const void* p_max, const char* format, float power) IMGUI_NOEXCEPT
+bool ImGui::SliderScalar(const char* label, ImGuiDataType data_type, void* p_data, const void* p_min, const void* p_max, const char* format, float power) IM_NOEXCEPT
 {
     ImGuiSliderFlags slider_flags = ImGuiSliderFlags_None;
     if (power != 1.0f)
@@ -3164,7 +3164,7 @@ bool ImGui::SliderScalar(const char* label, ImGuiDataType data_type, void* p_dat
     return SliderScalar(label, data_type, p_data, p_min, p_max, format, slider_flags);
 }
 
-bool ImGui::SliderScalarN(const char* label, ImGuiDataType data_type, void* v, int components, const void* v_min, const void* v_max, const char* format, float power) IMGUI_NOEXCEPT
+bool ImGui::SliderScalarN(const char* label, ImGuiDataType data_type, void* v, int components, const void* v_min, const void* v_max, const char* format, float power) IM_NOEXCEPT
 {
     ImGuiSliderFlags slider_flags = ImGuiSliderFlags_None;
     if (power != 1.0f)
@@ -3199,7 +3199,7 @@ bool ImGui::SliderScalarN(const char* label, ImGuiDataType data_type, void* v, i
 //-------------------------------------------------------------------------
 
 // We don't use strchr() because our strings are usually very short and often start with '%'
-const char* ImParseFormatFindStart(const char* fmt) IMGUI_NOEXCEPT
+const char* ImParseFormatFindStart(const char* fmt) IM_NOEXCEPT
 {
     while (char c = fmt[0])
     {
@@ -3212,7 +3212,7 @@ const char* ImParseFormatFindStart(const char* fmt) IMGUI_NOEXCEPT
     return fmt;
 }
 
-const char* ImParseFormatFindEnd(const char* fmt) IMGUI_NOEXCEPT
+const char* ImParseFormatFindEnd(const char* fmt) IM_NOEXCEPT
 {
     // Printf/scanf types modifiers: I/L/h/j/l/t/w/z. Other uppercase letters qualify as types aka end of the format.
     if (fmt[0] != '%')
@@ -3234,7 +3234,7 @@ const char* ImParseFormatFindEnd(const char* fmt) IMGUI_NOEXCEPT
 //  fmt = "%.3f"       -> return fmt
 //  fmt = "hello %.3f" -> return fmt + 6
 //  fmt = "%.3f hello" -> return buf written with "%.3f"
-const char* ImParseFormatTrimDecorations(const char* fmt, char* buf, size_t buf_size) IMGUI_NOEXCEPT
+const char* ImParseFormatTrimDecorations(const char* fmt, char* buf, size_t buf_size) IM_NOEXCEPT
 {
     const char* fmt_start = ImParseFormatFindStart(fmt);
     if (fmt_start[0] != '%')
@@ -3248,7 +3248,7 @@ const char* ImParseFormatTrimDecorations(const char* fmt, char* buf, size_t buf_
 
 // Parse display precision back from the display format string
 // FIXME: This is still used by some navigation code path to infer a minimum tweak step, but we should aim to rework widgets so it isn't needed.
-int ImParseFormatPrecision(const char* fmt, int default_precision) IMGUI_NOEXCEPT
+int ImParseFormatPrecision(const char* fmt, int default_precision) IM_NOEXCEPT
 {
     fmt = ImParseFormatFindStart(fmt);
     if (fmt[0] != '%')
@@ -3272,7 +3272,7 @@ int ImParseFormatPrecision(const char* fmt, int default_precision) IMGUI_NOEXCEP
 
 // Create text input in place of another active widget (e.g. used when doing a CTRL+Click on drag/slider widgets)
 // FIXME: Facilitate using this in variety of other situations.
-bool ImGui::TempInputText(const ImRect& bb, ImGuiID id, const char* label, char* buf, int buf_size, ImGuiInputTextFlags flags) IMGUI_NOEXCEPT
+bool ImGui::TempInputText(const ImRect& bb, ImGuiID id, const char* label, char* buf, int buf_size, ImGuiInputTextFlags flags) IM_NOEXCEPT
 {
     // On the first frame, g.TempInputTextId == 0, then on subsequent frames it becomes == id.
     // We clear ActiveID on the first frame to allow the InputText() taking it back.
@@ -3295,7 +3295,7 @@ bool ImGui::TempInputText(const ImRect& bb, ImGuiID id, const char* label, char*
 // Note that Drag/Slider functions are only forwarding the min/max values clamping values if the ImGuiSliderFlags_AlwaysClamp flag is set!
 // This is intended: this way we allow CTRL+Click manual input to set a value out of bounds, for maximum flexibility.
 // However this may not be ideal for all uses, as some user code may break on out of bound values.
-bool ImGui::TempInputScalar(const ImRect& bb, ImGuiID id, const char* label, ImGuiDataType data_type, void* p_data, const char* format, const void* p_clamp_min, const void* p_clamp_max) IMGUI_NOEXCEPT
+bool ImGui::TempInputScalar(const ImRect& bb, ImGuiID id, const char* label, ImGuiDataType data_type, void* p_data, const char* format, const void* p_clamp_min, const void* p_clamp_max) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -3334,7 +3334,7 @@ bool ImGui::TempInputScalar(const ImRect& bb, ImGuiID id, const char* label, ImG
 
 // Note: p_data, p_step, p_step_fast are _pointers_ to a memory address holding the data. For an Input widget, p_step and p_step_fast are optional.
 // Read code of e.g. InputFloat(), InputInt() etc. or examples in 'Demo->Widgets->Data Types' to understand how to use this function directly.
-bool ImGui::InputScalar(const char* label, ImGuiDataType data_type, void* p_data, const void* p_step, const void* p_step_fast, const char* format, ImGuiInputTextFlags flags) IMGUI_NOEXCEPT
+bool ImGui::InputScalar(const char* label, ImGuiDataType data_type, void* p_data, const void* p_step, const void* p_step_fast, const char* format, ImGuiInputTextFlags flags) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -3406,7 +3406,7 @@ bool ImGui::InputScalar(const char* label, ImGuiDataType data_type, void* p_data
     return value_changed;
 }
 
-bool ImGui::InputScalarN(const char* label, ImGuiDataType data_type, void* p_data, int components, const void* p_step, const void* p_step_fast, const char* format, ImGuiInputTextFlags flags) IMGUI_NOEXCEPT
+bool ImGui::InputScalarN(const char* label, ImGuiDataType data_type, void* p_data, int components, const void* p_step, const void* p_step_fast, const char* format, ImGuiInputTextFlags flags) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -3441,50 +3441,50 @@ bool ImGui::InputScalarN(const char* label, ImGuiDataType data_type, void* p_dat
     return value_changed;
 }
 
-bool ImGui::InputFloat(const char* label, float* v, float step, float step_fast, const char* format, ImGuiInputTextFlags flags) IMGUI_NOEXCEPT
+bool ImGui::InputFloat(const char* label, float* v, float step, float step_fast, const char* format, ImGuiInputTextFlags flags) IM_NOEXCEPT
 {
     flags |= ImGuiInputTextFlags_CharsScientific;
     return InputScalar(label, ImGuiDataType_Float, (void*)v, (void*)(step > 0.0f ? &step : NULL), (void*)(step_fast > 0.0f ? &step_fast : NULL), format, flags);
 }
 
-bool ImGui::InputFloat2(const char* label, float v[2], const char* format, ImGuiInputTextFlags flags) IMGUI_NOEXCEPT
+bool ImGui::InputFloat2(const char* label, float v[2], const char* format, ImGuiInputTextFlags flags) IM_NOEXCEPT
 {
     return InputScalarN(label, ImGuiDataType_Float, v, 2, NULL, NULL, format, flags);
 }
 
-bool ImGui::InputFloat3(const char* label, float v[3], const char* format, ImGuiInputTextFlags flags) IMGUI_NOEXCEPT
+bool ImGui::InputFloat3(const char* label, float v[3], const char* format, ImGuiInputTextFlags flags) IM_NOEXCEPT
 {
     return InputScalarN(label, ImGuiDataType_Float, v, 3, NULL, NULL, format, flags);
 }
 
-bool ImGui::InputFloat4(const char* label, float v[4], const char* format, ImGuiInputTextFlags flags) IMGUI_NOEXCEPT
+bool ImGui::InputFloat4(const char* label, float v[4], const char* format, ImGuiInputTextFlags flags) IM_NOEXCEPT
 {
     return InputScalarN(label, ImGuiDataType_Float, v, 4, NULL, NULL, format, flags);
 }
 
-bool ImGui::InputInt(const char* label, int* v, int step, int step_fast, ImGuiInputTextFlags flags) IMGUI_NOEXCEPT
+bool ImGui::InputInt(const char* label, int* v, int step, int step_fast, ImGuiInputTextFlags flags) IM_NOEXCEPT
 {
     // Hexadecimal input provided as a convenience but the flag name is awkward. Typically you'd use InputText() to parse your own data, if you want to handle prefixes.
     const char* format = (flags & ImGuiInputTextFlags_CharsHexadecimal) ? "%08X" : "%d";
     return InputScalar(label, ImGuiDataType_S32, (void*)v, (void*)(step > 0 ? &step : NULL), (void*)(step_fast > 0 ? &step_fast : NULL), format, flags);
 }
 
-bool ImGui::InputInt2(const char* label, int v[2], ImGuiInputTextFlags flags) IMGUI_NOEXCEPT
+bool ImGui::InputInt2(const char* label, int v[2], ImGuiInputTextFlags flags) IM_NOEXCEPT
 {
     return InputScalarN(label, ImGuiDataType_S32, v, 2, NULL, NULL, "%d", flags);
 }
 
-bool ImGui::InputInt3(const char* label, int v[3], ImGuiInputTextFlags flags) IMGUI_NOEXCEPT
+bool ImGui::InputInt3(const char* label, int v[3], ImGuiInputTextFlags flags) IM_NOEXCEPT
 {
     return InputScalarN(label, ImGuiDataType_S32, v, 3, NULL, NULL, "%d", flags);
 }
 
-bool ImGui::InputInt4(const char* label, int v[4], ImGuiInputTextFlags flags) IMGUI_NOEXCEPT
+bool ImGui::InputInt4(const char* label, int v[4], ImGuiInputTextFlags flags) IM_NOEXCEPT
 {
     return InputScalarN(label, ImGuiDataType_S32, v, 4, NULL, NULL, "%d", flags);
 }
 
-bool ImGui::InputDouble(const char* label, double* v, double step, double step_fast, const char* format, ImGuiInputTextFlags flags) IMGUI_NOEXCEPT
+bool ImGui::InputDouble(const char* label, double* v, double step, double step_fast, const char* format, ImGuiInputTextFlags flags) IM_NOEXCEPT
 {
     flags |= ImGuiInputTextFlags_CharsScientific;
     return InputScalar(label, ImGuiDataType_Double, (void*)v, (void*)(step > 0.0 ? &step : NULL), (void*)(step_fast > 0.0 ? &step_fast : NULL), format, flags);
@@ -3499,24 +3499,24 @@ bool ImGui::InputDouble(const char* label, double* v, double step, double step_f
 // - InputTextEx() [Internal]
 //-------------------------------------------------------------------------
 
-bool ImGui::InputText(const char* label, char* buf, size_t buf_size, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback, void* user_data) IMGUI_NOEXCEPT
+bool ImGui::InputText(const char* label, char* buf, size_t buf_size, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback, void* user_data) IM_NOEXCEPT
 {
     IM_ASSERT(!(flags & ImGuiInputTextFlags_Multiline)); // call InputTextMultiline()
     return InputTextEx(label, NULL, buf, (int)buf_size, ImVec2(0, 0), flags, callback, user_data);
 }
 
-bool ImGui::InputTextMultiline(const char* label, char* buf, size_t buf_size, const ImVec2& size, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback, void* user_data) IMGUI_NOEXCEPT
+bool ImGui::InputTextMultiline(const char* label, char* buf, size_t buf_size, const ImVec2& size, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback, void* user_data) IM_NOEXCEPT
 {
     return InputTextEx(label, NULL, buf, (int)buf_size, size, flags | ImGuiInputTextFlags_Multiline, callback, user_data);
 }
 
-bool ImGui::InputTextWithHint(const char* label, const char* hint, char* buf, size_t buf_size, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback, void* user_data) IMGUI_NOEXCEPT
+bool ImGui::InputTextWithHint(const char* label, const char* hint, char* buf, size_t buf_size, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback, void* user_data) IM_NOEXCEPT
 {
     IM_ASSERT(!(flags & ImGuiInputTextFlags_Multiline)); // call InputTextMultiline()
     return InputTextEx(label, hint, buf, (int)buf_size, ImVec2(0, 0), flags, callback, user_data);
 }
 
-static int InputTextCalcTextLenAndLineCount(const char* text_begin, const char** out_text_end) IMGUI_NOEXCEPT
+static int InputTextCalcTextLenAndLineCount(const char* text_begin, const char** out_text_end) IM_NOEXCEPT
 {
     int line_count = 0;
     const char* s = text_begin;
@@ -3530,7 +3530,7 @@ static int InputTextCalcTextLenAndLineCount(const char* text_begin, const char**
     return line_count;
 }
 
-static ImVec2 InputTextCalcTextSizeW(const ImWchar* text_begin, const ImWchar* text_end, const ImWchar** remaining, ImVec2* out_offset, bool stop_on_new_line) IMGUI_NOEXCEPT
+static ImVec2 InputTextCalcTextSizeW(const ImWchar* text_begin, const ImWchar* text_end, const ImWchar** remaining, ImVec2* out_offset, bool stop_on_new_line) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImFont* font = g.Font;
@@ -3579,12 +3579,12 @@ static ImVec2 InputTextCalcTextSizeW(const ImWchar* text_begin, const ImWchar* t
 namespace ImStb
 {
 
-static int     STB_TEXTEDIT_STRINGLEN(const ImGuiInputTextState* obj)                            IMGUI_NOEXCEPT { return obj->CurLenW; }
-static ImWchar STB_TEXTEDIT_GETCHAR(const ImGuiInputTextState* obj, int idx)                     IMGUI_NOEXCEPT { return obj->TextW[idx]; }
-static float   STB_TEXTEDIT_GETWIDTH(ImGuiInputTextState* obj, int line_start_idx, int char_idx) IMGUI_NOEXCEPT { ImWchar c = obj->TextW[line_start_idx + char_idx]; if (c == '\n') return STB_TEXTEDIT_GETWIDTH_NEWLINE; ImGuiContext& g = *GImGui; return g.Font->GetCharAdvance(c) * (g.FontSize / g.Font->FontSize); }
-static int     STB_TEXTEDIT_KEYTOTEXT(int key)                                                   IMGUI_NOEXCEPT { return key >= 0x200000 ? 0 : key; }
+static int     STB_TEXTEDIT_STRINGLEN(const ImGuiInputTextState* obj)                            IM_NOEXCEPT { return obj->CurLenW; }
+static ImWchar STB_TEXTEDIT_GETCHAR(const ImGuiInputTextState* obj, int idx)                     IM_NOEXCEPT { return obj->TextW[idx]; }
+static float   STB_TEXTEDIT_GETWIDTH(ImGuiInputTextState* obj, int line_start_idx, int char_idx) IM_NOEXCEPT { ImWchar c = obj->TextW[line_start_idx + char_idx]; if (c == '\n') return STB_TEXTEDIT_GETWIDTH_NEWLINE; ImGuiContext& g = *GImGui; return g.Font->GetCharAdvance(c) * (g.FontSize / g.Font->FontSize); }
+static int     STB_TEXTEDIT_KEYTOTEXT(int key)                                                   IM_NOEXCEPT { return key >= 0x200000 ? 0 : key; }
 static ImWchar STB_TEXTEDIT_NEWLINE = '\n';
-static void    STB_TEXTEDIT_LAYOUTROW(StbTexteditRow* r, ImGuiInputTextState* obj, int line_start_idx) IMGUI_NOEXCEPT
+static void    STB_TEXTEDIT_LAYOUTROW(StbTexteditRow* r, ImGuiInputTextState* obj, int line_start_idx) IM_NOEXCEPT
 {
     const ImWchar* text = obj->TextW.Data;
     const ImWchar* text_remaining = NULL;
@@ -3598,19 +3598,19 @@ static void    STB_TEXTEDIT_LAYOUTROW(StbTexteditRow* r, ImGuiInputTextState* ob
 }
 
 // When ImGuiInputTextFlags_Password is set, we don't want actions such as CTRL+Arrow to leak the fact that underlying data are blanks or separators.
-static bool is_separator(unsigned int c)                                       IMGUI_NOEXCEPT { return ImCharIsBlankW(c) || c==',' || c==';' || c=='(' || c==')' || c=='{' || c=='}' || c=='[' || c==']' || c=='|'; }
-static int  is_word_boundary_from_right(ImGuiInputTextState* obj, int idx)     IMGUI_NOEXCEPT { if (obj->Flags & ImGuiInputTextFlags_Password) return 0; return idx > 0 ? (is_separator(obj->TextW[idx - 1]) && !is_separator(obj->TextW[idx]) ) : 1; }
-static int  STB_TEXTEDIT_MOVEWORDLEFT_IMPL(ImGuiInputTextState* obj, int idx)  IMGUI_NOEXCEPT { idx--; while (idx >= 0 && !is_word_boundary_from_right(obj, idx)) idx--; return idx < 0 ? 0 : idx; }
+static bool is_separator(unsigned int c)                                       IM_NOEXCEPT { return ImCharIsBlankW(c) || c==',' || c==';' || c=='(' || c==')' || c=='{' || c=='}' || c=='[' || c==']' || c=='|'; }
+static int  is_word_boundary_from_right(ImGuiInputTextState* obj, int idx)     IM_NOEXCEPT { if (obj->Flags & ImGuiInputTextFlags_Password) return 0; return idx > 0 ? (is_separator(obj->TextW[idx - 1]) && !is_separator(obj->TextW[idx]) ) : 1; }
+static int  STB_TEXTEDIT_MOVEWORDLEFT_IMPL(ImGuiInputTextState* obj, int idx)  IM_NOEXCEPT { idx--; while (idx >= 0 && !is_word_boundary_from_right(obj, idx)) idx--; return idx < 0 ? 0 : idx; }
 #ifdef __APPLE__    // FIXME: Move setting to IO structure
-static int  is_word_boundary_from_left(ImGuiInputTextState* obj, int idx)      IMGUI_NOEXCEPT { if (obj->Flags & ImGuiInputTextFlags_Password) return 0; return idx > 0 ? (!is_separator(obj->TextW[idx - 1]) && is_separator(obj->TextW[idx]) ) : 1; }
-static int  STB_TEXTEDIT_MOVEWORDRIGHT_IMPL(ImGuiInputTextState* obj, int idx) IMGUI_NOEXCEPT { idx++; int len = obj->CurLenW; while (idx < len && !is_word_boundary_from_left(obj, idx)) idx++; return idx > len ? len : idx; }
+static int  is_word_boundary_from_left(ImGuiInputTextState* obj, int idx)      IM_NOEXCEPT { if (obj->Flags & ImGuiInputTextFlags_Password) return 0; return idx > 0 ? (!is_separator(obj->TextW[idx - 1]) && is_separator(obj->TextW[idx]) ) : 1; }
+static int  STB_TEXTEDIT_MOVEWORDRIGHT_IMPL(ImGuiInputTextState* obj, int idx) IM_NOEXCEPT { idx++; int len = obj->CurLenW; while (idx < len && !is_word_boundary_from_left(obj, idx)) idx++; return idx > len ? len : idx; }
 #else
-static int  STB_TEXTEDIT_MOVEWORDRIGHT_IMPL(ImGuiInputTextState* obj, int idx) IMGUI_NOEXCEPT { idx++; int len = obj->CurLenW; while (idx < len && !is_word_boundary_from_right(obj, idx)) idx++; return idx > len ? len : idx; }
+static int  STB_TEXTEDIT_MOVEWORDRIGHT_IMPL(ImGuiInputTextState* obj, int idx) IM_NOEXCEPT { idx++; int len = obj->CurLenW; while (idx < len && !is_word_boundary_from_right(obj, idx)) idx++; return idx > len ? len : idx; }
 #endif
 #define STB_TEXTEDIT_MOVEWORDLEFT   STB_TEXTEDIT_MOVEWORDLEFT_IMPL    // They need to be #define for stb_textedit.h
 #define STB_TEXTEDIT_MOVEWORDRIGHT  STB_TEXTEDIT_MOVEWORDRIGHT_IMPL
 
-static void STB_TEXTEDIT_DELETECHARS(ImGuiInputTextState* obj, int pos, int n) IMGUI_NOEXCEPT
+static void STB_TEXTEDIT_DELETECHARS(ImGuiInputTextState* obj, int pos, int n) IM_NOEXCEPT
 {
     ImWchar* dst = obj->TextW.Data + pos;
 
@@ -3626,7 +3626,7 @@ static void STB_TEXTEDIT_DELETECHARS(ImGuiInputTextState* obj, int pos, int n) I
     *dst = '\0';
 }
 
-static bool STB_TEXTEDIT_INSERTCHARS(ImGuiInputTextState* obj, int pos, const ImWchar* new_text, int new_text_len) IMGUI_NOEXCEPT
+static bool STB_TEXTEDIT_INSERTCHARS(ImGuiInputTextState* obj, int pos, const ImWchar* new_text, int new_text_len) IM_NOEXCEPT
 {
     const bool is_resizable = (obj->Flags & ImGuiInputTextFlags_CallbackResize) != 0;
     const int text_len = obj->CurLenW;
@@ -3682,7 +3682,7 @@ static bool STB_TEXTEDIT_INSERTCHARS(ImGuiInputTextState* obj, int pos, const Im
 
 // stb_textedit internally allows for a single undo record to do addition and deletion, but somehow, calling
 // the stb_textedit_paste() function creates two separate records, so we perform it manually. (FIXME: Report to nothings/stb?)
-static void stb_textedit_replace(STB_TEXTEDIT_STRING* str, STB_TexteditState* state, const STB_TEXTEDIT_CHARTYPE* text, int text_len) IMGUI_NOEXCEPT
+static void stb_textedit_replace(STB_TEXTEDIT_STRING* str, STB_TexteditState* state, const STB_TEXTEDIT_CHARTYPE* text, int text_len) IM_NOEXCEPT
 {
     stb_text_makeundo_replace(str, state, 0, str->CurLenW, text_len);
     ImStb::STB_TEXTEDIT_DELETECHARS(str, 0, str->CurLenW);
@@ -3699,14 +3699,14 @@ static void stb_textedit_replace(STB_TEXTEDIT_STRING* str, STB_TexteditState* st
 
 } // namespace ImStb
 
-void ImGuiInputTextState::OnKeyPressed(int key) IMGUI_NOEXCEPT
+void ImGuiInputTextState::OnKeyPressed(int key) IM_NOEXCEPT
 {
     stb_textedit_key(this, &Stb, key);
     CursorFollow = true;
     CursorAnimReset();
 }
 
-ImGuiInputTextCallbackData::ImGuiInputTextCallbackData() IMGUI_NOEXCEPT
+ImGuiInputTextCallbackData::ImGuiInputTextCallbackData() IM_NOEXCEPT
 {
     memset(this, 0, sizeof(*this));
 }
@@ -3714,7 +3714,7 @@ ImGuiInputTextCallbackData::ImGuiInputTextCallbackData() IMGUI_NOEXCEPT
 // Public API to manipulate UTF-8 text
 // We expose UTF-8 to the user (unlike the STB_TEXTEDIT_* functions which are manipulating wchar)
 // FIXME: The existence of this rarely exercised code path is a bit of a nuisance.
-void ImGuiInputTextCallbackData::DeleteChars(int pos, int bytes_count) IMGUI_NOEXCEPT
+void ImGuiInputTextCallbackData::DeleteChars(int pos, int bytes_count) IM_NOEXCEPT
 {
     IM_ASSERT(pos + bytes_count <= BufTextLen);
     char* dst = Buf + pos;
@@ -3732,7 +3732,7 @@ void ImGuiInputTextCallbackData::DeleteChars(int pos, int bytes_count) IMGUI_NOE
     BufTextLen -= bytes_count;
 }
 
-void ImGuiInputTextCallbackData::InsertChars(int pos, const char* new_text, const char* new_text_end) IMGUI_NOEXCEPT
+void ImGuiInputTextCallbackData::InsertChars(int pos, const char* new_text, const char* new_text_end) IM_NOEXCEPT
 {
     const bool is_resizable = (Flags & ImGuiInputTextFlags_CallbackResize) != 0;
     const int new_text_len = new_text_end ? (int)(new_text_end - new_text) : (int)strlen(new_text);
@@ -3765,7 +3765,7 @@ void ImGuiInputTextCallbackData::InsertChars(int pos, const char* new_text, cons
 }
 
 // Return false to discard a character.
-static bool InputTextFilterCharacter(unsigned int* p_char, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback, void* user_data, ImGuiInputSource input_source) IMGUI_NOEXCEPT
+static bool InputTextFilterCharacter(unsigned int* p_char, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback, void* user_data, ImGuiInputSource input_source) IM_NOEXCEPT
 {
     IM_ASSERT(input_source == ImGuiInputSource_Keyboard || input_source == ImGuiInputSource_Clipboard);
     unsigned int c = *p_char;
@@ -3858,7 +3858,7 @@ static bool InputTextFilterCharacter(unsigned int* p_char, ImGuiInputTextFlags f
 // - If you want to use ImGui::InputText() with std::string, see misc/cpp/imgui_stdlib.h
 // (FIXME: Rather confusing and messy function, among the worse part of our codebase, expecting to rewrite a V2 at some point.. Partly because we are
 //  doing UTF8 > U16 > UTF8 conversions on the go to easily interface with stb_textedit. Ideally should stay in UTF-8 all the time. See https://github.com/nothings/stb/issues/188)
-bool ImGui::InputTextEx(const char* label, const char* hint, char* buf, int buf_size, const ImVec2& size_arg, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback, void* callback_user_data) IMGUI_NOEXCEPT
+bool ImGui::InputTextEx(const char* label, const char* hint, char* buf, int buf_size, const ImVec2& size_arg, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback, void* callback_user_data) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -4677,7 +4677,7 @@ bool ImGui::InputTextEx(const char* label, const char* hint, char* buf, int buf_
 // - ColorPickerOptionsPopup() [Internal]
 //-------------------------------------------------------------------------
 
-bool ImGui::ColorEdit3(const char* label, float col[3], ImGuiColorEditFlags flags) IMGUI_NOEXCEPT
+bool ImGui::ColorEdit3(const char* label, float col[3], ImGuiColorEditFlags flags) IM_NOEXCEPT
 {
     return ColorEdit4(label, col, flags | ImGuiColorEditFlags_NoAlpha);
 }
@@ -4685,7 +4685,7 @@ bool ImGui::ColorEdit3(const char* label, float col[3], ImGuiColorEditFlags flag
 // Edit colors components (each component in 0.0f..1.0f range).
 // See enum ImGuiColorEditFlags_ for available options. e.g. Only access 3 floats if ImGuiColorEditFlags_NoAlpha flag is set.
 // With typical options: Left-click on color square to open color picker. Right-click to open option menu. CTRL-Click over input fields to edit them and TAB to go to next item.
-bool ImGui::ColorEdit4(const char* label, float col[4], ImGuiColorEditFlags flags) IMGUI_NOEXCEPT
+bool ImGui::ColorEdit4(const char* label, float col[4], ImGuiColorEditFlags flags) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -4925,7 +4925,7 @@ bool ImGui::ColorEdit4(const char* label, float col[4], ImGuiColorEditFlags flag
     return value_changed;
 }
 
-bool ImGui::ColorPicker3(const char* label, float col[3], ImGuiColorEditFlags flags) IMGUI_NOEXCEPT
+bool ImGui::ColorPicker3(const char* label, float col[3], ImGuiColorEditFlags flags) IM_NOEXCEPT
 {
     float col4[4] = { col[0], col[1], col[2], 1.0f };
     if (!ColorPicker4(label, col4, flags | ImGuiColorEditFlags_NoAlpha))
@@ -4935,7 +4935,7 @@ bool ImGui::ColorPicker3(const char* label, float col[3], ImGuiColorEditFlags fl
 }
 
 // Helper for ColorPicker4()
-static void RenderArrowsForVerticalBar(ImDrawList* draw_list, ImVec2 pos, ImVec2 half_sz, float bar_w, float alpha) IMGUI_NOEXCEPT
+static void RenderArrowsForVerticalBar(ImDrawList* draw_list, ImVec2 pos, ImVec2 half_sz, float bar_w, float alpha) IM_NOEXCEPT
 {
     ImU32 alpha8 = IM_F32_TO_INT8_SAT(alpha);
     ImGui::RenderArrowPointingAt(draw_list, ImVec2(pos.x + half_sz.x + 1,         pos.y), ImVec2(half_sz.x + 2, half_sz.y + 1), ImGuiDir_Right, IM_COL32(0,0,0,alpha8));
@@ -4948,7 +4948,7 @@ static void RenderArrowsForVerticalBar(ImDrawList* draw_list, ImVec2 pos, ImVec2
 // (In C++ the 'float col[4]' notation for a function argument is equivalent to 'float* col', we only specify a size to facilitate understanding of the code.)
 // FIXME: we adjust the big color square height based on item width, which may cause a flickering feedback loop (if automatic height makes a vertical scrollbar appears, affecting automatic width..)
 // FIXME: this is trying to be aware of style.Alpha but not fully correct. Also, the color wheel will have overlapping glitches with (style.Alpha < 1.0)
-bool ImGui::ColorPicker4(const char* label, float col[4], ImGuiColorEditFlags flags, const float* ref_col) IMGUI_NOEXCEPT
+bool ImGui::ColorPicker4(const char* label, float col[4], ImGuiColorEditFlags flags, const float* ref_col) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = GetCurrentWindow();
@@ -5327,7 +5327,7 @@ bool ImGui::ColorPicker4(const char* label, float col[4], ImGuiColorEditFlags fl
 // FIXME: May want to display/ignore the alpha component in the color display? Yet show it in the tooltip.
 // 'desc_id' is not called 'label' because we don't display it next to the button, but only in the tooltip.
 // Note that 'col' may be encoded in HSV if ImGuiColorEditFlags_InputHSV is set.
-bool ImGui::ColorButton(const char* desc_id, const ImVec4& col, ImGuiColorEditFlags flags, ImVec2 size) IMGUI_NOEXCEPT
+bool ImGui::ColorButton(const char* desc_id, const ImVec4& col, ImGuiColorEditFlags flags, ImVec2 size) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -5411,7 +5411,7 @@ bool ImGui::ColorButton(const char* desc_id, const ImVec4& col, ImGuiColorEditFl
 }
 
 // Initialize/override default color options
-void ImGui::SetColorEditOptions(ImGuiColorEditFlags flags) IMGUI_NOEXCEPT
+void ImGui::SetColorEditOptions(ImGuiColorEditFlags flags) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if ((flags & ImGuiColorEditFlags__DisplayMask) == 0)
@@ -5430,7 +5430,7 @@ void ImGui::SetColorEditOptions(ImGuiColorEditFlags flags) IMGUI_NOEXCEPT
 }
 
 // Note: only access 3 floats if ImGuiColorEditFlags_NoAlpha flag is set.
-void ImGui::ColorTooltip(const char* text, const float* col, ImGuiColorEditFlags flags) IMGUI_NOEXCEPT
+void ImGui::ColorTooltip(const char* text, const float* col, ImGuiColorEditFlags flags) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -5464,7 +5464,7 @@ void ImGui::ColorTooltip(const char* text, const float* col, ImGuiColorEditFlags
     EndTooltip();
 }
 
-void ImGui::ColorEditOptionsPopup(const float* col, ImGuiColorEditFlags flags) IMGUI_NOEXCEPT
+void ImGui::ColorEditOptionsPopup(const float* col, ImGuiColorEditFlags flags) IM_NOEXCEPT
 {
     bool allow_opt_inputs = !(flags & ImGuiColorEditFlags__DisplayMask);
     bool allow_opt_datatype = !(flags & ImGuiColorEditFlags__DataTypeMask);
@@ -5515,7 +5515,7 @@ void ImGui::ColorEditOptionsPopup(const float* col, ImGuiColorEditFlags flags) I
     EndPopup();
 }
 
-void ImGui::ColorPickerOptionsPopup(const float* ref_col, ImGuiColorEditFlags flags) IMGUI_NOEXCEPT
+void ImGui::ColorPickerOptionsPopup(const float* ref_col, ImGuiColorEditFlags flags) IM_NOEXCEPT
 {
     bool allow_opt_picker = !(flags & ImGuiColorEditFlags__PickerMask);
     bool allow_opt_alpha_bar = !(flags & ImGuiColorEditFlags_NoAlpha) && !(flags & ImGuiColorEditFlags_AlphaBar);
@@ -5568,7 +5568,7 @@ void ImGui::ColorPickerOptionsPopup(const float* ref_col, ImGuiColorEditFlags fl
 // - CollapsingHeader()
 //-------------------------------------------------------------------------
 
-bool ImGui::TreeNode(const char* str_id, const char* fmt, ...) IMGUI_NOEXCEPT
+bool ImGui::TreeNode(const char* str_id, const char* fmt, ...) IM_NOEXCEPT
 {
     va_list args;
     va_start(args, fmt);
@@ -5577,7 +5577,7 @@ bool ImGui::TreeNode(const char* str_id, const char* fmt, ...) IMGUI_NOEXCEPT
     return is_open;
 }
 
-bool ImGui::TreeNode(const void* ptr_id, const char* fmt, ...) IMGUI_NOEXCEPT
+bool ImGui::TreeNode(const void* ptr_id, const char* fmt, ...) IM_NOEXCEPT
 {
     va_list args;
     va_start(args, fmt);
@@ -5586,7 +5586,7 @@ bool ImGui::TreeNode(const void* ptr_id, const char* fmt, ...) IMGUI_NOEXCEPT
     return is_open;
 }
 
-bool ImGui::TreeNode(const char* label) IMGUI_NOEXCEPT
+bool ImGui::TreeNode(const char* label) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -5594,17 +5594,17 @@ bool ImGui::TreeNode(const char* label) IMGUI_NOEXCEPT
     return TreeNodeBehavior(window->GetID(label), 0, label, NULL);
 }
 
-bool ImGui::TreeNodeV(const char* str_id, const char* fmt, va_list args) IMGUI_NOEXCEPT
+bool ImGui::TreeNodeV(const char* str_id, const char* fmt, va_list args) IM_NOEXCEPT
 {
     return TreeNodeExV(str_id, 0, fmt, args);
 }
 
-bool ImGui::TreeNodeV(const void* ptr_id, const char* fmt, va_list args) IMGUI_NOEXCEPT
+bool ImGui::TreeNodeV(const void* ptr_id, const char* fmt, va_list args) IM_NOEXCEPT
 {
     return TreeNodeExV(ptr_id, 0, fmt, args);
 }
 
-bool ImGui::TreeNodeEx(const char* label, ImGuiTreeNodeFlags flags) IMGUI_NOEXCEPT
+bool ImGui::TreeNodeEx(const char* label, ImGuiTreeNodeFlags flags) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -5613,7 +5613,7 @@ bool ImGui::TreeNodeEx(const char* label, ImGuiTreeNodeFlags flags) IMGUI_NOEXCE
     return TreeNodeBehavior(window->GetID(label), flags, label, NULL);
 }
 
-bool ImGui::TreeNodeEx(const char* str_id, ImGuiTreeNodeFlags flags, const char* fmt, ...) IMGUI_NOEXCEPT
+bool ImGui::TreeNodeEx(const char* str_id, ImGuiTreeNodeFlags flags, const char* fmt, ...) IM_NOEXCEPT
 {
     va_list args;
     va_start(args, fmt);
@@ -5622,7 +5622,7 @@ bool ImGui::TreeNodeEx(const char* str_id, ImGuiTreeNodeFlags flags, const char*
     return is_open;
 }
 
-bool ImGui::TreeNodeEx(const void* ptr_id, ImGuiTreeNodeFlags flags, const char* fmt, ...) IMGUI_NOEXCEPT
+bool ImGui::TreeNodeEx(const void* ptr_id, ImGuiTreeNodeFlags flags, const char* fmt, ...) IM_NOEXCEPT
 {
     va_list args;
     va_start(args, fmt);
@@ -5631,7 +5631,7 @@ bool ImGui::TreeNodeEx(const void* ptr_id, ImGuiTreeNodeFlags flags, const char*
     return is_open;
 }
 
-bool ImGui::TreeNodeExV(const char* str_id, ImGuiTreeNodeFlags flags, const char* fmt, va_list args) IMGUI_NOEXCEPT
+bool ImGui::TreeNodeExV(const char* str_id, ImGuiTreeNodeFlags flags, const char* fmt, va_list args) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -5642,7 +5642,7 @@ bool ImGui::TreeNodeExV(const char* str_id, ImGuiTreeNodeFlags flags, const char
     return TreeNodeBehavior(window->GetID(str_id), flags, g.TempBuffer, label_end);
 }
 
-bool ImGui::TreeNodeExV(const void* ptr_id, ImGuiTreeNodeFlags flags, const char* fmt, va_list args) IMGUI_NOEXCEPT
+bool ImGui::TreeNodeExV(const void* ptr_id, ImGuiTreeNodeFlags flags, const char* fmt, va_list args) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -5653,7 +5653,7 @@ bool ImGui::TreeNodeExV(const void* ptr_id, ImGuiTreeNodeFlags flags, const char
     return TreeNodeBehavior(window->GetID(ptr_id), flags, g.TempBuffer, label_end);
 }
 
-bool ImGui::TreeNodeBehaviorIsOpen(ImGuiID id, ImGuiTreeNodeFlags flags) IMGUI_NOEXCEPT
+bool ImGui::TreeNodeBehaviorIsOpen(ImGuiID id, ImGuiTreeNodeFlags flags) IM_NOEXCEPT
 {
     if (flags & ImGuiTreeNodeFlags_Leaf)
         return true;
@@ -5699,7 +5699,7 @@ bool ImGui::TreeNodeBehaviorIsOpen(ImGuiID id, ImGuiTreeNodeFlags flags) IMGUI_N
     return is_open;
 }
 
-bool ImGui::TreeNodeBehavior(ImGuiID id, ImGuiTreeNodeFlags flags, const char* label, const char* label_end) IMGUI_NOEXCEPT
+bool ImGui::TreeNodeBehavior(ImGuiID id, ImGuiTreeNodeFlags flags, const char* label, const char* label_end) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -5886,7 +5886,7 @@ bool ImGui::TreeNodeBehavior(ImGuiID id, ImGuiTreeNodeFlags flags, const char* l
     return is_open;
 }
 
-void ImGui::TreePush(const char* str_id) IMGUI_NOEXCEPT
+void ImGui::TreePush(const char* str_id) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     Indent();
@@ -5894,7 +5894,7 @@ void ImGui::TreePush(const char* str_id) IMGUI_NOEXCEPT
     PushID(str_id ? str_id : "#TreePush");
 }
 
-void ImGui::TreePush(const void* ptr_id) IMGUI_NOEXCEPT
+void ImGui::TreePush(const void* ptr_id) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     Indent();
@@ -5902,7 +5902,7 @@ void ImGui::TreePush(const void* ptr_id) IMGUI_NOEXCEPT
     PushID(ptr_id ? ptr_id : (const void*)"#TreePush");
 }
 
-void ImGui::TreePushOverrideID(ImGuiID id) IMGUI_NOEXCEPT
+void ImGui::TreePushOverrideID(ImGuiID id) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -5911,7 +5911,7 @@ void ImGui::TreePushOverrideID(ImGuiID id) IMGUI_NOEXCEPT
     window->IDStack.push_back(id);
 }
 
-void ImGui::TreePop() IMGUI_NOEXCEPT
+void ImGui::TreePop() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -5934,14 +5934,14 @@ void ImGui::TreePop() IMGUI_NOEXCEPT
 }
 
 // Horizontal distance preceding label when using TreeNode() or Bullet()
-float ImGui::GetTreeNodeToLabelSpacing() IMGUI_NOEXCEPT
+float ImGui::GetTreeNodeToLabelSpacing() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return g.FontSize + (g.Style.FramePadding.x * 2.0f);
 }
 
 // Set next TreeNode/CollapsingHeader open state.
-void ImGui::SetNextItemOpen(bool is_open, ImGuiCond cond) IMGUI_NOEXCEPT
+void ImGui::SetNextItemOpen(bool is_open, ImGuiCond cond) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.CurrentWindow->SkipItems)
@@ -5953,7 +5953,7 @@ void ImGui::SetNextItemOpen(bool is_open, ImGuiCond cond) IMGUI_NOEXCEPT
 
 // CollapsingHeader returns true when opened but do not indent nor push into the ID stack (because of the ImGuiTreeNodeFlags_NoTreePushOnOpen flag).
 // This is basically the same as calling TreeNodeEx(label, ImGuiTreeNodeFlags_CollapsingHeader). You can remove the _NoTreePushOnOpen flag if you want behavior closer to normal TreeNode().
-bool ImGui::CollapsingHeader(const char* label, ImGuiTreeNodeFlags flags) IMGUI_NOEXCEPT
+bool ImGui::CollapsingHeader(const char* label, ImGuiTreeNodeFlags flags) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -5966,7 +5966,7 @@ bool ImGui::CollapsingHeader(const char* label, ImGuiTreeNodeFlags flags) IMGUI_
 // p_visible != NULL && *p_visible == true  : show a small close button on the corner of the header, clicking the button will set *p_visible = false
 // p_visible != NULL && *p_visible == false : do not show the header at all
 // Do not mistake this with the Open state of the header itself, which you can adjust with SetNextItemOpen() or ImGuiTreeNodeFlags_DefaultOpen.
-bool ImGui::CollapsingHeader(const char* label, bool* p_visible, ImGuiTreeNodeFlags flags) IMGUI_NOEXCEPT
+bool ImGui::CollapsingHeader(const char* label, bool* p_visible, ImGuiTreeNodeFlags flags) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -6009,7 +6009,7 @@ bool ImGui::CollapsingHeader(const char* label, bool* p_visible, ImGuiTreeNodeFl
 // But you need to make sure the ID is unique, e.g. enclose calls in PushID/PopID or use ##unique_id.
 // With this scheme, ImGuiSelectableFlags_SpanAllColumns and ImGuiSelectableFlags_AllowItemOverlap are also frequently used flags.
 // FIXME: Selectable() with (size.x == 0.0f) and (SelectableTextAlign.x > 0.0f) followed by SameLine() is currently not supported.
-bool ImGui::Selectable(const char* label, bool selected, ImGuiSelectableFlags flags, const ImVec2& size_arg) IMGUI_NOEXCEPT
+bool ImGui::Selectable(const char* label, bool selected, ImGuiSelectableFlags flags, const ImVec2& size_arg) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -6153,7 +6153,7 @@ bool ImGui::Selectable(const char* label, bool selected, ImGuiSelectableFlags fl
     return pressed;
 }
 
-bool ImGui::Selectable(const char* label, bool* p_selected, ImGuiSelectableFlags flags, const ImVec2& size_arg) IMGUI_NOEXCEPT
+bool ImGui::Selectable(const char* label, bool* p_selected, ImGuiSelectableFlags flags, const ImVec2& size_arg) IM_NOEXCEPT
 {
     if (Selectable(label, *p_selected, flags, size_arg))
     {
@@ -6173,7 +6173,7 @@ bool ImGui::Selectable(const char* label, bool* p_selected, ImGuiSelectableFlags
 
 // Tip: To have a list filling the entire window width, use size.x = -FLT_MIN and pass an non-visible label e.g. "##empty"
 // Tip: If your vertical size is calculated from an item count (e.g. 10 * item_height) consider adding a fractional part to facilitate seeing scrolling boundaries (e.g. 10.25 * item_height).
-bool ImGui::BeginListBox(const char* label, const ImVec2& size_arg) IMGUI_NOEXCEPT
+bool ImGui::BeginListBox(const char* label, const ImVec2& size_arg) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = GetCurrentWindow();
@@ -6214,7 +6214,7 @@ bool ImGui::BeginListBox(const char* label, const ImVec2& size_arg) IMGUI_NOEXCE
 
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
 // OBSOLETED in 1.81 (from February 2021)
-bool ImGui::ListBoxHeader(const char* label, int items_count, int height_in_items) IMGUI_NOEXCEPT
+bool ImGui::ListBoxHeader(const char* label, int items_count, int height_in_items) IM_NOEXCEPT
 {
     // If height_in_items == -1, default height is maximum 7.
     ImGuiContext& g = *GImGui;
@@ -6226,7 +6226,7 @@ bool ImGui::ListBoxHeader(const char* label, int items_count, int height_in_item
 }
 #endif
 
-void ImGui::EndListBox() IMGUI_NOEXCEPT
+void ImGui::EndListBox() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -6237,7 +6237,7 @@ void ImGui::EndListBox() IMGUI_NOEXCEPT
     EndGroup(); // This is only required to be able to do IsItemXXX query on the whole ListBox including label
 }
 
-bool ImGui::ListBox(const char* label, int* current_item, const char* const items[], int items_count, int height_items) IMGUI_NOEXCEPT
+bool ImGui::ListBox(const char* label, int* current_item, const char* const items[], int items_count, int height_items) IM_NOEXCEPT
 {
     const bool value_changed = ListBox(label, current_item, Items_ArrayGetter, (void*)items, items_count, height_items);
     return value_changed;
@@ -6245,7 +6245,7 @@ bool ImGui::ListBox(const char* label, int* current_item, const char* const item
 
 // This is merely a helper around BeginListBox(), EndListBox().
 // Considering using those directly to submit custom data or store selection differently.
-bool ImGui::ListBox(const char* label, int* current_item, bool (*items_getter)(void*, int, const char**), void* data, int items_count, int height_in_items) IMGUI_NOEXCEPT
+bool ImGui::ListBox(const char* label, int* current_item, bool (*items_getter)(void*, int, const char**), void* data, int items_count, int height_in_items) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
 
@@ -6301,7 +6301,7 @@ bool ImGui::ListBox(const char* label, int* current_item, bool (*items_getter)(v
 // - others https://github.com/ocornut/imgui/wiki/Useful-Widgets
 //-------------------------------------------------------------------------
 
-int ImGui::PlotEx(ImGuiPlotType plot_type, const char* label, float (*values_getter)(void* data, int idx), void* data, int values_count, int values_offset, const char* overlay_text, float scale_min, float scale_max, ImVec2 frame_size) IMGUI_NOEXCEPT
+int ImGui::PlotEx(ImGuiPlotType plot_type, const char* label, float (*values_getter)(void* data, int idx), void* data, int values_count, int values_offset, const char* overlay_text, float scale_min, float scale_max, ImVec2 frame_size) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = GetCurrentWindow();
@@ -6424,34 +6424,34 @@ struct ImGuiPlotArrayGetterData
     const float* Values;
     int Stride;
 
-    ImGuiPlotArrayGetterData(const float* values, int stride) IMGUI_NOEXCEPT { Values = values; Stride = stride; }
+    ImGuiPlotArrayGetterData(const float* values, int stride) IM_NOEXCEPT { Values = values; Stride = stride; }
 };
 
-static float Plot_ArrayGetter(void* data, int idx) IMGUI_NOEXCEPT
+static float Plot_ArrayGetter(void* data, int idx) IM_NOEXCEPT
 {
     ImGuiPlotArrayGetterData* plot_data = (ImGuiPlotArrayGetterData*)data;
     const float v = *(const float*)(const void*)((const unsigned char*)plot_data->Values + (size_t)idx * plot_data->Stride);
     return v;
 }
 
-void ImGui::PlotLines(const char* label, const float* values, int values_count, int values_offset, const char* overlay_text, float scale_min, float scale_max, ImVec2 graph_size, int stride) IMGUI_NOEXCEPT
+void ImGui::PlotLines(const char* label, const float* values, int values_count, int values_offset, const char* overlay_text, float scale_min, float scale_max, ImVec2 graph_size, int stride) IM_NOEXCEPT
 {
     ImGuiPlotArrayGetterData data(values, stride);
     PlotEx(ImGuiPlotType_Lines, label, &Plot_ArrayGetter, (void*)&data, values_count, values_offset, overlay_text, scale_min, scale_max, graph_size);
 }
 
-void ImGui::PlotLines(const char* label, float (*values_getter)(void* data, int idx), void* data, int values_count, int values_offset, const char* overlay_text, float scale_min, float scale_max, ImVec2 graph_size) IMGUI_NOEXCEPT
+void ImGui::PlotLines(const char* label, float (*values_getter)(void* data, int idx), void* data, int values_count, int values_offset, const char* overlay_text, float scale_min, float scale_max, ImVec2 graph_size) IM_NOEXCEPT
 {
     PlotEx(ImGuiPlotType_Lines, label, values_getter, data, values_count, values_offset, overlay_text, scale_min, scale_max, graph_size);
 }
 
-void ImGui::PlotHistogram(const char* label, const float* values, int values_count, int values_offset, const char* overlay_text, float scale_min, float scale_max, ImVec2 graph_size, int stride) IMGUI_NOEXCEPT
+void ImGui::PlotHistogram(const char* label, const float* values, int values_count, int values_offset, const char* overlay_text, float scale_min, float scale_max, ImVec2 graph_size, int stride) IM_NOEXCEPT
 {
     ImGuiPlotArrayGetterData data(values, stride);
     PlotEx(ImGuiPlotType_Histogram, label, &Plot_ArrayGetter, (void*)&data, values_count, values_offset, overlay_text, scale_min, scale_max, graph_size);
 }
 
-void ImGui::PlotHistogram(const char* label, float (*values_getter)(void* data, int idx), void* data, int values_count, int values_offset, const char* overlay_text, float scale_min, float scale_max, ImVec2 graph_size) IMGUI_NOEXCEPT
+void ImGui::PlotHistogram(const char* label, float (*values_getter)(void* data, int idx), void* data, int values_count, int values_offset, const char* overlay_text, float scale_min, float scale_max, ImVec2 graph_size) IM_NOEXCEPT
 {
     PlotEx(ImGuiPlotType_Histogram, label, values_getter, data, values_count, values_offset, overlay_text, scale_min, scale_max, graph_size);
 }
@@ -6463,22 +6463,22 @@ void ImGui::PlotHistogram(const char* label, float (*values_getter)(void* data, 
 // - Value()
 //-------------------------------------------------------------------------
 
-void ImGui::Value(const char* prefix, bool b) IMGUI_NOEXCEPT
+void ImGui::Value(const char* prefix, bool b) IM_NOEXCEPT
 {
     Text("%s: %s", prefix, (b ? "true" : "false"));
 }
 
-void ImGui::Value(const char* prefix, int v) IMGUI_NOEXCEPT
+void ImGui::Value(const char* prefix, int v) IM_NOEXCEPT
 {
     Text("%s: %d", prefix, v);
 }
 
-void ImGui::Value(const char* prefix, unsigned int v) IMGUI_NOEXCEPT
+void ImGui::Value(const char* prefix, unsigned int v) IM_NOEXCEPT
 {
     Text("%s: %d", prefix, v);
 }
 
-void ImGui::Value(const char* prefix, float v, const char* float_format) IMGUI_NOEXCEPT
+void ImGui::Value(const char* prefix, float v, const char* float_format) IM_NOEXCEPT
 {
     if (float_format)
     {
@@ -6506,7 +6506,7 @@ void ImGui::Value(const char* prefix, float v, const char* float_format) IMGUI_N
 //-------------------------------------------------------------------------
 
 // Helpers for internal use
-void ImGuiMenuColumns::Update(int count, float spacing, bool clear) IMGUI_NOEXCEPT
+void ImGuiMenuColumns::Update(int count, float spacing, bool clear) IM_NOEXCEPT
 {
     IM_ASSERT(count == IM_ARRAYSIZE(Pos));
     IM_UNUSED(count);
@@ -6524,7 +6524,7 @@ void ImGuiMenuColumns::Update(int count, float spacing, bool clear) IMGUI_NOEXCE
     }
 }
 
-float ImGuiMenuColumns::DeclColumns(float w0, float w1, float w2) IMGUI_NOEXCEPT  // not using va_arg because they promote float to double
+float ImGuiMenuColumns::DeclColumns(float w0, float w1, float w2) IM_NOEXCEPT  // not using va_arg because they promote float to double
 {
     NextWidth = 0.0f;
     NextWidths[0] = ImMax(NextWidths[0], w0);
@@ -6535,7 +6535,7 @@ float ImGuiMenuColumns::DeclColumns(float w0, float w1, float w2) IMGUI_NOEXCEPT
     return ImMax(Width, NextWidth);
 }
 
-float ImGuiMenuColumns::CalcExtraSpace(float avail_w) const IMGUI_NOEXCEPT
+float ImGuiMenuColumns::CalcExtraSpace(float avail_w) const IM_NOEXCEPT
 {
     return ImMax(0.0f, avail_w - Width);
 }
@@ -6544,7 +6544,7 @@ float ImGuiMenuColumns::CalcExtraSpace(float avail_w) const IMGUI_NOEXCEPT
 // Currently the main responsibility of this function being to setup clip-rect + horizontal layout + menu navigation layer.
 // Ideally we also want this to be responsible for claiming space out of the main window scrolling rectangle, in which case ImGuiWindowFlags_MenuBar will become unnecessary.
 // Then later the same system could be used for multiple menu-bars, scrollbars, side-bars.
-bool ImGui::BeginMenuBar() IMGUI_NOEXCEPT
+bool ImGui::BeginMenuBar() IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -6572,7 +6572,7 @@ bool ImGui::BeginMenuBar() IMGUI_NOEXCEPT
     return true;
 }
 
-void ImGui::EndMenuBar() IMGUI_NOEXCEPT
+void ImGui::EndMenuBar() IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -6616,7 +6616,7 @@ void ImGui::EndMenuBar() IMGUI_NOEXCEPT
 // Important: calling order matters!
 // FIXME: Somehow overlapping with docking tech.
 // FIXME: The "rect-cut" aspect of this could be formalized into a lower-level helper (rect-cut: https://halt.software/dead-simple-layouts)
-bool ImGui::BeginViewportSideBar(const char* name, ImGuiViewport* viewport_p, ImGuiDir dir, float axis_size, ImGuiWindowFlags window_flags) IMGUI_NOEXCEPT
+bool ImGui::BeginViewportSideBar(const char* name, ImGuiViewport* viewport_p, ImGuiDir dir, float axis_size, ImGuiWindowFlags window_flags) IM_NOEXCEPT
 {
     IM_ASSERT(dir != ImGuiDir_None);
 
@@ -6651,7 +6651,7 @@ bool ImGui::BeginViewportSideBar(const char* name, ImGuiViewport* viewport_p, Im
     return is_open;
 }
 
-bool ImGui::BeginMainMenuBar() IMGUI_NOEXCEPT
+bool ImGui::BeginMainMenuBar() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiViewportP* viewport = (ImGuiViewportP*)(void*)GetMainViewport();
@@ -6672,7 +6672,7 @@ bool ImGui::BeginMainMenuBar() IMGUI_NOEXCEPT
     return is_open;
 }
 
-void ImGui::EndMainMenuBar() IMGUI_NOEXCEPT
+void ImGui::EndMainMenuBar() IM_NOEXCEPT
 {
     EndMenuBar();
 
@@ -6685,7 +6685,7 @@ void ImGui::EndMainMenuBar() IMGUI_NOEXCEPT
     End();
 }
 
-bool ImGui::BeginMenu(const char* label, bool enabled) IMGUI_NOEXCEPT
+bool ImGui::BeginMenu(const char* label, bool enabled) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -6849,7 +6849,7 @@ bool ImGui::BeginMenu(const char* label, bool enabled) IMGUI_NOEXCEPT
     return menu_is_open;
 }
 
-void ImGui::EndMenu() IMGUI_NOEXCEPT
+void ImGui::EndMenu() IM_NOEXCEPT
 {
     // Nav: When a left move request _within our child menu_ failed, close ourselves (the _parent_ menu).
     // A menu doesn't close itself because EndMenuBar() wants the catch the last Left<>Right inputs.
@@ -6865,7 +6865,7 @@ void ImGui::EndMenu() IMGUI_NOEXCEPT
     EndPopup();
 }
 
-bool ImGui::MenuItem(const char* label, const char* shortcut, bool selected, bool enabled) IMGUI_NOEXCEPT
+bool ImGui::MenuItem(const char* label, const char* shortcut, bool selected, bool enabled) IM_NOEXCEPT
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -6914,7 +6914,7 @@ bool ImGui::MenuItem(const char* label, const char* shortcut, bool selected, boo
     return pressed;
 }
 
-bool ImGui::MenuItem(const char* label, const char* shortcut, bool* p_selected, bool enabled) IMGUI_NOEXCEPT
+bool ImGui::MenuItem(const char* label, const char* shortcut, bool* p_selected, bool enabled) IM_NOEXCEPT
 {
     if (MenuItem(label, shortcut, p_selected ? *p_selected : false, enabled))
     {
@@ -6950,33 +6950,33 @@ struct ImGuiTabBarSection
     float               Width;                  // Sum of width of tabs in this section (after shrinking down)
     float               Spacing;                // Horizontal spacing at the end of the section.
 
-    ImGuiTabBarSection() IMGUI_NOEXCEPT { memset(this, 0, sizeof(*this)); }
+    ImGuiTabBarSection() IM_NOEXCEPT { memset(this, 0, sizeof(*this)); }
 };
 
 namespace ImGui
 {
-    static void             TabBarLayout(ImGuiTabBar* tab_bar) IMGUI_NOEXCEPT;
-    static ImU32            TabBarCalcTabID(ImGuiTabBar* tab_bar, const char* label) IMGUI_NOEXCEPT;
-    static float            TabBarCalcMaxTabWidth() IMGUI_NOEXCEPT;
-    static float            TabBarScrollClamp(ImGuiTabBar* tab_bar, float scrolling) IMGUI_NOEXCEPT;
-    static void             TabBarScrollToTab(ImGuiTabBar* tab_bar, ImGuiID tab_id, ImGuiTabBarSection* sections) IMGUI_NOEXCEPT;
-    static ImGuiTabItem*    TabBarScrollingButtons(ImGuiTabBar* tab_bar) IMGUI_NOEXCEPT;
-    static ImGuiTabItem*    TabBarTabListPopupButton(ImGuiTabBar* tab_bar) IMGUI_NOEXCEPT;
+    static void             TabBarLayout(ImGuiTabBar* tab_bar) IM_NOEXCEPT;
+    static ImU32            TabBarCalcTabID(ImGuiTabBar* tab_bar, const char* label) IM_NOEXCEPT;
+    static float            TabBarCalcMaxTabWidth() IM_NOEXCEPT;
+    static float            TabBarScrollClamp(ImGuiTabBar* tab_bar, float scrolling) IM_NOEXCEPT;
+    static void             TabBarScrollToTab(ImGuiTabBar* tab_bar, ImGuiID tab_id, ImGuiTabBarSection* sections) IM_NOEXCEPT;
+    static ImGuiTabItem*    TabBarScrollingButtons(ImGuiTabBar* tab_bar) IM_NOEXCEPT;
+    static ImGuiTabItem*    TabBarTabListPopupButton(ImGuiTabBar* tab_bar) IM_NOEXCEPT;
 }
 
-ImGuiTabBar::ImGuiTabBar() IMGUI_NOEXCEPT
+ImGuiTabBar::ImGuiTabBar() IM_NOEXCEPT
 {
     memset(this, 0, sizeof(*this));
     CurrFrameVisible = PrevFrameVisible = -1;
     LastTabItemIdx = -1;
 }
 
-static inline int TabItemGetSectionIdx(const ImGuiTabItem* tab) IMGUI_NOEXCEPT
+static inline int TabItemGetSectionIdx(const ImGuiTabItem* tab) IM_NOEXCEPT
 {
     return (tab->Flags & ImGuiTabItemFlags_Leading) ? 0 : (tab->Flags & ImGuiTabItemFlags_Trailing) ? 2 : 1;
 }
 
-static int IMGUI_CDECL TabItemComparerBySection(const void* lhs, const void* rhs) IMGUI_NOEXCEPT
+static int IMGUI_CDECL TabItemComparerBySection(const void* lhs, const void* rhs) IM_NOEXCEPT
 {
     const ImGuiTabItem* a = (const ImGuiTabItem*)lhs;
     const ImGuiTabItem* b = (const ImGuiTabItem*)rhs;
@@ -6987,20 +6987,20 @@ static int IMGUI_CDECL TabItemComparerBySection(const void* lhs, const void* rhs
     return (int)(a->IndexDuringLayout - b->IndexDuringLayout);
 }
 
-static int IMGUI_CDECL TabItemComparerByBeginOrder(const void* lhs, const void* rhs) IMGUI_NOEXCEPT
+static int IMGUI_CDECL TabItemComparerByBeginOrder(const void* lhs, const void* rhs) IM_NOEXCEPT
 {
     const ImGuiTabItem* a = (const ImGuiTabItem*)lhs;
     const ImGuiTabItem* b = (const ImGuiTabItem*)rhs;
     return (int)(a->BeginOrder - b->BeginOrder);
 }
 
-static ImGuiTabBar* GetTabBarFromTabBarRef(const ImGuiPtrOrIndex& ref) IMGUI_NOEXCEPT
+static ImGuiTabBar* GetTabBarFromTabBarRef(const ImGuiPtrOrIndex& ref) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return ref.Ptr ? (ImGuiTabBar*)ref.Ptr : g.TabBars.GetByIndex(ref.Index);
 }
 
-static ImGuiPtrOrIndex GetTabBarRefFromTabBar(ImGuiTabBar* tab_bar) IMGUI_NOEXCEPT
+static ImGuiPtrOrIndex GetTabBarRefFromTabBar(ImGuiTabBar* tab_bar) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     if (g.TabBars.Contains(tab_bar))
@@ -7008,7 +7008,7 @@ static ImGuiPtrOrIndex GetTabBarRefFromTabBar(ImGuiTabBar* tab_bar) IMGUI_NOEXCE
     return ImGuiPtrOrIndex(tab_bar);
 }
 
-bool    ImGui::BeginTabBar(const char* str_id, ImGuiTabBarFlags flags) IMGUI_NOEXCEPT
+bool    ImGui::BeginTabBar(const char* str_id, ImGuiTabBarFlags flags) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7022,7 +7022,7 @@ bool    ImGui::BeginTabBar(const char* str_id, ImGuiTabBarFlags flags) IMGUI_NOE
     return BeginTabBarEx(tab_bar, tab_bar_bb, flags | ImGuiTabBarFlags_IsFocused);
 }
 
-bool    ImGui::BeginTabBarEx(ImGuiTabBar* tab_bar, const ImRect& tab_bar_bb, ImGuiTabBarFlags flags) IMGUI_NOEXCEPT
+bool    ImGui::BeginTabBarEx(ImGuiTabBar* tab_bar, const ImRect& tab_bar_bb, ImGuiTabBarFlags flags) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7081,7 +7081,7 @@ bool    ImGui::BeginTabBarEx(ImGuiTabBar* tab_bar, const ImRect& tab_bar_bb, ImG
     return true;
 }
 
-void    ImGui::EndTabBar() IMGUI_NOEXCEPT
+void    ImGui::EndTabBar() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7122,7 +7122,7 @@ void    ImGui::EndTabBar() IMGUI_NOEXCEPT
 
 // This is called only once a frame before by the first call to ItemTab()
 // The reason we're not calling it in BeginTabBar() is to leave a chance to the user to call the SetTabItemClosed() functions.
-static void ImGui::TabBarLayout(ImGuiTabBar* tab_bar) IMGUI_NOEXCEPT
+static void ImGui::TabBarLayout(ImGuiTabBar* tab_bar) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     tab_bar->WantLayout = false;
@@ -7352,7 +7352,7 @@ static void ImGui::TabBarLayout(ImGuiTabBar* tab_bar) IMGUI_NOEXCEPT
 }
 
 // Dockables uses Name/ID in the global namespace. Non-dockable items use the ID stack.
-static ImU32   ImGui::TabBarCalcTabID(ImGuiTabBar* tab_bar, const char* label) IMGUI_NOEXCEPT
+static ImU32   ImGui::TabBarCalcTabID(ImGuiTabBar* tab_bar, const char* label) IM_NOEXCEPT
 {
     if (tab_bar->Flags & ImGuiTabBarFlags_DockNode)
     {
@@ -7367,13 +7367,13 @@ static ImU32   ImGui::TabBarCalcTabID(ImGuiTabBar* tab_bar, const char* label) I
     }
 }
 
-static float ImGui::TabBarCalcMaxTabWidth() IMGUI_NOEXCEPT
+static float ImGui::TabBarCalcMaxTabWidth() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     return g.FontSize * 20.0f;
 }
 
-ImGuiTabItem* ImGui::TabBarFindTabByID(ImGuiTabBar* tab_bar, ImGuiID tab_id) IMGUI_NOEXCEPT
+ImGuiTabItem* ImGui::TabBarFindTabByID(ImGuiTabBar* tab_bar, ImGuiID tab_id) IM_NOEXCEPT
 {
     if (tab_id != 0)
         for (int n = 0; n < tab_bar->Tabs.Size; n++)
@@ -7383,7 +7383,7 @@ ImGuiTabItem* ImGui::TabBarFindTabByID(ImGuiTabBar* tab_bar, ImGuiID tab_id) IMG
 }
 
 // The *TabId fields be already set by the docking system _before_ the actual TabItem was created, so we clear them regardless.
-void ImGui::TabBarRemoveTab(ImGuiTabBar* tab_bar, ImGuiID tab_id) IMGUI_NOEXCEPT
+void ImGui::TabBarRemoveTab(ImGuiTabBar* tab_bar, ImGuiID tab_id) IM_NOEXCEPT
 {
     if (ImGuiTabItem* tab = TabBarFindTabByID(tab_bar, tab_id))
         tab_bar->Tabs.erase(tab);
@@ -7393,7 +7393,7 @@ void ImGui::TabBarRemoveTab(ImGuiTabBar* tab_bar, ImGuiID tab_id) IMGUI_NOEXCEPT
 }
 
 // Called on manual closure attempt
-void ImGui::TabBarCloseTab(ImGuiTabBar* tab_bar, ImGuiTabItem* tab) IMGUI_NOEXCEPT
+void ImGui::TabBarCloseTab(ImGuiTabBar* tab_bar, ImGuiTabItem* tab) IM_NOEXCEPT
 {
     IM_ASSERT(!(tab->Flags & ImGuiTabItemFlags_Button));
     if (!(tab->Flags & ImGuiTabItemFlags_UnsavedDocument))
@@ -7415,14 +7415,14 @@ void ImGui::TabBarCloseTab(ImGuiTabBar* tab_bar, ImGuiTabItem* tab) IMGUI_NOEXCE
     }
 }
 
-static float ImGui::TabBarScrollClamp(ImGuiTabBar* tab_bar, float scrolling) IMGUI_NOEXCEPT
+static float ImGui::TabBarScrollClamp(ImGuiTabBar* tab_bar, float scrolling) IM_NOEXCEPT
 {
     scrolling = ImMin(scrolling, tab_bar->WidthAllTabs - tab_bar->BarRect.GetWidth());
     return ImMax(scrolling, 0.0f);
 }
 
 // Note: we may scroll to tab that are not selected! e.g. using keyboard arrow keys
-static void ImGui::TabBarScrollToTab(ImGuiTabBar* tab_bar, ImGuiID tab_id, ImGuiTabBarSection* sections) IMGUI_NOEXCEPT
+static void ImGui::TabBarScrollToTab(ImGuiTabBar* tab_bar, ImGuiID tab_id, ImGuiTabBarSection* sections) IM_NOEXCEPT
 {
     ImGuiTabItem* tab = TabBarFindTabByID(tab_bar, tab_id);
     if (tab == NULL)
@@ -7456,7 +7456,7 @@ static void ImGui::TabBarScrollToTab(ImGuiTabBar* tab_bar, ImGuiID tab_id, ImGui
     }
 }
 
-void ImGui::TabBarQueueReorder(ImGuiTabBar* tab_bar, const ImGuiTabItem* tab, int offset) IMGUI_NOEXCEPT
+void ImGui::TabBarQueueReorder(ImGuiTabBar* tab_bar, const ImGuiTabItem* tab, int offset) IM_NOEXCEPT
 {
     IM_ASSERT(offset != 0);
     IM_ASSERT(tab_bar->ReorderRequestTabId == 0);
@@ -7464,7 +7464,7 @@ void ImGui::TabBarQueueReorder(ImGuiTabBar* tab_bar, const ImGuiTabItem* tab, in
     tab_bar->ReorderRequestOffset = (ImS16)offset;
 }
 
-void ImGui::TabBarQueueReorderFromMousePos(ImGuiTabBar* tab_bar, const ImGuiTabItem* src_tab, ImVec2 mouse_pos) IMGUI_NOEXCEPT
+void ImGui::TabBarQueueReorderFromMousePos(ImGuiTabBar* tab_bar, const ImGuiTabItem* src_tab, ImVec2 mouse_pos) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     IM_ASSERT(tab_bar->ReorderRequestTabId == 0);
@@ -7500,7 +7500,7 @@ void ImGui::TabBarQueueReorderFromMousePos(ImGuiTabBar* tab_bar, const ImGuiTabI
         TabBarQueueReorder(tab_bar, src_tab, dst_idx - src_idx);
 }
 
-bool ImGui::TabBarProcessReorder(ImGuiTabBar* tab_bar) IMGUI_NOEXCEPT
+bool ImGui::TabBarProcessReorder(ImGuiTabBar* tab_bar) IM_NOEXCEPT
 {
     ImGuiTabItem* tab1 = TabBarFindTabByID(tab_bar, tab_bar->ReorderRequestTabId);
     if (tab1 == NULL || (tab1->Flags & ImGuiTabItemFlags_NoReorder))
@@ -7531,7 +7531,7 @@ bool ImGui::TabBarProcessReorder(ImGuiTabBar* tab_bar) IMGUI_NOEXCEPT
     return true;
 }
 
-static ImGuiTabItem* ImGui::TabBarScrollingButtons(ImGuiTabBar* tab_bar) IMGUI_NOEXCEPT
+static ImGuiTabItem* ImGui::TabBarScrollingButtons(ImGuiTabBar* tab_bar) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7592,7 +7592,7 @@ static ImGuiTabItem* ImGui::TabBarScrollingButtons(ImGuiTabBar* tab_bar) IMGUI_N
     return tab_to_scroll_to;
 }
 
-static ImGuiTabItem* ImGui::TabBarTabListPopupButton(ImGuiTabBar* tab_bar) IMGUI_NOEXCEPT
+static ImGuiTabItem* ImGui::TabBarTabListPopupButton(ImGuiTabBar* tab_bar) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7643,7 +7643,7 @@ static ImGuiTabItem* ImGui::TabBarTabListPopupButton(ImGuiTabBar* tab_bar) IMGUI
 // - TabItemLabelAndCloseButton() [Internal]
 //-------------------------------------------------------------------------
 
-bool    ImGui::BeginTabItem(const char* label, bool* p_open, ImGuiTabItemFlags flags) IMGUI_NOEXCEPT
+bool    ImGui::BeginTabItem(const char* label, bool* p_open, ImGuiTabItemFlags flags) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7667,7 +7667,7 @@ bool    ImGui::BeginTabItem(const char* label, bool* p_open, ImGuiTabItemFlags f
     return ret;
 }
 
-void    ImGui::EndTabItem() IMGUI_NOEXCEPT
+void    ImGui::EndTabItem() IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7686,7 +7686,7 @@ void    ImGui::EndTabItem() IMGUI_NOEXCEPT
         PopID();
 }
 
-bool    ImGui::TabItemButton(const char* label, ImGuiTabItemFlags flags) IMGUI_NOEXCEPT
+bool    ImGui::TabItemButton(const char* label, ImGuiTabItemFlags flags) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -7702,7 +7702,7 @@ bool    ImGui::TabItemButton(const char* label, ImGuiTabItemFlags flags) IMGUI_N
     return TabItemEx(tab_bar, label, NULL, flags | ImGuiTabItemFlags_Button | ImGuiTabItemFlags_NoReorder);
 }
 
-bool    ImGui::TabItemEx(ImGuiTabBar* tab_bar, const char* label, bool* p_open, ImGuiTabItemFlags flags) IMGUI_NOEXCEPT
+bool    ImGui::TabItemEx(ImGuiTabBar* tab_bar, const char* label, bool* p_open, ImGuiTabItemFlags flags) IM_NOEXCEPT
 {
     // Layout whole tab bar if not already done
     if (tab_bar->WantLayout)
@@ -7918,7 +7918,7 @@ bool    ImGui::TabItemEx(ImGuiTabBar* tab_bar, const char* label, bool* p_open, 
 // [Public] This is call is 100% optional but it allows to remove some one-frame glitches when a tab has been unexpectedly removed.
 // To use it to need to call the function SetTabItemClosed() between BeginTabBar() and EndTabBar().
 // Tabs closed by the close button will automatically be flagged to avoid this issue.
-void    ImGui::SetTabItemClosed(const char* label) IMGUI_NOEXCEPT
+void    ImGui::SetTabItemClosed(const char* label) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     bool is_within_manual_tab_bar = g.CurrentTabBar && !(g.CurrentTabBar->Flags & ImGuiTabBarFlags_DockNode);
@@ -7931,7 +7931,7 @@ void    ImGui::SetTabItemClosed(const char* label) IMGUI_NOEXCEPT
     }
 }
 
-ImVec2 ImGui::TabItemCalcSize(const char* label, bool has_close_button) IMGUI_NOEXCEPT
+ImVec2 ImGui::TabItemCalcSize(const char* label, bool has_close_button) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImVec2 label_size = CalcTextSize(label, NULL, true);
@@ -7943,7 +7943,7 @@ ImVec2 ImGui::TabItemCalcSize(const char* label, bool has_close_button) IMGUI_NO
     return ImVec2(ImMin(size.x, TabBarCalcMaxTabWidth()), size.y);
 }
 
-void ImGui::TabItemBackground(ImDrawList* draw_list, const ImRect& bb, ImGuiTabItemFlags flags, ImU32 col) IMGUI_NOEXCEPT
+void ImGui::TabItemBackground(ImDrawList* draw_list, const ImRect& bb, ImGuiTabItemFlags flags, ImU32 col) IM_NOEXCEPT
 {
     // While rendering tabs, we trim 1 pixel off the top of our bounding box so they can fit within a regular frame height while looking "detached" from it.
     ImGuiContext& g = *GImGui;
@@ -7970,7 +7970,7 @@ void ImGui::TabItemBackground(ImDrawList* draw_list, const ImRect& bb, ImGuiTabI
 
 // Render text label (with custom clipping) + Unsaved Document marker + Close Button logic
 // We tend to lock style.FramePadding for a given tab-bar, hence the 'frame_padding' parameter.
-void ImGui::TabItemLabelAndCloseButton(ImDrawList* draw_list, const ImRect& bb, ImGuiTabItemFlags flags, ImVec2 frame_padding, const char* label, ImGuiID tab_id, ImGuiID close_button_id, bool is_contents_visible, bool* out_just_closed, bool* out_text_clipped) IMGUI_NOEXCEPT
+void ImGui::TabItemLabelAndCloseButton(ImDrawList* draw_list, const ImRect& bb, ImGuiTabItemFlags flags, ImVec2 frame_padding, const char* label, ImGuiID tab_id, ImGuiID close_button_id, bool is_contents_visible, bool* out_just_closed, bool* out_text_clipped) IM_NOEXCEPT
 {
     ImGuiContext& g = *GImGui;
     ImVec2 label_size = CalcTextSize(label, NULL, true);


### PR DESCRIPTION
While working on my own C++ bindings for Dear ImGui I noticed a lot of bloatifacts in the generated code. C++11 introduced a "noexcept" specifier that tells compilers a function will not throw any exceptions, allowing for additional optimizations and a smaller code fingerprint.

See this trivial example at https://gcc.godbolt.org/z/fWdYPMfTT

```
struct S { ~S(); };
struct T { ~T() noexcept; };

extern S& ext_std(S* s);
extern T& ext_nox(T* t) noexcept;

extern S f1(S& a)
{
    S x(a);
    return ext_std(&x);
}

extern T f2(T& a)
{
    T x(a);
    return ext_nox(&x);
}
```

Even in this most trivial example, the noexcept specifier reduces compile time and output instructions by 6:

```
f1(S&):
        pushq   %r12
        movq    %rdi, %r12
        subq    $16, %rsp
        leaq    15(%rsp), %rdi
        call    ext_std(S*)
        leaq    15(%rsp), %rdi
        call    S::~S() [complete object destructor]
        addq    $16, %rsp
        movq    %r12, %rax
        popq    %r12
        ret
        movq    %rax, %r12
        jmp     .L2
f1(S&) [clone .cold]:
.L2:
        leaq    15(%rsp), %rdi
        call    S::~S() [complete object destructor]
        movq    %r12, %rdi
        call    _Unwind_Resume
f2(T&):
        pushq   %r12
        movq    %rdi, %r12
        subq    $16, %rsp
        leaq    15(%rsp), %rdi
        call    ext_nox(T*)
        leaq    15(%rsp), %rdi
        call    T::~T() [complete object destructor]
        addq    $16, %rsp
        movq    %r12, %rax
        popq    %r12
        ret
```

The absence of exceptions can be deduced by the compiler within a compilation unit, at the cost of additional compilation time.

So, people who are using a unity build (not Unity(R)) or for calls within imgui functions themselves, adding the specifier has little effect.

However anyone writing modern C++ code and using a vendor'd or librarized imgui can expect to see their code suddenly behaving as though exceptions were turned on.

This PR:

a) Limits itself to entry/exit points (Begin/End) that are intended to be invoked externally, as these typically straddle scope changes (`if (ImGui::Begin(...)) { ... }`, these appear to be commonly associated in use and bindings with object construction (scope guards), see https://github.com/kfsone/imguiwrap
b) Introduces IMGUI_NOEXCEPT in imconfig.h, annotated but commented out and with a `#if __cplusplus >= 201103L` to disable it for earlier C++ versions,
c) Ensures it is defined-null in imgui.h if it is not already defined to eliminate the effect on users not opting in.

A demonstration of it impacting scope guarding: https://gcc.godbolt.org/z/5r7aoof5b

Some cases are more dramatic than others:

![image](https://user-images.githubusercontent.com/323009/118564138-a3381780-b724-11eb-8489-85777a06cbbc.png)
