### PR TITLE
Modified reserve() and push_back() functions for ImVector

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -1791,11 +1791,11 @@ struct ImVector
     inline void         resize(int new_size)                { if (new_size > Capacity) reserve(_grow_capacity(new_size)); Size = new_size; }
     inline void         resize(int new_size, const T& v)    { if (new_size > Capacity) reserve(_grow_capacity(new_size)); if (new_size > Size) for (int n = Size; n < new_size; n++) memcpy(&Data[n], &v, sizeof(v)); Size = new_size; }
     inline void         shrink(int new_size)                { IM_ASSERT(new_size <= Size); Size = new_size; } // Resize a vector to a smaller size, guaranteed not to cause a reallocation
-    inline void         reserve(int new_capacity)           { if (new_capacity <= Capacity) return; T* new_data = (T*)IM_ALLOC((size_t)new_capacity * sizeof(T)); if (Data) { memcpy(new_data, Data, (size_t)Size * sizeof(T)); IM_FREE(Data); } Data = new_data; Capacity = new_capacity; }
+    inline void         reserve(int new_capacity)           { if (new_capacity <= Capacity) return; T* new_data = (T*)IM_ALLOC((size_t)new_capacity * sizeof(T)); memset(new_data, 0, (size_t)new_capacity * sizeof(T)); if (Data) { memcpy(new_data, Data, (size_t)Size * sizeof(T)); IM_FREE(Data); } Data = new_data; Capacity = new_capacity; }
     inline void         reserve_discard(int new_capacity)   { if (new_capacity <= Capacity) return; if (Data) IM_FREE(Data); Data = (T*)IM_ALLOC((size_t)new_capacity * sizeof(T)); Capacity = new_capacity; }
 
     // NB: It is illegal to call push_back/push_front/insert with a reference pointing inside the ImVector data itself! e.g. v.push_back(v[10]) is forbidden.
-    inline void         push_back(const T& v)               { if (Size == Capacity) reserve(_grow_capacity(Size + 1)); memcpy(&Data[Size], &v, sizeof(v)); Size++; }
+    inline void         push_back(const T& v)               { if (Size == Capacity) reserve(_grow_capacity(Size + 1)); Data[Size] = v; Size++; }
     inline void         pop_back()                          { IM_ASSERT(Size > 0); Size--; }
     inline void         push_front(const T& v)              { if (Size == 0) push_back(v); else insert(Data, v); }
     inline T*           erase(const T* it)                  { IM_ASSERT(it >= Data && it < Data + Size); const ptrdiff_t off = it - Data; memmove(Data + off, Data + off + 1, ((size_t)Size - (size_t)off - 1) * sizeof(T)); Size--; return Data + off; }


### PR DESCRIPTION
Operator `=` should probably be used in `push_back()` function instead of `memcpy`, because if object `v` is a local variable and it contains any pointer member, when it goes out of scope its destructor will automatically be called, then the memory blocks pointed by that pointer member will very likely be freed, resulting in that pointer in `Data[Size]` object pointing to an invalid memory address. Take the following code for an example:
```cpp
ImVector<ImVector<int>> func()
{
    ImVector<ImVector<int>> mat;
    ImVector<int> row;
    row.push_back(1);
    row.push_back(2);
    row.push_back(3);
    mat.push_back(row);

    return mat;
}

void func2()
{
    ImVector<ImVector<int>> mat = func();
    printf("%d\n", mat[0][0]);  //wrong result
}
```
When `func()` returns, destructor for local variable row is called, the memory blocks pointed by `row.Data` are freed. So given that `mat[0].Data` and `row.Data` has the same value, the memory address pointed by `mat[0].Data` becomes invalid. So perhaps operator `=` should be used instead of simply memcpy data from `v` object to `Data[Size]`, so that data pointed by the pointers can be manually copied by overloading operator `=`.