### PR TITLE
Fix integer overflow in ImFontGlyphRangesBuilder::AddRanges

### DIFF
--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -3080,8 +3080,8 @@ void ImFontGlyphRangesBuilder::AddText(const char* text, const char* text_end)
 void ImFontGlyphRangesBuilder::AddRanges(const ImWchar* ranges)
 {
     for (; ranges[0]; ranges += 2)
-        for (ImWchar c = ranges[0]; c <= ranges[1]; c++)
-            AddChar(c);
+        for (unsigned int c = ranges[0]; c <= ranges[1] && c <= IM_UNICODE_CODEPOINT_MAX; c++)
+            AddChar((ImWchar)c);
 }
 
 void ImFontGlyphRangesBuilder::BuildRanges(ImVector<ImWchar>* out_ranges)


### PR DESCRIPTION
Results in an infinite loop if the user passes upper range = UINT16_MAX or UINT32_MAX with ImWchar32.

Assumes IM_UNICODE_CODEPOINT_MAX < UINT32_MAX.

