### PR TITLE
Add IsItemDisabled 

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -4909,6 +4909,12 @@ bool ImGui::IsItemDeactivatedAfterEdit()
     return IsItemDeactivated() && (g.ActiveIdPreviousFrameHasBeenEditedBefore || (g.ActiveId == 0 && g.ActiveIdHasBeenEditedBefore));
 }
 
+bool ImGui::IsItemDisabled()
+{
+    ImGuiContext& g = *GImGui;
+    return (g.CurrentItemFlags & ImGuiItemFlags_Disabled) != 0;
+}
+
 // == GetItemID() == GetFocusID()
 bool ImGui::IsItemFocused()
 {

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -4912,7 +4912,7 @@ bool ImGui::IsItemDeactivatedAfterEdit()
 bool ImGui::IsItemDisabled()
 {
     ImGuiContext& g = *GImGui;
-    return (g.CurrentItemFlags & ImGuiItemFlags_Disabled) != 0;
+    return (g.LastItemData.InFlags & ImGuiItemFlags_Disabled) != 0;
 }
 
 // == GetItemID() == GetFocusID()

--- a/imgui.h
+++ b/imgui.h
@@ -843,6 +843,7 @@ namespace ImGui
     IMGUI_API bool          IsItemActivated();                                                  // was the last item just made active (item was previously inactive).
     IMGUI_API bool          IsItemDeactivated();                                                // was the last item just made inactive (item was previously active). Useful for Undo/Redo patterns with widgets that requires continuous editing.
     IMGUI_API bool          IsItemDeactivatedAfterEdit();                                       // was the last item just made inactive and made a value change when it was active? (e.g. Slider/Drag moved). Useful for Undo/Redo patterns with widgets that requires continuous editing. Note that you may get false positives (some widgets such as Combo()/ListBox()/Selectable() will return true even when clicking an already selected item).
+    IMGUI_API bool          IsItemDisabled();                                                   // is the last item disabled? (e.g. we can't interact with it because BeginDisabled() was called before it)    
     IMGUI_API bool          IsItemToggledOpen();                                                // was the last item open state toggled? set by TreeNode().
     IMGUI_API bool          IsAnyItemHovered();                                                 // is any item hovered?
     IMGUI_API bool          IsAnyItemActive();                                                  // is any item active?


### PR DESCRIPTION
I am currently using an [ImDrawList](https://gist.github.com/ocornut/51367cc7dfd2c41d607bb0acfa6caf66) like in the party's to do custom drawing for a record button using a ImGui::InvisibleButton. I draw the background of the button  i.e. : 
```
if(!ImGui::IsItemDisabled() && mouse.x > 0.0f  && mouse.x < 1.0f && mouse.y > 0.0f && mouse.y < 1.0f){
    col = colors[ImGuiCol_ButtonHovered];
}
 d->AddRectFilled(a,b,ImGui::GetColorU32(col),0.0f,ImDrawFlags_None);
```
As I needed to detect if my item was disabled and the BeginDisabled api is Beta I saw the need to add it. The workaround would of needed that I include imgui_internal.h in my project to have access to the ImGuiContext struct def.

I imagine that imgui_internal should not be used by users ? 


Example:
https://imgur.com/a/AiJ4sHk