### PR TITLE
Power save mode. Allow user call RequestRedraw to redraw a new frame.

### DIFF
--- a/backends/imgui_impl_glfw.cpp
+++ b/backends/imgui_impl_glfw.cpp
@@ -638,6 +638,46 @@ void ImGui_ImplGlfw_NewFrame()
     ImGui_ImplGlfw_UpdateGamepads();
 }
 
+void ImGui::RequestRedraw(ImGuiRedrawFlags flags)
+{
+#ifdef _WIN32
+    // Only implement ImGuiRedrawFlags_Everything logic
+    IM_ASSERT(flags == ImGuiRedrawFlags_Everything && "Other redraw mode has not been implemented yet.");
+    if (flags == ImGuiRedrawFlags_Everything)
+    {
+        // Post WM_PAINT messag for windows32 platform system to awake the
+        // glfwWaitEventsTimeout function
+        ImGui_ImplGlfw_Data* bd = ImGui_ImplGlfw_GetBackendData();
+        HWND win32_window = glfwGetWin32Window(bd->Window);
+        ::RedrawWindow(win32_window, NULL, NULL, RDW_INTERNALPAINT);
+    }
+#endif
+    //DODO implementation for Linux and Mac OS
+}
+
+bool ImGui::WaitAndPollEvents(int timeout/* = 0*/)
+{
+    if (timeout > 0)
+    {
+        // This function puts the calling thread to sleep until at least one event is available in the event queue,
+        // or until the specified timeout is reached.If one or more events are available, it behaves exactly like
+        // glfwPollEvents, i.e.the events in the queue are processedand the function then returns immediately.
+        // Processing events will cause the windowand input callbacks associated with those events to be called.
+        glfwWaitEventsTimeout(timeout);
+    }
+    else if(timeout == 0)
+    {
+        glfwPollEvents();
+    }
+    else if (timeout == -1)
+    {
+        glfwWaitEvents();
+        glfwPollEvents();
+    }
+
+    return true;
+}
+
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #endif

--- a/examples/example_glfw_opengl2/main.cpp
+++ b/examples/example_glfw_opengl2/main.cpp
@@ -78,12 +78,19 @@ int main(int, char**)
     // Main loop
     while (!glfwWindowShouldClose(window))
     {
+        // wait and poll event
+        // timeout:
+        //  0 process event immediatly, not blocking
+        // -1 wait for ever untill an event comes
+        // positive number wait untill timedout or event comes
+        // call ImGui::RequestRedraw to awake waiting of this function. Return 0 to signel a quict event.
+        int timeout = 0;
         // Poll and handle events (inputs, window resize, etc.)
         // You can read the io.WantCaptureMouse, io.WantCaptureKeyboard flags to tell if dear imgui wants to use your inputs.
         // - When io.WantCaptureMouse is true, do not dispatch mouse input data to your main application, or clear/overwrite your copy of the mouse data.
         // - When io.WantCaptureKeyboard is true, do not dispatch keyboard input data to your main application, or clear/overwrite your copy of the keyboard data.
         // Generally you may always pass all inputs to dear imgui, and hide them from your application based on those two flags.
-        glfwPollEvents();
+        ImGui::WaitAndPollEvents(timeout);
 
         // Start the Dear ImGui frame
         ImGui_ImplOpenGL2_NewFrame();

--- a/examples/example_glfw_opengl3/main.cpp
+++ b/examples/example_glfw_opengl3/main.cpp
@@ -99,12 +99,20 @@ int main(int, char**)
     // Main loop
     while (!glfwWindowShouldClose(window))
     {
+
+        // wait and poll event
+        // timeout:
+        //  0 process event immediatly, not blocking
+        // -1 wait for ever untill an event comes
+        // positive number wait untill timedout or event comes
+        // call ImGui::RequestRedraw to awake waiting of this function. Return 0 to signel a quict event.
+        int timeout = 0;
         // Poll and handle events (inputs, window resize, etc.)
         // You can read the io.WantCaptureMouse, io.WantCaptureKeyboard flags to tell if dear imgui wants to use your inputs.
         // - When io.WantCaptureMouse is true, do not dispatch mouse input data to your main application, or clear/overwrite your copy of the mouse data.
         // - When io.WantCaptureKeyboard is true, do not dispatch keyboard input data to your main application, or clear/overwrite your copy of the keyboard data.
         // Generally you may always pass all inputs to dear imgui, and hide them from your application based on those two flags.
-        glfwPollEvents();
+        ImGui::WaitAndPollEvents(timeout);
 
         // Start the Dear ImGui frame
         ImGui_ImplOpenGL3_NewFrame();

--- a/examples/example_glfw_vulkan/main.cpp
+++ b/examples/example_glfw_vulkan/main.cpp
@@ -465,12 +465,19 @@ int main(int, char**)
     // Main loop
     while (!glfwWindowShouldClose(window))
     {
+        // wait and poll event
+        // timeout:
+        //  0 process event immediatly, not blocking
+        // -1 wait for ever untill an event comes
+        // positive number wait untill timedout or event comes
+        // call ImGui::RequestRedraw to awake waiting of this function. Return 0 to signel a quict event.
+        int timeout = 0;
         // Poll and handle events (inputs, window resize, etc.)
         // You can read the io.WantCaptureMouse, io.WantCaptureKeyboard flags to tell if dear imgui wants to use your inputs.
         // - When io.WantCaptureMouse is true, do not dispatch mouse input data to your main application, or clear/overwrite your copy of the mouse data.
         // - When io.WantCaptureKeyboard is true, do not dispatch keyboard input data to your main application, or clear/overwrite your copy of the keyboard data.
         // Generally you may always pass all inputs to dear imgui, and hide them from your application based on those two flags.
-        glfwPollEvents();
+        ImGui::WaitAndPollEvents(timeout);
 
         // Resize swap chain?
         if (g_SwapChainRebuild)

--- a/examples/example_win32_directx10/main.cpp
+++ b/examples/example_win32_directx10/main.cpp
@@ -81,18 +81,17 @@ int main(int, char**)
     bool done = false;
     while (!done)
     {
-        // Poll and handle messages (inputs, window resize, etc.)
-        // See the WndProc() function below for our to dispatch events to the Win32 backend.
-        MSG msg;
-        while (::PeekMessage(&msg, NULL, 0U, 0U, PM_REMOVE))
+        // wait and poll event
+        // timeout:
+        //  0 process event immediatly, not blocking
+        // -1 wait for ever untill an event comes
+        // positive number wait untill timedout or event comes
+        // call ImGui::RequestRedraw to awake waiting of this function. Return 0 to signel a quict event.
+        int timeout = 0;
+        if (!ImGui::WaitAndPollEvents(timeout))
         {
-            ::TranslateMessage(&msg);
-            ::DispatchMessage(&msg);
-            if (msg.message == WM_QUIT)
-                done = true;
+            done = true; break;
         }
-        if (done)
-            break;
 
         // Start the Dear ImGui frame
         ImGui_ImplDX10_NewFrame();

--- a/examples/example_win32_directx11/main.cpp
+++ b/examples/example_win32_directx11/main.cpp
@@ -81,18 +81,17 @@ int main(int, char**)
     bool done = false;
     while (!done)
     {
-        // Poll and handle messages (inputs, window resize, etc.)
-        // See the WndProc() function below for our to dispatch events to the Win32 backend.
-        MSG msg;
-        while (::PeekMessage(&msg, NULL, 0U, 0U, PM_REMOVE))
+        // wait and poll event
+        // timeout:
+        //  0 process event immediatly, not blocking
+        // -1 wait for ever untill an event comes
+        // positive number wait untill timedout or event comes
+        // call ImGui::RequestRedraw to awake waiting of this function. Return 0 to signel a quict event.
+        int timeout = 0;
+        if (!ImGui::WaitAndPollEvents(timeout))
         {
-            ::TranslateMessage(&msg);
-            ::DispatchMessage(&msg);
-            if (msg.message == WM_QUIT)
-                done = true;
+            done = true; break;
         }
-        if (done)
-            break;
 
         // Start the Dear ImGui frame
         ImGui_ImplDX11_NewFrame();

--- a/examples/example_win32_directx12/main.cpp
+++ b/examples/example_win32_directx12/main.cpp
@@ -119,18 +119,17 @@ int main(int, char**)
     bool done = false;
     while (!done)
     {
-        // Poll and handle messages (inputs, window resize, etc.)
-        // See the WndProc() function below for our to dispatch events to the Win32 backend.
-        MSG msg;
-        while (::PeekMessage(&msg, NULL, 0U, 0U, PM_REMOVE))
+        // wait and poll event
+        // timeout:
+        //  0 process event immediatly, not blocking
+        // -1 wait for ever untill an event comes
+        // positive number wait untill timedout or event comes
+        // call ImGui::RequestRedraw to awake waiting of this function. Return 0 to signel a quict event.
+        int timeout = 0;
+        if (!ImGui::WaitAndPollEvents(timeout))
         {
-            ::TranslateMessage(&msg);
-            ::DispatchMessage(&msg);
-            if (msg.message == WM_QUIT)
-                done = true;
+            done = true; break;
         }
-        if (done)
-            break;
 
         // Start the Dear ImGui frame
         ImGui_ImplDX12_NewFrame();

--- a/examples/example_win32_directx9/main.cpp
+++ b/examples/example_win32_directx9/main.cpp
@@ -79,18 +79,17 @@ int main(int, char**)
     bool done = false;
     while (!done)
     {
-        // Poll and handle messages (inputs, window resize, etc.)
-        // See the WndProc() function below for our to dispatch events to the Win32 backend.
-        MSG msg;
-        while (::PeekMessage(&msg, NULL, 0U, 0U, PM_REMOVE))
+        // wait and poll event
+        // timeout:
+        //  0 process event immediatly, not blocking
+        // -1 wait for ever untill an event comes
+        // positive number wait untill timedout or event comes
+        // call ImGui::RequestRedraw to awake waiting of this function. Return 0 to signel a quict event.
+        int timeout = 0;
+        if (!ImGui::WaitAndPollEvents(timeout))
         {
-            ::TranslateMessage(&msg);
-            ::DispatchMessage(&msg);
-            if (msg.message == WM_QUIT)
-                done = true;
+            done = true; break;
         }
-        if (done)
-            break;
 
         // Start the Dear ImGui frame
         ImGui_ImplDX9_NewFrame();

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -12172,6 +12172,7 @@ void ImGui::ShowMetricsWindow(bool* p_open)
     Text("Application average %.3f ms/frame (%.1f FPS)", 1000.0f / io.Framerate, io.Framerate);
     Text("%d vertices, %d indices (%d triangles)", io.MetricsRenderVertices, io.MetricsRenderIndices, io.MetricsRenderIndices / 3);
     Text("%d visible windows, %d active allocations", io.MetricsRenderWindows, io.MetricsActiveAllocations);
+    Text("Frame count %d, frame count ended %d, frame coung rendered %d", g.FrameCount, g.FrameCountEnded, g.FrameCountRendered);
     //SameLine(); if (SmallButton("GC")) { g.GcCompactAll = true; }
 
     Separator();

--- a/imgui.h
+++ b/imgui.h
@@ -201,6 +201,7 @@ typedef int ImGuiTableRowFlags;     // -> enum ImGuiTableRowFlags_   // Flags: F
 typedef int ImGuiTreeNodeFlags;     // -> enum ImGuiTreeNodeFlags_   // Flags: for TreeNode(), TreeNodeEx(), CollapsingHeader()
 typedef int ImGuiViewportFlags;     // -> enum ImGuiViewportFlags_   // Flags: for ImGuiViewport
 typedef int ImGuiWindowFlags;       // -> enum ImGuiWindowFlags_     // Flags: for Begin(), BeginChild()
+typedef int ImGuiRedrawFlags;       // -> enum ImGuiRedrawFlags_     // Flags: for RequestRedraw()
 
 // ImTexture: user data for renderer backend to identify a texture [Compile-time configurable type]
 // - To use something else than an opaque void* pointer: override with e.g. '#define ImTextureID MyTextureType*' in your imconfig.h file.
@@ -348,6 +349,8 @@ namespace ImGui
     IMGUI_API ImVec2        GetWindowSize();                            // get current window size
     IMGUI_API float         GetWindowWidth();                           // get current window width (shortcut for GetWindowSize().x)
     IMGUI_API float         GetWindowHeight();                          // get current window height (shortcut for GetWindowSize().y)
+    IMGUI_API bool          WaitAndPollEvents(int timeout);             // block the frame drawing loop untill a event is detected. timeout: 0 process event immediatly, not blocking;  -1 wait for ever untill untill an event comes; positive number wait untill timedout or event comes. Call RequestRedraw to awake waiting of this function. Return 0 to signel a quict event.
+    IMGUI_API void          RequestRedraw(ImGuiRedrawFlags flags);      // request to redraw (currently redraw everything, may redraw specific region/window/widget only in the future)
 
     // Window manipulation
     // - Prefer using SetNextXXX functions (before Begin) rather that SetXXX functions (after Begin).
@@ -1732,6 +1735,14 @@ enum ImGuiCond_
     ImGuiCond_Appearing     = 1 << 3    // Set the variable if the object/window is appearing after being hidden/inactive (or the first time)
 };
 
+// Enumeration for ImGui::RequestRedraw()
+enum ImGuiRedrawFlags_
+{
+    ImGuiRedrawFlags_Everything = 0,          // Redraw everything visible
+    ImGuiRedrawFlags_SpcifiedWindow = 1 << 2, // Specific window
+    ImGuiRedrawFlags_RegionOfWindow = 1 << 3, // Region of a specific window
+};
+
 //-----------------------------------------------------------------------------
 // [SECTION] Helpers: Memory allocations macros, ImVector<>
 //-----------------------------------------------------------------------------
@@ -2939,6 +2950,7 @@ struct ImGuiPlatformImeData
 
     ImGuiPlatformImeData() { memset(this, 0, sizeof(*this)); }
 };
+
 
 //-----------------------------------------------------------------------------
 // [SECTION] Obsolete functions and types

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -1701,6 +1701,8 @@ static void ShowDemoWindowWidgets()
             progress += progress_dir * 0.4f * ImGui::GetIO().DeltaTime;
             if (progress >= +1.1f) { progress = +1.1f; progress_dir *= -1.0f; }
             if (progress <= -0.1f) { progress = -0.1f; progress_dir *= -1.0f; }
+            // in power save mode when animate is enabled and, request redraw a new frame to show animation
+            ImGui::RequestRedraw(ImGuiRedrawFlags_Everything);
         }
 
         // Typically we would use ImVec2(-1.0f,0.0f) or ImVec2(-FLT_MIN,0.0f) to use all available width,


### PR DESCRIPTION
This is a new try inspired by the pull request of [#5116](https://github.com/ocornut/imgui/pull/5116).

This new approach allows the user to choose which mode to use by specifying the timeout. 

To tryout, please set the **timeout value to -1** and **open the Tools->Matics/Debugge**r to see how many frames are drawed when you interact with the demo.


![image](https://user-images.githubusercontent.com/5875631/160276483-b8e4dc5a-6d78-4f46-84ef-7ea90ecd74ea.png)


Sample of code in the file of main.cpp to enable/disable power save. The default timeout value is 0 which keeps current ImGui no blocking behavior. Users can change it as needed.
```
   while (!glfwWindowShouldClose(window))
   {
        // wait and poll event
        // timeout:
        //  0 process event immediatly, not blocking
        // -1 wait for ever untill an event comes
        // positive number wait untill timedout or event comes
        // call ImGui::RequestRedraw to awake waiting of this function. Return 0 to signel a quict event.
        int timeout = 0;
        ImGui::WaitAndPollEvents(timeout);

       ...
    }

```
This PR also allows users to request a redraw on demand. For example, the Widgets/Plotting/ProgressBar animation calls this `ImGui::RequestRedraw(ImGuiRedrawFlags_Everything)` to animate the progress bar change. 

```
        // Animate a simple progress bar
        IMGUI_DEMO_MARKER("Widgets/Plotting/ProgressBar");
        static float progress = 0.0f, progress_dir = 1.0f;
        if (animate)
        {
            progress += progress_dir * 0.4f * ImGui::GetIO().DeltaTime;
            if (progress >= +1.1f) { progress = +1.1f; progress_dir *= -1.0f; }
            if (progress <= -0.1f) { progress = -0.1f; progress_dir *= -1.0f; }
            // in power save mode when animate is enabled and, request redraw a new frame to show animation
            ImGui::RequestRedraw(ImGuiRedrawFlags_Everything);
        }
```
![image](https://user-images.githubusercontent.com/5875631/160276562-9674c95f-712c-4511-9711-27bf52c96f78.png)


`ImGuiRedrawFlags` is an enum currently only implemented the redraw for everything. We can implement redraw for specific window or region of a window in the future.


Currently, only tested on Windows works well for all backends. Any feedback or suggestions on Linux and Mac are welcomed.


