### PR TITLE
Clear pressed keys after loosing input focus (#3532)

### DIFF
--- a/backends/imgui_impl_allegro5.cpp
+++ b/backends/imgui_impl_allegro5.cpp
@@ -390,6 +390,19 @@ bool ImGui_ImplAllegro5_ProcessEvent(ALLEGRO_EVENT* ev)
         if (ev->keyboard.display == bd->Display)
             io.KeysDown[ev->keyboard.keycode] = (ev->type == ALLEGRO_EVENT_KEY_DOWN);
         return true;
+    case ALLEGRO_EVENT_DISPLAY_SWITCH_OUT:
+        if (ev->display.source == bd->Display)
+            io.AddFocusEvent(false);
+        return false; // don't consume event
+    case ALLEGRO_EVENT_DISPLAY_SWITCH_IN:
+        if (ev->display.source == bd->Display)
+        {
+            io.AddFocusEvent(true);
+#if defined(ALLEGRO_UNSTABLE)
+            al_clear_keyboard_state(bd->Display);
+#endif
+        }
+        return false; // don't consume event
     }
     return false;
 }

--- a/backends/imgui_impl_glfw.h
+++ b/backends/imgui_impl_glfw.h
@@ -32,6 +32,7 @@ IMGUI_IMPL_API void     ImGui_ImplGlfw_NewFrame();
 // GLFW callbacks
 // - When calling Init with 'install_callbacks=true': GLFW callbacks will be installed for you. They will call user's previously installed callbacks, if any.
 // - When calling Init with 'install_callbacks=false': GLFW callbacks won't be installed. You will need to call those function yourself from your own GLFW callbacks.
+IMGUI_IMPL_API void     ImGui_ImplGlfw_WindowFocusCallback(GLFWwindow* window, int focused);
 IMGUI_IMPL_API void     ImGui_ImplGlfw_CursorEnterCallback(GLFWwindow* window, int entered);
 IMGUI_IMPL_API void     ImGui_ImplGlfw_MouseButtonCallback(GLFWwindow* window, int button, int action, int mods);
 IMGUI_IMPL_API void     ImGui_ImplGlfw_ScrollCallback(GLFWwindow* window, double xoffset, double yoffset);

--- a/backends/imgui_impl_osx.mm
+++ b/backends/imgui_impl_osx.mm
@@ -60,14 +60,24 @@ static void resetKeys()
 
 @interface ImFocusObserver : NSObject
 
+- (void)onApplicationBecomeActive:(NSNotification*)aNotification;
 - (void)onApplicationBecomeInactive:(NSNotification*)aNotification;
 
 @end
 
 @implementation ImFocusObserver
 
+- (void)onApplicationBecomeActive:(NSNotification*)aNotification
+{
+    ImGuiIO& io = ImGui::GetIO();
+    io.AddFocusEvent(true);
+}
+
 - (void)onApplicationBecomeInactive:(NSNotification*)aNotification
 {
+    ImGuiIO& io = ImGui::GetIO();
+    io.AddFocusEvent(false);
+
     // Unfocused applications do not receive input events, therefore we must manually
     // release any pressed keys when application loses focus, otherwise they would remain
     // stuck in a pressed state. https://github.com/ocornut/imgui/issues/3832
@@ -155,6 +165,10 @@ bool ImGui_ImplOSX_Init()
     };
 
     g_FocusObserver = [[ImFocusObserver alloc] init];
+    [[NSNotificationCenter defaultCenter] addObserver:g_FocusObserver
+                                             selector:@selector(onApplicationBecomeActive:)
+                                                 name:NSApplicationDidBecomeActiveNotification
+                                               object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:g_FocusObserver
                                              selector:@selector(onApplicationBecomeInactive:)
                                                  name:NSApplicationDidResignActiveNotification

--- a/backends/imgui_impl_sdl.cpp
+++ b/backends/imgui_impl_sdl.cpp
@@ -148,6 +148,15 @@ bool ImGui_ImplSDL2_ProcessEvent(const SDL_Event* event)
 #endif
             return true;
         }
+    case SDL_WINDOWEVENT:
+        {
+            if (event->window.event == SDL_WINDOWEVENT_FOCUS_GAINED)
+                io.AddFocusEvent(true);
+            else if (event->window.event == SDL_WINDOWEVENT_FOCUS_LOST)
+                io.AddFocusEvent(false);
+
+            return false; // don't consume event
+        }
     }
     return false;
 }

--- a/backends/imgui_impl_win32.cpp
+++ b/backends/imgui_impl_win32.cpp
@@ -431,9 +431,11 @@ IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hwnd, UINT msg, WPARA
             io.KeyAlt = down;
         return 0;
     }
+    case WM_SETFOCUS:
+        io.AddFocusEvent(true);
+        return 0;
     case WM_KILLFOCUS:
-        memset(io.KeysDown, 0, sizeof(io.KeysDown));
-        io.KeyCtrl = io.KeyShift = io.KeyAlt = io.KeySuper = false;
+        io.AddFocusEvent(false);
         return 0;
     case WM_CHAR:
         // You can also use ToAscii()+GetKeyboardState() to retrieve characters.

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -1180,6 +1180,21 @@ void ImGuiIO::ClearInputCharacters()
     InputQueueCharacters.resize(0);
 }
 
+void ImGuiIO::AddFocusEvent(bool gain)
+{
+    if (!gain)
+    {
+        // Reset pressed buttons when focus is lost
+        memset(KeysDown, 0, sizeof(KeysDown));
+        for (int n = 0; n < IM_ARRAYSIZE(KeysDownDuration); n++)
+            KeysDownDuration[n] = KeysDownDurationPrev[n] = -1.0f;
+        KeyCtrl = KeyShift = KeyAlt = KeySuper = false;
+        KeyMods = 0;
+        for (int n = 0; n < IM_ARRAYSIZE(NavInputsDownDuration); n++)
+            NavInputsDownDuration[n] = NavInputsDownDurationPrev[n] = -1.0f;
+    }
+}
+
 //-----------------------------------------------------------------------------
 // [SECTION] MISC HELPERS/UTILITIES (Geometry functions)
 //-----------------------------------------------------------------------------

--- a/imgui.h
+++ b/imgui.h
@@ -1869,6 +1869,7 @@ struct ImGuiIO
     IMGUI_API void  AddInputCharacterUTF16(ImWchar16 c);        // Queue new character input from an UTF-16 character, it can be a surrogate
     IMGUI_API void  AddInputCharactersUTF8(const char* str);    // Queue new characters input from an UTF-8 string
     IMGUI_API void  ClearInputCharacters();                     // Clear the text input buffer manually
+    IMGUI_API void  AddFocusEvent(bool gain);                   // Notifies ImGui when underlying windows lose or gain input focus
 
     //------------------------------------------------------------------
     // Output - Updated by NewFrame() or EndFrame()/Render()


### PR DESCRIPTION
This PR address #3532.

Implemented on all backends except: glut and marmalade.