### PR TITLE
More eager colour clamping in ColorEdit4

### DIFF
--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -4975,12 +4975,12 @@ bool ImGui::ColorEdit4(const char* label, float col[4], ImGuiColorEditFlags flag
             // FIXME: When ImGuiColorEditFlags_HDR flag is passed HS values snap in weird ways when SV values go below 0.
             if (flags & ImGuiColorEditFlags_Float)
             {
-                value_changed |= DragFloat(ids[n], &f[n], 1.0f / 255.0f, 0.0f, hdr ? 0.0f : 1.0f, fmt_table_float[fmt_idx][n]);
+                value_changed |= DragFloat(ids[n], &f[n], 1.0f / 255.0f, 0.0f, hdr ? 0.0f : 1.0f, fmt_table_float[fmt_idx][n], hdr ? ImGuiSliderFlags_None : ImGuiSliderFlags_AlwaysClamp);
                 value_changed_as_float |= value_changed;
             }
             else
             {
-                value_changed |= DragInt(ids[n], &i[n], 1.0f, 0, hdr ? 0 : 255, fmt_table_int[fmt_idx][n]);
+                value_changed |= DragInt(ids[n], &i[n], 1.0f, 0, hdr ? 0 : 255, fmt_table_int[fmt_idx][n], hdr ? ImGuiSliderFlags_None : ImGuiSliderFlags_AlwaysClamp);
             }
             if (!(flags & ImGuiColorEditFlags_NoOptions))
                 OpenPopupOnItemClick("context");
@@ -5097,6 +5097,16 @@ bool ImGui::ColorEdit4(const char* label, float col[4], ImGuiColorEditFlags flag
         {
             memcpy((float*)col, payload->Data, sizeof(float) * components);
             value_changed = accepted_drag_drop = true;
+        }
+        
+        // Clamp if HDR is disabled
+        if (!hdr)
+        {
+            col[0] = ImClamp(col[0], 0.0f, 1.0f);
+            col[1] = ImClamp(col[1], 0.0f, 1.0f);
+            col[2] = ImClamp(col[2], 0.0f, 1.0f);
+            if (alpha)
+                col[3] = ImClamp(col[3], 0.0f, 1.0f);
         }
 
         // Drag-drop payloads are always RGB


### PR DESCRIPTION
I deeply apologise for the distraught I caused in #4413 and I have to say this library has been a pleasure to work with over the past months!

If ImGuiColorEditFlags_HDR is disabled, force clamp colour input on drag & drop and CTRL+Click.
This will fully prevent col[] variables being set to values out of 0.0f...1.0f range while using the ColorEdit4 widget with this flag unset, instead of just on dragging (does this break other code?).

If the flag was set previously and unset later, the values will be clamped upon interacting with the widget (like previously with dragging). I'm not sure how to work around this problem in a clean way yet, but I'm going with the assumption that if you unset this flag later in the lifetime in your app, you can handle this yourself for the time being.