### PR TITLE
Backends: Vulkan: Added missing font object destruction

### DIFF
--- a/backends/imgui_impl_vulkan.cpp
+++ b/backends/imgui_impl_vulkan.cpp
@@ -550,6 +550,7 @@ bool ImGui_ImplVulkan_CreateFontsTexture(VkCommandBuffer command_buffer)
     io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);
     size_t upload_size = width * height * 4 * sizeof(char);
 
+    vkQueueWaitIdle(v->Queue);
     if (bd->FontView) {
         vkDestroyImageView(v->Device, bd->FontView, v->Allocator);
     }

--- a/backends/imgui_impl_vulkan.cpp
+++ b/backends/imgui_impl_vulkan.cpp
@@ -550,6 +550,16 @@ bool ImGui_ImplVulkan_CreateFontsTexture(VkCommandBuffer command_buffer)
     io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);
     size_t upload_size = width * height * 4 * sizeof(char);
 
+    if (bd->FontView) {
+        vkDestroyImageView(v->Device, bd->FontView, v->Allocator);
+    }
+    if (bd->FontImage) {
+        vkDestroyImage(v->Device, bd->FontImage, v->Allocator);
+    }
+    if (bd->FontMemory) {
+        vkFreeMemory(v->Device, bd->FontMemory, v->Allocator);
+    }
+
     VkResult err;
 
     // Create the Image:


### PR DESCRIPTION
If you use the Vulkan backend and create the font texture twice, three object are not destroyed properly. This problem was already observed in issue https://github.com/ocornut/imgui/issues/3743. Unfortunately, there wasn't a pull request which is why I'm making one now. Thanks to @guybrush77 who already solved this problem!

For completeness, below are the relevant validation layers without the fix. 


```
Error: { Validation }:
    Message ID Name   : VUID-vkDestroyDevice-device-00378
    Message ID Number : 1901072314
    Message           : Validation Error: [ VUID-vkDestroyDevice-device-00378 ] Object 0: handle = 0x2700dc42480, ty
pe = VK_OBJECT_TYPE_DEVICE; Object 1: handle = 0xab64de0000000020, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0x71500fba
 | OBJ ERROR : For VkDevice 0x2700dc42480[], VkImage 0xab64de0000000020[] has not been destroyed. The Vulkan spec states
: All child objects created on device must have been destroyed prior to destroying device (https://vulkan.lunarg.com/doc
/view/1.2.182.0/windows/1.2-extensions/vkspec.html#VUID-vkDestroyDevice-device-00378)

    Objects:
            Object 0:
                    objectType   = Device
                    objectHandle = 2680290550912
            Object 1:
                    objectType   = Image
                    objectHandle = 12350240169738108960


Error: { Validation }:
    Message ID Name   : VUID-vkDestroyDevice-device-00378
    Message ID Number : 1901072314
    Message           : Validation Error: [ VUID-vkDestroyDevice-device-00378 ] Object 0: handle = 0x2700dc42480, ty
pe = VK_OBJECT_TYPE_DEVICE; Object 1: handle = 0xc4f3070000000021, type = VK_OBJECT_TYPE_DEVICE_MEMORY; | MessageID = 0x
71500fba | OBJ ERROR : For VkDevice 0x2700dc42480[], VkDeviceMemory 0xc4f3070000000021[] has not been destroyed. The Vul
kan spec states: All child objects created on device must have been destroyed prior to destroying device (https://vulkan
.lunarg.com/doc/view/1.2.182.0/windows/1.2-extensions/vkspec.html#VUID-vkDestroyDevice-device-00378)

    Objects:
            Object 0:
                    objectType   = Device
                    objectHandle = 2680290550912
            Object 1:
                    objectType   = DeviceMemory
                    objectHandle = 14191694547355959329


Error: { Validation }:
    Message ID Name   : VUID-vkDestroyDevice-device-00378
    Message ID Number : 1901072314
    Message           : Validation Error: [ VUID-vkDestroyDevice-device-00378 ] Object 0: handle = 0x2700dc42480, ty
pe = VK_OBJECT_TYPE_DEVICE; Object 1: handle = 0x301e6c0000000022, type = VK_OBJECT_TYPE_IMAGE_VIEW; | MessageID = 0x715
00fba | OBJ ERROR : For VkDevice 0x2700dc42480[], VkImageView 0x301e6c0000000022[] has not been destroyed. The Vulkan sp
ec states: All child objects created on device must have been destroyed prior to destroying device (https://vulkan.lunar
g.com/doc/view/1.2.182.0/windows/1.2-extensions/vkspec.html#VUID-vkDestroyDevice-device-00378)

    Objects:
            Object 0:
                    objectType   = Device
                    objectHandle = 2680290550912
            Object 1:
                    objectType   = ImageView
                    objectHandle = 3467327510377660450

```