### PR TITLE
Viewports for win32+opengl backend (fix #2600)

### DIFF
--- a/backends/imgui_impl_opengl3.cpp
+++ b/backends/imgui_impl_opengl3.cpp
@@ -825,6 +825,11 @@ void    ImGui_ImplOpenGL3_DestroyDeviceObjects()
 
 static void ImGui_ImplOpenGL3_RenderWindow(ImGuiViewport* viewport, void*)
 {
+    ImGuiPlatformIO& platform_io = ImGui::GetPlatformIO();
+
+    if (platform_io.Platform_PushOglContext)
+        platform_io.Platform_PushOglContext(viewport);
+
     if (!(viewport->Flags & ImGuiViewportFlags_NoRendererClear))
     {
         ImVec4 clear_color = ImVec4(0.0f, 0.0f, 0.0f, 1.0f);
@@ -832,6 +837,9 @@ static void ImGui_ImplOpenGL3_RenderWindow(ImGuiViewport* viewport, void*)
         glClear(GL_COLOR_BUFFER_BIT);
     }
     ImGui_ImplOpenGL3_RenderDrawData(viewport->DrawData);
+    
+    if (platform_io.Platform_PopOglContext)
+        platform_io.Platform_PopOglContext(viewport);
 }
 
 static void ImGui_ImplOpenGL3_InitPlatformInterface()

--- a/backends/imgui_impl_win32.cpp
+++ b/backends/imgui_impl_win32.cpp
@@ -90,8 +90,6 @@ typedef DWORD (WINAPI *PFN_XInputGetState)(DWORD, XINPUT_STATE*);
 static void ImGui_ImplWin32_InitPlatformInterface();
 static void ImGui_ImplWin32_ShutdownPlatformInterface();
 static void ImGui_ImplWin32_UpdateMonitors();
-static void ImGui_ImplWin32_SetWindowFocus(ImGuiViewport* viewport);
-static void ImGui_ImplWin32_ShowWindow(ImGuiViewport* viewport);
 
 struct ImGui_ImplWin32_Data
 {

--- a/backends/imgui_impl_win32.cpp
+++ b/backends/imgui_impl_win32.cpp
@@ -82,6 +82,8 @@ typedef DWORD (WINAPI *PFN_XInputGetState)(DWORD, XINPUT_STATE*);
 static void ImGui_ImplWin32_InitPlatformInterface();
 static void ImGui_ImplWin32_ShutdownPlatformInterface();
 static void ImGui_ImplWin32_UpdateMonitors();
+static void ImGui_ImplWin32_SetWindowFocus(ImGuiViewport* viewport);
+static void ImGui_ImplWin32_ShowWindow(ImGuiViewport* viewport);
 
 struct ImGui_ImplWin32_Data
 {
@@ -95,6 +97,10 @@ struct ImGui_ImplWin32_Data
     bool                        HasGamepad;
     bool                        WantUpdateHasGamepad;
     bool                        WantUpdateMonitors;
+
+#ifdef IMGUI_IMPL_WIN32_OPENGL3
+    HGLRC                       HgLrc;
+#endif //IMGUI_IMPL_WIN32_OPENGL3
 
 #ifndef IMGUI_IMPL_WIN32_DISABLE_GAMEPAD
     HMODULE                     XInputDLL;
@@ -115,7 +121,11 @@ static ImGui_ImplWin32_Data* ImGui_ImplWin32_GetBackendData()
 }
 
 // Functions
+#ifdef IMGUI_IMPL_WIN32_OPENGL3
+bool    ImGui_ImplWin32_Init(void* hwnd, void* hglrc)
+#else
 bool    ImGui_ImplWin32_Init(void* hwnd)
+#endif
 {
     ImGuiIO& io = ImGui::GetIO();
     IM_ASSERT(io.BackendPlatformUserData == NULL && "Already initialized a platform backend!");
@@ -141,6 +151,10 @@ bool    ImGui_ImplWin32_Init(void* hwnd)
     bd->TicksPerSecond = perf_frequency;
     bd->Time = perf_counter;
     bd->LastMouseCursor = ImGuiMouseCursor_COUNT;
+
+#ifdef IMGUI_IMPL_WIN32_OPENGL3
+    bd->HgLrc = (HGLRC)hglrc;
+#endif //IMGUI_IMPL_WIN32_OPENGL3
 
     // Our mouse update function expect PlatformHandle to be filled for the main viewport
     ImGuiViewport* main_viewport = ImGui::GetMainViewport();
@@ -846,7 +860,23 @@ struct ImGui_ImplWin32_ViewportData
     DWORD   DwStyle;
     DWORD   DwExStyle;
 
-    ImGui_ImplWin32_ViewportData() { Hwnd = NULL; HwndOwned = false;  DwStyle = DwExStyle = 0; }
+#ifdef IMGUI_IMPL_WIN32_OPENGL3
+    HDC     Hdc;
+    HGLRC   HgLrc;
+#endif //IMGUI_IMPL_WIN32_OPENGL3
+
+    ImGui_ImplWin32_ViewportData()
+    {
+        Hwnd = NULL;
+        HwndOwned = false;
+        DwStyle = 0;
+        DwExStyle = 0;
+
+#ifdef IMGUI_IMPL_WIN32_OPENGL3
+        Hdc = NULL;
+        HgLrc = NULL;
+#endif //IMGUI_IMPL_WIN32_OPENGL3
+    }
     ~ImGui_ImplWin32_ViewportData() { IM_ASSERT(Hwnd == NULL); }
 };
 
@@ -888,6 +918,27 @@ static void ImGui_ImplWin32_CreateWindow(ImGuiViewport* viewport)
     vd->HwndOwned = true;
     viewport->PlatformRequestResize = false;
     viewport->PlatformHandle = viewport->PlatformHandleRaw = vd->Hwnd;
+
+#ifdef IMGUI_IMPL_WIN32_OPENGL3
+    vd->Hdc = GetDC(vd->Hwnd);
+    ImGui_ImplWin32_Data* bd = ImGui_ImplWin32_GetBackendData();
+
+    // Set pixel format to match base window
+    HDC Hdc = GetDC(bd->hWnd);
+    int pf = GetPixelFormat(Hdc);
+    PIXELFORMATDESCRIPTOR pfd;
+    DescribePixelFormat(Hdc, pf, sizeof(pfd), &pfd);
+    SetPixelFormat(vd->Hdc, pf, &pfd);
+
+    // Create OpenGL context for new window
+    vd->HgLrc = wglCreateContext(vd->Hdc);
+    wglMakeCurrent(vd->Hdc, vd->HgLrc);
+    wglShareLists(bd->HgLrc, vd->HgLrc);
+
+    // Present new window
+    ImGui_ImplWin32_SetWindowFocus(viewport);
+    ImGui_ImplWin32_ShowWindow(viewport);
+#endif //IMGUI_IMPL_WIN32_OPENGL3
 }
 
 static void ImGui_ImplWin32_DestroyWindow(ImGuiViewport* viewport)
@@ -902,7 +953,13 @@ static void ImGui_ImplWin32_DestroyWindow(ImGuiViewport* viewport)
             ::SetCapture(bd->hWnd);
         }
         if (vd->Hwnd && vd->HwndOwned)
+        {
+            #ifdef IMGUI_IMPL_WIN32_OPENGL3
+            wglDeleteContext(vd->HgLrc);
+            #endif //IMGUI_IMPL_WIN32_OPENGL3
+
             ::DestroyWindow(vd->Hwnd);
+        }
         vd->Hwnd = NULL;
         IM_DELETE(vd);
     }
@@ -1062,6 +1119,21 @@ static void ImGui_ImplWin32_OnChangedViewport(ImGuiViewport* viewport)
 #endif
 }
 
+#ifdef IMGUI_IMPL_WIN32_OPENGL3
+static void ImGui_ImplWin32_RenderWindow(ImGuiViewport* viewport, void*)
+{
+    ImGui_ImplWin32_ViewportData* vd = (ImGui_ImplWin32_ViewportData*)viewport->PlatformUserData;
+    wglMakeCurrent(vd->Hdc, vd->HgLrc);
+}
+
+static void ImGui_ImplWin32_SwapBuffers(ImGuiViewport* viewport, void*)
+{
+    ImGui_ImplWin32_ViewportData* vd = (ImGui_ImplWin32_ViewportData*)viewport->PlatformUserData;
+    wglMakeCurrent(vd->Hdc, vd->HgLrc);
+    SwapBuffers(vd->Hdc);
+}
+#endif //IMGUI_IMPL_WIN32_OPENGL3
+
 static LRESULT CALLBACK ImGui_ImplWin32_WndProcHandler_PlatformWindow(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
     if (ImGui_ImplWin32_WndProcHandler(hWnd, msg, wParam, lParam))
@@ -1071,6 +1143,10 @@ static LRESULT CALLBACK ImGui_ImplWin32_WndProcHandler_PlatformWindow(HWND hWnd,
     {
         switch (msg)
         {
+#ifdef IMGUI_IMPL_WIN32_OPENGL3
+        case WM_ERASEBKGND:
+            return 0; // Prevent flickering on window invalidation
+#endif //IMGUI_IMPL_WIN32_OPENGL3
         case WM_CLOSE:
             viewport->PlatformRequestClose = true;
             return 0;
@@ -1134,6 +1210,11 @@ static void ImGui_ImplWin32_InitPlatformInterface()
     platform_io.Platform_UpdateWindow = ImGui_ImplWin32_UpdateWindow;
     platform_io.Platform_GetWindowDpiScale = ImGui_ImplWin32_GetWindowDpiScale; // FIXME-DPI
     platform_io.Platform_OnChangedViewport = ImGui_ImplWin32_OnChangedViewport; // FIXME-DPI
+    
+#ifdef IMGUI_IMPL_WIN32_OPENGL3
+    platform_io.Platform_RenderWindow = ImGui_ImplWin32_RenderWindow;
+    platform_io.Platform_SwapBuffers = ImGui_ImplWin32_SwapBuffers;
+#endif //IMGUI_IMPL_WIN32_OPENGL3
 
     // Register main window handle (which is owned by the main application, not by us)
     // This is mostly for simplicity and consistency, so that our code (e.g. mouse handling etc.) can use same logic for main and secondary viewports.

--- a/backends/imgui_impl_win32.h
+++ b/backends/imgui_impl_win32.h
@@ -16,11 +16,7 @@
 #pragma once
 #include "imgui.h"      // IMGUI_IMPL_API
 
-#ifdef IMGUI_IMPL_WIN32_OPENGL3
-IMGUI_IMPL_API bool     ImGui_ImplWin32_Init(void* hwnd, void* hglrc);
-#else
-IMGUI_IMPL_API bool     ImGui_ImplWin32_Init(void* hwnd);
-#endif
+IMGUI_IMPL_API bool     ImGui_ImplWin32_Init(void* hwnd, void* hglrc = NULL);
 IMGUI_IMPL_API void     ImGui_ImplWin32_Shutdown();
 IMGUI_IMPL_API void     ImGui_ImplWin32_NewFrame();
 

--- a/backends/imgui_impl_win32.h
+++ b/backends/imgui_impl_win32.h
@@ -16,7 +16,8 @@
 #pragma once
 #include "imgui.h"      // IMGUI_IMPL_API
 
-IMGUI_IMPL_API bool     ImGui_ImplWin32_Init(void* hwnd, void* hglrc = NULL);
+IMGUI_IMPL_API bool     ImGui_ImplWin32_Init(void* hwnd);
+IMGUI_IMPL_API bool     ImGui_ImplWin32_InitForOpenGL(void* hwnd, void* hglrc);
 IMGUI_IMPL_API void     ImGui_ImplWin32_Shutdown();
 IMGUI_IMPL_API void     ImGui_ImplWin32_NewFrame();
 

--- a/backends/imgui_impl_win32.h
+++ b/backends/imgui_impl_win32.h
@@ -16,7 +16,11 @@
 #pragma once
 #include "imgui.h"      // IMGUI_IMPL_API
 
+#ifdef IMGUI_IMPL_WIN32_OPENGL3
+IMGUI_IMPL_API bool     ImGui_ImplWin32_Init(void* hwnd, void* hglrc);
+#else
 IMGUI_IMPL_API bool     ImGui_ImplWin32_Init(void* hwnd);
+#endif
 IMGUI_IMPL_API void     ImGui_ImplWin32_Shutdown();
 IMGUI_IMPL_API void     ImGui_ImplWin32_NewFrame();
 

--- a/imgui.h
+++ b/imgui.h
@@ -3154,6 +3154,8 @@ struct ImGuiPlatformIO
     float   (*Platform_GetWindowDpiScale)(ImGuiViewport* vp);               // N . . . .  // (Optional) [BETA] FIXME-DPI: DPI handling: Return DPI scale for this viewport. 1.0f = 96 DPI.
     void    (*Platform_OnChangedViewport)(ImGuiViewport* vp);               // . F . . .  // (Optional) [BETA] FIXME-DPI: DPI handling: Called during Begin() every time the viewport we are outputting into changes, so backend has a chance to swap fonts to adjust style.
     int     (*Platform_CreateVkSurface)(ImGuiViewport* vp, ImU64 vk_inst, const void* vk_allocators, ImU64* out_vk_surface); // (Optional) For a Vulkan Renderer to call into Platform code (since the surface creation needs to tie them both).
+    void    (*Platform_PushOglContext)(ImGuiViewport* vp);                  // . . . R .  // (Optional) For an OpenGL Renderer to make a platform window's rendering context current for rendering
+    void    (*Platform_PopOglContext)(ImGuiViewport* vp);                   // . . . R .  // (Optional) For an OpenGL Renderer to revert to the previous rendering context after rendering a platform window
 
     // (Optional) Renderer functions (e.g. DirectX, OpenGL, Vulkan)
     void    (*Renderer_CreateWindow)(ImGuiViewport* vp);                    // . . U . .  // Create swap chain, frame buffers etc. (called after Platform_CreateWindow)


### PR DESCRIPTION
Adds support for Win32 + OpenGL backends.  Previously, this combination didn't work correctly because spawned windows weren't given rendering contexts.  This PR makes it so OpenGL contexts are created and destroyed correctly for each new window.  Additionally, it links the contexts to the main one via `wglShareLists()`.

The only API change is the addition of an optional parameter, `hglrc`, in `ImGui_ImplWin32_Init()`.  Passing in the main window's render context handle here will engage the new code.  If only the first parameter is passed, a non-OpenGL API will be inferred.  This makes it so existing projects using the Win32 backend will be able to merge this change without issue.

When an OpenGL render context is specified, four WGL functions, `wglCreateContext()`, `wglDeleteContext()`, `wglMakeCurrent()`, and `wglShareLists()` will be loaded dynamically to enable the context management.  The OpenGL library will not be loaded if no `hglrc` is specified.