### PR TITLE
Fix version 1.83 release date in changelog

### DIFF
--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -99,7 +99,7 @@ Other Changes:
 
 
 -----------------------------------------------------------------------
- VERSION 1.83 (Released 2011-05-24)
+ VERSION 1.83 (Released 2021-05-24)
 -----------------------------------------------------------------------
 
 Decorated log: https://github.com/ocornut/imgui/releases/tag/v1.83


### PR DESCRIPTION
I wouldn't normally bother fixing such a minor typo, but I often look at the changelog of project dependencies to figure out how up-to-date they are.