### PR TITLE
Disable DXGI window management features for swap chains owned by the backend

### DIFF
--- a/backends/imgui_impl_dx10.cpp
+++ b/backends/imgui_impl_dx10.cpp
@@ -624,6 +624,7 @@ static void ImGui_ImplDX10_CreateWindow(ImGuiViewport* viewport)
 
     IM_ASSERT(vd->SwapChain == NULL && vd->RTView == NULL);
     bd->pFactory->CreateSwapChain(bd->pd3dDevice, &sd, &vd->SwapChain);
+    bd->pFactory->MakeWindowAssociation(hwnd, DXGI_MWA_NO_ALT_ENTER | DXGI_MWA_NO_PRINT_SCREEN | DXGI_MWA_NO_WINDOW_CHANGES);
 
     // Create the render target
     if (vd->SwapChain)

--- a/backends/imgui_impl_dx11.cpp
+++ b/backends/imgui_impl_dx11.cpp
@@ -641,6 +641,7 @@ static void ImGui_ImplDX11_CreateWindow(ImGuiViewport* viewport)
 
     IM_ASSERT(vd->SwapChain == NULL && vd->RTView == NULL);
     bd->pFactory->CreateSwapChain(bd->pd3dDevice, &sd, &vd->SwapChain);
+    bd->pFactory->MakeWindowAssociation(hwnd, DXGI_MWA_NO_ALT_ENTER | DXGI_MWA_NO_PRINT_SCREEN | DXGI_MWA_NO_WINDOW_CHANGES);
 
     // Create the render target
     if (vd->SwapChain)

--- a/backends/imgui_impl_dx12.cpp
+++ b/backends/imgui_impl_dx12.cpp
@@ -898,6 +898,8 @@ static void ImGui_ImplDX12_CreateWindow(ImGuiViewport* viewport)
     IDXGISwapChain1* swap_chain = NULL;
     res = dxgi_factory->CreateSwapChainForHwnd(vd->CommandQueue, hwnd, &sd1, NULL, NULL, &swap_chain);
     IM_ASSERT(res == S_OK);
+    res = dxgi_factory->MakeWindowAssociation(hwnd, DXGI_MWA_NO_ALT_ENTER | DXGI_MWA_NO_PRINT_SCREEN | DXGI_MWA_NO_WINDOW_CHANGES);
+    IM_ASSERT(res == S_OK);
 
     dxgi_factory->Release();
 

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -181,6 +181,7 @@ Docking+Viewports Branch:
 - Viewports: Fix popup/tooltip created without a parent window from being given a ParentViewportId value
   from the implicit/fallback window. (#4236, #2409)
 - Backends: Vulkan: Fix the use of the incorrect fence for secondary viewports. (#4208) [@FunMiles]
+- Examples: Disabled DXGI window management features (such as Alt+Enter fullscreen) for DirectX 10/11 samples. (#4350) [@PathogenDavid]
 
 
 -----------------------------------------------------------------------

--- a/examples/example_sdl_directx11/main.cpp
+++ b/examples/example_sdl_directx11/main.cpp
@@ -223,6 +223,12 @@ bool CreateDeviceD3D(HWND hWnd)
     if (D3D11CreateDeviceAndSwapChain(NULL, D3D_DRIVER_TYPE_HARDWARE, NULL, createDeviceFlags, featureLevelArray, 2, D3D11_SDK_VERSION, &sd, &g_pSwapChain, &g_pd3dDevice, &featureLevel, &g_pd3dDeviceContext) != S_OK)
         return false;
 
+    // Disable DXGI's window management features
+    // (This doesn't play nice with multiple viewports and must be done on all windows associated with the device.)
+    IDXGIFactory* pSwapChainFactory;
+    if (SUCCEEDED(g_pSwapChain->GetParent(IID_PPV_ARGS(&pSwapChainFactory))))
+        pSwapChainFactory->MakeWindowAssociation(hWnd, DXGI_MWA_NO_ALT_ENTER | DXGI_MWA_NO_PRINT_SCREEN | DXGI_MWA_NO_WINDOW_CHANGES);
+
     CreateRenderTarget();
     return true;
 }

--- a/examples/example_win32_directx10/main.cpp
+++ b/examples/example_win32_directx10/main.cpp
@@ -206,6 +206,12 @@ bool CreateDeviceD3D(HWND hWnd)
     if (D3D10CreateDeviceAndSwapChain(NULL, D3D10_DRIVER_TYPE_HARDWARE, NULL, createDeviceFlags, D3D10_SDK_VERSION, &sd, &g_pSwapChain, &g_pd3dDevice) != S_OK)
         return false;
 
+    // Disable DXGI's window management features
+    // (This doesn't play nice with multiple viewports and must be done on all windows associated with the device.)
+    IDXGIFactory* pSwapChainFactory;
+    if (SUCCEEDED(g_pSwapChain->GetParent(IID_PPV_ARGS(&pSwapChainFactory))))
+        pSwapChainFactory->MakeWindowAssociation(hWnd, DXGI_MWA_NO_ALT_ENTER | DXGI_MWA_NO_PRINT_SCREEN | DXGI_MWA_NO_WINDOW_CHANGES);
+
     CreateRenderTarget();
     return true;
 }

--- a/examples/example_win32_directx11/main.cpp
+++ b/examples/example_win32_directx11/main.cpp
@@ -214,6 +214,12 @@ bool CreateDeviceD3D(HWND hWnd)
     if (D3D11CreateDeviceAndSwapChain(NULL, D3D_DRIVER_TYPE_HARDWARE, NULL, createDeviceFlags, featureLevelArray, 2, D3D11_SDK_VERSION, &sd, &g_pSwapChain, &g_pd3dDevice, &featureLevel, &g_pd3dDeviceContext) != S_OK)
         return false;
 
+    // Disable DXGI's window management features
+    // (This doesn't play nice with multiple viewports and must be done on all windows associated with the device.)
+    IDXGIFactory* pSwapChainFactory;
+    if (SUCCEEDED(g_pSwapChain->GetParent(IID_PPV_ARGS(&pSwapChainFactory))))
+        pSwapChainFactory->MakeWindowAssociation(hWnd, DXGI_MWA_NO_ALT_ENTER | DXGI_MWA_NO_PRINT_SCREEN | DXGI_MWA_NO_WINDOW_CHANGES);
+
     CreateRenderTarget();
     return true;
 }


### PR DESCRIPTION
By default, a swap chain created by DXGI will have the behavior of automatically fullscreening the window when the user presses Alt+Enter. This doesn't make a ton of sense for secondary swap chains for windows owned by the backend, this PR disables this feature.

How this feature works with multiple swap chains varies between versions of DirectX: (Based on my observations, I don't think this is documented anywhere.)

* DirectX 9: I do not believe DirectX 9 has this behavior built-in.
* DirectX 10: If any window associated with the device does not have Alt+Enter disabled, Alt+Enter on **any** window will cause **all** swap chains to experience a fullscreen transition.
* DirectX 11: For any window without Alt+Enter disabled, pressing Alt+Enter with that window focused will cause **all** swap chains to experience a fullscreen transition.
* DirectX 12: For any window without Alt+Enter disabled, pressing Alt+Enter will cause only that window to experience a fullscreen transition.

As such, this PR also disables window management for the main viewport window in the DirectX 10 and 11 examples (including the SDL DirectX11 sample.)

If we do not want to recommend/require disabling DXGI's window management on the main viewport for DirectX 10/11, we will need to recommend/require people handle Alt+Enter on the main viewport themselves. (This is considered best practice on Windows 10 anyway*)

(*Sorry for no source for this claim, this comes from my own notes on the DirectX presentation model. [It probably comes from here](https://www.youtube.com/watch?v=E3wTajGZOsA) or a random Microsoft Docs page. IIRC, the reasoning is that the default fullscreen transition does a bunch of extra junk to emulate legacy behaviors that are usually unnecessary.)