### PR TITLE
Fixed typo

### DIFF
--- a/backends/imgui_impl_sdl.cpp
+++ b/backends/imgui_impl_sdl.cpp
@@ -207,7 +207,7 @@ static bool ImGui_ImplSDL2_Init(SDL_Window* window)
     io.KeyMap[ImGuiKey_Space] = SDL_SCANCODE_SPACE;
     io.KeyMap[ImGuiKey_Enter] = SDL_SCANCODE_RETURN;
     io.KeyMap[ImGuiKey_Escape] = SDL_SCANCODE_ESCAPE;
-    io.KeyMap[ImGuiKey_KeypadEnter] = SDL_SCANCODE_KP_ENTER;
+    io.KeyMap[ImGuiKey_KeyPadEnter] = SDL_SCANCODE_KP_ENTER;
     io.KeyMap[ImGuiKey_A] = SDL_SCANCODE_A;
     io.KeyMap[ImGuiKey_C] = SDL_SCANCODE_C;
     io.KeyMap[ImGuiKey_V] = SDL_SCANCODE_V;


### PR DESCRIPTION
Compilation error:
```c++
$ g++ -o imsdl.o imgui_impl_sdl.cpp -I/usr/include/SDL2 -c
imgui_impl_sdl.cpp: In function ‘bool ImGui_ImplSDL2_Init(SDL_Window*)’:
imgui_impl_sdl.cpp:253:13: error: ‘ImGuiKey_KeypadEnter’ was not declared in this scope; did you mean ‘ImGuiKey_KeyPadEnter’?
  253 |   io.KeyMap[ImGuiKey_KeypadEnter] = SDL_SCANCODE_KP_ENTER;
      |             ^~~~~~~~~~~~~~~~~~~~
      |             ImGuiKey_KeyPadEnter
```