### PR TITLE
Add missing null check pointer in imgui_impl_glfw.cpp - ImGui_ImplGlfw_DestroyWindow

### DIFF
--- a/backends/imgui_impl_glfw.cpp
+++ b/backends/imgui_impl_glfw.cpp
@@ -699,9 +699,10 @@ static void ImGui_ImplGlfw_DestroyWindow(ImGuiViewport* viewport)
 
             // Release any keys that were pressed in the window being destroyed and are still held down,
             // because we will not receive any release events after window is destroyed.
-            for (int i = 0; i < IM_ARRAYSIZE(bd->KeyOwnerWindows); i++)
-                if (bd->KeyOwnerWindows[i] == vd->Window)
-                    ImGui_ImplGlfw_KeyCallback(vd->Window, i, 0, GLFW_RELEASE, 0); // Later params are only used for main viewport, on which this function is never called.
+            if (bd)
+                for (int i = 0; i < IM_ARRAYSIZE(bd->KeyOwnerWindows); i++)
+                    if (bd->KeyOwnerWindows[i] == vd->Window)
+                        ImGui_ImplGlfw_KeyCallback(vd->Window, i, 0, GLFW_RELEASE, 0); // Later params are only used for main viewport, on which this function is never called.
 
             glfwDestroyWindow(vd->Window);
         }


### PR DESCRIPTION
Been experimenting a bit with my application which uses ImGui with GLFW and OpenGL3 as its backend. Sometimes when closing the application I notices the following output:
```
/mnt/data/dev/DLXEmu/external/imgui/backends/imgui_impl_glfw.cpp:703:25: runtime error: member access within null pointer of type 'ImGui_ImplGlfw_Data'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /mnt/data/dev/DLXEmu/external/imgui/backends/imgui_impl_glfw.cpp:703:25 in
```
Look like the function is trying to deference a null pointer, which this patch should prevent.