### PR TITLE
Fix texture-based anti-aliasing with RGBA textures

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -2335,6 +2335,7 @@ struct ImGuiListClipper
 #define IM_COL32_WHITE       IM_COL32(255,255,255,255)  // Opaque white = 0xFFFFFFFF
 #define IM_COL32_BLACK       IM_COL32(0,0,0,255)        // Opaque black
 #define IM_COL32_BLACK_TRANS IM_COL32(0,0,0,0)          // Transparent black = 0x00000000
+#define IM_COL32_WHITE_TRANS IM_COL32(255,255,255,0)    // Transparent white = 0x00FFFFFF
 
 // Helper: ImColor() implicitly converts colors to either ImU32 (packed 4x1 byte) or ImVec4 (4x1 float)
 // Prefer using IM_COL32() macros if you want a guaranteed compile-time ImU32 for usage with ImDrawList API.

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -2738,13 +2738,13 @@ static void ImFontAtlasBuildRenderLinesTexData(ImFontAtlas* atlas)
         {
             unsigned int* write_ptr = &atlas->TexPixelsRGBA32[r->X + ((r->Y + y) * atlas->TexWidth)];
             for (unsigned int i = 0; i < pad_left; i++)
-                *(write_ptr + i) = IM_COL32_BLACK_TRANS;
+                *(write_ptr + i) = IM_COL32_WHITE_TRANS;
 
             for (unsigned int i = 0; i < line_width; i++)
                 *(write_ptr + pad_left + i) = IM_COL32_WHITE;
 
             for (unsigned int i = 0; i < pad_right; i++)
-                *(write_ptr + pad_left + line_width + i) = IM_COL32_BLACK_TRANS;
+                *(write_ptr + pad_left + line_width + i) = IM_COL32_WHITE_TRANS;
         }
 
         // Calculate UVs for this line


### PR DESCRIPTION
Texture-based anti-aliasing is broken after loading a font using imgui_freetype.cpp with `ImGuiFreeTypeBuilderFlags_LoadColor` set in `ImFontConfig::FontBuilderFlags`.

![Screenshot of the bug](https://i.imgur.com/ycIk32k.png)

```cpp
#define IMGUI_ENABLE_FREETYPE
// ...
ImFontConfig cfg;
cfg.FontBuilderFlags |= ImGuiFreeTypeBuilderFlags_LoadColor;
io.Fonts->AddFontFromFileTTF("/usr/share/fonts/TTF/DejaVuSans.ttf", 14, &cfg);
```

This appears to be because `ImFontAtlasBuildRenderLinesTexData` uses transparent black when writing to `TexPixelsRGBA32`. It writes `0x00` to `TexPixelsAlpha8` which is then converted to transparent white by `GetTexDataAsRGBA32`.

This PR removes that difference by having `ImFontAtlasBuildRenderLinesTexData` write transparent white to `TexPixelsRGBA32`. It restores anti-aliasing (although I'm don't fully understand why, so I'm not 100% certain whether this is the correct fix):

![Patched to write transparent white](https://i.imgur.com/TCwwZZH.png)