### PR TITLE
AddCircle{Filled} - Use _PathArcToFastEx directly to emit circle vert…

### DIFF
--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -1479,24 +1479,40 @@ void ImDrawList::AddCircle(const ImVec2& center, float radius, ImU32 col, int nu
     if ((col & IM_COL32_A_MASK) == 0 || radius <= 0.0f)
         return;
 
-    // Obtain segment count
     if (num_segments <= 0)
     {
-        // Automatic segment count
-        num_segments = _CalcCircleAutoSegmentCount(radius);
+        // Use arc with automatic segment count
+        _PathArcToFastEx(center, radius - 0.5f, 0, IM_DRAWLIST_ARCFAST_SAMPLE_MAX, 0);
+        _Path.pop_back();
     }
+#if IM_IS_DIVISIBLE_BY(IM_DRAWLIST_ARCFAST_SAMPLE_MAX, 12)
+    else if (num_segments == 12)
+    {
+        // If IM_DRAWLIST_ARCFAST_SAMPLE_MAX is dividable by 12, we can use _PathArcToFastEx
+        // with constant step size.
+        _PathArcToFastEx(center, radius - 0.5f, 0, IM_DRAWLIST_ARCFAST_SAMPLE_MAX, IM_DRAWLIST_ARCFAST_SAMPLE_MAX / 12);
+        _Path.pop_back();
+    }
+#endif
+#if IM_IS_DIVISIBLE_BY(IM_DRAWLIST_ARCFAST_SAMPLE_MAX, 24)
+    else if (num_segments == 24)
+    {
+        // If IM_DRAWLIST_ARCFAST_SAMPLE_MAX is dividable by 12, we can use _PathArcToFastEx
+        // with constant step size.
+        _PathArcToFastEx(center, radius - 0.5f, 0, IM_DRAWLIST_ARCFAST_SAMPLE_MAX, IM_DRAWLIST_ARCFAST_SAMPLE_MAX / 24);
+        _Path.pop_back();
+    }
+#endif
     else
     {
         // Explicit segment count (still clamp to avoid drawing insanely tessellated shapes)
         num_segments = ImClamp(num_segments, 3, IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_MAX);
+
+        // Because we are filling a closed shape we remove 1 from the count of segments/points
+        const float a_max = (IM_PI * 2.0f) * ((float)num_segments - 1.0f) / (float)num_segments;
+        PathArcTo(center, radius - 0.5f, 0.0f, a_max, num_segments - 1);
     }
 
-    // Because we are filling a closed shape we remove 1 from the count of segments/points
-    const float a_max = (IM_PI * 2.0f) * ((float)num_segments - 1.0f) / (float)num_segments;
-    if (num_segments == 12)
-        _PathArcToFastEx(center, radius - 0.5f, 0, IM_DRAWLIST_ARCFAST_SAMPLE_MAX - 1, 0);
-    else
-        PathArcTo(center, radius - 0.5f, 0.0f, a_max, num_segments - 1);
     PathStroke(col, ImDrawFlags_Closed, thickness);
 }
 
@@ -1505,24 +1521,40 @@ void ImDrawList::AddCircleFilled(const ImVec2& center, float radius, ImU32 col, 
     if ((col & IM_COL32_A_MASK) == 0 || radius <= 0.0f)
         return;
 
-    // Obtain segment count
     if (num_segments <= 0)
     {
-        // Automatic segment count
-        num_segments = _CalcCircleAutoSegmentCount(radius);
+        // Use arc with automatic segment count
+        _PathArcToFastEx(center, radius, 0, IM_DRAWLIST_ARCFAST_SAMPLE_MAX, 0);
+        _Path.pop_back();
     }
+#if IM_IS_DIVISIBLE_BY(IM_DRAWLIST_ARCFAST_SAMPLE_MAX, 12)
+    else if (num_segments == 12)
+    {
+        // If IM_DRAWLIST_ARCFAST_SAMPLE_MAX is dividable by 12, we can use _PathArcToFastEx
+        // with constant step size.
+        _PathArcToFastEx(center, radius, 0, IM_DRAWLIST_ARCFAST_SAMPLE_MAX, IM_DRAWLIST_ARCFAST_SAMPLE_MAX / 12);
+        _Path.pop_back();
+    }
+#endif
+#if IM_IS_DIVISIBLE_BY(IM_DRAWLIST_ARCFAST_SAMPLE_MAX, 24)
+    else if (num_segments == 24)
+    {
+        // If IM_DRAWLIST_ARCFAST_SAMPLE_MAX is dividable by 12, we can use _PathArcToFastEx
+        // with constant step size.
+        _PathArcToFastEx(center, radius, 0, IM_DRAWLIST_ARCFAST_SAMPLE_MAX, IM_DRAWLIST_ARCFAST_SAMPLE_MAX / 24);
+        _Path.pop_back();
+    }
+#endif
     else
     {
         // Explicit segment count (still clamp to avoid drawing insanely tessellated shapes)
         num_segments = ImClamp(num_segments, 3, IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_MAX);
+
+        // Because we are filling a closed shape we remove 1 from the count of segments/points
+        const float a_max = (IM_PI * 2.0f) * ((float)num_segments - 1.0f) / (float)num_segments;
+        PathArcTo(center, radius, 0.0f, a_max, num_segments - 1);
     }
 
-    // Because we are filling a closed shape we remove 1 from the count of segments/points
-    const float a_max = (IM_PI * 2.0f) * ((float)num_segments - 1.0f) / (float)num_segments;
-    if (num_segments == 12)
-        _PathArcToFastEx(center, radius, 0, IM_DRAWLIST_ARCFAST_SAMPLE_MAX - 1, 0);
-    else
-        PathArcTo(center, radius, 0.0f, a_max, num_segments - 1);
     PathFillConvex(col);
 }
 

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -1494,7 +1494,7 @@ void ImDrawList::AddCircle(const ImVec2& center, float radius, ImU32 col, int nu
     // Because we are filling a closed shape we remove 1 from the count of segments/points
     const float a_max = (IM_PI * 2.0f) * ((float)num_segments - 1.0f) / (float)num_segments;
     if (num_segments == 12)
-        PathArcToFast(center, radius - 0.5f, 0, 12 - 1);
+        _PathArcToFastEx(center, radius - 0.5f, 0, IM_DRAWLIST_ARCFAST_SAMPLE_MAX - 1, 0);
     else
         PathArcTo(center, radius - 0.5f, 0.0f, a_max, num_segments - 1);
     PathStroke(col, ImDrawFlags_Closed, thickness);
@@ -1520,7 +1520,7 @@ void ImDrawList::AddCircleFilled(const ImVec2& center, float radius, ImU32 col, 
     // Because we are filling a closed shape we remove 1 from the count of segments/points
     const float a_max = (IM_PI * 2.0f) * ((float)num_segments - 1.0f) / (float)num_segments;
     if (num_segments == 12)
-        PathArcToFast(center, radius, 0, 12 - 1);
+        _PathArcToFastEx(center, radius, 0, IM_DRAWLIST_ARCFAST_SAMPLE_MAX - 1, 0);
     else
         PathArcTo(center, radius, 0.0f, a_max, num_segments - 1);
     PathFillConvex(col);

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -233,6 +233,7 @@ namespace ImStb
 #define IM_F32_TO_INT8_SAT(_VAL)        ((int)(ImSaturate(_VAL) * 255.0f + 0.5f))               // Saturated, always output 0..255
 #define IM_FLOOR(_VAL)                  ((float)(int)(_VAL))                                    // ImFloor() is not inlined in MSVC debug builds
 #define IM_ROUND(_VAL)                  ((float)(int)((_VAL) + 0.5f))                           //
+#define IM_IS_DIVISIBLE_BY(number, divisor) ((((number) / (divisor)) * (divisor)) == (number))  //
 
 // Enforce cdecl calling convention for functions called by the standard library, in case compilation settings changed the default to e.g. __vectorcall
 #ifdef _MSC_VER


### PR DESCRIPTION
…ices for 12 segment case (#4419)

Before introduction of adaptive arcs PathArcToFast() were operating on 12 vertices table.
Now it is replaced by internal _PathArcToFastEx() doing same job but with greater granularity,
PathArcToFast was left as a fallback.
