### PR TITLE
Font scale in PushFont

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -390,7 +390,7 @@ namespace ImGui
     IMGUI_API void          SetScrollFromPosY(float local_y, float center_y_ratio = 0.5f);  // adjust scrolling amount to make given position visible. Generally GetCursorStartPos() + offset to compute a valid position.
 
     // Parameters stacks (shared)
-    IMGUI_API void          PushFont(ImFont* font);                                         // use NULL as a shortcut to push default font
+    IMGUI_API void          PushFont(ImFont* font, float scale = 1.0f);                     // use NULL as a shortcut to push default font
     IMGUI_API void          PopFont();
     IMGUI_API void          PushStyleColor(ImGuiCol idx, ImU32 col);                        // modify a style color. always use this if you modify the style after NewFrame().
     IMGUI_API void          PushStyleColor(ImGuiCol idx, const ImVec4& col);

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -1573,6 +1573,12 @@ struct ImGuiContextHook
 // [SECTION] ImGuiContext (main Dear ImGui context)
 //-----------------------------------------------------------------------------
 
+struct ImGuiFontStackData
+{
+    ImFont*                 Font;
+    float                   Scale;
+};
+
 struct ImGuiContext
 {
     bool                    Initialized;
@@ -1657,7 +1663,7 @@ struct ImGuiContext
     // Shared stacks
     ImVector<ImGuiColorMod> ColorStack;                         // Stack for PushStyleColor()/PopStyleColor() - inherited by Begin()
     ImVector<ImGuiStyleMod> StyleVarStack;                      // Stack for PushStyleVar()/PopStyleVar() - inherited by Begin()
-    ImVector<ImFont*>       FontStack;                          // Stack for PushFont()/PopFont() - inherited by Begin()
+    ImVector<ImGuiFontStackData> FontStack;                     // Stack for PushFont()/PopFont() - inherited by Begin()
     ImVector<ImGuiID>       FocusScopeStack;                    // Stack for PushFocusScope()/PopFocusScope() - not inherited by Begin(), unless child window
     ImVector<ImGuiItemFlags>ItemFlagsStack;                     // Stack for PushItemFlag()/PopItemFlag() - inherited by Begin()
     ImVector<ImGuiGroupData>GroupStack;                         // Stack for BeginGroup()/EndGroup() - not inherited by Begin()
@@ -2541,7 +2547,7 @@ namespace ImGui
     IMGUI_API ImGuiWindow*  FindBottomMostVisibleWindowWithinBeginStack(ImGuiWindow* window);
 
     // Fonts, drawing
-    IMGUI_API void          SetCurrentFont(ImFont* font);
+    IMGUI_API void          SetCurrentFont(ImFont* font, float scale = 1.0f);
     inline ImFont*          GetDefaultFont() { ImGuiContext& g = *GImGui; return g.IO.FontDefault ? g.IO.FontDefault : g.IO.Fonts->Fonts[0]; }
     inline ImDrawList*      GetForegroundDrawList(ImGuiWindow* window) { IM_UNUSED(window); return GetForegroundDrawList(); } // This seemingly unnecessary wrapper simplifies compatibility between the 'master' and 'docking' branches.
     IMGUI_API ImDrawList*   GetBackgroundDrawList(ImGuiViewport* viewport);                     // get background draw list for the given viewport. this draw list will be the first rendering one. Useful to quickly draw shapes/text behind dear imgui contents.


### PR DESCRIPTION

Attempt to solve issue #1018

`PushFont` api change from `void PushFont(ImFont* font);` to `void PushFont(ImFont* font, float scale = 1.0f);`, to allow additional scale for each font scope.

In my case this change is valuable to simpler implementation of font resize after dpi change or user request without rebuilding font textures (using only couple of sizes built on loading).

<details>
  <summary>Simple demo panel:</summary>

  Code:
  ```cpp
  void fonts_demo_node(ImFont* font, float scale=1.0f)
  {
      ImGui::PushFont(font, scale);
      ImGui::Text("Font scale: %f", scale);
      if (ImGui::TreeNode("smaller node"))
      {
          fonts_demo_node(font, scale * 0.9f);
          ImGui::TreePop();
      }
      if (ImGui::TreeNode("bigger node"))
      {
          fonts_demo_node(font, scale * 1.1f);
          ImGui::TreePop();
      }
      ImGui::PopFont();
  }
  
  void font_demo_panel(bool* p_open)
  {
      if (!p_open || *p_open)
      {
          ImGui::Begin("Font Resize Demo", p_open);
  
          fonts_demo_node(ImGui::GetFont());
  
          ImGui::End();
      }
  }
  ```
  
  Visual (in examples/example_win32_directx11 project):
  ![image](https://user-images.githubusercontent.com/67688812/176174502-508506b8-042e-48e2-9e27-6f3701ee2fe0.png)
</details>
