### PR TITLE
Updated comment about Edit.NavigateTo to Edit.GoToAll.

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -164,7 +164,7 @@ struct ImGuiViewport;               // A Platform Window (always only one in 'ma
 
 // Enums/Flags (declared as int for compatibility with old C++, to allow using as flags without overhead, and to not pollute the top of this file)
 // - Tip: Use your programming IDE navigation facilities on the names in the _central column_ below to find the actual flags/enum lists!
-//   In Visual Studio IDE: CTRL+comma ("Edit.NavigateTo") can follow symbols in comments, whereas CTRL+F12 ("Edit.GoToImplementation") cannot.
+//   In Visual Studio IDE: CTRL+comma ("Edit.GoToAll") can follow symbols in comments, whereas CTRL+F12 ("Edit.GoToImplementation") cannot.
 //   With Visual Assist installed: ALT+G ("VAssistX.GoToImplementation") can also follow symbols in comments.
 typedef int ImGuiCol;               // -> enum ImGuiCol_             // Enum: A color identifier for styling
 typedef int ImGuiCond;              // -> enum ImGuiCond_            // Enum: A condition for many Set*() functions


### PR DESCRIPTION
Happened to notice during https://github.com/ocornut/imgui/issues/5177 that for whatever reason this command was renamed in Visual Studio 2017.