### PR TITLE
Fix: IM_DEBUG_BREAK macro on ARM GCC

### DIFF
--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -264,7 +264,7 @@ namespace ImStb
 #define IM_DEBUG_BREAK()    __asm__ volatile("int $0x03")
 #elif defined(__GNUC__) && defined(__thumb__)
 #define IM_DEBUG_BREAK()    __asm__ volatile(".inst 0xde01")
-#elif defined(__GNUC__) defined(__arm__) && !defined(__thumb__)
+#elif defined(__GNUC__) && defined(__arm__) && !defined(__thumb__)
 #define IM_DEBUG_BREAK()    __asm__ volatile(".inst 0xe7f001f0");
 #else
 #define IM_DEBUG_BREAK()    IM_ASSERT(0)    // It is expected that you define IM_DEBUG_BREAK() into something that will break nicely in a debugger!


### PR DESCRIPTION
This prevents compilation on ARM GCC. Compilation log:
```
error: missing binary operator before token "defined"
  267 | #elif defined(__GNUC__) defined(__arm__) && !defined(__thumb__)
      |                         ^~~~~~~
```
