### PR TITLE
Add Apple Metal C++ bindings support.

### DIFF
--- a/backends/imgui_impl_metal.h
+++ b/backends/imgui_impl_metal.h
@@ -32,9 +32,9 @@ IMGUI_IMPL_API void ImGui_ImplMetal_DestroyDeviceObjects();
 
 #endif
 
-// Enable Metal C++ bindings support with
-// #define IMGUI_IMPL_METAL_CPP     // imconfig.h
-// More info about this bindings:
+// Enable Metal C++ binding support with
+//#define IMGUI_IMPL_METAL_CPP     // imconfig.h
+// More info about this binding:
 // https://developer.apple.com/metal/cpp/
 
 #ifdef IMGUI_IMPL_METAL_CPP

--- a/backends/imgui_impl_metal.h
+++ b/backends/imgui_impl_metal.h
@@ -12,6 +12,8 @@
 
 #include "imgui.h"      // IMGUI_IMPL_API
 
+#ifdef __OBJC__
+
 @class MTLRenderPassDescriptor;
 @protocol MTLDevice, MTLCommandBuffer, MTLRenderCommandEncoder;
 
@@ -27,3 +29,32 @@ IMGUI_IMPL_API bool ImGui_ImplMetal_CreateFontsTexture(id<MTLDevice> device);
 IMGUI_IMPL_API void ImGui_ImplMetal_DestroyFontsTexture();
 IMGUI_IMPL_API bool ImGui_ImplMetal_CreateDeviceObjects(id<MTLDevice> device);
 IMGUI_IMPL_API void ImGui_ImplMetal_DestroyDeviceObjects();
+
+#endif
+
+// Enable Metal C++ bindings support with
+// #define IMGUI_IMPL_METAL_CPP     // imconfig.h
+// More info about this bindings:
+// https://developer.apple.com/metal/cpp/
+
+#ifdef IMGUI_IMPL_METAL_CPP
+
+#include <Metal/Metal.hpp>
+
+#ifndef __OBJC__
+
+IMGUI_IMPL_API bool ImGui_ImplMetal_Init(MTL::Device* device);
+IMGUI_IMPL_API void ImGui_ImplMetal_Shutdown();
+IMGUI_IMPL_API void ImGui_ImplMetal_NewFrame(MTL::RenderPassDescriptor* renderPassDescriptor);
+IMGUI_IMPL_API void ImGui_ImplMetal_RenderDrawData(ImDrawData* draw_data,
+                                    MTL::CommandBuffer* commandBuffer,
+                                    MTL::RenderCommandEncoder* commandEncoder);
+
+IMGUI_IMPL_API bool ImGui_ImplMetal_CreateFontsTexture(MTL::Device* device);
+IMGUI_IMPL_API void ImGui_ImplMetal_DestroyFontsTexture();
+IMGUI_IMPL_API bool ImGui_ImplMetal_CreateDeviceObjects(MTL::Device* device);
+IMGUI_IMPL_API void ImGui_ImplMetal_DestroyDeviceObjects();
+
+#endif
+
+#endif

--- a/backends/imgui_impl_metal.mm
+++ b/backends/imgui_impl_metal.mm
@@ -82,28 +82,28 @@ static MetalContext *g_sharedMetalContext = nil;
 #pragma mark - ImGui Metal C++ Bindings
 
 bool ImGui_ImplMetal_Init(MTL::Device* device) {
-    return ImGui_ImplMetal_Init(static_cast<id<MTLDevice>>(device));
+    return ImGui_ImplMetal_Init((id<MTLDevice>)(device));
 }
 
 void ImGui_ImplMetal_NewFrame(MTL::RenderPassDescriptor* renderPassDescriptor) {
-    ImGui_ImplMetal_NewFrame(static_cast<MTLRenderPassDescriptor*>(renderPassDescriptor));
+    ImGui_ImplMetal_NewFrame((MTLRenderPassDescriptor*)(renderPassDescriptor));
 }
 
 void ImGui_ImplMetal_RenderDrawData(ImDrawData* draw_data,
                                     MTL::CommandBuffer* commandBuffer,
                                     MTL::RenderCommandEncoder* commandEncoder) {
     ImGui_ImplMetal_RenderDrawData(draw_data,
-                                   static_cast<id<MTLCommandBuffer>>(commandBuffer),
-                                   static_cast<id<MTLRenderCommandEncoder>>(commandEncoder));
+                                   (id<MTLCommandBuffer>)(commandBuffer),
+                                   (id<MTLRenderCommandEncoder>)(commandEncoder));
 
 }
 
 bool ImGui_ImplMetal_CreateFontsTexture(MTL::Device* device) {
-    return ImGui_ImplMetal_CreateFontsTexture(static_cast<id<MTLDevice>>(device));
+    return ImGui_ImplMetal_CreateFontsTexture((id<MTLDevice>)(device));
 }
 
 bool ImGui_ImplMetal_CreateDeviceObjects(MTL::Device* device) {
-    return ImGui_ImplMetal_CreateDeviceObjects(static_cast<id<MTLDevice>>(device));
+    return ImGui_ImplMetal_CreateDeviceObjects((id<MTLDevice>)(device));
 }
 
 #endif

--- a/backends/imgui_impl_metal.mm
+++ b/backends/imgui_impl_metal.mm
@@ -77,6 +77,37 @@
 
 static MetalContext *g_sharedMetalContext = nil;
 
+#ifdef IMGUI_IMPL_METAL_CPP
+
+#pragma mark - ImGui Metal C++ Bindings
+
+bool ImGui_ImplMetal_Init(MTL::Device* device) {
+    return ImGui_ImplMetal_Init(static_cast<id<MTLDevice>>(device));
+}
+
+void ImGui_ImplMetal_NewFrame(MTL::RenderPassDescriptor* renderPassDescriptor) {
+    ImGui_ImplMetal_NewFrame(static_cast<MTLRenderPassDescriptor*>(renderPassDescriptor));
+}
+
+void ImGui_ImplMetal_RenderDrawData(ImDrawData* draw_data,
+                                    MTL::CommandBuffer* commandBuffer,
+                                    MTL::RenderCommandEncoder* commandEncoder) {
+    ImGui_ImplMetal_RenderDrawData(draw_data,
+                                   static_cast<id<MTLCommandBuffer>>(commandBuffer),
+                                   static_cast<id<MTLRenderCommandEncoder>>(commandEncoder));
+
+}
+
+bool ImGui_ImplMetal_CreateFontsTexture(MTL::Device* device) {
+    return ImGui_ImplMetal_CreateFontsTexture(static_cast<id<MTLDevice>>(device));
+}
+
+bool ImGui_ImplMetal_CreateDeviceObjects(MTL::Device* device) {
+    return ImGui_ImplMetal_CreateDeviceObjects(static_cast<id<MTLDevice>>(device));
+}
+
+#endif
+
 #pragma mark - ImGui API implementation
 
 bool ImGui_ImplMetal_Init(id<MTLDevice> device)


### PR DESCRIPTION
This pull request adds support for the [Metal C++ Bindings](https://developer.apple.com/metal/cpp/) distributed by Apple. This has to be enabled explicitly with `#define IMGUI_IMPL_METAL_CPP`. It also make possible to include `imgui_impl_metal.h` from the C++ code. 