### PR TITLE
 Fix for High DPI and resizing in example_sdl_vulkan

### DIFF
--- a/backends/imgui_impl_vulkan.cpp
+++ b/backends/imgui_impl_vulkan.cpp
@@ -130,7 +130,7 @@ void ImGui_ImplVulkanH_DestroyFrame(VkDevice device, ImGui_ImplVulkanH_Frame* fd
 void ImGui_ImplVulkanH_DestroyFrameSemaphores(VkDevice device, ImGui_ImplVulkanH_FrameSemaphores* fsd, const VkAllocationCallbacks* allocator);
 void ImGui_ImplVulkanH_DestroyFrameRenderBuffers(VkDevice device, ImGui_ImplVulkanH_FrameRenderBuffers* buffers, const VkAllocationCallbacks* allocator);
 void ImGui_ImplVulkanH_DestroyWindowRenderBuffers(VkDevice device, ImGui_ImplVulkanH_WindowRenderBuffers* buffers, const VkAllocationCallbacks* allocator);
-void ImGui_ImplVulkanH_CreateWindowSwapChain(VkPhysicalDevice physical_device, VkDevice device, ImGui_ImplVulkanH_Window* wd, const VkAllocationCallbacks* allocator, int w, int h, uint32_t min_image_count);
+void ImGui_ImplVulkanH_CreateWindowSwapChain(VkPhysicalDevice physical_device, VkDevice device, ImGui_ImplVulkanH_Window* wd, const VkAllocationCallbacks* allocator, VkExtent2D framebufferSize, uint32_t min_image_count);
 void ImGui_ImplVulkanH_CreateWindowCommandBuffers(VkPhysicalDevice physical_device, VkDevice device, ImGui_ImplVulkanH_Window* wd, uint32_t queue_family, const VkAllocationCallbacks* allocator);
 
 // Vulkan prototypes for use with custom loaders
@@ -1268,7 +1268,7 @@ int ImGui_ImplVulkanH_GetMinImageCountFromPresentMode(VkPresentModeKHR present_m
 }
 
 // Also destroy old swap chain and in-flight frames data, if any.
-void ImGui_ImplVulkanH_CreateWindowSwapChain(VkPhysicalDevice physical_device, VkDevice device, ImGui_ImplVulkanH_Window* wd, const VkAllocationCallbacks* allocator, int w, int h, uint32_t min_image_count)
+void ImGui_ImplVulkanH_CreateWindowSwapChain(VkPhysicalDevice physical_device, VkDevice device, ImGui_ImplVulkanH_Window* wd, const VkAllocationCallbacks* allocator, VkExtent2D framebufferSize, uint32_t min_image_count)
 {
     VkResult err;
     VkSwapchainKHR old_swapchain = wd->Swapchain;
@@ -1323,8 +1323,8 @@ void ImGui_ImplVulkanH_CreateWindowSwapChain(VkPhysicalDevice physical_device, V
 
         if (cap.currentExtent.width == 0xffffffff)
         {
-            info.imageExtent.width = wd->Width = w;
-            info.imageExtent.height = wd->Height = h;
+            info.imageExtent.width = wd->Width = framebufferSize.width;
+            info.imageExtent.height = wd->Height = framebufferSize.height;
         }
         else
         {
@@ -1436,11 +1436,11 @@ void ImGui_ImplVulkanH_CreateWindowSwapChain(VkPhysicalDevice physical_device, V
 }
 
 // Create or resize window
-void ImGui_ImplVulkanH_CreateOrResizeWindow(VkInstance instance, VkPhysicalDevice physical_device, VkDevice device, ImGui_ImplVulkanH_Window* wd, uint32_t queue_family, const VkAllocationCallbacks* allocator, int width, int height, uint32_t min_image_count)
+void ImGui_ImplVulkanH_CreateOrResizeWindow(VkInstance instance, VkPhysicalDevice physical_device, VkDevice device, ImGui_ImplVulkanH_Window* wd, uint32_t queue_family, const VkAllocationCallbacks* allocator, VkExtent2D framebufferSize, uint32_t min_image_count)
 {
     IM_ASSERT(g_FunctionsLoaded && "Need to call ImGui_ImplVulkan_LoadFunctions() if IMGUI_IMPL_VULKAN_NO_PROTOTYPES or VK_NO_PROTOTYPES are set!");
     (void)instance;
-    ImGui_ImplVulkanH_CreateWindowSwapChain(physical_device, device, wd, allocator, width, height, min_image_count);
+    ImGui_ImplVulkanH_CreateWindowSwapChain(physical_device, device, wd, allocator, framebufferSize, min_image_count);
     ImGui_ImplVulkanH_CreateWindowCommandBuffers(physical_device, device, wd, queue_family, allocator);
 }
 

--- a/backends/imgui_impl_vulkan.h
+++ b/backends/imgui_impl_vulkan.h
@@ -100,7 +100,7 @@ struct ImGui_ImplVulkanH_Frame;
 struct ImGui_ImplVulkanH_Window;
 
 // Helpers
-IMGUI_IMPL_API void                 ImGui_ImplVulkanH_CreateOrResizeWindow(VkInstance instance, VkPhysicalDevice physical_device, VkDevice device, ImGui_ImplVulkanH_Window* wnd, uint32_t queue_family, const VkAllocationCallbacks* allocator, int w, int h, uint32_t min_image_count);
+IMGUI_IMPL_API void                 ImGui_ImplVulkanH_CreateOrResizeWindow(VkInstance instance, VkPhysicalDevice physical_device, VkDevice device, ImGui_ImplVulkanH_Window* wnd, uint32_t queue_family, const VkAllocationCallbacks* allocator, VkExtent2D framebufferSize, uint32_t min_image_count);
 IMGUI_IMPL_API void                 ImGui_ImplVulkanH_DestroyWindow(VkInstance instance, VkDevice device, ImGui_ImplVulkanH_Window* wnd, const VkAllocationCallbacks* allocator);
 IMGUI_IMPL_API VkSurfaceFormatKHR   ImGui_ImplVulkanH_SelectSurfaceFormat(VkPhysicalDevice physical_device, VkSurfaceKHR surface, const VkFormat* request_formats, int request_formats_count, VkColorSpaceKHR request_color_space);
 IMGUI_IMPL_API VkPresentModeKHR     ImGui_ImplVulkanH_SelectPresentMode(VkPhysicalDevice physical_device, VkSurfaceKHR surface, const VkPresentModeKHR* request_modes, int request_modes_count);

--- a/examples/example_sdl_vulkan/CMakeLists.txt
+++ b/examples/example_sdl_vulkan/CMakeLists.txt
@@ -1,0 +1,60 @@
+cmake_minimum_required(VERSION 3.16...3.21)
+
+if(${CMAKE_VERSION} VERSION_LESS 3.12)
+    cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
+endif()
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+Project(RayTracing)
+
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+    set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}" CACHE FILEPATH "Path to a compiler launcher program, e.g. ccache")
+    set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}" CACHE FILEPATH "Path to a compiler launcher program, e.g. ccache")
+endif()
+
+add_compile_options(-Wall)
+add_compile_options(-Wextra)
+add_compile_options(-Werror)
+add_compile_options(-Wpedantic)
+
+set(SDL2_DIR /usr/include/SDL2)
+set(IMGUI_DIR ../..)
+set(VULKAN_SDK_DIR /usr/include/vulkan)
+
+add_executable(rayTracing)
+
+target_sources(rayTracing PRIVATE
+    main.cpp
+    ${IMGUI_DIR}/backends/imgui_impl_sdl.cpp
+    ${IMGUI_DIR}/backends/imgui_impl_vulkan.cpp
+
+    ${IMGUI_DIR}/imgui.cpp
+    ${IMGUI_DIR}/imgui_draw.cpp
+    ${IMGUI_DIR}/imgui_demo.cpp
+    ${IMGUI_DIR}/imgui_tables.cpp
+    ${IMGUI_DIR}/imgui_widgets.cpp
+
+)
+
+
+execute_process(COMMAND pkg-config --libs sdl2 OUTPUT_VARIABLE SDL2_LIBS OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND pkg-config --libs vulkan OUTPUT_VARIABLE VULKAN_LIBS OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+target_include_directories(rayTracing
+    PRIVATE
+    ${SDL2_DIR}
+    ${VULKAN_SDK_DIR}
+    ${IMGUI_DIR}
+    ${IMGUI_DIR}/backends
+)
+
+target_link_libraries(rayTracing
+    PRIVATE
+    ${SDL2_LIBS}
+    ${VULKAN_LIBS}
+    -ldl
+)

--- a/examples/example_sdl_vulkan/CMakeLists.txt
+++ b/examples/example_sdl_vulkan/CMakeLists.txt
@@ -4,30 +4,51 @@ if(${CMAKE_VERSION} VERSION_LESS 3.12)
     cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
 endif()
 
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD 11)
 
-Project(RayTracing)
+Project(imgui_example_sdl_vulkan C CXX)
+add_executable(example_sdl_vulkan)
 
-find_program(CCACHE_PROGRAM ccache)
-if(CCACHE_PROGRAM)
-    set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}" CACHE FILEPATH "Path to a compiler launcher program, e.g. ccache")
-    set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}" CACHE FILEPATH "Path to a compiler launcher program, e.g. ccache")
+#Use ccache if available
+find_program(CCACHE_FOUND "ccache")
+set(CCACHE_SUPPORT ON CACHE BOOL "Enable ccache support")
+if (CCACHE_FOUND AND CCACHE_SUPPORT)
+  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" # GNU is GNU GCC
+      OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    # without this compiler messages in `make` backend would be uncolored
+    target_compile_options(example_sdl_vulkan PRIVATE -fdiagnostics-color=auto)
+  endif()
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "ccache")
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK "ccache")
 endif()
 
-add_compile_options(-Wall)
-add_compile_options(-Wextra)
-add_compile_options(-Werror)
-add_compile_options(-Wpedantic)
 
-set(SDL2_DIR /usr/include/SDL2)
-set(IMGUI_DIR ../..)
-set(VULKAN_SDK_DIR /usr/include/vulkan)
+# Find required dependencies
+find_package(Vulkan REQUIRED)
+find_package(SDL2 REQUIRED)
+set(FOUND_LIBRARIES "Vulkan::Vulkan;SDL2::SDL2")
 
-add_executable(rayTracing)
 
-target_sources(rayTracing PRIVATE
+# Get compile flags
+execute_process(COMMAND pkg-config --cflags-only-other sdl2 OUTPUT_VARIABLE SDL2_CFLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND pkg-config --cflags-only-other vulkan OUTPUT_VARIABLE VULKAN_CFLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
+set(FOUND_CFLAGS ${SDL2_CFLAGS} ${VULKAN_CFLAGS})
+
+
+# Set compile flags
+target_compile_definitions(example_sdl_vulkan PUBLIC -DImTextureID=ImU64 -DVK_PROTOTYPES) # Preprocessor definitions
+target_compile_options(example_sdl_vulkan PRIVATE ${FOUND_CFLAGS}) # Compile flags
+target_link_libraries(example_sdl_vulkan ${FOUND_LIBRARIES}) # Link against vulkan, sdl, etc
+
+
+set(IMGUI_DIR ../..) # Relative path to the Dear Imgui repo
+target_include_directories(example_sdl_vulkan
+    PRIVATE
+    ${IMGUI_DIR}
+    ${IMGUI_DIR}/backends
+)
+
+target_sources(example_sdl_vulkan PRIVATE
     main.cpp
     ${IMGUI_DIR}/backends/imgui_impl_sdl.cpp
     ${IMGUI_DIR}/backends/imgui_impl_vulkan.cpp
@@ -40,21 +61,3 @@ target_sources(rayTracing PRIVATE
 
 )
 
-
-execute_process(COMMAND pkg-config --libs sdl2 OUTPUT_VARIABLE SDL2_LIBS OUTPUT_STRIP_TRAILING_WHITESPACE)
-execute_process(COMMAND pkg-config --libs vulkan OUTPUT_VARIABLE VULKAN_LIBS OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-target_include_directories(rayTracing
-    PRIVATE
-    ${SDL2_DIR}
-    ${VULKAN_SDK_DIR}
-    ${IMGUI_DIR}
-    ${IMGUI_DIR}/backends
-)
-
-target_link_libraries(rayTracing
-    PRIVATE
-    ${SDL2_LIBS}
-    ${VULKAN_LIBS}
-    -ldl
-)

--- a/examples/example_sdl_vulkan/main.cpp
+++ b/examples/example_sdl_vulkan/main.cpp
@@ -374,7 +374,6 @@ int main(int, char**)
 
     SDL_Vulkan_GetDrawableSize(window, &w, &h);
     ImGui_ImplVulkanH_Window* wd = &g_MainWindowData;
-
     SetupVulkanWindow(wd, surface, w, h);
 
     // Setup Dear ImGui context

--- a/examples/example_sdl_vulkan/main.cpp
+++ b/examples/example_sdl_vulkan/main.cpp
@@ -371,8 +371,10 @@ int main(int, char**)
 
     // Create Framebuffers
     int w, h;
-    SDL_GetWindowSize(window, &w, &h);
+
+    SDL_Vulkan_GetDrawableSize(window, &w, &h);
     ImGui_ImplVulkanH_Window* wd = &g_MainWindowData;
+
     SetupVulkanWindow(wd, surface, w, h);
 
     // Setup Dear ImGui context
@@ -471,13 +473,16 @@ int main(int, char**)
                 done = true;
             if (event.type == SDL_WINDOWEVENT && event.window.event == SDL_WINDOWEVENT_CLOSE && event.window.windowID == SDL_GetWindowID(window))
                 done = true;
+            if(event.type == SDL_WINDOWEVENT || event.window.event == SDL_WINDOWEVENT_RESIZED)
+                g_SwapChainRebuild = true;
         }
 
         // Resize swap chain?
         if (g_SwapChainRebuild)
         {
             int width, height;
-            SDL_GetWindowSize(window, &width, &height);
+            SDL_Vulkan_GetDrawableSize(window, &width, &height);
+
             if (width > 0 && height > 0)
             {
                 ImGui_ImplVulkan_SetMinImageCount(g_MinImageCount);


### PR DESCRIPTION
**Overview**: Fixed resizing on Wayland at least, fixed SwapChain size when using High DPI, refactored function related to SwapChain creation, and created CMakeLists.txt.

I found there was an issue with example_sdl_vulkan on my laptop when I had the scaling set to anything greater than 100% (e.i. High DPI). I noticed that the right and bottom section of the window would stretch the Imgui window to the edge of the desktop window (Seen in the first few seconds of the video below). 
The second issue I found was that the window would never resize properly, at least on Wayland. (Also seen in the first few seconds)

https://user-images.githubusercontent.com/20785870/180585314-4066db94-2e8e-4b71-a87b-8db47ea876de.mp4

I have not added any new functionality, but I did take the time to slightly refactor the functions related to the SwapChain creation. 

I first created a helper function so that getting the needed framebuffer size is a single function call which returns a struct with 2 ints. I then replaced any instances of `int w, int h` with `VkExtent2D framebufferSize`. 

One thing to note about this fix, is that it is necessary to update the SwapChain when SDL reports a screen resize because the Vulkan driver might not report `VK_SUBOPTIMAL_KHR` or  `VK_ERROR_OUT_OF_DATE_KHR` on a resize. (For now at least)

1. https://gitlab.freedesktop.org/mesa/mesa/-/issues/5331
    > Tangentially related to this issue, but the assumption that `ERROR_OUT_OF_DATE` or `SUBOPTIMAL` is returned when the window is resized is easily broken on at least Wayland. It's thus probably a good idea in general to resize once the application receives a resize message from the windowing system (i.e. client notify on X11), right in the windowing system message handler.
2. https://vulkan-tutorial.com/Drawing_a_triangle/Swap_chain_recreation (See Handling resizes explicitly)
    > Although many drivers and platforms trigger `VK_ERROR_OUT_OF_DATE_KHR` automatically after a window resize, it is not guaranteed to happen. That's why we'll add some extra code to also handle resizes explicitly. 