### PR TITLE
Fix CMake for GLFW_Vulkan and add CMake for SDL_Vulkan on Linux

### DIFF
--- a/examples/example_glfw_vulkan/CMakeLists.txt
+++ b/examples/example_glfw_vulkan/CMakeLists.txt
@@ -14,14 +14,23 @@ set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DVK_PROTOTYPES")
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DVK_PROTOTYPES")
 
 # GLFW
-set(GLFW_DIR ../../../glfw) # Set this to point to an up-to-date GLFW repo
-option(GLFW_BUILD_EXAMPLES "Build the GLFW example programs" OFF)
-option(GLFW_BUILD_TESTS "Build the GLFW test programs" OFF)
-option(GLFW_BUILD_DOCS "Build the GLFW documentation" OFF)
-option(GLFW_INSTALL "Generate installation target" OFF)
-option(GLFW_DOCUMENT_INTERNALS "Include internals in documentation" OFF)
-add_subdirectory(${GLFW_DIR} binary_dir EXCLUDE_FROM_ALL)
-include_directories(${GLFW_DIR}/include)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GLFW REQUIRED glfw3)
+
+include_directories(
+  ${GLFW_INCLUDE_DIRS}
+)
+
+# Alternatively, use a source repo for GLFW:
+# set(GLFW_DIR ../../../glfw) # Set this to point to an up-to-date GLFW repo
+# option(GLFW_BUILD_EXAMPLES "Build the GLFW example programs" OFF)
+# option(GLFW_BUILD_TESTS "Build the GLFW test programs" OFF)
+# option(GLFW_BUILD_DOCS "Build the GLFW documentation" OFF)
+# option(GLFW_INSTALL "Generate installation target" OFF)
+# option(GLFW_DOCUMENT_INTERNALS "Include internals in documentation" OFF)
+# add_subdirectory(${GLFW_DIR} binary_dir EXCLUDE_FROM_ALL)
+# include_directories(${GLFW_DIR}/include)
+
 
 # Dear ImGui
 set(IMGUI_DIR ../../)

--- a/examples/example_sdl_vulkan/CMakeLists.txt
+++ b/examples/example_sdl_vulkan/CMakeLists.txt
@@ -1,0 +1,36 @@
+# Example usage:
+#  mkdir build
+#  cd build
+#  cmake -g "Visual Studio 14 2015" ..
+
+cmake_minimum_required(VERSION 3.0)
+project(imgui_example_sdl_vulkan C CXX)
+
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Debug CACHE STRING "" FORCE)
+endif()
+
+# set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DVK_PROTOTYPES")
+# set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DVK_PROTOTYPES")
+
+# SDL
+find_package(SDL2 REQUIRED)
+
+# Dear ImGui
+set(IMGUI_DIR ../../)
+include_directories(${IMGUI_DIR} ${IMGUI_DIR}/backends ..)
+
+# Libraries
+find_package(Vulkan REQUIRED)
+#find_library(VULKAN_LIBRARY
+  #NAMES vulkan vulkan-1)
+#set(LIBRARIES "sdl;${VULKAN_LIBRARY}")
+set(LIBRARIES "SDL2::SDL2;Vulkan::Vulkan")
+
+# Use vulkan headers from sdl:
+include_directories(${VULKAN_INCLUDES})
+
+file(GLOB sources *.cpp)
+
+add_executable(example_sdl_vulkan ${sources} ${IMGUI_DIR}/backends/imgui_impl_sdl.cpp ${IMGUI_DIR}/backends/imgui_impl_vulkan.cpp ${IMGUI_DIR}/imgui.cpp ${IMGUI_DIR}/imgui_draw.cpp ${IMGUI_DIR}/imgui_demo.cpp ${IMGUI_DIR}/imgui_tables.cpp ${IMGUI_DIR}/imgui_widgets.cpp)
+target_link_libraries(example_sdl_vulkan ${LIBRARIES})


### PR DESCRIPTION
This fixes the GLFW and SDL2 Vulkan examples so they build cleanly on any modern Linux OS.

Should be helpful for anyone getting started in IMGUI.
