### PR TITLE
Fix using named filters with InputTextMultiline

### DIFF
--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -3841,6 +3841,8 @@ static bool InputTextFilterCharacter(unsigned int* p_char, ImGuiInputTextFlags f
     IM_ASSERT(input_source == ImGuiInputSource_Keyboard || input_source == ImGuiInputSource_Clipboard);
     unsigned int c = *p_char;
 
+    bool apply_named_filters = flags & (ImGuiInputTextFlags_CharsDecimal | ImGuiInputTextFlags_CharsHexadecimal | ImGuiInputTextFlags_CharsUppercase | ImGuiInputTextFlags_CharsNoBlank | ImGuiInputTextFlags_CharsScientific);
+
     // Filter non-printable (NB: isprint is unreliable! see #2467)
     if (c < 0x20)
     {
@@ -3849,6 +3851,9 @@ static bool InputTextFilterCharacter(unsigned int* p_char, ImGuiInputTextFlags f
         pass |= (c == '\t' && (flags & ImGuiInputTextFlags_AllowTabInput));
         if (!pass)
             return false;
+
+        // Allow input text flags to override named filter behaviors for tab and newline.
+        apply_named_filters = false;
     }
 
     if (input_source != ImGuiInputSource_Clipboard)
@@ -3867,7 +3872,7 @@ static bool InputTextFilterCharacter(unsigned int* p_char, ImGuiInputTextFlags f
         return false;
 
     // Generic named filters
-    if (flags & (ImGuiInputTextFlags_CharsDecimal | ImGuiInputTextFlags_CharsHexadecimal | ImGuiInputTextFlags_CharsUppercase | ImGuiInputTextFlags_CharsNoBlank | ImGuiInputTextFlags_CharsScientific))
+    if (apply_named_filters)
     {
         // The libc allows overriding locale, with e.g. 'setlocale(LC_NUMERIC, "de_DE.UTF-8");' which affect the output/input of printf/scanf.
         // The standard mandate that programs starts in the "C" locale where the decimal point is '.'.


### PR DESCRIPTION
This change leverages the existing < 0x20 check and it's newline/tab-to-flag matching to allow those characters to explicitly bypass the named filter checks when the given flag is enabled.

You can thus have a multiline input text that only allows, e.g, uppercase hex characters, but still have multipline lines.
