### PR TITLE
Fix printf format warnings on mingw clang

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -92,7 +92,7 @@ Index of this file:
 #endif
 
 // Helper Macros - IM_FMTARGS, IM_FMTLIST: Apply printf-style warnings to our formatting functions.
-#if !defined(IMGUI_USE_STB_SPRINTF) && defined(__MINGW32__)
+#if !defined(IMGUI_USE_STB_SPRINTF) && defined(__MINGW32__) && !defined(__clang__)
 #define IM_FMTARGS(FMT)             __attribute__((format(gnu_printf, FMT, FMT+1)))
 #define IM_FMTLIST(FMT)             __attribute__((format(gnu_printf, FMT, 0)))
 #elif !defined(IMGUI_USE_STB_SPRINTF) && (defined(__clang__) || defined(__GNUC__))


### PR DESCRIPTION

Hey,
When compiling with mingw bundled clang, it will complain that the `gnu_printf` format argument is not supported.
using the other macro with `printf` however works fine.

```
./imgui.h:608:118: warning: 'format' attribute argument not supported: gnu_printf [-Wignored-attributes]
    IMGUI_API bool          TreeNodeExV(const char* str_id, ImGuiTreeNodeFlags flags, const char* fmt, va_list args) IM_FMTLIST(3);
                                                                                                                     ^
./imgui.h:98:52: note: expanded from macro 'IM_FMTLIST'
#define IM_FMTLIST(FMT)             __attribute__((format(gnu_printf, FMT, 0)))
                                                   ^
```

I changed the conditions so it will use `format(printf, ...)` on mingw clang, but still use `format(gnu_printf,...)` for mingw gcc

Tested with mingw clang/gcc and also native windows clang. All report no errors with this fix.

```
>g++ --version
g++.exe (Rev5, Built by MSYS2 project) 10.3.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
>clang++ --version
clang version 12.0.1
Target: x86_64-w64-windows-gnu
Thread model: posix
InstalledDir: C:/msys64/mingw64/bin
>/a/LLVM/bin/clang++ --version              
clang version 12.0.1
Target: x86_64-pc-windows-msvc
Thread model: posix
InstalledDir: A:\LLVM\bin
```
