### PR TITLE
Fix Alt+Enter fullscreen in DirectX 12 example

### DIFF
--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -96,6 +96,8 @@ Other Changes:
   Other OSX examples were not affected. (#4253, #1873) [@rokups]
 - Examples: Updated all .vcxproj to VS2015 (toolset v140) to facilitate usage with vcpkg.
 - Examples: SDL2: Accomodate for vcpkg install having headers in SDL2/SDL.h vs SDL.h.
+- Examples: DirectX 12: Fixed Alt+Enter fullscreen. (#4346) [@PathogenDavid]
+- Examples: DirectX 12: Removed unecessary recreation of backend-owned device objects when window is resized. (#4347) [@PathogenDavid]
 
 
 -----------------------------------------------------------------------

--- a/examples/example_win32_directx12/main.cpp
+++ b/examples/example_win32_directx12/main.cpp
@@ -34,6 +34,7 @@ static FrameContext                 g_frameContext[NUM_FRAMES_IN_FLIGHT] = {};
 static UINT                         g_frameIndex = 0;
 
 static int const                    NUM_BACK_BUFFERS = 3;
+static UINT const                   SWAP_CHAIN_FLAGS = DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT;
 static ID3D12Device*                g_pd3dDevice = NULL;
 static ID3D12DescriptorHeap*        g_pd3dRtvDescHeap = NULL;
 static ID3D12DescriptorHeap*        g_pd3dSrvDescHeap = NULL;
@@ -54,7 +55,6 @@ void CreateRenderTarget();
 void CleanupRenderTarget();
 void WaitForLastSubmittedFrame();
 FrameContext* WaitForNextFrameResources();
-void ResizeSwapChain(HWND hWnd, int width, int height);
 LRESULT WINAPI WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
 
 // Main code
@@ -432,31 +432,6 @@ FrameContext* WaitForNextFrameResources()
     return frameCtx;
 }
 
-void ResizeSwapChain(HWND hWnd, int width, int height)
-{
-    DXGI_SWAP_CHAIN_DESC1 sd;
-    g_pSwapChain->GetDesc1(&sd);
-    sd.Width = width;
-    sd.Height = height;
-
-    IDXGIFactory4* dxgiFactory = NULL;
-    g_pSwapChain->GetParent(IID_PPV_ARGS(&dxgiFactory));
-
-    g_pSwapChain->Release();
-    CloseHandle(g_hSwapChainWaitableObject);
-
-    IDXGISwapChain1* swapChain1 = NULL;
-    dxgiFactory->CreateSwapChainForHwnd(g_pd3dCommandQueue, hWnd, &sd, NULL, NULL, &swapChain1);
-    swapChain1->QueryInterface(IID_PPV_ARGS(&g_pSwapChain));
-    swapChain1->Release();
-    dxgiFactory->Release();
-
-    g_pSwapChain->SetMaximumFrameLatency(NUM_BACK_BUFFERS);
-
-    g_hSwapChainWaitableObject = g_pSwapChain->GetFrameLatencyWaitableObject();
-    assert(g_hSwapChainWaitableObject != NULL);
-}
-
 // Forward declare message handler from imgui_impl_win32.cpp
 extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
 
@@ -472,11 +447,10 @@ LRESULT WINAPI WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
         if (g_pd3dDevice != NULL && wParam != SIZE_MINIMIZED)
         {
             WaitForLastSubmittedFrame();
-            ImGui_ImplDX12_InvalidateDeviceObjects();
             CleanupRenderTarget();
-            ResizeSwapChain(hWnd, (UINT)LOWORD(lParam), (UINT)HIWORD(lParam));
+            HRESULT result = g_pSwapChain->ResizeBuffers(0, (UINT)LOWORD(lParam), (UINT)HIWORD(lParam), DXGI_FORMAT_UNKNOWN, SWAP_CHAIN_FLAGS);
+            assert(SUCCEEDED(result) && "Failed to resize swapchain.");
             CreateRenderTarget();
-            ImGui_ImplDX12_CreateDeviceObjects();
         }
         return 0;
     case WM_SYSCOMMAND:


### PR DESCRIPTION
(Apologies for the notification spam, apparently you can't reopen a PR if you force-push to it while it is closed.)

This PR fixes https://github.com/ocornut/imgui/issues/4346 as well as the unnecessary recreation of backend-owned device objects mentioned in https://github.com/ocornut/imgui/pull/4347#issuecomment-884540385.

Not sure why this example was recreating the entire swap chain on resize (it's been like that forever), but `ResizeBuffers` is the correct way to react to `WM_SIZE`.

Only the Direct3D 12 sample was affected, other samples and viewport-aware backends are fine:

* [Direct3D 10 Sample](https://github.com/ocornut/imgui/blob/c881667c00655c98dba41deb942587e0041d0ed0/examples/example_win32_directx10/main.cpp#L229)
* [Direct3D 11 Sample](https://github.com/ocornut/imgui/blob/c881667c00655c98dba41deb942587e0041d0ed0/examples/example_win32_directx11/main.cpp#L233)
* [Direct3D 10 Docking Backend](https://github.com/ocornut/imgui/blob/7bfc379a23e97b6777eb80aafb50a8e6248904cd/backends/imgui_impl_dx10.cpp#L666)
* [Direct3D 11 Docking Backend](https://github.com/ocornut/imgui/blob/7bfc379a23e97b6777eb80aafb50a8e6248904cd/backends/imgui_impl_dx11.cpp#L683)
* [Direct3D 12 Docking Backend](https://github.com/ocornut/imgui/blob/7bfc379a23e97b6777eb80aafb50a8e6248904cd/backends/imgui_impl_dx12.cpp#L997)

-------

Note that there is still an unrelated alt+enter debug layer crash on the docking branch even with this fix. It's a more complicated issue that I need to investigate further. (It _seems_ that command queues owned by platform windows are referencing the main viewport's back buffers for some reason.)