### PR TITLE
Move parent platform window

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -3537,13 +3537,6 @@ void ImGui::StartMouseMovingWindow(ImGuiWindow* window)
         g.MovingWindow = window;
 }
 
-typedef struct tagRECT
-{
-    LONG    left;
-    LONG    top;
-    LONG    right;
-    LONG    bottom;
-} RECT; // I'm not sure if this already exists in the library. I didn't find it anywhere so it's defined here to keep everything regarding this pull request closer together.
 typedef BOOL(WINAPI* PFN_GetWindowRect)(HWND hWnd, LPRECT lpRect);
 typedef BOOL(WINAPI* PFN_MoveWindow)(HWND hWnd, int  X, int  Y, int  nWidth, int  nHeight, BOOL bRepaint); // for dynamically loading the winapi functions need. 
 

--- a/imgui.h
+++ b/imgui.h
@@ -946,6 +946,7 @@ enum ImGuiWindowFlags_
     ImGuiWindowFlags_NoNavInputs            = 1 << 18,  // No gamepad/keyboard navigation within the window
     ImGuiWindowFlags_NoNavFocus             = 1 << 19,  // No focusing toward this window with gamepad/keyboard navigation (e.g. skipped by CTRL+TAB)
     ImGuiWindowFlags_UnsavedDocument        = 1 << 20,  // Display a dot next to the title. When used in a tab/docking context, tab is selected when clicking the X + closure is not assumed (will wait for user to stop submitting the tab). Otherwise closure is assumed when pressing the X, so if you keep submitting the tab may reappear at end of tab bar.
+    ImGuiWindowFlags_MoveHWND               = 1 << 21,  // Moving this window will not move the actual window but the hwnd window.
     ImGuiWindowFlags_NoNav                  = ImGuiWindowFlags_NoNavInputs | ImGuiWindowFlags_NoNavFocus,
     ImGuiWindowFlags_NoDecoration           = ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoCollapse,
     ImGuiWindowFlags_NoInputs               = ImGuiWindowFlags_NoMouseInputs | ImGuiWindowFlags_NoNavInputs | ImGuiWindowFlags_NoNavFocus,


### PR DESCRIPTION
The idea of this new flag is to create an imgui window the size of the parent Windows window and then to redirect movement to it. This allows for very easy creation of simple apps with a UI.
This only works on windows.

The result:
![Desktop_2021 07 07_-_17 09 17 01_Trim](https://user-images.githubusercontent.com/67655795/124789223-60d3cf80-df4a-11eb-8a05-db9b9e2048bb.gif)

Now making the windows window transparent you can get something nice looking like this:
![Desktop_2021 07 07_-_17 35 40 04_Trim](https://user-images.githubusercontent.com/67655795/124789026-341fb800-df4a-11eb-9671-252d17f9486f.gif)

