### PR TITLE
Another Power Saving Mode

### DIFF
--- a/backends/imgui_impl_win32.h
+++ b/backends/imgui_impl_win32.h
@@ -24,7 +24,7 @@
 IMGUI_IMPL_API bool     ImGui_ImplWin32_Init(void* hwnd);
 IMGUI_IMPL_API bool     ImGui_ImplWin32_InitForOpenGL(void* hwnd);
 IMGUI_IMPL_API void     ImGui_ImplWin32_Shutdown();
-IMGUI_IMPL_API void     ImGui_ImplWin32_NewFrame();
+IMGUI_IMPL_API bool     ImGui_ImplWin32_NewFrame(bool poll = false);
 
 // Win32 message handler your application need to call.
 // - Intentionally commented out in a '#if 0' block to avoid dragging dependencies on <windows.h> from this helper.

--- a/examples/example_win32_directx11/main.cpp
+++ b/examples/example_win32_directx11/main.cpp
@@ -11,6 +11,8 @@
 #include "imgui_impl_dx11.h"
 #include <d3d11.h>
 #include <tchar.h>
+#include <cstdio>
+#include <string>
 
 // Data
 static ID3D11Device*            g_pd3dDevice = nullptr;
@@ -91,6 +93,10 @@ int main(int, char**)
     bool show_demo_window = true;
     bool show_another_window = false;
     ImVec4 clear_color = ImVec4(0.45f, 0.55f, 0.60f, 1.00f);
+    int fame_number = 0;
+    LARGE_INTEGER last_frame_time, timer_freq;
+    QueryPerformanceFrequency(&timer_freq);
+    QueryPerformanceCounter(&last_frame_time);
 
     // Main loop
     bool done = false;
@@ -98,6 +104,7 @@ int main(int, char**)
     {
         // Poll and handle messages (inputs, window resize, etc.)
         // See the WndProc() function below for our to dispatch events to the Win32 backend.
+#if 0
         MSG msg;
         while (::PeekMessage(&msg, nullptr, 0U, 0U, PM_REMOVE))
         {
@@ -106,6 +113,8 @@ int main(int, char**)
             if (msg.message == WM_QUIT)
                 done = true;
         }
+#endif
+
         if (done)
             break;
 
@@ -126,9 +135,19 @@ int main(int, char**)
             CreateRenderTarget();
         }
 
+        
+        // Start the Dear ImGui frame
+        if (!ImGui_ImplWin32_NewFrame())
+           break;
+
+        LARGE_INTEGER t0; QueryPerformanceCounter(&t0);
+        auto refresh_reason = io.NextRefreshStack.Entries[0];// double refresh_delay = io.NextRefresh >= FLT_MAX ? 99.99f : io.NextRefresh;
+
         // Start the Dear ImGui frame
         ImGui_ImplDX11_NewFrame();
-        ImGui_ImplWin32_NewFrame();
+
+        LARGE_INTEGER t1; QueryPerformanceCounter(&t1);
+
         ImGui::NewFrame();
 
         // 1. Show the big demo window (Most of the sample code is in ImGui::ShowDemoWindow()! You can browse its code to learn more about Dear ImGui!).
@@ -168,17 +187,39 @@ int main(int, char**)
             ImGui::End();
         }
 
+        LARGE_INTEGER t2; QueryPerformanceCounter(&t2);
+
         // Rendering
         ImGui::Render();
+
         const float clear_color_with_alpha[4] = { clear_color.x * clear_color.w, clear_color.y * clear_color.w, clear_color.z * clear_color.w, clear_color.w };
         g_pd3dDeviceContext->OMSetRenderTargets(1, &g_mainRenderTargetView, nullptr);
         g_pd3dDeviceContext->ClearRenderTargetView(g_mainRenderTargetView, clear_color_with_alpha);
         ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData());
 
+        LARGE_INTEGER t3; QueryPerformanceCounter(&t3);
+
         // Present
         HRESULT hr = g_pSwapChain->Present(1, 0);   // Present with vsync
         //HRESULT hr = g_pSwapChain->Present(0, 0); // Present without vsync
         g_SwapChainOccluded = (hr == DXGI_STATUS_OCCLUDED);
+
+
+        LARGE_INTEGER t4; QueryPerformanceCounter(&t4);
+
+        double layout_time = double(t2.QuadPart - t1.QuadPart) / timer_freq.QuadPart;
+        double render_time = double((t1.QuadPart - t0.QuadPart) + (t3.QuadPart - t2.QuadPart)) / timer_freq.QuadPart;
+        double present_time = double(t4.QuadPart - t3.QuadPart) / timer_freq.QuadPart;
+        double sleep_time = double(t0.QuadPart - last_frame_time.QuadPart) / timer_freq.QuadPart;
+
+        printf("ImGui #%i(%+6.3fs %ims(I%ims,R%ims,P%ims)), reason: %s (%0.2fs) ... %s", fame_number++, sleep_time, (int)round((layout_time + render_time) * 1000.0), (int)round(layout_time * 1000.0), (int)round(render_time * 1000.0), (int)round(present_time * 1000.0), refresh_reason.reason, refresh_reason.delay, io.NextRefreshStack.Size ? "" : "\n");
+        if (io.NextRefreshStack.Size)
+        {
+           printf(" refresh stack:");
+           for (int i = 0; i < io.NextRefreshStack.Size; ++i)
+              printf("%c%s(+%0.2fs)", i == 0 ? ' ' : ',', io.NextRefreshStack.Entries[i].reason, io.NextRefreshStack.Entries[i].delay);
+           printf("\n");
+        }
     }
 
     // Cleanup

--- a/imgui.h
+++ b/imgui.h
@@ -2536,6 +2536,53 @@ struct ImGuiIO
     int         MetricsRenderWindows;               // Number of visible windows
     int         MetricsActiveWindows;               // Number of active windows
     ImVec2      MouseDelta;                         // Mouse delta. Note that this is zero if either current or previous position are invalid (-FLT_MAX,-FLT_MAX), so a disappearing/reappearing mouse won't have a huge delta.
+    float       NextRefresh;                    // Optional: tells when should next render happen to see any change in results, 0 on init so that first draw goes through
+#if 1
+    struct NextRefreshStack_t
+    {
+      size_t      Size;
+      struct      NextRefreshEntry_t { float delay; char reason[64]; } Entries[16];
+    } NextRefreshStack;
+
+    void ResetNextRefresh() 
+    {
+       NextRefresh = FLT_MAX;
+       NextRefreshStack.Size = 0;
+       NextRefreshStack.Entries[0].reason[0]='\0';
+       NextRefreshStack.Entries[0].delay = FLT_MAX;
+    }
+    void SetNextRefresh(float pause_ms, const char* dbg_reason)
+    {
+        if (pause_ms <= NextRefresh)
+           NextRefresh = pause_ms;
+
+         auto* s = NextRefreshStack.Entries;
+         while (s != NextRefreshStack.Entries + NextRefreshStack.Size)
+         {
+            if (pause_ms <= s->delay)
+               break;
+            ++s;
+         }
+
+         if (s < NextRefreshStack.Entries + sizeof(NextRefreshStack.Entries) / sizeof(NextRefreshStack.Entries[0]))
+         {
+            size_t new_size = (NextRefreshStack.Size < sizeof(NextRefreshStack.Entries) / sizeof(NextRefreshStack.Entries[0]) ? NextRefreshStack.Size + 1 : sizeof(NextRefreshStack.Entries) / sizeof(NextRefreshStack.Entries[0]));
+            memmove(s + 1, s, sizeof(NextRefreshStack.Entries[0]) * (NextRefreshStack.Entries + new_size - 1 - s));
+            s->delay = pause_ms;
+#ifdef _MSC_VER
+            strncpy_s(s->reason, dbg_reason, sizeof(s->reason) / sizeof(char) - 1);
+#else
+            strncpy(s->reason, dbg_reason, sizeof(s->reason) / sizeof(char) - 1);
+#endif
+            NextRefreshStack.Size = new_size;
+         }      
+    }
+    //const char* GetNextRefreshReason() const { return NextRefresh_dbg; }
+#else
+    void ResetNextRefresh() { NextRefresh = FLT_MAX; }
+    void SetNextRefresh(float pause_ms, const char* /*dbg_line*/) { if (pause_ms <= NextRefresh) NextRefresh = pause_ms; }
+    const char* GetNextRefreshReason() const { return ""; }
+#endif
 
     //------------------------------------------------------------------
     // [Internal] Dear ImGui will maintain those fields. Forward compatibility not guaranteed!


### PR DESCRIPTION
This is  a follow up to earlier request  #3124 (which was auto-closed because I'm a git noob still)
The idea behind this pull request is to ONLY render a frame when there's either a change due to animation or mouse/keyboard event happened.  You can still use it the old way (i.e. - render every frame as fast as possible), but for desktop-like application not rendering when nothing changed is a must-have feature, which is what this pull request implements. The reason I like this approach is that completely no rendering happens if there's no active animation or user input, compared to other approaches which simply reduce the framerate

Let me know if you find some dynamic feature which doesn't get handled properly by this update.

Features in this request (I've updated only dx12 backend):
   - frame is rendered only when it needs to render
   - reason for frame render is shown in console
   - fixed spurious mouse events causing needles updates
   - fixed dpi handling and added redraw on dpi change (and made dpi-enabled as default) (dx12 backend only)