### PR TITLE
Prevent access violation due to NULL from glGetStringi.

### DIFF
--- a/backends/imgui_impl_opengl3.cpp
+++ b/backends/imgui_impl_opengl3.cpp
@@ -247,7 +247,7 @@ bool    ImGui_ImplOpenGL3_Init(const char* glsl_version)
     for (GLint i = 0; i < num_extensions; i++)
     {
         const char* extension = (const char*)glGetStringi(GL_EXTENSIONS, i);
-        if (strcmp(extension, "GL_ARB_clip_control") == 0)
+        if (extension != NULL && strcmp(extension, "GL_ARB_clip_control") == 0)
             g_HasClipOrigin = true;
     }
 #endif


### PR DESCRIPTION
This fix is to solve the problem due to a commit 556689591c529855ceb07e779dd8a46a12f38008 for  #4170.
In some platform, `extension` returned from `glGetStringi` can be `NULL`, and then, it causes access violation in `strcmp`.
