### PR TITLE
Add safe SetTime function in glfw backend

### DIFF
--- a/backends/imgui_impl_glfw.cpp
+++ b/backends/imgui_impl_glfw.cpp
@@ -657,6 +657,12 @@ void ImGui_ImplGlfw_NewFrame()
     ImGui_ImplGlfw_UpdateGamepads();
 }
 
+void ImGui_ImplGlfw_SetTime(double time)
+{
+    ImGui_ImplGlfw_Data* bd = ImGui_ImplGlfw_GetBackendData();
+    bd->Time += (time - glfwGetTime());
+    glfwSetTime(time);
+}
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #endif

--- a/backends/imgui_impl_glfw.h
+++ b/backends/imgui_impl_glfw.h
@@ -44,3 +44,5 @@ IMGUI_IMPL_API void     ImGui_ImplGlfw_ScrollCallback(GLFWwindow* window, double
 IMGUI_IMPL_API void     ImGui_ImplGlfw_KeyCallback(GLFWwindow* window, int key, int scancode, int action, int mods);
 IMGUI_IMPL_API void     ImGui_ImplGlfw_CharCallback(GLFWwindow* window, unsigned int c);
 IMGUI_IMPL_API void     ImGui_ImplGlfw_MonitorCallback(GLFWmonitor* monitor, int event);
+
+IMGUI_IMPL_API void     ImGui_ImplGlfw_SetTime(double time);


### PR DESCRIPTION
This PR adds a dedicated function to use `glfwSetTime` function safely.

Currently, calling `glfwSetTime(0)` each frame makes the program throw runtime error caused by [this](https://github.com/ocornut/imgui/blob/master/imgui.cpp#L8022) assertion.

This behavior makes sense due to how `DeltaTime` is calculated [here](https://github.com/ocornut/imgui/blob/master/backends/imgui_impl_glfw.cpp#L650). This function will always yield invalid `DeltaTime` if `glfwSetTime` is called each frame.

I implemented a custom function that updates the timestamp before calling `glfwSetTime` so that `DeltaTime` is properly calculated