### PR TITLE
Backend : GLFW + multi-viewports : fix exception raised when rendering is reset without exiting the application

### DIFF
--- a/backends/imgui_impl_glfw.cpp
+++ b/backends/imgui_impl_glfw.cpp
@@ -569,6 +569,9 @@ bool ImGui_ImplGlfw_InitForOther(GLFWwindow* window, bool install_callbacks)
     return ImGui_ImplGlfw_Init(window, install_callbacks, GlfwClientApi_Unknown);
 }
 
+#if !GLFW_HAS_MOUSE_PASSTHROUGH && GLFW_HAS_WINDOW_HOVERED && defined(_WIN32)
+static WNDPROC g_GlfwWndProc = NULL;
+#endif
 void ImGui_ImplGlfw_Shutdown()
 {
     ImGui_ImplGlfw_Data* bd = ImGui_ImplGlfw_GetBackendData();
@@ -585,6 +588,9 @@ void ImGui_ImplGlfw_Shutdown()
 
     io.BackendPlatformName = NULL;
     io.BackendPlatformUserData = NULL;
+#if !GLFW_HAS_MOUSE_PASSTHROUGH && GLFW_HAS_WINDOW_HOVERED && defined(_WIN32)
+    g_GlfwWndProc = NULL;
+#endif
     IM_DELETE(bd);
 }
 
@@ -937,7 +943,6 @@ static void ImGui_ImplGlfw_DestroyWindow(ImGuiViewport* viewport)
 // We have submitted https://github.com/glfw/glfw/pull/1568 to allow GLFW to support "transparent inputs".
 // In the meanwhile we implement custom per-platform workarounds here (FIXME-VIEWPORT: Implement same work-around for Linux/OSX!)
 #if !GLFW_HAS_MOUSE_PASSTHROUGH && GLFW_HAS_WINDOW_HOVERED && defined(_WIN32)
-static WNDPROC g_GlfwWndProc = NULL;
 static LRESULT CALLBACK WndProcNoInputs(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
     if (msg == WM_NCHITTEST)


### PR DESCRIPTION
Hello there, this is the follow up to https://github.com/ocornut/imgui/issues/4616 ... I put the explanations and captures in the last comment of the issue, not sure if I need to put it in the PR too. If that's the case just tell me, I will do it.

Nothing fancy for this PR, I just moved the declaration of g_GlfwWndProc before ImGui_ImplGlfw_Shutdown() in order to be able to reset it inside the function. That way rendering can be reset without having an exception raised when a window gets outside the parent in multi viewport.





