### PR TITLE
Move test from ImGui_ImplVulkan_RenderDrawData to ImGui_ImplVulkan_CreateFontsTexture

### DIFF
--- a/backends/imgui_impl_vulkan.cpp
+++ b/backends/imgui_impl_vulkan.cpp
@@ -543,12 +543,6 @@ void ImGui_ImplVulkan_RenderDrawData(ImDrawData* draw_data, VkCommandBuffer comm
 
                 // Bind DescriptorSet with font or user texture
                 VkDescriptorSet desc_set[1] = { (VkDescriptorSet)pcmd->TextureId };
-                if (sizeof(ImTextureID) < sizeof(ImU64))
-                {
-                    // We don't support texture switches if ImTextureID hasn't been redefined to be 64-bit. Do a flaky check that other textures haven't been used.
-                    IM_ASSERT(pcmd->TextureId == (ImTextureID)bd->FontDescriptorSet);
-                    desc_set[0] = bd->FontDescriptorSet;
-                }
                 vkCmdBindDescriptorSets(command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, bd->PipelineLayout, 0, 1, desc_set, 0, NULL);
 
                 // Draw
@@ -706,6 +700,10 @@ bool ImGui_ImplVulkan_CreateFontsTexture(VkCommandBuffer command_buffer)
     }
 
     // Store our identifier
+    //
+    // This backend uses ImTextureID to store a VkDescriptorSet.
+    // On a 32-bit machine ImTextureID must be redefined to be 64-bit (for example ImU64, or even VkDescriptorSet) instead of void*.
+    IM_ASSERT(sizeof(ImTextureID) == sizeof(VkDescriptorSet));
     io.Fonts->SetTexID((ImTextureID)bd->FontDescriptorSet);
 
     return true;


### PR DESCRIPTION
The test should never fail: if it fails then the user is on
a 32-bit machine and neglected to redefine ImTextureID.

It confused me a lot that this test was done where it is done
(in code executed every frame). Although it should end up as a
no-op, it suggests that the user is *allowed* to redefine
ImTextureID to something that is less than 64-bit, in which
case the `desc_set[0] = bd->FontDescriptorSet;` would be
necessary, under certain circumstances. And that suggests
that ImTextureID is *still* under the users control, despite
using this backed.

This backend (imgui_impl_vulkan.cpp) uses ImTextureID to store
a VkDescriptorSet - no matter what the user does. And therefore
this backend should not allow the user to have an ImTextureID
that can't contain 64-bits of data, at all.

The patch moves the test of a 32-bit user neglecting to redefine
ImTextureID to a more logical place and simply always fails if
they didn't, as it should with this backend when ImTextureID can't
hold a VkDescriptorSet.
