### PR TITLE
Fixed 'VERTEX_CONSTANT_BUFFER': 'struct' type redefinition when enabling Unity Builds

### DIFF
--- a/backends/imgui_impl_dx10.cpp
+++ b/backends/imgui_impl_dx10.cpp
@@ -30,7 +30,6 @@
 
 #include "imgui.h"
 #include "imgui_impl_dx10.h"
-#include "imgui_impl_dxshared.h"
 
 // DirectX
 #include <stdio.h>
@@ -61,6 +60,11 @@ struct ImGui_ImplDX10_Data
     int                         IndexBufferSize;
 
     ImGui_ImplDX10_Data()       { memset((void*)this, 0, sizeof(*this)); VertexBufferSize = 5000; IndexBufferSize = 10000; }
+};
+
+struct VERTEX_CONSTANT_BUFFER_DX10
+{
+    float   mvp[4][4];
 };
 
 // Backend data stored in io.BackendRendererUserData to allow support for multiple Dear ImGui contexts
@@ -167,7 +171,7 @@ void ImGui_ImplDX10_RenderDrawData(ImDrawData* draw_data)
         void* mapped_resource;
         if (bd->pVertexConstantBuffer->Map(D3D10_MAP_WRITE_DISCARD, 0, &mapped_resource) != S_OK)
             return;
-        VERTEX_CONSTANT_BUFFER* constant_buffer = (VERTEX_CONSTANT_BUFFER*)mapped_resource;
+        VERTEX_CONSTANT_BUFFER_DX10* constant_buffer = (VERTEX_CONSTANT_BUFFER_DX10*)mapped_resource;
         float L = draw_data->DisplayPos.x;
         float R = draw_data->DisplayPos.x + draw_data->DisplaySize.x;
         float T = draw_data->DisplayPos.y;
@@ -419,7 +423,7 @@ bool    ImGui_ImplDX10_CreateDeviceObjects()
         // Create the constant buffer
         {
             D3D10_BUFFER_DESC desc;
-            desc.ByteWidth = sizeof(VERTEX_CONSTANT_BUFFER);
+            desc.ByteWidth = sizeof(VERTEX_CONSTANT_BUFFER_DX10);
             desc.Usage = D3D10_USAGE_DYNAMIC;
             desc.BindFlags = D3D10_BIND_CONSTANT_BUFFER;
             desc.CPUAccessFlags = D3D10_CPU_ACCESS_WRITE;

--- a/backends/imgui_impl_dx10.cpp
+++ b/backends/imgui_impl_dx10.cpp
@@ -30,6 +30,7 @@
 
 #include "imgui.h"
 #include "imgui_impl_dx10.h"
+#include "imgui_impl_dxshared.h"
 
 // DirectX
 #include <stdio.h>
@@ -60,11 +61,6 @@ struct ImGui_ImplDX10_Data
     int                         IndexBufferSize;
 
     ImGui_ImplDX10_Data()       { memset((void*)this, 0, sizeof(*this)); VertexBufferSize = 5000; IndexBufferSize = 10000; }
-};
-
-struct VERTEX_CONSTANT_BUFFER
-{
-    float   mvp[4][4];
 };
 
 // Backend data stored in io.BackendRendererUserData to allow support for multiple Dear ImGui contexts

--- a/backends/imgui_impl_dx11.cpp
+++ b/backends/imgui_impl_dx11.cpp
@@ -31,7 +31,6 @@
 
 #include "imgui.h"
 #include "imgui_impl_dx11.h"
-#include "imgui_impl_dxshared.h"
 
 // DirectX
 #include <stdio.h>
@@ -62,6 +61,11 @@ struct ImGui_ImplDX11_Data
     int                         IndexBufferSize;
 
     ImGui_ImplDX11_Data()       { memset((void*)this, 0, sizeof(*this)); VertexBufferSize = 5000; IndexBufferSize = 10000; }
+};
+
+struct VERTEX_CONSTANT_BUFFER_DX11
+{
+    float   mvp[4][4];
 };
 
 // Backend data stored in io.BackendRendererUserData to allow support for multiple Dear ImGui contexts
@@ -173,7 +177,7 @@ void ImGui_ImplDX11_RenderDrawData(ImDrawData* draw_data)
         D3D11_MAPPED_SUBRESOURCE mapped_resource;
         if (ctx->Map(bd->pVertexConstantBuffer, 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped_resource) != S_OK)
             return;
-        VERTEX_CONSTANT_BUFFER* constant_buffer = (VERTEX_CONSTANT_BUFFER*)mapped_resource.pData;
+        VERTEX_CONSTANT_BUFFER_DX11* constant_buffer = (VERTEX_CONSTANT_BUFFER_DX11*)mapped_resource.pData;
         float L = draw_data->DisplayPos.x;
         float R = draw_data->DisplayPos.x + draw_data->DisplaySize.x;
         float T = draw_data->DisplayPos.y;
@@ -431,7 +435,7 @@ bool    ImGui_ImplDX11_CreateDeviceObjects()
         // Create the constant buffer
         {
             D3D11_BUFFER_DESC desc;
-            desc.ByteWidth = sizeof(VERTEX_CONSTANT_BUFFER);
+            desc.ByteWidth = sizeof(VERTEX_CONSTANT_BUFFER_DX11);
             desc.Usage = D3D11_USAGE_DYNAMIC;
             desc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
             desc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;

--- a/backends/imgui_impl_dx11.cpp
+++ b/backends/imgui_impl_dx11.cpp
@@ -31,6 +31,7 @@
 
 #include "imgui.h"
 #include "imgui_impl_dx11.h"
+#include "imgui_impl_dxshared.h"
 
 // DirectX
 #include <stdio.h>
@@ -61,11 +62,6 @@ struct ImGui_ImplDX11_Data
     int                         IndexBufferSize;
 
     ImGui_ImplDX11_Data()       { memset((void*)this, 0, sizeof(*this)); VertexBufferSize = 5000; IndexBufferSize = 10000; }
-};
-
-struct VERTEX_CONSTANT_BUFFER
-{
-    float   mvp[4][4];
 };
 
 // Backend data stored in io.BackendRendererUserData to allow support for multiple Dear ImGui contexts

--- a/backends/imgui_impl_dx12.cpp
+++ b/backends/imgui_impl_dx12.cpp
@@ -39,7 +39,6 @@
 
 #include "imgui.h"
 #include "imgui_impl_dx12.h"
-#include "imgui_impl_dxshared.h"
 
 // DirectX
 #include <d3d12.h>
@@ -75,6 +74,11 @@ struct ImGui_ImplDX12_Data
     ImGui_ImplDX12_Data()           { memset((void*)this, 0, sizeof(*this)); frameIndex = UINT_MAX; }
 };
 
+struct VERTEX_CONSTANT_BUFFER_DX12
+{
+    float   mvp[4][4];
+};
+
 // Backend data stored in io.BackendRendererUserData to allow support for multiple Dear ImGui contexts
 // It is STRONGLY preferred that you use docking branch with multi-viewports (== single Dear ImGui context + multiple windows) instead of multiple Dear ImGui contexts.
 static ImGui_ImplDX12_Data* ImGui_ImplDX12_GetBackendData()
@@ -89,7 +93,7 @@ static void ImGui_ImplDX12_SetupRenderState(ImDrawData* draw_data, ID3D12Graphic
 
     // Setup orthographic projection matrix into our constant buffer
     // Our visible imgui space lies from draw_data->DisplayPos (top left) to draw_data->DisplayPos+data_data->DisplaySize (bottom right).
-    VERTEX_CONSTANT_BUFFER vertex_constant_buffer;
+    VERTEX_CONSTANT_BUFFER_DX12 vertex_constant_buffer;
     {
         float L = draw_data->DisplayPos.x;
         float R = draw_data->DisplayPos.x + draw_data->DisplaySize.x;

--- a/backends/imgui_impl_dx12.cpp
+++ b/backends/imgui_impl_dx12.cpp
@@ -39,6 +39,7 @@
 
 #include "imgui.h"
 #include "imgui_impl_dx12.h"
+#include "imgui_impl_dxshared.h"
 
 // DirectX
 #include <d3d12.h>
@@ -72,11 +73,6 @@ struct ImGui_ImplDX12_Data
     UINT                            frameIndex;
 
     ImGui_ImplDX12_Data()           { memset((void*)this, 0, sizeof(*this)); frameIndex = UINT_MAX; }
-};
-
-struct VERTEX_CONSTANT_BUFFER
-{
-    float   mvp[4][4];
 };
 
 // Backend data stored in io.BackendRendererUserData to allow support for multiple Dear ImGui contexts

--- a/backends/imgui_impl_dxshared.h
+++ b/backends/imgui_impl_dxshared.h
@@ -1,0 +1,8 @@
+// dear imgui: Shared header for DirectX backends
+
+#pragma once
+
+struct VERTEX_CONSTANT_BUFFER
+{
+    float   mvp[4][4];
+};

--- a/backends/imgui_impl_dxshared.h
+++ b/backends/imgui_impl_dxshared.h
@@ -1,8 +1,0 @@
-// dear imgui: Shared header for DirectX backends
-
-#pragma once
-
-struct VERTEX_CONSTANT_BUFFER
-{
-    float   mvp[4][4];
-};


### PR DESCRIPTION
**Platform:** Windows
**Compiler:** MSBuild 17.2.1+52cd2da31

Small fix for in certain unity build globs I'll sometimes be presented with `error C2011: 'VERTEX_CONSTANT_BUFFER': 'struct' type redefinition`.
Unity Build Enabled via Directory.Build.props `EnableUnitySupport>true</EnableUnitySupport`.

I could change the name of `VERTEX_CONSTANT_BUFFER` in each implementation (DX10, 11 and 12) but figured there may be some use long term in a shared implementation header for types. Kept shared includes however to each impl.cpp.
