### PR TITLE
ARC / Autorelease fixes with metal-cpp and extensions

### DIFF
--- a/backends/imgui_impl_metal.mm
+++ b/backends/imgui_impl_metal.mm
@@ -92,12 +92,12 @@ static inline CFTimeInterval     GetMachAbsoluteTimeInSeconds()       { return s
 
 bool ImGui_ImplMetal_Init(MTL::Device* device)
 {
-    return ImGui_ImplMetal_Init((id<MTLDevice>)(device));
+    return ImGui_ImplMetal_Init((__bridge id<MTLDevice>)(device));
 }
 
 void ImGui_ImplMetal_NewFrame(MTL::RenderPassDescriptor* renderPassDescriptor)
 {
-    ImGui_ImplMetal_NewFrame((MTLRenderPassDescriptor*)(renderPassDescriptor));
+    ImGui_ImplMetal_NewFrame((__bridge MTLRenderPassDescriptor*)(renderPassDescriptor));
 }
 
 void ImGui_ImplMetal_RenderDrawData(ImDrawData* draw_data,
@@ -105,19 +105,19 @@ void ImGui_ImplMetal_RenderDrawData(ImDrawData* draw_data,
                                     MTL::RenderCommandEncoder* commandEncoder)
 {
     ImGui_ImplMetal_RenderDrawData(draw_data,
-                                   (id<MTLCommandBuffer>)(commandBuffer),
-                                   (id<MTLRenderCommandEncoder>)(commandEncoder));
+                                   (__bridge id<MTLCommandBuffer>)(commandBuffer),
+                                   (__bridge id<MTLRenderCommandEncoder>)(commandEncoder));
 
 }
 
 bool ImGui_ImplMetal_CreateFontsTexture(MTL::Device* device)
 {
-    return ImGui_ImplMetal_CreateFontsTexture((id<MTLDevice>)(device));
+    return ImGui_ImplMetal_CreateFontsTexture((__bridge id<MTLDevice>)(device));
 }
 
 bool ImGui_ImplMetal_CreateDeviceObjects(MTL::Device* device)
 {
-    return ImGui_ImplMetal_CreateDeviceObjects((id<MTLDevice>)(device));
+    return ImGui_ImplMetal_CreateDeviceObjects((__bridge id<MTLDevice>)(device));
 }
 
 #endif // #ifdef IMGUI_IMPL_METAL_CPP
@@ -413,7 +413,7 @@ static void ImGui_ImplMetal_CreateWindow(ImGuiViewport* viewport)
     CAMetalLayer* layer = [CAMetalLayer layer];
     layer.device = device;
     layer.framebufferOnly = YES;
-    layer.pixelFormat = MTLPixelFormatBGRA8Unorm;
+    layer.pixelFormat = bd->SharedMetalContext.framebufferDescriptor.colorPixelFormat;
 #if TARGET_OS_OSX
     NSWindow* window = (__bridge NSWindow*)handle;
     NSView* view = window.contentView;
@@ -589,8 +589,8 @@ static void ImGui_ImplMetal_InvalidateDeviceObjectsForPlatformWindows()
 {
     if ((self = [super init]))
     {
-        _renderPipelineStateCache = [NSMutableDictionary dictionary];
-        _bufferCache = [NSMutableArray array];
+        self.renderPipelineStateCache = [NSMutableDictionary dictionary];
+        self.bufferCache = [NSMutableArray array];
         _lastBufferCachePurge = GetMachAbsoluteTimeInSeconds();
     }
     return self;

--- a/backends/imgui_impl_osx.h
+++ b/backends/imgui_impl_osx.h
@@ -17,9 +17,27 @@
 
 #include "imgui.h"      // IMGUI_IMPL_API
 
+#ifdef __OBJC__
+
 @class NSEvent;
 @class NSView;
 
 IMGUI_IMPL_API bool     ImGui_ImplOSX_Init(NSView* _Nonnull view);
 IMGUI_IMPL_API void     ImGui_ImplOSX_Shutdown();
 IMGUI_IMPL_API void     ImGui_ImplOSX_NewFrame(NSView* _Nullable view);
+
+#endif
+
+#ifdef IMGUI_IMPL_METAL_CPP_EXTENSIONS
+
+// #include <AppKit/AppKit.hpp>
+
+#ifndef __OBJC__
+
+IMGUI_IMPL_API bool     ImGui_ImplOSX_Init(void* _Nonnull view);
+IMGUI_IMPL_API void     ImGui_ImplOSX_Shutdown();
+IMGUI_IMPL_API void     ImGui_ImplOSX_NewFrame(void* _Nullable view);
+
+#endif
+
+#endif

--- a/backends/imgui_impl_osx.mm
+++ b/backends/imgui_impl_osx.mm
@@ -376,6 +376,18 @@ static ImGuiKey ImGui_ImplOSX_KeyCodeToImGuiKey(int key_code)
     }
 }
 
+#ifdef IMGUI_IMPL_METAL_CPP
+
+IMGUI_IMPL_API bool ImGui_ImplOSX_Init(void* _Nonnull view) {
+    return ImGui_ImplOSX_Init((__bridge NSView*)(view));
+}
+
+IMGUI_IMPL_API void ImGui_ImplOSX_NewFrame(void* _Nullable view) {
+    return ImGui_ImplOSX_NewFrame((__bridge NSView*)(view));
+}
+
+#endif
+
 
 bool ImGui_ImplOSX_Init(NSView* view)
 {

--- a/backends/imgui_impl_osx.mm
+++ b/backends/imgui_impl_osx.mm
@@ -376,7 +376,7 @@ static ImGuiKey ImGui_ImplOSX_KeyCodeToImGuiKey(int key_code)
     }
 }
 
-#ifdef IMGUI_IMPL_METAL_CPP
+#ifdef IMGUI_IMPL_METAL_CPP_EXTENSIONS
 
 IMGUI_IMPL_API bool ImGui_ImplOSX_Init(void* _Nonnull view) {
     return ImGui_ImplOSX_Init((__bridge NSView*)(view));


### PR DESCRIPTION
Apple has released some additional extensions to metal-cpp that provide the ability to create full macOS applications in C++. While working with these and implementing a simple test application, I came across some issues in imgui that this PR should address.

In ARC based systems, `__bridge` is needed for the casts between the metal-cpp objects and their native types. For non-ARC systems, this is just a warning.

The docking code assumes a BGRA8Unorm pixel format, but that may not be correct. The correct format is pulled from the frame buffer description to prevent a crash.

The MetalContext initializer was losing references to `renderPipelineStateCache` and `bufferCache` for systems within an autorelease pool. The initializer now uses the property setters to ensure memory management is correct regardless of memory management scheme.

WWDC22 introduced some new extensions akin to metal-cpp to allow for a full app creation in C++. There are conflicts with the OSX backend. The backend has been updated similarly to the metal-cpp support in the Metal backend. A `IMGUI_IMPL_METAL_CPP_EXTENSIONS` preprocessor macro and supporting functions has been added to allow use of these APIs that then handle the proper bridging / casting.

Sample application using these changes: https://github.com/stack/walnut-apple
WWDC22 session: https://developer.apple.com/wwdc22/10160