### PR TITLE
GLFW: some support for child HWNDs

### DIFF
--- a/backends/imgui_impl_glfw.cpp
+++ b/backends/imgui_impl_glfw.cpp
@@ -977,14 +977,18 @@ static void ImGui_ImplGlfw_SetWindowPos(ImGuiViewport* viewport, ImVec2 pos)
     ImGui_ImplGlfw_ViewportData* vd = (ImGui_ImplGlfw_ViewportData*)viewport->PlatformUserData;
     vd->IgnoreWindowPosEventFrame = ImGui::GetFrameCount();
 
-#ifdef _WIN32
-    HWND hwnd = glfwGetWin32Window(vd->Window), par;
-    if (hwnd && (GetWindowLong(hwnd, GWL_STYLE) & WS_CHILDWINDOW) != 0 && (par = GetParent(hwnd)))
+#if defined _WIN32
+    HWND hwnd = glfwGetWin32Window(vd->Window);
+    if (hwnd && (GetWindowLong(hwnd, GWL_STYLE) & WS_CHILDWINDOW) != 0)
     {
-      RECT par_rect;
-      GetWindowRect(par, &par_rect);
-      pos.x -= par_rect.left;
-      pos.y -= par_rect.top;
+        HWND par = GetParent(hwnd);
+        if (par)
+        {
+            RECT par_rect;
+            GetWindowRect(par, &par_rect);
+            pos.x -= par_rect.left;
+            pos.y -= par_rect.top;
+        }
     }
 #endif
 

--- a/backends/imgui_impl_glfw.cpp
+++ b/backends/imgui_impl_glfw.cpp
@@ -74,6 +74,10 @@
 #define GLFW_EXPOSE_NATIVE_WIN32
 #include <GLFW/glfw3native.h>   // for glfwGetWin32Window
 #endif
+#if defined __linux__
+#define GLFW_EXPOSE_NATIVE_X11
+#include <GLFW/glfw3native.h>   // for glfwGetX11Window
+#endif
 #define GLFW_HAS_WINDOW_TOPMOST       (GLFW_VERSION_MAJOR * 1000 + GLFW_VERSION_MINOR * 100 >= 3200) // 3.2+ GLFW_FLOATING
 #define GLFW_HAS_WINDOW_HOVERED       (GLFW_VERSION_MAJOR * 1000 + GLFW_VERSION_MINOR * 100 >= 3300) // 3.3+ GLFW_HOVERED
 #define GLFW_HAS_WINDOW_ALPHA         (GLFW_VERSION_MAJOR * 1000 + GLFW_VERSION_MINOR * 100 >= 3300) // 3.3+ glfwSetWindowOpacity
@@ -988,6 +992,23 @@ static void ImGui_ImplGlfw_SetWindowPos(ImGuiViewport* viewport, ImVec2 pos)
             GetWindowRect(par, &par_rect);
             pos.x -= par_rect.left;
             pos.y -= par_rect.top;
+        }
+    }
+#elif defined __linux__
+    Display *xdisp = glfwGetX11Display();
+    Window xwin = glfwGetX11Window(vd->Window);
+    if (xdisp && xwin)
+    {
+        Window xroot = 0, xpar = 0, *xchildren = NULL;
+        unsigned int num_xchildren = 0;
+        if (XQueryTree(xdisp, xwin, &xroot, &xpar, &xchildren, &num_xchildren) != 0 &&
+            xroot != 0 && xpar != 0 && xpar != xroot)
+        {
+            Window xchild = 0;
+            int xx = 0, xy = 0;
+            XTranslateCoordinates(xdisp, xroot, xpar, pos.x, pos.y, &xx, &xy, &xchild);
+            pos.x = xx;
+            pos.y = xy;
         }
     }
 #endif

--- a/backends/imgui_impl_glfw.cpp
+++ b/backends/imgui_impl_glfw.cpp
@@ -418,7 +418,7 @@ static void ImGui_ImplGlfw_UpdateMousePosAndButtons()
         GLFWwindow* mouse_window = (bd->MouseWindow == window || focused) ? window : NULL;
 
         // Update mouse buttons
-        if (focused)
+        if (mouse_window)
             for (int i = 0; i < IM_ARRAYSIZE(io.MouseDown); i++)
                 io.MouseDown[i] |= glfwGetMouseButton(window, i) != 0;
 

--- a/backends/imgui_impl_glfw.cpp
+++ b/backends/imgui_impl_glfw.cpp
@@ -793,6 +793,18 @@ static void ImGui_ImplGlfw_SetWindowPos(ImGuiViewport* viewport, ImVec2 pos)
 {
     ImGui_ImplGlfw_ViewportData* vd = (ImGui_ImplGlfw_ViewportData*)viewport->PlatformUserData;
     vd->IgnoreWindowPosEventFrame = ImGui::GetFrameCount();
+
+#ifdef _WIN32
+    HWND hwnd = glfwGetWin32Window(vd->Window), par;
+    if (hwnd && (GetWindowLong(hwnd, GWL_STYLE) & WS_CHILDWINDOW) != 0 && (par = GetParent(hwnd)))
+    {
+      RECT par_rect;
+      GetWindowRect(par, &par_rect);
+      pos.x -= par_rect.left;
+      pos.y -= par_rect.top;
+    }
+#endif
+
     glfwSetWindowPos(vd->Window, (int)pos.x, (int)pos.y);
 }
 

--- a/backends/imgui_impl_glfw.cpp
+++ b/backends/imgui_impl_glfw.cpp
@@ -418,7 +418,7 @@ static void ImGui_ImplGlfw_UpdateMousePosAndButtons()
         GLFWwindow* mouse_window = (bd->MouseWindow == window || focused) ? window : NULL;
 
         // Update mouse buttons
-        if (mouse_window)
+        if (focused)
             for (int i = 0; i < IM_ARRAYSIZE(io.MouseDown); i++)
                 io.MouseDown[i] |= glfwGetMouseButton(window, i) != 0;
 


### PR DESCRIPTION
Translate window coordinates and handle mouse capture for GLFW windows that are child HWNDs. At present the only way GLFW windows can be child HWNDs is if the ImGui caller explicitly setparents them. See #4860 for the use case.