### PR TITLE
CompareWithCurrentState uses IM_ASSERT_USER_ERROR

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -8468,18 +8468,18 @@ void ImGuiStackSizes::CompareWithCurrentState()
 
     // Window stacks
     // NOT checking: DC.ItemWidth, DC.TextWrapPos (per window) to allow user to conveniently push once and not pop (they are cleared on Begin)
-    IM_ASSERT(SizeOfIDStack         == window->IDStack.Size     && "PushID/PopID or TreeNode/TreePop Mismatch!");
+    IM_ASSERT_USER_ERROR(SizeOfIDStack         == window->IDStack.Size     , "PushID/PopID or TreeNode/TreePop Mismatch!");
 
     // Global stacks
     // For color, style and font stacks there is an incentive to use Push/Begin/Pop/.../End patterns, so we relax our checks a little to allow them.
-    IM_ASSERT(SizeOfGroupStack      == g.GroupStack.Size        && "BeginGroup/EndGroup Mismatch!");
-    IM_ASSERT(SizeOfBeginPopupStack == g.BeginPopupStack.Size   && "BeginPopup/EndPopup or BeginMenu/EndMenu Mismatch!");
-    IM_ASSERT(SizeOfDisabledStack   == g.DisabledStackSize      && "BeginDisabled/EndDisabled Mismatch!");
-    IM_ASSERT(SizeOfItemFlagsStack  >= g.ItemFlagsStack.Size    && "PushItemFlag/PopItemFlag Mismatch!");
-    IM_ASSERT(SizeOfColorStack      >= g.ColorStack.Size        && "PushStyleColor/PopStyleColor Mismatch!");
-    IM_ASSERT(SizeOfStyleVarStack   >= g.StyleVarStack.Size     && "PushStyleVar/PopStyleVar Mismatch!");
-    IM_ASSERT(SizeOfFontStack       >= g.FontStack.Size         && "PushFont/PopFont Mismatch!");
-    IM_ASSERT(SizeOfFocusScopeStack == g.FocusScopeStack.Size   && "PushFocusScope/PopFocusScope Mismatch!");
+    IM_ASSERT_USER_ERROR(SizeOfGroupStack      == g.GroupStack.Size        , "BeginGroup/EndGroup Mismatch!");
+    IM_ASSERT_USER_ERROR(SizeOfBeginPopupStack == g.BeginPopupStack.Size   , "BeginPopup/EndPopup or BeginMenu/EndMenu Mismatch!");
+    IM_ASSERT_USER_ERROR(SizeOfDisabledStack   == g.DisabledStackSize      , "BeginDisabled/EndDisabled Mismatch!");
+    IM_ASSERT_USER_ERROR(SizeOfItemFlagsStack  >= g.ItemFlagsStack.Size    , "PushItemFlag/PopItemFlag Mismatch!");
+    IM_ASSERT_USER_ERROR(SizeOfColorStack      >= g.ColorStack.Size        , "PushStyleColor/PopStyleColor Mismatch!");
+    IM_ASSERT_USER_ERROR(SizeOfStyleVarStack   >= g.StyleVarStack.Size     , "PushStyleVar/PopStyleVar Mismatch!");
+    IM_ASSERT_USER_ERROR(SizeOfFontStack       >= g.FontStack.Size         , "PushFont/PopFont Mismatch!");
+    IM_ASSERT_USER_ERROR(SizeOfFocusScopeStack == g.FocusScopeStack.Size   , "PushFocusScope/PopFocusScope Mismatch!");
 }
 
 


### PR DESCRIPTION
I believe the current code is too harsh, and will fail on recoverable errors. This uses `IM_ASSERT_USER_ERROR` instead of `IM_ASSERT` in order to allow the UI in dev mode to yield errors. Also useful when doing scripting like Lua. Tried locally, and most of those errors seem recoverable properly anyway.
