### PR TITLE
Removing useless io's void conversion from examples/example_glfw_opengl3

### DIFF
--- a/examples/example_glfw_opengl3/main.cpp
+++ b/examples/example_glfw_opengl3/main.cpp
@@ -64,7 +64,7 @@ int main(int, char**)
     // Setup Dear ImGui context
     IMGUI_CHECKVERSION();
     ImGui::CreateContext();
-    ImGuiIO& io = ImGui::GetIO(); (void)io;
+    ImGuiIO& io = ImGui::GetIO();
     //io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;     // Enable Keyboard Controls
     //io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;      // Enable Gamepad Controls
 


### PR DESCRIPTION
I noticed this little conversion that seems unnecessary when using the template for a personal project. 
After removing it, nothing seems to have broken, and the other examples don't seem to have it.
