### PR TITLE
Implement ImGuiSelectableFlags_AllowRightClick flag

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -1034,6 +1034,7 @@ enum ImGuiSelectableFlags_
     ImGuiSelectableFlags_AllowDoubleClick   = 1 << 2,   // Generate press events on double clicks too
     ImGuiSelectableFlags_Disabled           = 1 << 3,   // Cannot be selected, display grayed out text
     ImGuiSelectableFlags_AllowItemOverlap   = 1 << 4    // (WIP) Hit testing to allow subsequent widgets to overlap this one
+    ImGuiSelectableFlags_AllowRightClick    = 1 << 5    // Generate press events on right clicks too
 };
 
 // Flags for ImGui::BeginCombo()

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -6110,6 +6110,7 @@ bool ImGui::Selectable(const char* label, bool selected, ImGuiSelectableFlags fl
     if (flags & ImGuiSelectableFlags_Disabled)          { button_flags |= ImGuiButtonFlags_Disabled; }
     if (flags & ImGuiSelectableFlags_AllowDoubleClick)  { button_flags |= ImGuiButtonFlags_PressedOnClickRelease | ImGuiButtonFlags_PressedOnDoubleClick; }
     if (flags & ImGuiSelectableFlags_AllowItemOverlap)  { button_flags |= ImGuiButtonFlags_AllowItemOverlap; }
+    if (flags & ImGuiSelectableFlags_AllowRightClick)   { button_flags |= ImGuiButtonFlags_PressedOnClickRelease | ImGuiButtonFlags_MouseButtonRight | ImGuiButtonFlags_MouseButtonLeft; }
 
     if (flags & ImGuiSelectableFlags_Disabled)
         selected = false;


### PR DESCRIPTION
Solves issue: https://github.com/ocornut/imgui/issues/769

Description:
This pull request adds an `ImGuiSelectableFlags_AllowRightClick` flag allowing selection of an item with right click.

Usage:
```
if (ImGui::Selectable(<label>, <selected>, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_AllowRightClick))
{
    if (ImGui::IsMouseReleased(ImGuiMouseButton_Right))
    {
        // Rick click pressed on current item
    }
}
```