### PR TITLE
Fix undefined behaviour

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -1765,7 +1765,7 @@ struct ImVector
     // Constructors, destructor
     inline ImVector()                                       { Size = Capacity = 0; Data = NULL; }
     inline ImVector(const ImVector<T>& src)                 { Size = Capacity = 0; Data = NULL; operator=(src); }
-    inline ImVector<T>& operator=(const ImVector<T>& src)   { clear(); resize(src.Size); memcpy(Data, src.Data, (size_t)Size * sizeof(T)); return *this; }
+    inline ImVector<T>& operator=(const ImVector<T>& src)   { clear(); resize(src.Size); if (Data && src.Data) memcpy(Data, src.Data, (size_t)Size * sizeof(T)); return *this; }
     inline ~ImVector()                                      { if (Data) IM_FREE(Data); } // Important: does not destruct anything
 
     inline void         clear()                             { if (Data) { Size = Capacity = 0; IM_FREE(Data); Data = NULL; } }  // Important: does not destruct anything


### PR DESCRIPTION
If an ImVector is being initialised by another ImVector that does not have any allocated memory yet, it causes `memcpy` to be called with `null, null, 0`. According to the C specification this is undefined behaviour and triggers undefined behaviour sanitisers.

> Where an argument declared as size_t n specifies the length of the array for a function, n can have the value zero on a call to that function. **Unless explicitly stated otherwise in the description of a particular function in this subclause, pointer arguments on such a call shall still have valid values, as described in 7.1.4**. On such a call, a function that locates a character finds no occurrence, a function that compares two character sequences returns zero, and a function that copies characters copies zero characters.

The reference indicated here points to this:

> If an argument to a function has an invalid value (such as a value outside the domain of the function, or a pointer outside the address space of the program, **or a null pointer**, or a pointer to non-modifiable storage when the corresponding parameter is not const-qualified) or a type (after promotion) not expected by a function with variable number of arguments, the behavior is undefined.