### PR TITLE
features/string_view: enhanced VS debugger visualizer support (imgui.natvis) for ImStrv

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -12182,7 +12182,7 @@ static void RenderViewportsThumbnails()
 // Helper tool to diagnose between text encoding issues and font loading issues. Pass your UTF-8 string and verify that there are correct.
 void ImGui::DebugTextEncoding(ImStrv str)
 {
-    Text("Text: \"%.*s\"", str.length(), str.Begin);
+    Text("Text: \"%.*s\"", (int)str.length(), str.Begin);
     if (!BeginTable("list", 4, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_SizingFixedFit))
         return;
     TableSetupColumn("Offset");

--- a/misc/debuggers/imgui.natvis
+++ b/misc/debuggers/imgui.natvis
@@ -53,7 +53,8 @@ More information at: https://docs.microsoft.com/en-us/visualstudio/debugger/crea
 
 <!-- String view (non zero-terminated begin/end pair) -->
 <Type Name="ImStrv">
-  <DisplayString>{Begin,[End-Begin]s} ({End-Begin,d})</DisplayString>
+  <DisplayString>{Begin,[End-Begin]s8} ({End-Begin,d})</DisplayString>
+  <StringView>Begin,[End-Begin]s8</StringView>
 </Type>
 
 <Type Name="ImGuiWindow">


### PR DESCRIPTION
Public API all recive utf-8 encoding string. So I think this modification is reasonable.

See [Visual Studio 2022 format specifiers](https://docs.microsoft.com/en-us/visualstudio/debugger/format-specifiers-in-cpp?view=vs-2022).
This specifier is supported since Visual Studio **2012**.

> s8 | UTF-8 string

Test codes:
```C++
ImGui::Checkbox("😀 | Demo Window | 测试窗口 | テストウィンドウ | 테스트 창", &show_demo_window);
```

Before:
![image](https://user-images.githubusercontent.com/57629614/169685440-040dac22-0c67-43c0-9b56-6454da65df80.png)

After:
![image](https://user-images.githubusercontent.com/57629614/169685504-c7eb1b10-6bff-4027-8d44-497f1831de17.png)
