### PR TITLE
Disable deprecated-enum-enum-conversion for gcc as well

### DIFF
--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -82,6 +82,7 @@ Index of this file:
 #pragma GCC diagnostic ignored "-Wpragmas"                          // warning: unknown option after '#pragma GCC diagnostic' kind
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"                // warning: format not a string literal, format string not checked
 #pragma GCC diagnostic ignored "-Wclass-memaccess"                  // [__GNUC__ >= 8] warning: 'memset/memcpy' clearing/writing an object of type 'xxxx' with no trivial copy-assignment; use assignment or value-initialization instead
+#pragma GCC diagnostic ignored "-Wdeprecated-enum-enum-conversion"  // warning: bitwise operation between different enumeration types ('XXXFlags_' and 'XXXFlagsPrivate_') is deprecated
 #endif
 
 //-------------------------------------------------------------------------


### PR DESCRIPTION
This C++20 warning was first observed and reported with clang in #3040 were it was decided that is should be ignored

The warning also appears with gcc 11 and and std=c++20 so this commit disables it as per #3040

