### PR TITLE
#5037 for docking branch: Support for dynamic_rendering

### DIFF
--- a/backends/imgui_impl_vulkan.h
+++ b/backends/imgui_impl_vulkan.h
@@ -62,6 +62,8 @@ struct ImGui_ImplVulkan_InitInfo
     VkSampleCountFlagBits           MSAASamples;            // >= VK_SAMPLE_COUNT_1_BIT (0 -> default to VK_SAMPLE_COUNT_1_BIT)
     const VkAllocationCallbacks*    Allocator;
     void                            (*CheckVkResultFn)(VkResult err);
+    bool                            UseDynamicRendering;
+    VkFormat                        ColorAttachmentFormat;
 };
 
 // Called by user code

--- a/backends/imgui_impl_vulkan.h
+++ b/backends/imgui_impl_vulkan.h
@@ -62,7 +62,7 @@ struct ImGui_ImplVulkan_InitInfo
     VkSampleCountFlagBits           MSAASamples;            // >= VK_SAMPLE_COUNT_1_BIT (0 -> default to VK_SAMPLE_COUNT_1_BIT)
     const VkAllocationCallbacks*    Allocator;
     void                            (*CheckVkResultFn)(VkResult err);
-    bool                            UseDynamicRendering;
+    bool                            UseDynamicRendering;    // Need to explicitly enable VK_KHR_dynamic_rendering extension to use this, even for Vulkan 1.3.
     VkFormat                        ColorAttachmentFormat;
 };
 
@@ -140,6 +140,7 @@ struct ImGui_ImplVulkanH_Window
     VkPresentModeKHR    PresentMode;
     VkRenderPass        RenderPass;
     VkPipeline          Pipeline;               // The window pipeline may uses a different VkRenderPass than the one passed in ImGui_ImplVulkan_InitInfo
+    bool                UseDynamicRendering;
     bool                ClearEnable;
     VkClearValue        ClearValue;
     uint32_t            FrameIndex;             // Current frame being rendered to (0 <= FrameIndex < FrameInFlightCount)


### PR DESCRIPTION
Version of #5037 for docking branch as requested by https://github.com/ocornut/imgui/pull/5037#issuecomment-1152482524. Sorry for the delay, completely forgot about my original PR.

As we now load function pointers manually, it's possible for `vkCmdBeginRenderingKHR` and `vkCmdEndRenderingKHR` to be nullptr. Is it fine to just cause a segfault in `ImGui_ImplVulkan_RenderWindow` when `UseDynamicRendering` is enabled but the extension wasn't enabled on the device and the function pointers therefore possibly be nullptr?