### PR TITLE
Add text alignment support for wrapped paragraphs

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -3034,6 +3034,7 @@ void ImGui::GcCompactTransientWindowBuffers(ImGuiWindow* window)
     window->DC.ChildWindows.clear();
     window->DC.ItemWidthStack.clear();
     window->DC.TextWrapPosStack.clear();
+    window->DC.TextAlignmentStack.clear();
 }
 
 void ImGui::GcAwakeTransientWindowBuffers(ImGuiWindow* window)
@@ -6262,6 +6263,7 @@ bool ImGui::Begin(const char* name, bool* p_open, ImGuiWindowFlags flags)
         window->DC.TextWrapPos = -1.0f; // disabled
         window->DC.ItemWidthStack.resize(0);
         window->DC.TextWrapPosStack.resize(0);
+        window->DC.TextAlignmentStack.resize(0);
 
         if (window->AutoFitFramesX > 0)
             window->AutoFitFramesX--;
@@ -6601,6 +6603,20 @@ void ImGui::PopTextWrapPos()
     ImGuiWindow* window = GetCurrentWindow();
     window->DC.TextWrapPos = window->DC.TextWrapPosStack.back();
     window->DC.TextWrapPosStack.pop_back();
+}
+
+void ImGui::PushTextAlignment(float alignment)
+{
+    ImGuiWindow *window = GetCurrentWindow();
+    window->DC.TextAlignmentStack.push_back(window->DC.TextAlignment);
+    window->DC.TextAlignment = alignment;
+}
+
+void ImGui::PopTextAlignment()
+{
+    ImGuiWindow* window = GetCurrentWindow();
+    window->DC.TextAlignment = window->DC.TextAlignmentStack.back();
+    window->DC.TextAlignmentStack.pop_back();
 }
 
 bool ImGui::IsWindowChildOf(ImGuiWindow* window, ImGuiWindow* potential_parent)

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -2688,7 +2688,7 @@ void ImGui::RenderText(ImVec2 pos, const char* text, const char* text_end, bool 
     }
 }
 
-void ImGui::RenderTextWrapped(ImVec2 pos, const char* text, const char* text_end, float wrap_width)
+void ImGui::RenderTextWrapped(ImVec2 pos, const char* text, const char* text_end, float wrap_width, float text_alignment)
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
@@ -2698,7 +2698,7 @@ void ImGui::RenderTextWrapped(ImVec2 pos, const char* text, const char* text_end
 
     if (text != text_end)
     {
-        window->DrawList->AddText(g.Font, g.FontSize, pos, GetColorU32(ImGuiCol_Text), text, text_end, wrap_width);
+        window->DrawList->AddText(g.Font, g.FontSize, pos, GetColorU32(ImGuiCol_Text), text, text_end, wrap_width, text_alignment);
         if (g.LogEnabled)
             LogRenderedText(&pos, text, text_end);
     }
@@ -2726,11 +2726,11 @@ void ImGui::RenderTextClippedEx(ImDrawList* draw_list, const ImVec2& pos_min, co
     if (need_clipping)
     {
         ImVec4 fine_clip_rect(clip_min->x, clip_min->y, clip_max->x, clip_max->y);
-        draw_list->AddText(NULL, 0.0f, pos, GetColorU32(ImGuiCol_Text), text, text_display_end, 0.0f, &fine_clip_rect);
+        draw_list->AddText(NULL, 0.0f, pos, GetColorU32(ImGuiCol_Text), text, text_display_end, 0.0f, 0.0f, &fine_clip_rect);
     }
     else
     {
-        draw_list->AddText(NULL, 0.0f, pos, GetColorU32(ImGuiCol_Text), text, text_display_end, 0.0f, NULL);
+        draw_list->AddText(NULL, 0.0f, pos, GetColorU32(ImGuiCol_Text), text, text_display_end, 0.0f, 0.0f, NULL);
     }
 }
 

--- a/imgui.h
+++ b/imgui.h
@@ -403,6 +403,8 @@ namespace ImGui
     IMGUI_API float         CalcItemWidth();                                                // width of item given pushed settings and current cursor position. NOT necessarily the width of last item unlike most 'Item' functions.
     IMGUI_API void          PushTextWrapPos(float wrap_local_pos_x = 0.0f);                 // push word-wrapping position for Text*() commands. < 0.0f: no wrapping; 0.0f: wrap to end of window (or column); > 0.0f: wrap at 'wrap_pos_x' position in window local space
     IMGUI_API void          PopTextWrapPos();
+    IMGUI_API void          PushTextAlignment(float alignment = 0.0f);                      // push text alignment position for TextWrapped*() commands. 0.0f: no alignment; 1.0f: align right; 0.5f: align center
+    IMGUI_API void          PopTextAlignment();
 
     // Style read access
     IMGUI_API ImFont*       GetFont();                                                      // get current font

--- a/imgui.h
+++ b/imgui.h
@@ -2398,7 +2398,7 @@ struct ImDrawList
     IMGUI_API void  AddNgon(const ImVec2& center, float radius, ImU32 col, int num_segments, float thickness = 1.0f);
     IMGUI_API void  AddNgonFilled(const ImVec2& center, float radius, ImU32 col, int num_segments);
     IMGUI_API void  AddText(const ImVec2& pos, ImU32 col, const char* text_begin, const char* text_end = NULL);
-    IMGUI_API void  AddText(const ImFont* font, float font_size, const ImVec2& pos, ImU32 col, const char* text_begin, const char* text_end = NULL, float wrap_width = 0.0f, const ImVec4* cpu_fine_clip_rect = NULL);
+    IMGUI_API void  AddText(const ImFont* font, float font_size, const ImVec2& pos, ImU32 col, const char* text_begin, const char* text_end = NULL, float wrap_width = 0.0f, float text_align = 0.0f, const ImVec4* cpu_fine_clip_rect = NULL);
     IMGUI_API void  AddPolyline(const ImVec2* points, int num_points, ImU32 col, ImDrawFlags flags, float thickness);
     IMGUI_API void  AddConvexPolyFilled(const ImVec2* points, int num_points, ImU32 col); // Note: Anti-aliased filling requires points to be in clockwise order.
     IMGUI_API void  AddBezierCubic(const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, ImU32 col, float thickness, int num_segments = 0); // Cubic Bezier (4 control points)
@@ -2724,9 +2724,9 @@ struct ImFont
     // 'max_width' stops rendering after a certain width (could be turned into a 2d size). FLT_MAX to disable.
     // 'wrap_width' enable automatic word-wrapping across multiple lines to fit into given width. 0.0f to disable.
     IMGUI_API ImVec2            CalcTextSizeA(float size, float max_width, float wrap_width, const char* text_begin, const char* text_end = NULL, const char** remaining = NULL) const; // utf8
-    IMGUI_API const char*       CalcWordWrapPositionA(float scale, const char* text, const char* text_end, float wrap_width) const;
+    IMGUI_API const char*       CalcWordWrapPositionA(float scale, const char* text, const char* text_end, float wrap_width, float *line_width = NULL) const;
     IMGUI_API void              RenderChar(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col, ImWchar c) const;
-    IMGUI_API void              RenderText(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col, const ImVec4& clip_rect, const char* text_begin, const char* text_end, float wrap_width = 0.0f, bool cpu_fine_clip = false) const;
+    IMGUI_API void              RenderText(ImDrawList* draw_list, float size, ImVec2 pos, ImU32 col, const ImVec4& clip_rect, const char* text_begin, const char* text_end, float wrap_width = 0.0f, float text_align = 0.0f, bool cpu_fine_clip = false) const;
 
     // [Internal] Don't use!
     IMGUI_API void              BuildLookupTable();

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -881,13 +881,35 @@ static void ShowDemoWindowWidgets()
         if (ImGui::TreeNode("Word Wrapping"))
         {
             // Using shortcut. You can use PushTextWrapPos()/PopTextWrapPos() for more flexibility.
+            ImGui::TextUnformatted("[Left Align]");
             ImGui::TextWrapped(
                 "This text should automatically wrap on the edge of the window. The current implementation "
                 "for text wrapping follows simple rules suitable for English and possibly other languages.");
+            ImGui::GetWindowDrawList()->AddRect(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), IM_COL32(255, 255, 0, 255));
+            ImGui::Spacing();
+
+            ImGui::PushTextAlignment(0.5f);
+            ImGui::TextUnformatted("[Center Align]");
+            ImGui::TextWrapped(
+                "This text should automatically wrap on the edge of the window. The current implementation "
+                "for text wrapping follows simple rules suitable for English and possibly other languages.");
+            ImGui::GetWindowDrawList()->AddRect(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), IM_COL32(255, 255, 0, 255));
+            ImGui::PopTextAlignment();
+            ImGui::Spacing();
+            
+            ImGui::PushTextAlignment(1.0f);
+            ImGui::TextUnformatted("[Right Align]");
+            ImGui::TextWrapped(
+                "This text should automatically wrap on the edge of the window. The current implementation "
+                "for text wrapping follows simple rules suitable for English and possibly other languages.");
+            ImGui::GetWindowDrawList()->AddRect(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), IM_COL32(255, 255, 0, 255));
+            ImGui::PopTextAlignment();
             ImGui::Spacing();
 
             static float wrap_width = 200.0f;
             ImGui::SliderFloat("Wrap width", &wrap_width, -20, 600, "%.0f");
+            static float text_align = 0.0f;
+            ImGui::SliderFloat("Text alignment", &text_align, 0.0f, 1.0f, "%.2f");
 
             ImDrawList* draw_list = ImGui::GetWindowDrawList();
             for (int n = 0; n < 2; n++)
@@ -897,16 +919,44 @@ static void ShowDemoWindowWidgets()
                 ImVec2 marker_min = ImVec2(pos.x + wrap_width, pos.y);
                 ImVec2 marker_max = ImVec2(pos.x + wrap_width + 10, pos.y + ImGui::GetTextLineHeight());
                 ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + wrap_width);
+                ImGui::PushTextAlignment(text_align);
                 if (n == 0)
-                    ImGui::Text("The lazy dog is a good dog. This paragraph should fit within %.0f pixels. Testing a 1 character word. The quick brown fox jumps over the lazy dog.", wrap_width);
-                else
-                    ImGui::Text("aaaaaaaa bbbbbbbb, c cccccccc,dddddddd. d eeeeeeee   ffffffff. gggggggg!hhhhhhhh");
+                    ImGui::Text(
+                        "The lazy dog is a good dog. This paragraph should fit within %.0f pixels. "
+                        "Testing a 1 character word. The quick brown fox jumps over the lazy dog.", wrap_width);
+                else {
+                    ImGui::TextWrapped("aaaaaaaa bbbbbbbb, c\n\ttest\r\n  cccccccc,dddddddd. d eeeeeeee   ffffffff. gggggggg!hhhhhhhh");
+                }
+                ImGui::PopTextAlignment();
 
                 // Draw actual text bounding box, following by marker of our expected limit (should not overlap!)
                 draw_list->AddRect(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), IM_COL32(255, 255, 0, 255));
                 draw_list->AddRectFilled(marker_min, marker_max, IM_COL32(255, 0, 255, 255));
                 ImGui::PopTextWrapPos();
             }
+            ImGui::Spacing();
+
+            ImGui::TextUnformatted("[Typesetting Example]");
+            ImGui::SameLine(); HelpMarker("Use SetCursorPos and TextWrapPos to horizontally align text blocks.");
+            ImGui::PushTextAlignment(text_align);
+            
+            float max_wrap_width = ImGui::GetContentRegionAvailWidth();
+            if (wrap_width < max_wrap_width) {
+                ImGui::SetCursorPos(ImVec2(ImGui::GetCursorPosX() + fabs(max_wrap_width - wrap_width) * text_align, ImGui::GetCursorPosY()));
+            }
+
+            ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + wrap_width);
+            ImGui::Text(
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt "
+                "ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation "
+                "ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in "
+                "reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur "
+                "sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id "
+                "est laborum.");
+            ImGui::GetWindowDrawList()->AddRect(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), IM_COL32(255, 255, 0, 255));
+            ImGui::PopTextWrapPos();
+            
+            ImGui::PopTextAlignment();
 
             ImGui::TreePop();
         }
@@ -3079,7 +3129,7 @@ static void ShowDemoWindowLayout()
                     "(this is often used internally to avoid altering the clipping rectangle and minimize draw calls)");
                 ImVec4 clip_rect(p0.x, p0.y, p1.x, p1.y); // AddText() takes a ImVec4* here so let's convert.
                 draw_list->AddRectFilled(p0, p1, IM_COL32(90, 90, 120, 255));
-                draw_list->AddText(ImGui::GetFont(), ImGui::GetFontSize(), text_pos, IM_COL32_WHITE, text_str, NULL, 0.0f, &clip_rect);
+                draw_list->AddText(ImGui::GetFont(), ImGui::GetFontSize(), text_pos, IM_COL32_WHITE, text_str, NULL, 0.0f, 0.0f, &clip_rect);
                 break;
             }
             ImGui::EndGroup();

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -2517,7 +2517,7 @@ namespace ImGui
     // AVOID USING OUTSIDE OF IMGUI.CPP! NOT FOR PUBLIC CONSUMPTION. THOSE FUNCTIONS ARE A MESS. THEIR SIGNATURE AND BEHAVIOR WILL CHANGE, THEY NEED TO BE REFACTORED INTO SOMETHING DECENT.
     // NB: All position are in absolute pixels coordinates (we are never using window coordinates internally)
     IMGUI_API void          RenderText(ImVec2 pos, const char* text, const char* text_end = NULL, bool hide_text_after_hash = true);
-    IMGUI_API void          RenderTextWrapped(ImVec2 pos, const char* text, const char* text_end, float wrap_width);
+    IMGUI_API void          RenderTextWrapped(ImVec2 pos, const char* text, const char* text_end, float wrap_width, float text_alignment);
     IMGUI_API void          RenderTextClipped(const ImVec2& pos_min, const ImVec2& pos_max, const char* text, const char* text_end, const ImVec2* text_size_if_known, const ImVec2& align = ImVec2(0, 0), const ImRect* clip_rect = NULL);
     IMGUI_API void          RenderTextClippedEx(ImDrawList* draw_list, const ImVec2& pos_min, const ImVec2& pos_max, const char* text, const char* text_end, const ImVec2* text_size_if_known, const ImVec2& align = ImVec2(0, 0), const ImRect* clip_rect = NULL);
     IMGUI_API void          RenderTextEllipsis(ImDrawList* draw_list, const ImVec2& pos_min, const ImVec2& pos_max, float clip_max_x, float ellipsis_max_x, const char* text, const char* text_end, const ImVec2* text_size_if_known);

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -1797,8 +1797,10 @@ struct IMGUI_API ImGuiWindowTempData
     // We store the current settings outside of the vectors to increase memory locality (reduce cache misses). The vectors are rarely modified. Also it allows us to not heap allocate for short-lived windows which are not using those settings.
     float                   ItemWidth;              // Current item width (>0.0: width in pixels, <0.0: align xx pixels to the right of window).
     float                   TextWrapPos;            // Current text wrap pos.
+    float                   TextAlignment;          // Current text alignment.
     ImVector<float>         ItemWidthStack;         // Store item widths to restore (attention: .back() is not == ItemWidth)
     ImVector<float>         TextWrapPosStack;       // Store text wrap pos to restore (attention: .back() is not == TextWrapPos)
+    ImVector<float>         TextAlignmentStack;     // Store text alignment to restore (attention: .back() is not == TextAlignment)
     ImGuiStackSizes         StackSizesOnBegin;      // Store size of various stacks for asserting
 };
 

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -160,6 +160,7 @@ void ImGui::TextEx(const char* text, const char* text_end, ImGuiTextFlags flags)
         text_end = text + strlen(text); // FIXME-OPT
 
     const ImVec2 text_pos(window->DC.CursorPos.x, window->DC.CursorPos.y + window->DC.CurrLineTextBaseOffset);
+    const float text_alignment = window->DC.TextAlignment;
     const float wrap_pos_x = window->DC.TextWrapPos;
     const bool wrap_enabled = (wrap_pos_x >= 0.0f);
     if (text_end - text > 2000 && !wrap_enabled)
@@ -239,14 +240,17 @@ void ImGui::TextEx(const char* text, const char* text_end, ImGuiTextFlags flags)
     {
         const float wrap_width = wrap_enabled ? CalcWrapWidthForPos(window->DC.CursorPos, wrap_pos_x) : 0.0f;
         const ImVec2 text_size = CalcTextSize(text_begin, text_end, false, wrap_width);
+        const float text_offset = wrap_enabled ? IM_ROUND((wrap_width - text_size.x) * text_alignment) : 0.0f;
+        const ImVec2 final_pos = ImVec2(text_pos.x + text_offset, text_pos.y);
 
-        ImRect bb(text_pos, text_pos + text_size);
+        ImRect bb(final_pos, final_pos + text_size);
         ItemSize(text_size, 0.0f);
         if (!ItemAdd(bb, 0))
             return;
 
         // Render (we don't hide text after ## in this end-user function)
-        RenderTextWrapped(bb.Min, text_begin, text_end, wrap_width);
+        // we use text_size.x here as wrap_width to correctly handle text alignment
+        RenderTextWrapped(bb.Min, text_begin, text_end, text_size.x, text_alignment);
     }
 }
 
@@ -4599,7 +4603,7 @@ bool ImGui::InputTextEx(const char* label, const char* hint, char* buf, int buf_
         if (is_multiline || (buf_display_end - buf_display) < buf_display_max_length)
         {
             ImU32 col = GetColorU32(is_displaying_hint ? ImGuiCol_TextDisabled : ImGuiCol_Text);
-            draw_window->DrawList->AddText(g.Font, g.FontSize, draw_pos - draw_scroll, col, buf_display, buf_display_end, 0.0f, is_multiline ? NULL : &clip_rect);
+            draw_window->DrawList->AddText(g.Font, g.FontSize, draw_pos - draw_scroll, col, buf_display, buf_display_end, 0.0f, 0.0f, is_multiline ? NULL : &clip_rect);
         }
 
         // Draw blinking cursor
@@ -4630,7 +4634,7 @@ bool ImGui::InputTextEx(const char* label, const char* hint, char* buf, int buf_
         if (is_multiline || (buf_display_end - buf_display) < buf_display_max_length)
         {
             ImU32 col = GetColorU32(is_displaying_hint ? ImGuiCol_TextDisabled : ImGuiCol_Text);
-            draw_window->DrawList->AddText(g.Font, g.FontSize, draw_pos, col, buf_display, buf_display_end, 0.0f, is_multiline ? NULL : &clip_rect);
+            draw_window->DrawList->AddText(g.Font, g.FontSize, draw_pos, col, buf_display, buf_display_end, 0.0f, 0.0f, is_multiline ? NULL : &clip_rect);
         }
     }
 


### PR DESCRIPTION
Written as a re-implementation of #1980, which has lain fallow for almost three years now, this PR adds support for fluid horizontal alignment of text across the space defined by PushTextWrapPos. Enough from me for now, have a video!

https://user-images.githubusercontent.com/4218491/122719778-ab600700-d23c-11eb-8818-9a6687446c73.mp4

(Pardon the flickering, my capture software doesn't like GL applications.)

This is implemented in what I consider to be a much simpler fashion than the original PR - though it keeps a similar user-facing API (Push/PopTextAlignment), internally it handles the alignment by fixing quite a few quirks with `Font::CalcWordWrapPosA` and providing that function's calculated line length for the parent functions to use in text layout; this has the nice side effect of avoiding any further iteration over the text string, and other than a few extra branches should compare very favorably with the original code.

I have not done any rigorous performance testing of this change due to unfamiliarity with the test harness repo, but I do not expect any issues with merging this from a performance perspective. I have manually verified that the left-aligned wrapped text renders visually identical to the behavior of the test application prior to this change; other text alignments have been thoroughly tested to behave correctly under all cases, even including a negative wrap width (it is my opinion that a negative text wrap width has *no* semantic meaning, but I have left the demo code mostly as I found it in that regard).

Compared to the original implementation, I've done my best to avoid all blockers mentioned in the original review and make the code as easy to review and maintain as possible. This unfortunately does involve a nontrivial change to public API (`DrawList::AddText`) but I could not find any other clean way to provide the needed information.

The semantics of `CalcWordWrapPosA` have been changed to provide accurate lengths for the line fragment that survived wrapping - whitespace following a newline and internal whitespace is included in this length, but trailing whitespace directly before a break is stripped to support correct right-alignment behavior.

Support for text justification (extra, proportional space between words inside the broken fragment) is a non-trivial feature and I consider it to be out of scope for this PR.

I welcome any questions or comments about this PR! This was primarily written for use in Pioneer Space Sim as part of our primary user interface, but I've done my best to make it powerful and performant for all users of ImGui.