### PR TITLE
non-dispatchable handles should compare to VK_NULL_HANDLE, not NULL

### DIFF
--- a/backends/imgui_impl_vulkan.cpp
+++ b/backends/imgui_impl_vulkan.cpp
@@ -696,7 +696,7 @@ static void ImGui_ImplVulkan_CreateShaderModules(VkDevice device, const VkAlloca
 {
     // Create the shader modules
     ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
-    if (bd->ShaderModuleVert == NULL)
+    if (bd->ShaderModuleVert == VK_NULL_HANDLE)
     {
         VkShaderModuleCreateInfo vert_info = {};
         vert_info.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
@@ -705,7 +705,7 @@ static void ImGui_ImplVulkan_CreateShaderModules(VkDevice device, const VkAlloca
         VkResult err = vkCreateShaderModule(device, &vert_info, allocator, &bd->ShaderModuleVert);
         check_vk_result(err);
     }
-    if (bd->ShaderModuleFrag == NULL)
+    if (bd->ShaderModuleFrag == VK_NULL_HANDLE)
     {
         VkShaderModuleCreateInfo frag_info = {};
         frag_info.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
@@ -1227,7 +1227,7 @@ void ImGui_ImplVulkanH_CreateWindowSwapChain(VkPhysicalDevice physical_device, V
 {
     VkResult err;
     VkSwapchainKHR old_swapchain = wd->Swapchain;
-    wd->Swapchain = NULL;
+    wd->Swapchain = VK_NULL_HANDLE;
     err = vkDeviceWaitIdle(device);
     check_vk_result(err);
 


### PR DESCRIPTION
On some platforms (e.g. the Raspberry Pi 400), non-dispatchable Vulkan handles are typedef'd to `uint64_t`, not type-specific pointers. See the docs for [VK_DEFINE_NON_DISPATCHABLE_HANDLE](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_DEFINE_NON_DISPATCHABLE_HANDLE.html) for details. In this case, some compilers (such as RPi400's gcc 8.3.0) flag comparisons between non-dispatchable handles and `NULL` as an error. Dear Imgui's Vulkan backend contains three such comparisons, against `VkShaderModule` and `VkSwapchainKHR` handles.. Comparing these handles to `VK_NULL_HANDLE` instead of `NULL` avoids the compile error, as `VK_NULL_HANDLE` is automatically defined to either a `NULL` pointer or a `uint64_t` to match how other handles are typedef'd.