### PR TITLE
Fix main menu bar size

### DIFF
--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -6829,9 +6829,11 @@ bool ImGui::BeginMainMenuBar()
     ImGuiContext& g = *GImGui;
     ImGuiViewportP* viewport = (ImGuiViewportP*)(void*)GetMainViewport();
 
-    // Notify of viewport change so GetFrameHeight() can be accurate in case of DPI change
+    // Notify of viewport change and refresh font size so GetFrameHeight() can be accurate in case of DPI change
     SetCurrentViewport(NULL, viewport);
-
+    float font_scale = (g.IO.ConfigFlags & ImGuiConfigFlags_DpiEnableScaleFonts) ? viewport->DpiScale : 1.0f;
+    g.FontSize = g.FontBaseSize * font_scale;
+    
     // For the main menu bar, which cannot be moved, we honor g.Style.DisplaySafeAreaPadding to ensure text can be visible on a TV set.
     // FIXME: This could be generalized as an opt-in way to clamp window->DC.CursorStartPos to avoid SafeArea?
     // FIXME: Consider removing support for safe area down the line... it's messy. Nowadays consoles have support for TV calibration in OS settings.


### PR DESCRIPTION
When the default "Debug" window is in a separate viewport with a different DPI than the main viewport's, the height of the main menu bar is wrongly scaled using the Debug viewport's DPI instead of the main viewport's.

The main menu bar's height is set using GetFrameHeight, which uses the global font size.
This global font size is usually set by SetCurrentWindow, which can't be used here (as the main viewport can have no windows).
This PR fixes the height by refreshing the font size to honor the main viewport's DPI.