### PR TITLE
Fix GLFW_CURSOR_DISABLED being ignored when updating cursor position

### DIFF
--- a/backends/imgui_impl_glfw.cpp
+++ b/backends/imgui_impl_glfw.cpp
@@ -357,6 +357,12 @@ void ImGui_ImplGlfw_CursorPosCallback(GLFWwindow* window, double x, double y)
     if (bd->PrevUserCallbackCursorPos != NULL && window == bd->Window)
         bd->PrevUserCallbackCursorPos(window, x, y);
 
+    if (glfwGetInputMode(window, GLFW_CURSOR) == GLFW_CURSOR_DISABLED)
+    {
+        // Cursor position shouldn't move, though glfw's callback ignores this.
+        return;
+    }
+
     ImGuiIO& io = ImGui::GetIO();
     io.AddMousePosEvent((float)x, (float)y);
     bd->LastValidMousePos = ImVec2((float)x, (float)y);

--- a/backends/imgui_impl_glfw.cpp
+++ b/backends/imgui_impl_glfw.cpp
@@ -353,13 +353,13 @@ void ImGui_ImplGlfw_WindowFocusCallback(GLFWwindow* window, int focused)
 
 void ImGui_ImplGlfw_CursorPosCallback(GLFWwindow* window, double x, double y)
 {
-    ImGuiIO& io = ImGui::GetIO();
     ImGui_ImplGlfw_Data* bd = ImGui_ImplGlfw_GetBackendData();
     if (bd->PrevUserCallbackCursorPos != NULL && window == bd->Window)
         bd->PrevUserCallbackCursorPos(window, x, y);
 
     if (glfwGetInputMode(window, GLFW_CURSOR) != GLFW_CURSOR_DISABLED)
     {
+        ImGuiIO& io = ImGui::GetIO();
         io.AddMousePosEvent((float)x, (float)y);
         bd->LastValidMousePos = ImVec2((float)x, (float)y);
     }


### PR DESCRIPTION
The GLFW backend currently ignores that the cursor is disabled (GLFW_CURSOR_DISABLED is set by glfwSetInputMode).
This leads to an invisible cursor, that still highlights new ImGui elements when moving the mouse around, even though the cursor should remain static and only highlight the element it was last over before being disabled. This PR adds an check for the flag and returns out of function before ImGuiIO's position is updated. 

The current behavior stems from the fact, that GLFW still provides updated cursor position when GLFW_CURSOR_DISABLED is set. I don't know if this is intended though (The [documentation](https://www.glfw.org/docs/3.3/input_guide.html#cursor_mode) is a bit unclear about that, I think). 

