### PR TITLE
Tables: Fix AddCallback() being ignored when last in column (#4843)

### DIFF
--- a/imgui_tables.cpp
+++ b/imgui_tables.cpp
@@ -2353,7 +2353,7 @@ void ImGui::TableMergeDrawChannels(ImGuiTable* table)
 
             // Don't attempt to merge if there are multiple draw calls within the column
             ImDrawChannel* src_channel = &splitter->_Channels[channel_no];
-            if (src_channel->_CmdBuffer.Size > 0 && src_channel->_CmdBuffer.back().ElemCount == 0)
+            if (src_channel->_CmdBuffer.Size > 0 && src_channel->_CmdBuffer.back().ElemCount == 0 && src_channel->_CmdBuffer.back().UserCallback != NULL)
                 src_channel->_CmdBuffer.pop_back();
             if (src_channel->_CmdBuffer.Size != 1)
                 continue;


### PR DESCRIPTION
Simple fix related to #4843.

## Issue
Inside a table, calling `ImGui::AddCallback(...)` as the last item in a column has no effect.

## Solution
In `TableMergeDrawChannels(...)` inside _imgui_tables.cpp_, just ensure the last command buffer doesn't include a callback before popping.
