### PR TITLE
imgui_freetype: Assert if glyph bitmap size exceed chunk size to avoid buffer overflow

### DIFF
--- a/misc/freetype/imgui_freetype.cpp
+++ b/misc/freetype/imgui_freetype.cpp
@@ -556,6 +556,7 @@ bool ImFontAtlasBuildWithFreeTypeEx(FT_Library ft_library, ImFontAtlas* atlas, u
                 buf_bitmap_current_used_bytes = 0;
                 buf_bitmap_buffers.push_back((unsigned char*)IM_ALLOC(BITMAP_BUFFERS_CHUNK_SIZE));
             }
+            IM_ASSERT(buf_bitmap_current_used_bytes + bitmap_size_in_bytes <= BITMAP_BUFFERS_CHUNK_SIZE);
 
             // Blit rasterized pixels to our temporary buffer and keep a pointer to it.
             src_glyph.BitmapData = (unsigned int*)(buf_bitmap_buffers.back() + buf_bitmap_current_used_bytes);


### PR DESCRIPTION
`FreeTypeFont::BlitGlyph` may write past the destination buffer if the glyph cannot fit in `BITMAP_BUFFERS_CHUNK_SIZE` bytes (weird font or just by requesting a huge size).

```cpp
#define IMGUI_ENABLE_FREETYPE
// ...
io.Fonts->AddFontFromFileTTF("/usr/share/fonts/TTF/DejaVuSans.ttf", 1<<16);
```

This PR makes it assert instead of corrupting memory.