### PR TITLE
Add checking whether macro variable IMGUI_IMPL_OPENGL_ES2_ON_DESKTOP …

### DIFF
--- a/backends/imgui_impl_opengl3.cpp
+++ b/backends/imgui_impl_opengl3.cpp
@@ -154,7 +154,7 @@
 #endif
 
 // Desktop GL 2.0+ has glPolygonMode() which GL ES and WebGL don't have.
-#ifdef GL_POLYGON_MODE
+#if defined( GL_POLYGON_MODE ) && !defined( IMGUI_IMPL_OPENGL_ES2_ON_DESKTOP )
 #define IMGUI_IMPL_HAS_POLYGON_MODE
 #endif
 
@@ -284,7 +284,7 @@ bool    ImGui_ImplOpenGL3_Init(const char* glsl_version)
     // Note: GLSL version is NOT the same as GL version. Leave this to NULL if unsure.
     if (glsl_version == NULL)
     {
-#if defined(IMGUI_IMPL_OPENGL_ES2)
+#if defined( IMGUI_IMPL_OPENGL_ES2 ) || defined( IMGUI_IMPL_OPENGL_ES2_ON_DESKTOP )
         glsl_version = "#version 100";
 #elif defined(IMGUI_IMPL_OPENGL_ES3)
         glsl_version = "#version 300 es";


### PR DESCRIPTION
Use case: have an opengles2 renderer initialized under the windows platform with IMGUI used with OpenGL3 compatibility.
When I use opengles2 renderer on the windows platform, glDebugMessageCallbackARB gives me an error: BAD_ENUM.

It does not find `GL_POLYGON_MODE`.
Also, the shader header (version) is wrong, since opengles2 is only used when specific other requirements are met.

With this changes, user can run opengles2 renderer on windows with opengl 3 compatibility mode set on imgui, for example, with cmake, one can write: 
`add_compile_definitions( IMGUI_IMPL_OPENGL_ES2_ON_DESKTOP=1 )`

