### PR TITLE
Fix Alt+Enter fullscreen in DirectX 12 example.

### DIFF
--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -96,6 +96,7 @@ Other Changes:
   Other OSX examples were not affected. (#4253, #1873) [@rokups]
 - Examples: Updated all .vcxproj to VS2015 (toolset v140) to facilitate usage with vcpkg.
 - Examples: SDL2: Accomodate for vcpkg install having headers in SDL2/SDL.h vs SDL.h.
+- Examples: DirectX 12: Fixed Alt+Enter fullscreen. (#4346) [@PathogenDavid]
 
 
 -----------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes https://github.com/ocornut/imgui/issues/4346

Not sure why this example was recreating the entire swap chain on resize (it's been like that forever), but `ResizeBuffers` is the correct way to react to `WM_SIZE`.

Only the Direct3D 12 sample was affected, other samples and viewport-aware backends are fine:

* [Direct3D 10 Sample](https://github.com/ocornut/imgui/blob/c881667c00655c98dba41deb942587e0041d0ed0/examples/example_win32_directx10/main.cpp#L229)
* [Direct3D 11 Sample](https://github.com/ocornut/imgui/blob/c881667c00655c98dba41deb942587e0041d0ed0/examples/example_win32_directx11/main.cpp#L233)
* [Direct3D 10 Docking Backend](https://github.com/ocornut/imgui/blob/7bfc379a23e97b6777eb80aafb50a8e6248904cd/backends/imgui_impl_dx10.cpp#L666)
* [Direct3D 11 Docking Backend](https://github.com/ocornut/imgui/blob/7bfc379a23e97b6777eb80aafb50a8e6248904cd/backends/imgui_impl_dx11.cpp#L683)
* [Direct3D 12 Docking Backend](https://github.com/ocornut/imgui/blob/7bfc379a23e97b6777eb80aafb50a8e6248904cd/backends/imgui_impl_dx12.cpp#L997)