### PR TITLE
Remove SDL_WINDOW_OPENGL from SDL_Renderer example

### DIFF
--- a/examples/example_sdl_sdlrenderer/main.cpp
+++ b/examples/example_sdl_sdlrenderer/main.cpp
@@ -30,7 +30,7 @@ int main(int, char**)
     }
 
     // Setup window
-    SDL_WindowFlags window_flags = (SDL_WindowFlags)(SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
+    SDL_WindowFlags window_flags = (SDL_WindowFlags)(SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
     SDL_Window* window = SDL_CreateWindow("Dear ImGui SDL2+SDL_Renderer example", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 1280, 720, window_flags);
 
     // Setup SDL_Renderer instance


### PR DESCRIPTION
`SDL_WINDOW_OPENGL` is only necessary when using OpenGL directly, bypassing SDL2's Renderer API. There's a similar flag for doing the same with Vulkan - `SDL_WINDOW_VULKAN`. Since this example doesn't bypass the Renderer API, these flags aren't needed.