### PR TITLE
Update SDLRenderer backend to compile with SDL 2.0.19

### DIFF
--- a/backends/imgui_impl_sdlrenderer.cpp
+++ b/backends/imgui_impl_sdlrenderer.cpp
@@ -175,7 +175,13 @@ void ImGui_ImplSDLRenderer_RenderDrawData(ImDrawData* draw_data)
 
                 const float* xy = (const float*)((const char*)(vtx_buffer + pcmd->VtxOffset) + IM_OFFSETOF(ImDrawVert, pos));
                 const float* uv = (const float*)((const char*)(vtx_buffer + pcmd->VtxOffset) + IM_OFFSETOF(ImDrawVert, uv));
+#if SDL_VERSION_ATLEAST(2, 0, 19)
+				// They changed the function signature for SDL_RenderGeometryRaw() in 2.0.19
+				// to SDL_Color, but byte-wise it's the same
+				const SDL_Color *color = (const SDL_Color*)((const char*)(vtx_buffer + pcmd->VtxOffset) + IM_OFFSETOF(ImDrawVert, col));
+#else
                 const int* color = (const int*)((const char*)(vtx_buffer + pcmd->VtxOffset) + IM_OFFSETOF(ImDrawVert, col));
+#endif
 
                 // Bind texture, Draw
 				SDL_Texture* tex = (SDL_Texture*)pcmd->GetTexID();


### PR DESCRIPTION
In SDL 2.0.19 the SDL Renderer function ```SDL_RenderGeometryRaw()``` was changed from taking an ```int``` pointer for color to an ```SDL_Color``` pointer. Doesn't cause too much of a problem since bytewise they're both RGBA, just need to change the pointer casts and add a preprocessor guard so it won't break for people using SDL 2.0.18 (the latest stable version).