### PR TITLE
Support Platforms Sans-Alloca with Custom Backend Virtual Keyboard

### DIFF
--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -753,7 +753,12 @@ void ImDrawList::AddPolyline(const ImVec2* points, const int points_count, ImU32
 
         // Temporary buffer
         // The first <points_count> items are normals at each line point, then after that there are either 2 or 4 temp points for each line point
+#ifdef __WIIU__
+        // avoid using alloca on the Wii U
+        ImVec2 temp_normals[points_count * ((use_texture || !thick_line) ? 3 : 5) * sizeof(ImVec2)]; //-V630
+#else
         ImVec2* temp_normals = (ImVec2*)alloca(points_count * ((use_texture || !thick_line) ? 3 : 5) * sizeof(ImVec2)); //-V630
+#endif
         ImVec2* temp_points = temp_normals + points_count;
 
         // Calculate normals (tangents) for each line segment
@@ -1001,7 +1006,12 @@ void ImDrawList::AddConvexPolyFilled(const ImVec2* points, const int points_coun
         }
 
         // Compute normals
+#ifdef __WIIU__
+        // Avoid using alloca on the Wii U
+        ImVec2 temp_normals[points_count * sizeof(ImVec2)]; //-V630
+#else
         ImVec2* temp_normals = (ImVec2*)alloca(points_count * sizeof(ImVec2)); //-V630
+#endif
         for (int i0 = points_count - 1, i1 = 0; i1 < points_count; i0 = i1++)
         {
             const ImVec2& p0 = points[i0];

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -4591,8 +4591,10 @@ bool ImGui::InputTextEx(const char* label, const char* hint, char* buf, int buf_
             }
         }
 
+#ifndef __WIIU__
         // Clear temporary user storage
         state->Flags = ImGuiInputTextFlags_None;
+#endif
     }
 
     // Copy result to user buffer. This can currently only happen when (g.ActiveId == id)


### PR DESCRIPTION
This PR brings forward the few changes we have to use on our game that also supports the Wii U (through a custom GX2 backend).

I've made the initial commit specifically about the Wii U to open conversation about whether these changes can in fact be upstreamed and also if there's a better solution. The final result can likely generalize the checks to something that's non Wii U specific.

**Context on changes:**
We opt out of usages of `alloca` for that platform because that's not available in the build system for Wii U -- and we have one check to avoid clearing state flags. As we use our own backend to support the system, we use the state flags to open the keyboard where necessary but for some reason they're getting cleared here (is this an ImGui bug?).