### PR TITLE
fix OOB array index in circle segment calculation

### DIFF
--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -573,7 +573,7 @@ int ImDrawList::_CalcCircleAutoSegmentCount(float radius) const
 {
     // Automatic segment count
     const int radius_idx = (int)(radius + 0.999999f); // ceil to never reduce accuracy
-    if (radius_idx < IM_ARRAYSIZE(_Data->CircleSegmentCounts))
+    if (radius_idx >= 0 && radius_idx < IM_ARRAYSIZE(_Data->CircleSegmentCounts))
         return _Data->CircleSegmentCounts[radius_idx]; // Use cached value
     else
         return IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_CALC(radius, _Data->CircleSegmentMaxError);


### PR DESCRIPTION
Version/Branch of Dear ImGui: `master`

Back-end/Renderer/Compiler/OS:
Windows, Dx11

My Issue/Question:
A few months ago in production this crash happened to our users as an extremely rare edge case.
The crash ceased to occur when adding the bounds check before the array is indexed.

Screenshots/Video:
I did not archive anything from that time. 

Standalone, minimal, complete and verifiable example:
Call `_CalcCircleAutoSegmentCount` with something negative and watch what happens.

P.S. I did not go and try to see if this function receiving a negative value was a side effect of another part of the codebase. I did what was necessary to fix the crash and did not observe any consequences of adding the bounds check.