### PR TITLE
Prevent clicking on slider knob from shifting its position

### DIFF
--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -58,6 +58,8 @@ Other Changes:
   Not that even thought you shouldn't need to disable io.ConfigInputTrickleEventQueue, you can
   technically dynamically change its setting based on the context (e.g. disable only when hovering
   or interacting with a game/3D view).
+- IO: Fixed input queue trickling of mouse wheel events: multiple wheel events are merged, while
+  a mouse pos followed by a mouse wheel are now trickled. (#4921, #4821)
 - Windows: Fixed first-time windows appearing in negative coordinates from being initialized
   with a wrong size. This would most often be noticeable in multi-viewport mode (docking branch)
   when spawning a window in a monitor with negative coordinates. (#5215, #3414) [@DimaKoltun]

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -7851,7 +7851,7 @@ void ImGui::UpdateInputEvents(bool trickle_fast_inputs)
             if (e->MouseWheel.WheelX != 0.0f || e->MouseWheel.WheelY != 0.0f)
             {
                 // Trickling Rule: Stop processing queued events if we got multiple action on the event
-                if (trickle_fast_inputs && (mouse_wheeled || mouse_button_changed != 0))
+                if (trickle_fast_inputs && (mouse_moved || mouse_button_changed != 0))
                     break;
                 io.MouseWheelH += e->MouseWheel.WheelX;
                 io.MouseWheel += e->MouseWheel.WheelY;

--- a/imgui.h
+++ b/imgui.h
@@ -65,7 +65,7 @@ Index of this file:
 // Version
 // (Integer encoded as XYYZZ for use in #if preprocessor conditionals. Work in progress versions typically starts at XYY99 then bounce up to XYY00, XYY01 etc. when release tagging happens)
 #define IMGUI_VERSION               "1.88 WIP"
-#define IMGUI_VERSION_NUM           18721
+#define IMGUI_VERSION_NUM           18722
 #define IMGUI_CHECKVERSION()        ImGui::DebugCheckVersionAndDataLayout(IMGUI_VERSION, sizeof(ImGuiIO), sizeof(ImGuiStyle), sizeof(ImVec2), sizeof(ImVec4), sizeof(ImDrawVert), sizeof(ImDrawIdx))
 #define IMGUI_HAS_TABLE
 

--- a/imgui.h
+++ b/imgui.h
@@ -1683,6 +1683,7 @@ enum ImGuiSliderFlags_
     ImGuiSliderFlags_Logarithmic            = 1 << 5,       // Make the widget logarithmic (linear otherwise). Consider using ImGuiSliderFlags_NoRoundToFormat with this if using a format-string with small amount of digits.
     ImGuiSliderFlags_NoRoundToFormat        = 1 << 6,       // Disable rounding underlying value to match precision of the display format string (e.g. %.3f values are rounded to those 3 digits)
     ImGuiSliderFlags_NoInput                = 1 << 7,       // Disable CTRL+Click or Enter key allowing to input text directly into the widget
+    ImGuiSliderFlags_NoChangeInsideHandle   = 1 << 8,
     ImGuiSliderFlags_InvalidMask_           = 0x7000000F    // [Internal] We treat using those bits as being potentially a 'float power' argument from the previous API that has got miscast to this enum, and will trigger an assert if needed.
 
     // Obsolete names (will be removed)

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -712,12 +712,12 @@ static void ShowDemoWindowWidgets()
         {
             IMGUI_DEMO_MARKER("Widgets/Basic/SliderInt, SliderFloat");
             static int i1 = 0;
-            ImGui::SliderInt("slider int", &i1, -1, 3);
+            ImGui::SliderInt("slider int", &i1, -1, 3, "%d", ImGuiSliderFlags_NoChangeInsideHandle);
             ImGui::SameLine(); HelpMarker("CTRL+click to input value.");
 
             static float f1 = 0.123f, f2 = 0.0f;
             ImGui::SliderFloat("slider float", &f1, 0.0f, 1.0f, "ratio = %.3f");
-            ImGui::SliderFloat("slider float (log)", &f2, -10.0f, 10.0f, "%.4f", ImGuiSliderFlags_Logarithmic);
+            ImGui::SliderFloat("slider float (log, must click off handle)", &f2, -10.0f, 10.0f, "%.4f", ImGuiSliderFlags_Logarithmic | ImGuiSliderFlags_NoChangeInsideHandle);
 
             IMGUI_DEMO_MARKER("Widgets/Basic/SliderAngle");
             static float angle = 0.0f;
@@ -1919,6 +1919,8 @@ static void ShowDemoWindowWidgets()
         ImGui::SameLine(); HelpMarker("Disable rounding underlying value to match precision of the format string (e.g. %.3f values are rounded to those 3 digits).");
         ImGui::CheckboxFlags("ImGuiSliderFlags_NoInput", &flags, ImGuiSliderFlags_NoInput);
         ImGui::SameLine(); HelpMarker("Disable CTRL+Click or Enter key allowing to input text directly into the widget.");
+        ImGui::CheckboxFlags("ImGuiSliderFlags_NoChangeInsideHandle", &flags, ImGuiSliderFlags_NoChangeInsideHandle);
+        ImGui::SameLine(); HelpMarker("Clicking inside the slider box only changes the value if the click was off the handle");
 
         // Drags
         static float drag_f = 0.5f;
@@ -1936,6 +1938,7 @@ static void ShowDemoWindowWidgets()
         ImGui::Text("Underlying float value: %f", slider_f);
         ImGui::SliderFloat("SliderFloat (0 -> 1)", &slider_f, 0.0f, 1.0f, "%.3f", flags);
         ImGui::SliderInt("SliderInt (0 -> 100)", &slider_i, 0, 100, "%d", flags);
+        ImGui::SliderInt("SliderInt (10 -> 100)", &slider_i, 10, 100, "%d", flags);
 
         ImGui::TreePop();
     }


### PR DESCRIPTION
I saw that the v1.88 milestone has clicking on the slider knob changing its position (#1946) as one of the milestones. This is my first contribution, so I figured it would be a good place to start. 

What I changed:
* Added new slider flag `ImGuiSliderFlags_NoChangeInsideHandle`. Sliders behave exactly the same as before if this flag isn't passed. 
* When `ImGuiSliderFlags_NoChangeInsideHandle` is passed, sliders will ignore clicks inside the handle unless the handle is being dragged.
* Added an extra checkbox to Widgets/Drag and Slider Flags in the demo window to demo `ImGuiSliderFlags_NoChangeInsideHandle`

See attached screen recording for example behaviour

https://user-images.githubusercontent.com/80700901/169400922-b4ec266b-27e7-4cdf-8296-9a779e4bd9cb.mp4