### PR TITLE
Moving DockingSplitterSize to ImGuiStyle

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -1619,6 +1619,7 @@ enum ImGuiStyleVar_
     ImGuiStyleVar_TabRounding,         // float     TabRounding
     ImGuiStyleVar_ButtonTextAlign,     // ImVec2    ButtonTextAlign
     ImGuiStyleVar_SelectableTextAlign, // ImVec2    SelectableTextAlign
+    ImGuiStyleVar_DockingSplitterSize, // float     DockingSplitterSize
     ImGuiStyleVar_COUNT
 };
 
@@ -1881,6 +1882,7 @@ struct ImGuiStyle
     bool        AntiAliasedFill;            // Enable anti-aliased edges around filled shapes (rounded rectangles, circles, etc.). Disable if you are really tight on CPU/GPU. Latched at the beginning of the frame (copied to ImDrawList).
     float       CurveTessellationTol;       // Tessellation tolerance when using PathBezierCurveTo() without a specific number of segments. Decrease for highly tessellated curves (higher quality, more polygons), increase to reduce quality.
     float       CircleTessellationMaxError; // Maximum error (in pixels) allowed when using AddCircle()/AddCircleFilled() or drawing rounded corner rectangles with no explicit segment count specified. Decrease for higher quality but more geometry.
+    float       DockingSplitterSize;        // Thickness of the separator between docked windows.
     ImVec4      Colors[ImGuiCol_COUNT];
 
     IMGUI_API ImGuiStyle();

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -6166,6 +6166,7 @@ void ImGui::ShowStyleEditor(ImGuiStyle* ref)
             ImGui::SliderFloat("IndentSpacing", &style.IndentSpacing, 0.0f, 30.0f, "%.0f");
             ImGui::SliderFloat("ScrollbarSize", &style.ScrollbarSize, 1.0f, 20.0f, "%.0f");
             ImGui::SliderFloat("GrabMinSize", &style.GrabMinSize, 1.0f, 20.0f, "%.0f");
+            ImGui::SliderFloat("DockingSplitterSize", &style.DockingSplitterSize, 0.0f, 20.0f, "%.0f");
             ImGui::Text("Borders");
             ImGui::SliderFloat("WindowBorderSize", &style.WindowBorderSize, 0.0f, 1.0f, "%.0f");
             ImGui::SliderFloat("ChildBorderSize", &style.ChildBorderSize, 0.0f, 1.0f, "%.0f");


### PR DESCRIPTION
Hey! I got into styling ImGui quite a bit, and needed to modify the thickness of the docking splitter.

I moved the existing global variable into the style, I've updated the various places it was used, and added it to the style tab in imgui_demo.cpp

My only notes/questions are:
- Did I miss anything? 🥲 
- There's a spot in code where I've updated a comment that's questioning the relation to the splitter size and I'm not completely sure what eventually calls ImGui::DockNodeTreeFindVisibleNodeByPos, so I left it alone for now
- `const float dock_spacing = 0.0f;// g.Style.ItemInnerSpacing.x; // FIXME: Relation to Style.DockingSplitterSize?`

![Example](https://raw.githubusercontent.com/wobbier/MitchEngine/master/Docs/GitHub/Havana.png)
![Ik544P236z](https://user-images.githubusercontent.com/3254047/141704104-a3aaa0d6-57dd-4076-9025-123061ce9b3d.gif)

