### PR TITLE
Add Style.WindowCloseButtonPosition, Style.WindowTabCloseButtonPosition, Style.TabCloseButtonPosition

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -947,6 +947,7 @@ static bool             UpdateWindowManualResize(ImGuiWindow* window, const ImVe
 static void             RenderWindowOuterBorders(ImGuiWindow* window);
 static void             RenderWindowDecorations(ImGuiWindow* window, const ImRect& title_bar_rect, bool title_bar_is_highlight, bool handle_borders_and_resize_grips, int resize_grip_count, const ImU32 resize_grip_col[4], float resize_grip_draw_size);
 static void             RenderWindowTitleBarContents(ImGuiWindow* window, const ImRect& title_bar_rect, const char* name, bool* p_open);
+static void             WindowLayoutCloseAndMenuButton(bool has_close_button, bool has_collapse_button, const ImRect& title_bar_rect, ImVec2& close_button_pos, ImVec2& collapse_button_pos, float *pad_l, float* pad_r);
 static void             EndFrameDrawDimmedBackgrounds();
 
 // Viewports
@@ -1020,7 +1021,10 @@ ImGuiStyle::ImGuiStyle()
     WindowBorderSize        = 1.0f;             // Thickness of border around windows. Generally set to 0.0f or 1.0f. Other values not well tested.
     WindowMinSize           = ImVec2(32,32);    // Minimum window size
     WindowTitleAlign        = ImVec2(0.0f,0.5f);// Alignment for title bar text
-    WindowMenuButtonPosition= ImGuiDir_Left;    // Position of the collapsing/docking button in the title bar (left/right). Defaults to ImGuiDir_Left.
+    WindowCloseButtonPosition    = ImGuiDir_Right; // Position of the close button in the title bar (left/right). Defaults to ImGuiDir_Right.
+    WindowTabCloseButtonPosition = ImGuiDir_Right; // Position of the close button in the docking tabs for the windows (Left/Right). Defaults to ImGuiDir_Right.
+    TabCloseButtonPosition       = ImGuiDir_Right; // Position of the close button in the tabs (Left/Right). Defaults to ImGuiDir_Right.
+    WindowMenuButtonPosition     = ImGuiDir_Left;  // Position of the collapsing/docking button in the title bar (left/right). Defaults to ImGuiDir_Left.
     ChildRounding           = 0.0f;             // Radius of child window corners rounding. Set to 0.0f to have rectangular child windows
     ChildBorderSize         = 1.0f;             // Thickness of border around child windows. Generally set to 0.0f or 1.0f. Other values not well tested.
     PopupRounding           = 0.0f;             // Radius of popup window corners rounding. Set to 0.0f to have rectangular child windows
@@ -6017,6 +6021,39 @@ void ImGui::RenderWindowDecorations(ImGuiWindow* window, const ImRect& title_bar
     }
 }
 
+void ImGui::WindowLayoutCloseAndMenuButton(bool has_close_button, bool has_collapse_button, const ImRect& title_bar_rect, ImVec2& close_button_pos, ImVec2& collapse_button_pos, float *pad_l, float* pad_r) 
+{
+    ImGuiContext& g = *GImGui;
+    ImGuiStyle& style = g.Style;
+    float button_sz = g.FontSize;
+
+    if (has_close_button && style.WindowCloseButtonPosition == ImGuiDir_Left)
+    {
+        close_button_pos = ImVec2(title_bar_rect.Min.x + *pad_l - style.FramePadding.x, title_bar_rect.Min.y);
+        *pad_l += button_sz;
+    }
+    if (has_close_button && style.WindowCloseButtonPosition == ImGuiDir_Right)
+    {
+        *pad_r += button_sz;
+        close_button_pos = ImVec2(title_bar_rect.Max.x - *pad_r - style.FramePadding.x, title_bar_rect.Min.y);
+    }
+    if (has_collapse_button && style.WindowMenuButtonPosition == ImGuiDir_Right)
+    {
+        *pad_r += button_sz;
+        collapse_button_pos = ImVec2(title_bar_rect.Max.x - *pad_r - style.FramePadding.x, title_bar_rect.Min.y);
+    }
+    if (has_collapse_button && style.WindowMenuButtonPosition == ImGuiDir_Left)
+    {
+        collapse_button_pos = ImVec2(title_bar_rect.Min.x + *pad_l - style.FramePadding.x, title_bar_rect.Min.y);
+        *pad_l += button_sz;
+    }
+
+    if (*pad_l > style.FramePadding.x)
+        *pad_l += g.Style.ItemInnerSpacing.x;
+    if (*pad_r > style.FramePadding.x)
+        *pad_r += g.Style.ItemInnerSpacing.x;
+}
+
 // Render title text, collapse button, close button
 // When inside a dock node, this is handled in DockNodeCalcTabBarLayout() instead.
 void ImGui::RenderWindowTitleBarContents(ImGuiWindow* window, const ImRect& title_bar_rect, const char* name, bool* p_open)
@@ -6038,23 +6075,10 @@ void ImGui::RenderWindowTitleBarContents(ImGuiWindow* window, const ImRect& titl
     float pad_l = style.FramePadding.x;
     float pad_r = style.FramePadding.x;
     float button_sz = g.FontSize;
+
     ImVec2 close_button_pos;
     ImVec2 collapse_button_pos;
-    if (has_close_button)
-    {
-        pad_r += button_sz;
-        close_button_pos = ImVec2(title_bar_rect.Max.x - pad_r - style.FramePadding.x, title_bar_rect.Min.y);
-    }
-    if (has_collapse_button && style.WindowMenuButtonPosition == ImGuiDir_Right)
-    {
-        pad_r += button_sz;
-        collapse_button_pos = ImVec2(title_bar_rect.Max.x - pad_r - style.FramePadding.x, title_bar_rect.Min.y);
-    }
-    if (has_collapse_button && style.WindowMenuButtonPosition == ImGuiDir_Left)
-    {
-        collapse_button_pos = ImVec2(title_bar_rect.Min.x + pad_l - style.FramePadding.x, title_bar_rect.Min.y);
-        pad_l += button_sz;
-    }
+    WindowLayoutCloseAndMenuButton(has_close_button, has_collapse_button, title_bar_rect, close_button_pos, collapse_button_pos, &pad_l, &pad_r);
 
     // Collapse button (submitting first so it gets priority when choosing a navigation init fallback)
     if (has_collapse_button)
@@ -6076,10 +6100,6 @@ void ImGui::RenderWindowTitleBarContents(ImGuiWindow* window, const ImRect& titl
 
     // As a nice touch we try to ensure that centered title text doesn't get affected by visibility of Close/Collapse button,
     // while uncentered title text will still reach edges correctly.
-    if (pad_l > style.FramePadding.x)
-        pad_l += g.Style.ItemInnerSpacing.x;
-    if (pad_r > style.FramePadding.x)
-        pad_r += g.Style.ItemInnerSpacing.x;
     if (style.WindowTitleAlign.x > 0.0f && style.WindowTitleAlign.x < 1.0f)
     {
         float centerness = ImSaturate(1.0f - ImFabs(style.WindowTitleAlign.x - 0.5f) * 2.0f); // 0.0f on either edges, 1.0f on center
@@ -7825,6 +7845,9 @@ static void ImGui::ErrorCheckNewFrameSanityChecks()
     IM_ASSERT(g.Style.Alpha >= 0.0f && g.Style.Alpha <= 1.0f            && "Invalid style setting!"); // Allows us to avoid a few clamps in color computations
     IM_ASSERT(g.Style.WindowMinSize.x >= 1.0f && g.Style.WindowMinSize.y >= 1.0f && "Invalid style setting.");
     IM_ASSERT(g.Style.WindowMenuButtonPosition == ImGuiDir_None || g.Style.WindowMenuButtonPosition == ImGuiDir_Left || g.Style.WindowMenuButtonPosition == ImGuiDir_Right);
+    IM_ASSERT(g.Style.WindowCloseButtonPosition == ImGuiDir_Left || g.Style.WindowCloseButtonPosition == ImGuiDir_Right);
+    IM_ASSERT(g.Style.WindowTabCloseButtonPosition == ImGuiDir_Left || g.Style.WindowTabCloseButtonPosition == ImGuiDir_Right);
+    IM_ASSERT(g.Style.TabCloseButtonPosition == ImGuiDir_Left || g.Style.TabCloseButtonPosition == ImGuiDir_Right);
     for (int n = 0; n < ImGuiKey_COUNT; n++)
         IM_ASSERT(g.IO.KeyMap[n] >= -1 && g.IO.KeyMap[n] < IM_ARRAYSIZE(g.IO.KeysDown) && "io.KeyMap[] contains an out of bound value (need to be 0..512, or -1 for unmapped key)");
 
@@ -14289,30 +14312,17 @@ static void ImGui::DockNodeCalcTabBarLayout(const ImGuiDockNode* node, ImRect* o
     ImRect r = ImRect(node->Pos.x, node->Pos.y, node->Pos.x + node->Size.x, node->Pos.y + g.FontSize + g.Style.FramePadding.y * 2.0f);
     if (out_title_rect) { *out_title_rect = r; }
 
-    r.Min.x += style.WindowBorderSize;
-    r.Max.x -= style.WindowBorderSize;
+    ImVec2 window_menu_button_pos;
+    ImVec2 window_close_button_pos;
+    float pad_l = style.FramePadding.x + style.WindowBorderSize;
+    float pad_r = pad_l;
+    WindowLayoutCloseAndMenuButton(node->HasCloseButton, node->HasWindowMenuButton, r, window_close_button_pos, window_menu_button_pos, &pad_l, &pad_r);
+    r.Min.x += pad_l;
+    r.Max.x -= pad_r;
 
-    float button_sz = g.FontSize;
-
-    ImVec2 window_menu_button_pos = r.Min;
-    r.Min.x += style.FramePadding.x;
-    r.Max.x -= style.FramePadding.x;
-    if (node->HasCloseButton)
-    {
-        r.Max.x -= button_sz;
-        if (out_close_button_pos) *out_close_button_pos = ImVec2(r.Max.x - style.FramePadding.x, r.Min.y);
-    }
-    if (node->HasWindowMenuButton && style.WindowMenuButtonPosition == ImGuiDir_Left)
-    {
-        r.Min.x += button_sz + style.ItemInnerSpacing.x;
-    }
-    else if (node->HasWindowMenuButton && style.WindowMenuButtonPosition == ImGuiDir_Right)
-    {
-        r.Max.x -= button_sz + style.FramePadding.x;
-        window_menu_button_pos = ImVec2(r.Max.x, r.Min.y);
-    }
     if (out_tab_bar_rect) { *out_tab_bar_rect = r; }
     if (out_window_menu_button_pos) { *out_window_menu_button_pos = window_menu_button_pos; }
+    if (out_close_button_pos) { *out_close_button_pos = window_close_button_pos; }
 }
 
 void ImGui::DockNodeCalcSplitRects(ImVec2& pos_old, ImVec2& size_old, ImVec2& pos_new, ImVec2& size_new, ImGuiDir dir, ImVec2 size_new_desired)

--- a/imgui.h
+++ b/imgui.h
@@ -1827,6 +1827,9 @@ struct ImGuiStyle
     float       WindowBorderSize;           // Thickness of border around windows. Generally set to 0.0f or 1.0f. (Other values are not well tested and more CPU/GPU costly).
     ImVec2      WindowMinSize;              // Minimum window size. This is a global setting. If you want to constraint individual windows, use SetNextWindowSizeConstraints().
     ImVec2      WindowTitleAlign;           // Alignment for title bar text. Defaults to (0.0f,0.5f) for left-aligned,vertically centered.
+    ImGuiDir    WindowCloseButtonPosition;  // Side of the close button in the title bar (Left/Right). Defaults to ImGuiDir_Right.
+    ImGuiDir    WindowTabCloseButtonPosition;  // Side of the close button in the docking tabs for the windows (Left/Right). Defaults to ImGuiDir_Right.
+    ImGuiDir    TabCloseButtonPosition;     // Side of the close button in the tabs (Left/Right). Defaults to ImGuiDir_Right.
     ImGuiDir    WindowMenuButtonPosition;   // Side of the collapsing/docking button in the title bar (None/Left/Right). Defaults to ImGuiDir_Left.
     float       ChildRounding;              // Radius of child window corners rounding. Set to 0.0f to have rectangular windows.
     float       ChildBorderSize;            // Thickness of border around child windows. Generally set to 0.0f or 1.0f. (Other values are not well tested and more CPU/GPU costly).

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -5983,6 +5983,9 @@ void ImGui::ShowStyleEditor(ImGuiStyle* ref)
             int window_menu_button_position = style.WindowMenuButtonPosition + 1;
             if (ImGui::Combo("WindowMenuButtonPosition", (int*)&window_menu_button_position, "None\0Left\0Right\0"))
                 style.WindowMenuButtonPosition = window_menu_button_position - 1;
+            ImGui::Combo("WindowCloseButtonPosition", (int*)&style.WindowCloseButtonPosition, "Left\0Right\0");
+            ImGui::Combo("WindowTabCloseButtonPosition", (int*)&style.WindowTabCloseButtonPosition, "Left\0Right\0");
+            ImGui::Combo("TabCloseButtonPosition", (int*)&style.TabCloseButtonPosition, "Left\0Right\0");
             ImGui::Combo("ColorButtonPosition", (int*)&style.ColorButtonPosition, "Left\0Right\0");
             ImGui::SliderFloat2("ButtonTextAlign", (float*)&style.ButtonTextAlign, 0.0f, 1.0f, "%.2f");
             ImGui::SameLine(); HelpMarker("Alignment applies when a button is larger than its text content.");

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -2220,7 +2220,8 @@ enum ImGuiTabItemFlagsPrivate_
     ImGuiTabItemFlags_NoCloseButton             = 1 << 20,  // Track whether p_open was set or not (we'll need this info on the next frame to recompute ContentWidth during layout)
     ImGuiTabItemFlags_Button                    = 1 << 21,  // Used by TabItemButton, change the tab item behavior to mimic a button
     ImGuiTabItemFlags_Unsorted                  = 1 << 22,  // [Docking] Trailing tabs with the _Unsorted flag will be sorted based on the DockOrder of their Window.
-    ImGuiTabItemFlags_Preview                   = 1 << 23   // [Docking] Display tab shape for docking preview (height is adjusted slightly to compensate for the yet missing tab bar)
+    ImGuiTabItemFlags_Preview                   = 1 << 23,  // [Docking] Display tab shape for docking preview (height is adjusted slightly to compensate for the yet missing tab bar)
+    ImGuiTabItemFlags_DockedWindow              = 1 << 24   // [Docking] Tab is for a docked Window.
 };
 
 // Storage for one active tab item (sizeof() 48 bytes)

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -7929,6 +7929,9 @@ bool    ImGui::TabItemEx(ImGuiTabBar* tab_bar, const char* label, bool* p_open, 
     else if (p_open == NULL)
         flags |= ImGuiTabItemFlags_NoCloseButton;
 
+    if (docked_window != NULL)
+        flags |= ImGuiTabItemFlags_DockedWindow;
+
     // Calculate tab contents size
     ImVec2 size = TabItemCalcSize(label, p_open != NULL);
 
@@ -8271,7 +8274,20 @@ void ImGui::TabItemLabelAndCloseButton(ImDrawList* draw_list, const ImRect& bb, 
     }
 
     const float button_sz = g.FontSize;
-    const ImVec2 button_pos(ImMax(bb.Min.x, bb.Max.x - frame_padding.x * 2.0f - button_sz), bb.Min.y);
+    ImVec2 button_pos;
+    
+    bool close_on_left = (close_button_id != 0);
+    if ((flags & ImGuiTabItemFlags_DockedWindow) != 0) {
+        close_on_left = close_on_left && (g.Style.WindowTabCloseButtonPosition == ImGuiDir_Left);
+    } else {
+        close_on_left = close_on_left && (g.Style.TabCloseButtonPosition == ImGuiDir_Left);
+    }
+    if (close_on_left) {
+        button_pos.x = bb.Min.x;
+    } else {
+        button_pos.x = ImMax(bb.Min.x, bb.Max.x - frame_padding.x * 2.0f - button_sz);
+    }
+    button_pos.y = bb.Min.y;
 
     // Close Button & Unsaved Marker
     // We are relying on a subtle and confusing distinction between 'hovered' and 'g.HoveredId' which happens because we are using ImGuiButtonFlags_AllowOverlapMode + SetItemAllowOverlap()
@@ -8314,6 +8330,12 @@ void ImGui::TabItemLabelAndCloseButton(ImDrawList* draw_list, const ImRect& bb, 
         text_pixel_clip_bb.Max.x -= close_button_visible ? (button_sz) : (button_sz * 0.80f);
         text_ellipsis_clip_bb.Max.x -= unsaved_marker_visible ? (button_sz * 0.80f) : 0.0f;
         ellipsis_max_x = text_pixel_clip_bb.Max.x;
+    }
+    if (close_on_left) {
+        text_pixel_clip_bb.Min.x += button_sz + frame_padding.x;
+        text_pixel_clip_bb.Max.x += button_sz + frame_padding.x;
+        text_ellipsis_clip_bb.Min.x += button_sz + frame_padding.x;
+        text_ellipsis_clip_bb.Max.x += button_sz + frame_padding.x;
     }
     RenderTextEllipsis(draw_list, text_ellipsis_clip_bb.Min, text_ellipsis_clip_bb.Max, text_pixel_clip_bb.Max.x, ellipsis_max_x, label, NULL, &label_size);
 


### PR DESCRIPTION
Closes #4490 for docking branch. Also adds styles for close button on left for both dock tabs and normal tabs. 

If you want, I can port Style.TabCloseButtonPosition to master branch also: I don't know if there's a need for it, and I did because it was almost free once Style.WindowTabCloseButtonPosition was implemented.