### PR TITLE
Add simple cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,72 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(imgui CXX)
+
+option(IMGUI_BACKEND_ALLEGRO5 "Allegro Gaming Library")
+option(IMGUI_BACKEND_ANDROID "Android native API")
+option(IMGUI_BACKEND_DX9 "DirectX9")
+option(IMGUI_BACKEND_DX10 "DirectX10")
+option(IMGUI_BACKEND_DX11 "DirectX11")
+option(IMGUI_BACKEND_DX12 "DirectX12")
+option(IMGUI_BACKEND_GLFW "GLFW (Windows, macOS, Linux, etc.)")
+option(IMGUI_BACKEND_GLUT "GLUT/FreeGLUT (legacy, not recommended today)")
+option(IMGUI_BACKEND_MARMALADE "Marmalade SDK")
+option(IMGUI_BACKEND_METAL "Metal (with ObjC)")
+option(IMGUI_BACKEND_OPENGL2 "OpenGL 2 (legacy, not recommended today)")
+option(IMGUI_BACKEND_OPENGL3 "OpenGL 3/4")
+option(IMGUI_BACKEND_OSX "macOS native API")
+option(IMGUI_BACKEND_SDL "SDL2 (Windows, macOS, Linux, iOS, Android)")
+option(IMGUI_BACKEND_SDL_RENDERER "SDL2 renderer")
+option(IMGUI_BACKEND_VULKAN "Vulkan")
+option(IMGUI_BACKEND_WGPU "WebGPU")
+option(IMGUI_BACKEND_WINAPI "Win32 native API")
+
+add_library(${PROJECT_NAME}
+    imgui.cpp
+    imgui_demo.cpp
+    imgui_draw.cpp
+    imgui_tables.cpp
+    imgui_widgets.cpp
+    $<$<BOOL:${IMGUI_BACKEND_ALLEGRO5}>:backends/imgui_impl_allegro5.cpp>
+    $<$<BOOL:${IMGUI_BACKEND_ANDROID}>:backends/imgui_impl_android.cpp>
+    $<$<BOOL:${IMGUI_BACKEND_DX9}>:backends/imgui_impl_dx9.cpp>
+    $<$<BOOL:${IMGUI_BACKEND_DX10}>:backends/imgui_impl_dx10.cpp>
+    $<$<BOOL:${IMGUI_BACKEND_DX11}>:backends/imgui_impl_dx11.cpp>
+    $<$<BOOL:${IMGUI_BACKEND_DX12}>:backends/imgui_impl_dx12.cpp>
+    $<$<BOOL:${IMGUI_BACKEND_GLFW}>:backends/imgui_impl_glfw.cpp>
+    $<$<BOOL:${IMGUI_BACKEND_GLUT}>:backends/imgui_impl_glut.cpp>
+    $<$<BOOL:${IMGUI_BACKEND_MARMALADE}>:backends/imgui_impl_marmalade.cpp>
+    $<$<BOOL:${IMGUI_BACKEND_METAL}>:backends/imgui_impl_metal.mm>
+    $<$<BOOL:${IMGUI_BACKEND_OPENGL2}>:backends/imgui_impl_opengl2.cpp>
+    $<$<BOOL:${IMGUI_BACKEND_OPENGL3}>:backends/imgui_impl_opengl3.cpp>
+    $<$<BOOL:${IMGUI_BACKEND_OSX}>:backends/imgui_impl_osx.mm>
+    $<$<BOOL:${IMGUI_BACKEND_SDL}>:backends/imgui_impl_sdl.cpp>
+    $<$<BOOL:${IMGUI_BACKEND_SDL_RENDERER}>:backends/imgui_impl_sdlrenderer.cpp>
+    $<$<BOOL:${IMGUI_BACKEND_VULKAN}>:backends/imgui_impl_vulkan.cpp>
+    $<$<BOOL:${IMGUI_BACKEND_WGPU}>:backends/imgui_impl_wgpu.cpp>
+    $<$<BOOL:${IMGUI_BACKEND_WINAPI}>:backends/imgui_impl_win32.cpp>
+)
+
+target_include_directories(${PROJECT_NAME}
+    PUBLIC
+        .
+        backends
+)
+
+target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+        $<$<BOOL:${IMGUI_BACKEND_ANDROID}>:android>
+        $<$<BOOL:${IMGUI_BACKEND_DX9}>:d3d9.lib>
+        $<$<BOOL:${IMGUI_BACKEND_DX10}>:d3d10.lib;d3dcompiler.lib>
+        $<$<BOOL:${IMGUI_BACKEND_DX11}>:d3d11.lib;d3dcompiler.lib>
+        $<$<BOOL:${IMGUI_BACKEND_DX12}>:d3d12.lib;d3dcompiler.lib;dxgi.lib>
+        $<$<BOOL:${IMGUI_BACKEND_GLFW}>:glfw>
+        $<$<BOOL:${IMGUI_BACKEND_GLUT}>:glut>
+        $<$<BOOL:${IMGUI_BACKEND_METAL}>:"-framework Metal -framework MetalKit -framework QuartzCore">
+        $<$<BOOL:${IMGUI_BACKEND_OSX}>:"-framework Cocoa">
+        $<$<OR:$<BOOL:${IMGUI_BACKEND_SDL}>,$<BOOL:${IMGUI_BACKEND_SDL_RENDERER}>>:SDL2::SDL2main>
+        $<$<OR:$<BOOL:${IMGUI_BACKEND_SDL}>,$<BOOL:${IMGUI_BACKEND_SDL_RENDERER}>>:$<IF:$<BOOL:${SDL_STATIC_ENABLED_BY_DEFAULT}>,SDL2::SDL2-static,SDL2::SDL2>>
+        $<$<BOOL:${IMGUI_BACKEND_VULKAN}>:Vulkan::Vulkan>
+        $<$<AND:$<BOOL:${IMGUI_BACKEND_OPENGL3}>,$<BOOL:${OpenGL_FOUND}>>:OpenGL::OpenGL>
+        $<$<AND:$<BOOL:${IMGUI_BACKEND_OPENGL2}>,$<BOOL:${OpenGL_FOUND}>>:OpenGL::OpenGL>
+)

--- a/backends/imgui_impl_dx12.cpp
+++ b/backends/imgui_impl_dx12.cpp
@@ -481,12 +481,13 @@ bool    ImGui_ImplDX12_CreateDeviceObjects()
         staticSampler.RegisterSpace = 0;
         staticSampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
 
-        D3D12_ROOT_SIGNATURE_DESC desc = {};
-        desc.NumParameters = _countof(param);
-        desc.pParameters = param;
-        desc.NumStaticSamplers = 1;
-        desc.pStaticSamplers = &staticSampler;
-        desc.Flags =
+        D3D12_VERSIONED_ROOT_SIGNATURE_DESC desc = {};
+        desc.Version = D3D_ROOT_SIGNATURE_VERSION_1_0;
+        desc.Desc_1_0.NumParameters = _countof(param);
+        desc.Desc_1_0.pParameters = param;
+        desc.Desc_1_0.NumStaticSamplers = 1;
+        desc.Desc_1_0.pStaticSamplers = &staticSampler;
+        desc.Desc_1_0.Flags =
             D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |
             D3D12_ROOT_SIGNATURE_FLAG_DENY_HULL_SHADER_ROOT_ACCESS |
             D3D12_ROOT_SIGNATURE_FLAG_DENY_DOMAIN_SHADER_ROOT_ACCESS |
@@ -514,12 +515,13 @@ bool    ImGui_ImplDX12_CreateDeviceObjects()
                 return false;
         }
 
-        PFN_D3D12_SERIALIZE_ROOT_SIGNATURE D3D12SerializeRootSignatureFn = (PFN_D3D12_SERIALIZE_ROOT_SIGNATURE)::GetProcAddress(d3d12_dll, "D3D12SerializeRootSignature");
-        if (D3D12SerializeRootSignatureFn == NULL)
+        PFN_D3D12_SERIALIZE_VERSIONED_ROOT_SIGNATURE D3D12SerializeVersionedRootSignatureFn =
+            (PFN_D3D12_SERIALIZE_VERSIONED_ROOT_SIGNATURE)::GetProcAddress(d3d12_dll, "D3D12SerializeVersionedRootSignature");
+        if (D3D12SerializeVersionedRootSignatureFn == NULL)
             return false;
 
         ID3DBlob* blob = NULL;
-        if (D3D12SerializeRootSignatureFn(&desc, D3D_ROOT_SIGNATURE_VERSION_1, &blob, NULL) != S_OK)
+        if (D3D12SerializeVersionedRootSignatureFn(&desc, &blob, NULL) != S_OK)
             return false;
 
         bd->pd3dDevice->CreateRootSignature(0, blob->GetBufferPointer(), blob->GetBufferSize(), IID_PPV_ARGS(&bd->pRootSignature));

--- a/backends/imgui_impl_dx12.cpp
+++ b/backends/imgui_impl_dx12.cpp
@@ -481,13 +481,12 @@ bool    ImGui_ImplDX12_CreateDeviceObjects()
         staticSampler.RegisterSpace = 0;
         staticSampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
 
-        D3D12_VERSIONED_ROOT_SIGNATURE_DESC desc = {};
-        desc.Version = D3D_ROOT_SIGNATURE_VERSION_1_0;
-        desc.Desc_1_0.NumParameters = _countof(param);
-        desc.Desc_1_0.pParameters = param;
-        desc.Desc_1_0.NumStaticSamplers = 1;
-        desc.Desc_1_0.pStaticSamplers = &staticSampler;
-        desc.Desc_1_0.Flags =
+        D3D12_ROOT_SIGNATURE_DESC desc = {};
+        desc.NumParameters = _countof(param);
+        desc.pParameters = param;
+        desc.NumStaticSamplers = 1;
+        desc.pStaticSamplers = &staticSampler;
+        desc.Flags =
             D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |
             D3D12_ROOT_SIGNATURE_FLAG_DENY_HULL_SHADER_ROOT_ACCESS |
             D3D12_ROOT_SIGNATURE_FLAG_DENY_DOMAIN_SHADER_ROOT_ACCESS |
@@ -515,13 +514,12 @@ bool    ImGui_ImplDX12_CreateDeviceObjects()
                 return false;
         }
 
-        PFN_D3D12_SERIALIZE_VERSIONED_ROOT_SIGNATURE D3D12SerializeVersionedRootSignatureFn =
-            (PFN_D3D12_SERIALIZE_VERSIONED_ROOT_SIGNATURE)::GetProcAddress(d3d12_dll, "D3D12SerializeVersionedRootSignature");
-        if (D3D12SerializeVersionedRootSignatureFn == NULL)
+        PFN_D3D12_SERIALIZE_ROOT_SIGNATURE D3D12SerializeRootSignatureFn = (PFN_D3D12_SERIALIZE_ROOT_SIGNATURE)::GetProcAddress(d3d12_dll, "D3D12SerializeRootSignature");
+        if (D3D12SerializeRootSignatureFn == NULL)
             return false;
 
         ID3DBlob* blob = NULL;
-        if (D3D12SerializeVersionedRootSignatureFn(&desc, &blob, NULL) != S_OK)
+        if (D3D12SerializeRootSignatureFn(&desc, D3D_ROOT_SIGNATURE_VERSION_1, &blob, NULL) != S_OK)
             return false;
 
         bd->pd3dDevice->CreateRootSignature(0, blob->GetBufferPointer(), blob->GetBufferSize(), IID_PPV_ARGS(&bd->pRootSignature));


### PR DESCRIPTION
I have looked into pull requests which add cmake to imgui project. Trying to cover both, imgui backends and examples, they just stuck in review state.

Let's go another way: **add simple cmake for imgui itself**.
I tried to create a simple and easy to use CMakeLists.txt.

Here is how imgui integration will look into some project:
```cmake
set(IMGUI_BACKEND_GLFW ON CACHE BOOL "")
set(IMGUI_BACKEND_OPENGL3 ON CACHE BOOL "")
add_subdirectory(third_party/imgui)
...
target_link_libraries(some_project_name PRIVATE imgui)
```

*Tested on Windows and Linux.*

@ocornut, if you are not ok with keeping cmake file in imgui root, then we can move it to /cmake directory.