### PR TITLE
MixedValue item flag for DragScalars

### DIFF
--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -2360,8 +2360,10 @@ bool ImGui::DragScalar(const char* label, ImGuiDataType data_type, void* p_data,
     if (!ItemAdd(total_bb, id, &frame_bb, temp_input_allowed ? ImGuiItemFlags_Inputable : 0))
         return false;
 
-    // Default format string when passing NULL
-    if (format == NULL)
+    bool mixed_value = (g.LastItemData.InFlags & ImGuiItemFlags_MixedValue) != 0;
+    if (mixed_value) // Dash when value is mixed
+        format = "-";
+    else if (format == NULL) // Default format string when passing NULL
         format = DataTypeGetInfo(data_type)->PrintFmt;
     else if (data_type == ImGuiDataType_S32 && strcmp(format, "%d") != 0) // (FIXME-LEGACY: Patch old "%.0f" format string to use "%d", read function more details.)
         format = PatchFormatStringFloatToInt(format);
@@ -3378,8 +3380,10 @@ bool ImGui::TempInputScalar(const ImRect& bb, ImGuiID id, const char* label, ImG
             DataTypeClamp(data_type, p_data, p_clamp_min, p_clamp_max);
         }
 
-        // Only mark as edited if new value is different
-        value_changed = memcmp(&data_backup, p_data, data_type_size) != 0;
+        // Mark as edited if value is mixed or new value is different
+        ImGuiContext& g = *GImGui;
+        bool mixed_value = (g.LastItemData.InFlags & ImGuiItemFlags_MixedValue) != 0;
+        value_changed = mixed_value || memcmp(&data_backup, p_data, data_type_size) != 0;
         if (value_changed)
             MarkItemEdited(id);
     }


### PR DESCRIPTION
This PR implements the WIP item flag `ImGuiItemFlags_MixedValue` for drag scalars. When this flag is set, drag scalars will show a "-" to indicate a mixed value, and report a change even when typing the original value into the box.

![MixedDragScalars](https://user-images.githubusercontent.com/7654399/189715050-651594ad-f59e-40d7-a454-c8d10c490893.gif)

Use this flag to indicate the drag scalar currently represents multiple values. The following code sample shows how to use it:
```cpp
#include "imgui.h"
#include "imgui_internal.h"

// ...

void OnGui()
{
    static bool isMixed = true;
    static float fVal   = 0.0f;

    if (isMixed)
    {
        ImGui::PushItemFlag(ImGuiItemFlags_MixedValue, true);

        if (ImGui::DragFloat("Example", &fVal))
        {
            isMixed = false;
        }

        ImGui::PopItemFlag();
    }
    else
    {
        ImGui::DragFloat("Example", &fVal);
    }
}
```

This works for anything based on `DragScalar()` (`DragFloat()`, `DragInt4()`, etc.).