### PR TITLE
Backends: Vulkan: Support for dynamic_rendering

### DIFF
--- a/backends/imgui_impl_vulkan.cpp
+++ b/backends/imgui_impl_vulkan.cpp
@@ -902,6 +902,19 @@ static void ImGui_ImplVulkan_CreatePipeline(VkDevice device, const VkAllocationC
     info.layout = bd->PipelineLayout;
     info.renderPass = renderPass;
     info.subpass = subpass;
+
+#if defined(VK_VERSION_1_3) || defined(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME)
+    VkPipelineRenderingCreateInfoKHR pipelineRenderingCreateInfo = {};
+    pipelineRenderingCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO_KHR;
+    pipelineRenderingCreateInfo.colorAttachmentCount = 1;
+    pipelineRenderingCreateInfo.pColorAttachmentFormats = &bd->VulkanInitInfo.ColorAttachmentFormat;
+
+    if (bd->VulkanInitInfo.UseDynamicRendering) {
+        info.pNext = &pipelineRenderingCreateInfo;
+        info.renderPass = nullptr; // Just make sure it's actually nullptr.
+    }
+#endif
+
     VkResult err = vkCreateGraphicsPipelines(device, pipelineCache, 1, &info, allocator, pipeline);
     check_vk_result(err);
 }
@@ -1043,7 +1056,8 @@ bool    ImGui_ImplVulkan_Init(ImGui_ImplVulkan_InitInfo* info, VkRenderPass rend
     IM_ASSERT(info->DescriptorPool != VK_NULL_HANDLE);
     IM_ASSERT(info->MinImageCount >= 2);
     IM_ASSERT(info->ImageCount >= info->MinImageCount);
-    IM_ASSERT(render_pass != VK_NULL_HANDLE);
+    if (!info->UseDynamicRendering)
+        IM_ASSERT(render_pass != VK_NULL_HANDLE);
 
     bd->VulkanInitInfo = *info;
     bd->RenderPass = render_pass;

--- a/backends/imgui_impl_vulkan.h
+++ b/backends/imgui_impl_vulkan.h
@@ -61,6 +61,8 @@ struct ImGui_ImplVulkan_InitInfo
     VkSampleCountFlagBits           MSAASamples;            // >= VK_SAMPLE_COUNT_1_BIT (0 -> default to VK_SAMPLE_COUNT_1_BIT)
     const VkAllocationCallbacks*    Allocator;
     void                            (*CheckVkResultFn)(VkResult err);
+    bool                            UseDynamicRendering;
+    VkFormat                        ColorAttachmentFormat;
 };
 
 // Called by user code


### PR DESCRIPTION
With the `VK_KHR_dynamic_rendering` extension Vulkan received a whole new way of how to rasterize. In the end, it got rid of `VkRenderPass` and `VkFramebuffer`, which is the reason for me opening this PR. Developers who want to utilize the new extension, which also got made core in Vulkan 1.3, and are attempting to use its functionality would have to fallback to the old `VkRenderPass` and `VkFramebuffer` system, effectively being unable to utilize anything new.

With this PR, one can set a boolean in the `ImGui_ImplVulkan_InitInfo` struct while initializing the backend so that it does not require a valid `VkRenderPass` to be passed into `ImGui_ImplVulkan_Init`. The new dynamic_rendering functionality only requires an attachment format, which is the reasoning for the new `ColorAttachmentFormat` member in the `ImGui_ImplVulkan_InitInfo` struct. This value is used while creating the pipeline instead of the render pass. The color format is allowed to be `0`, or `VK_FORMAT_UNDEFINED`, which is why I do not assert there. The application developer is also responsible for checking if the extension is present or if the device supports Vulkan 1.3.