### PR TITLE
Include custom OpenGL loader header from define.

### DIFF
--- a/backends/imgui_impl_opengl3.cpp
+++ b/backends/imgui_impl_opengl3.cpp
@@ -114,7 +114,9 @@
 #include <GLES3/gl3.h>          // Use GL ES 3
 #endif
 #elif defined(IMGUI_IMPL_OPENGL_LOADER_CUSTOM)
-#include IMGUI_IMPL_OPENGL_LOADER_CUSTOM
+#if defined(IMGUI_IMPL_OPENGL_LOADER_CUSTOM_INCLUDE)
+#include IMGUI_IMPL_OPENGL_LOADER_CUSTOM_INCLUDE
+#endif
 #else
 // Modern desktop OpenGL doesn't have a standard portable header file to load OpenGL function pointers.
 // Helper libraries are often used for this purpose! Here we are using our own minimal custom loader based on gl3w.

--- a/backends/imgui_impl_opengl3.cpp
+++ b/backends/imgui_impl_opengl3.cpp
@@ -113,7 +113,9 @@
 #else
 #include <GLES3/gl3.h>          // Use GL ES 3
 #endif
-#elif !defined(IMGUI_IMPL_OPENGL_LOADER_CUSTOM)
+#elif defined(IMGUI_IMPL_OPENGL_LOADER_CUSTOM)
+#include IMGUI_IMPL_OPENGL_LOADER_CUSTOM
+#else
 // Modern desktop OpenGL doesn't have a standard portable header file to load OpenGL function pointers.
 // Helper libraries are often used for this purpose! Here we are using our own minimal custom loader based on gl3w.
 // In the rest of your app/engine, you can use another loader of your choice (gl3w, glew, glad, glbinding, glext, glLoadGen, etc.).


### PR DESCRIPTION
In case of Windows and custom loader file, no OpenGL API is visible to OpenGL3 implementation.
It is needed to include loader header that provides it.

Can be provided via CMake for example:

`target_compile_definitions(target PRIVATE IMGUI_IMPL_OPENGL_LOADER_CUSTOM="custom_opengl3_loader.h")`
