### PR TITLE
Intel compiler warning fix

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -101,7 +101,7 @@ Index of this file:
 #endif
 
 // Disable some of MSVC most aggressive Debug runtime checks in function header/footer (used in some simple/low-level functions)
-#if defined(_MSC_VER) && !defined(__clang__) && !defined(IMGUI_DEBUG_PARANOID)
+#if defined(_MSC_VER) && !defined(__clang__)  && !defined(__INTEL_COMPILER) && !defined(IMGUI_DEBUG_PARANOID)
 #define IM_MSVC_RUNTIME_CHECKS_OFF      __pragma(runtime_checks("",off))     __pragma(check_stack(off)) __pragma(strict_gs_check(push,off))
 #define IM_MSVC_RUNTIME_CHECKS_RESTORE  __pragma(runtime_checks("",restore)) __pragma(check_stack())    __pragma(strict_gs_check(pop))
 #else


### PR DESCRIPTION
Fixes following warnings generated when building with intel compiler

1>imgui_internal.h(351): warning #161: unrecognized #pragma
1>  IM_MSVC_RUNTIME_CHECKS_OFF
1>  ^
1>
1>imgui_internal.h(351): warning #296: expected a ","
1>  IM_MSVC_RUNTIME_CHECKS_OFF