### PR TITLE
Detect SDL2 headers using __has_include

### DIFF
--- a/backends/imgui_impl_sdl.cpp
+++ b/backends/imgui_impl_sdl.cpp
@@ -64,8 +64,18 @@
 #include "imgui_impl_sdl.h"
 
 // SDL
-#include <SDL.h>
-#include <SDL_syswm.h>
+#if defined(__has_include)
+    #if __has_include(<SDL2/SDL.h>)
+        #include <SDL2/SDL.h>
+        #include <SDL2/SDL_syswm.h>
+    #else
+        #include <SDL.h>
+        #include <SDL_syswm.h>
+    #endif
+#else
+    #include <SDL.h>
+    #include <SDL_syswm.h>
+#endif
 #if defined(__APPLE__)
 #include <TargetConditionals.h>
 #endif


### PR DESCRIPTION
This adds a `__has_include` condition to the `#include` directives for the SDL2 header files in `backends/imgui_impl_sdl.cpp`, so that the SDL2 header files can be found in multiple places.

The reason is that the location of the SDL2 headers seems to vary and can be either at:
* `<SDL2/SDL.h>` / `<SDL2/SDL_syswm.h>` - this is the case on my Linux system and in my Windows set-up.
* `<SDL.h>` / `<SDL_syswm.h>` - this is the case on my macOS system (with SDL2 installed using MacPorts).

Checking first for the existence of the header files with the added `SDL2/` prefix seemed the best option to me (as opposed to doing it the other way around), because without the prefix the [headers from SDL-1.2](https://github.com/libsdl-org/SDL-1.2/tree/main/include) might accidentally get included instead of the SDL2 headers if there was also an old SDL 1 version installed on the system.

If `__has_include` is not supported by the compiler, there is a fallback to the original `#include` directives, without the `SDL2/` prefix.