### PR TITLE
Removed redundant window flag in demo

### DIFF
--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -7358,7 +7358,7 @@ static void ShowExampleAppSimpleOverlay(bool* p_open)
 static void ShowExampleAppFullscreen(bool* p_open)
 {
     static bool use_work_area = true;
-    static ImGuiWindowFlags flags = ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoSavedSettings;
+    static ImGuiWindowFlags flags = ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoSavedSettings;
 
     // We demonstrate using the full viewport area or the work area (without menu-bars, task-bars etc.)
     // Based on your use case you may want one of the other.


### PR DESCRIPTION
The window flag "ImGuiWindowFlags_NoResize" is already a part of the window flag "ImGuiWindowFlags_NoDecoration."