### PR TITLE
Backend - WebGPU: Fix missing initialization of local variable

### DIFF
--- a/backends/imgui_impl_wgpu.cpp
+++ b/backends/imgui_impl_wgpu.cpp
@@ -270,7 +270,7 @@ static WGPUProgrammableStageDescriptor ImGui_ImplWGPU_CreateShaderModule(uint32_
     spirv_desc.codeSize = binary_data_size;
     spirv_desc.code = binary_data;
 
-    WGPUShaderModuleDescriptor desc;
+    WGPUShaderModuleDescriptor desc = {};
     desc.nextInChain = reinterpret_cast<WGPUChainedStruct*>(&spirv_desc);
 
     WGPUProgrammableStageDescriptor stage_desc = {};


### PR DESCRIPTION
Initializes a missing local variable leading to wrong memory accesses in Google Dawn
