### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,9 @@ on:
     types:
       - requested
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   Windows:
     runs-on: windows-2019

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -8,6 +8,7 @@ on:
   schedule:
     - cron:  '0 9 * * *'
 
+permissions: {}
 jobs:
   scheduled:
     runs-on: ubuntu-latest

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -8,6 +8,9 @@ on:
     types:
       - requested
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   PVS-Studio:
     runs-on: ubuntu-20.04
@@ -46,6 +49,10 @@ jobs:
           plog-converter -a 'GA:1,2;OP:1' -d V1071 -t errorfile -w pvs-studio.log
 
   Discord-CI:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+      actions: read # to get actions runs
+
     runs-on: ubuntu-20.04
     needs: [PVS-Studio]
     if: always()


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.