### PR TITLE
Add colour choosing functionality to combos via flags on BeginCombo() and Selectable()

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -495,7 +495,7 @@ namespace ImGui
     // Widgets: Combo Box
     // - The BeginCombo()/EndCombo() api allows you to manage your contents and selection state however you want it, by creating e.g. Selectable() items.
     // - The old Combo() api are helpers over BeginCombo()/EndCombo() which are kept available for convenience purpose. This is analogous to how ListBox are created.
-    IMGUI_API bool          BeginCombo(const char* label, const char* preview_value, ImGuiComboFlags flags = 0);
+    IMGUI_API bool          BeginCombo(const char* label, const char* preview_value, ImGuiComboFlags flags = 0, const ImVec4& preview_col = ImVec4(0,0,0,0));
     IMGUI_API void          EndCombo(); // only call EndCombo() if BeginCombo() returns true!
     IMGUI_API bool          Combo(const char* label, int* current_item, const char* const items[], int items_count, int popup_max_height_in_items = -1);
     IMGUI_API bool          Combo(const char* label, int* current_item, const char* items_separated_by_zeros, int popup_max_height_in_items = -1);      // Separate items with \0 within a string, end item-list with \0\0. e.g. "One\0Two\0Three\0"
@@ -597,8 +597,8 @@ namespace ImGui
     // Widgets: Selectables
     // - A selectable highlights when hovered, and can display another color when selected.
     // - Neighbors selectable extend their highlight bounds in order to leave no gap between them. This is so a series of selected Selectable appear contiguous.
-    IMGUI_API bool          Selectable(const char* label, bool selected = false, ImGuiSelectableFlags flags = 0, const ImVec2& size = ImVec2(0, 0)); // "bool selected" carry the selection state (read-only). Selectable() is clicked is returns true so you can modify your selection state. size.x==0.0: use remaining width, size.x>0.0: specify width. size.y==0.0: use label height, size.y>0.0: specify height
-    IMGUI_API bool          Selectable(const char* label, bool* p_selected, ImGuiSelectableFlags flags = 0, const ImVec2& size = ImVec2(0, 0));      // "bool* p_selected" point to the selection state (read-write), as a convenient helper.
+    IMGUI_API bool          Selectable(const char* label, bool selected = false, ImGuiSelectableFlags flags = 0, const ImVec2& size = ImVec2(0, 0), const ImVec4& preview_col = ImVec4(0, 0, 0, 0)); // "bool selected" carry the selection state (read-only). Selectable() is clicked is returns true so you can modify your selection state. size.x==0.0: use remaining width, size.x>0.0: specify width. size.y==0.0: use label height, size.y>0.0: specify height
+    IMGUI_API bool          Selectable(const char* label, bool* p_selected, ImGuiSelectableFlags flags = 0, const ImVec2& size = ImVec2(0, 0), const ImVec4& preview_col = ImVec4(0, 0, 0, 0));      // "bool* p_selected" point to the selection state (read-write), as a convenient helper.
 
     // Widgets: List Boxes
     // - This is essentially a thin wrapper to using BeginChild/EndChild with some stylistic changes.
@@ -1033,7 +1033,8 @@ enum ImGuiSelectableFlags_
     ImGuiSelectableFlags_SpanAllColumns     = 1 << 1,   // Selectable frame can span all columns (text will still fit in current column)
     ImGuiSelectableFlags_AllowDoubleClick   = 1 << 2,   // Generate press events on double clicks too
     ImGuiSelectableFlags_Disabled           = 1 << 3,   // Cannot be selected, display grayed out text
-    ImGuiSelectableFlags_AllowItemOverlap   = 1 << 4    // (WIP) Hit testing to allow subsequent widgets to overlap this one
+    ImGuiSelectableFlags_AllowItemOverlap   = 1 << 4,   // (WIP) Hit testing to allow subsequent widgets to overlap this one
+    ImGuiSelectableFlags_ColorPreview       = 1 << 5,   // Show a square of the given color to the left of the text
 };
 
 // Flags for ImGui::BeginCombo()
@@ -1047,6 +1048,7 @@ enum ImGuiComboFlags_
     ImGuiComboFlags_HeightLargest           = 1 << 4,   // As many fitting items as possible
     ImGuiComboFlags_NoArrowButton           = 1 << 5,   // Display on the preview box without the square arrow button
     ImGuiComboFlags_NoPreview               = 1 << 6,   // Display only a square arrow button
+    ImGuiComboFlags_ColorPreview            = 1 << 7,   // Show a square of the given color to the left side of the preview text
     ImGuiComboFlags_HeightMask_             = ImGuiComboFlags_HeightSmall | ImGuiComboFlags_HeightRegular | ImGuiComboFlags_HeightLarge | ImGuiComboFlags_HeightLargest
 };
 

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -1020,19 +1020,27 @@ static void ShowDemoWindowWidgets()
             flags &= ~ImGuiComboFlags_NoPreview;     // Clear the other flag, as we cannot combine both
         if (ImGui::CheckboxFlags("ImGuiComboFlags_NoPreview", &flags, ImGuiComboFlags_NoPreview))
             flags &= ~ImGuiComboFlags_NoArrowButton; // Clear the other flag, as we cannot combine both
+        ImGui::CheckboxFlags("ImGuiComboFlags_ColorPreview", &flags, ImGuiComboFlags_ColorPreview);
 
         // Using the generic BeginCombo() API, you have full control over how to display the combo contents.
         // (your selection data could be an index, a pointer to the object, an id for the object, a flag intrusively
         // stored in the object itself, etc.)
         const char* items[] = { "AAAA", "BBBB", "CCCC", "DDDD", "EEEE", "FFFF", "GGGG", "HHHH", "IIII", "JJJJ", "KKKK", "LLLLLLL", "MMMM", "OOOOOOO" };
+        ImVec4 colors[] = { ImVec4(1.0f, 0.0f, 0.0f, 1.0f), ImVec4(1.0f, 1.0f, 0.0f, 0.5f), ImVec4(0.0f, 0.5f, 1.0f, 0.75f) };
         static int item_current_idx = 0; // Here we store our selection data as an index.
         const char* combo_label = items[item_current_idx];  // Label to preview before opening the combo (technically it could be anything)
-        if (ImGui::BeginCombo("combo 1", combo_label, flags))
+        ImVec4 combo_color = colors[item_current_idx % IM_ARRAYSIZE(colors)];
+        if (ImGui::BeginCombo("combo 1", combo_label, flags, combo_color))
         {
             for (int n = 0; n < IM_ARRAYSIZE(items); n++)
             {
                 const bool is_selected = (item_current_idx == n);
-                if (ImGui::Selectable(items[n], is_selected))
+
+                ImGuiSelectableFlags selectable_flags = 0;
+                if (flags & ImGuiComboFlags_ColorPreview)
+                    selectable_flags |= ImGuiSelectableFlags_ColorPreview;
+
+                if (ImGui::Selectable(items[n], is_selected, selectable_flags, ImVec2(0, 0), colors[n % IM_ARRAYSIZE(colors)]))
                     item_current_idx = n;
 
                 // Set the initial focus when opening the combo (scrolling + keyboard navigation focus)


### PR DESCRIPTION
My application has a material editor that allows you to pick from a small fixed set of colours, and I wanted to use a combo box. I thought it would be nice to display preview swatches next to them. I can do this by adding rectangles to the DrawList, but there's no elegant way to adjust the position of the combo preview text without modifying BeginCombo().

This PR adds the following functionality:

- New flag: `ImGuiComboFlags_ColorPreview`
- New flag: `ImGuiSelectableFlags_ColorPreview`
- `col_preview` parameter (of type ImVec4) added to BeginCombo() and Selectable()
  - Displays a swatch to the left of the text when the corresponding flag is enabled
  - RenderColorRectWithAlphaCheckerboard is used to match the previews shown by ColorEdit, etc. for colours with alpha channels
- The demo is updated to demonstrate this

<img width="305" alt="imgui_combo_color_preview" src="https://user-images.githubusercontent.com/228195/119290581-ac554700-bc44-11eb-83fb-2742f8050e41.png">

There are some questions I wasn't sure about:

- Adding an extra parameter to these two functions just for one use case makes the API surface a bit more cluttered - is there a better way to do this? (Pushing to a stack or calling a new SetNextXXX function...?)
- Should the colour be supplied as an ImVec4 or an ImU32?
- The swatches may need to use one of the rounding settings from the style

I don't know if this is the ideal implementation, but hopefully it's a good starting point.
