### PR TITLE
Fix windows framebuffer scaling for glfw

### DIFF
--- a/backends/imgui_impl_glfw.cpp
+++ b/backends/imgui_impl_glfw.cpp
@@ -358,6 +358,10 @@ void ImGui_ImplGlfw_CursorPosCallback(GLFWwindow* window, double x, double y)
         bd->PrevUserCallbackCursorPos(window, x, y);
 
     ImGuiIO& io = ImGui::GetIO();
+    int w, h;
+    glfwGetWindowSize(bd->Window, &w, &h);
+    x *= io.DisplaySize.x / w;
+    y *= io.DisplaySize.y / h;
     io.AddMousePosEvent((float)x, (float)y);
     bd->LastValidMousePos = ImVec2((float)x, (float)y);
 }
@@ -549,6 +553,10 @@ static void ImGui_ImplGlfw_UpdateMouseData()
         {
             double mouse_x, mouse_y;
             glfwGetCursorPos(bd->Window, &mouse_x, &mouse_y);
+            int w, h;
+            glfwGetWindowSize(bd->Window, &w, &h);
+            mouse_x *= io.DisplaySize.x / w;
+            mouse_y *= io.DisplaySize.y / h;
             io.AddMousePosEvent((float)mouse_x, (float)mouse_y);
             bd->LastValidMousePos = ImVec2((float)mouse_x, (float)mouse_y);
         }
@@ -637,13 +645,12 @@ void ImGui_ImplGlfw_NewFrame()
     IM_ASSERT(bd != NULL && "Did you call ImGui_ImplGlfw_InitForXXX()?");
 
     // Setup display size (every frame to accommodate for window resizing)
-    int w, h;
     int display_w, display_h;
-    glfwGetWindowSize(bd->Window, &w, &h);
+    float scalex, scaley;
+    glfwGetWindowContentScale(bd->Window, &scalex, &scaley);
     glfwGetFramebufferSize(bd->Window, &display_w, &display_h);
-    io.DisplaySize = ImVec2((float)w, (float)h);
-    if (w > 0 && h > 0)
-        io.DisplayFramebufferScale = ImVec2((float)display_w / (float)w, (float)display_h / (float)h);
+    io.DisplaySize = ImVec2(display_w/scalex, display_h/scaley);
+    io.DisplayFramebufferScale = ImVec2(scalex, scaley);
 
     // Setup time step
     double current_time = glfwGetTime();

--- a/examples/example_glfw_metal/main.mm
+++ b/examples/example_glfw_metal/main.mm
@@ -55,6 +55,7 @@ int main(int, char**)
         return 1;
 
     // Create window with graphics context
+    glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_TRUE);
     glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
     GLFWwindow* window = glfwCreateWindow(1280, 720, "Dear ImGui GLFW+Metal example", NULL, NULL);
     if (window == NULL)

--- a/examples/example_glfw_opengl2/main.cpp
+++ b/examples/example_glfw_opengl2/main.cpp
@@ -34,6 +34,7 @@ int main(int, char**)
     glfwSetErrorCallback(glfw_error_callback);
     if (!glfwInit())
         return 1;
+    glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_TRUE);
     GLFWwindow* window = glfwCreateWindow(1280, 720, "Dear ImGui GLFW+OpenGL2 example", NULL, NULL);
     if (window == NULL)
         return 1;

--- a/examples/example_glfw_opengl3/main.cpp
+++ b/examples/example_glfw_opengl3/main.cpp
@@ -55,6 +55,7 @@ int main(int, char**)
 #endif
 
     // Create window with graphics context
+    glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_TRUE);
     GLFWwindow* window = glfwCreateWindow(1280, 720, "Dear ImGui GLFW+OpenGL3 example", NULL, NULL);
     if (window == NULL)
         return 1;

--- a/examples/example_glfw_vulkan/main.cpp
+++ b/examples/example_glfw_vulkan/main.cpp
@@ -359,6 +359,7 @@ int main(int, char**)
     if (!glfwInit())
         return 1;
 
+    glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_TRUE);
     glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
     GLFWwindow* window = glfwCreateWindow(1280, 720, "Dear ImGui GLFW+Vulkan example", NULL, NULL);
 


### PR DESCRIPTION
The current framebuffer scaling for GLFW backend is obtained by dividing
the framebuffer size by window size, but this is unreliable and only
works on macOS.

On Windows, it is possible to let GLFW scale the framebuffer according
to monitor DPI (similar to macOS behavior) using the hint

```c
glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_TRUE);
```

but unlike macOS, the window size and framebuffer size is always the
same on Windows. The automatic scaling scales both the framebuffer and
window size. The actual framebuffer scaling should be obtained from
`glfwGetWindowContentScale`. Try the following:

```c
int w, h;
glfwGetWindowSize(win, &w, &h);
ImGui::Text("window size: %d %d", w, h);
glfwGetFramebufferSize(win, &w, &h);
ImGui::Text("framebuffer size: %d %d", w, h);
float x, y;
glfwGetWindowContentScale(win, &x, &y);
ImGui::Text("glfw scale: %f %f", x, y);
```

You should see both the window size and framebuffer size changes after
moving the window to a different DPI screen.

Therefore, the actual `DisplaySize` for ImGui should be computed by
framebuffer size divided by the content scale. Because GLFW mouse
position is based on window size, there is some additional mouse
position scaling that needs to be done.
