### PR TITLE
Exposing the hover state through Selectable

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -612,6 +612,9 @@ namespace ImGui
     IMGUI_API bool          Selectable(const char* label, bool selected = false, ImGuiSelectableFlags flags = 0, const ImVec2& size = ImVec2(0, 0)); // "bool selected" carry the selection state (read-only). Selectable() is clicked is returns true so you can modify your selection state. size.x==0.0: use remaining width, size.x>0.0: specify width. size.y==0.0: use label height, size.y>0.0: specify height
     IMGUI_API bool          Selectable(const char* label, bool* p_selected, ImGuiSelectableFlags flags = 0, const ImVec2& size = ImVec2(0, 0));      // "bool* p_selected" point to the selection state (read-write), as a convenient helper.
 
+    IMGUI_API bool          SelectableHover(const char* label, bool* p_hovered, bool selected = false, ImGuiSelectableFlags flags = 0, const ImVec2& size = ImVec2(0, 0));
+    IMGUI_API bool          SelectableHover(const char* label, bool* p_hovered, bool* p_selected, ImGuiSelectableFlags flags = 0, const ImVec2& size = ImVec2(0, 0));
+
     // Widgets: List Boxes
     // - This is essentially a thin wrapper to using BeginChild/EndChild with some stylistic changes.
     // - The BeginListBox()/EndListBox() api allows you to manage your contents and selection state however you want it, by creating e.g. Selectable() or any items.
@@ -622,6 +625,8 @@ namespace ImGui
     IMGUI_API void          EndListBox();                                                       // only call EndListBox() if BeginListBox() returned true!
     IMGUI_API bool          ListBox(const char* label, int* current_item, const char* const items[], int items_count, int height_in_items = -1);
     IMGUI_API bool          ListBox(const char* label, int* current_item, bool (*items_getter)(void* data, int idx, const char** out_text), void* data, int items_count, int height_in_items = -1);
+    IMGUI_API bool          ListBox(const char* label, int* current_item, int* hovered_item, const char* const items[], int items_count, int height_in_items = -1);
+    IMGUI_API bool          ListBox(const char* label, int* current_item, int* hovered_item, bool (*items_getter)(void* data, int idx, const char** out_text), void* data, int items_count, int height_in_items = -1);
 
     // Widgets: Data Plotting
     // - Consider using ImPlot (https://github.com/epezent/implot) which is much better!

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -1132,8 +1132,12 @@ static void ShowDemoWindowWidgets()
             for (int n = 0; n < IM_ARRAYSIZE(items); n++)
             {
                 const bool is_selected = (item_current_idx == n);
-                if (ImGui::Selectable(items[n], is_selected))
+                bool is_hovered = false ;
+                if (ImGui::SelectableHover(items[n], &is_hovered, is_selected))
                     item_current_idx = n;
+
+                if( is_hovered )
+                    item_current_idx = n ;
 
                 // Set the initial focus when opening the combo (scrolling + keyboard navigation focus)
                 if (is_selected)


### PR DESCRIPTION
From the TODO list:
"- listbox: expose hovered item for a simplified ListBox api"

This PR does:
Exposing the hovered state of a Selectable and using the new function SelectableHover in the ListBox function for exposing the hovered item. This is very useful for visually giving a hint elsewhere if an item is hovered is a list box. 

For now, I changed only one demo so the effect can be observed and it didn't took me too much time if the PR is rejected ;)
