### PR TITLE
Add glyph ranges for currencies and mathematical symbols

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -2789,6 +2789,8 @@ struct ImFontAtlas
     IMGUI_API const ImWchar*    GetGlyphRangesCyrillic();               // Default + about 400 Cyrillic characters
     IMGUI_API const ImWchar*    GetGlyphRangesThai();                   // Default + Thai characters
     IMGUI_API const ImWchar*    GetGlyphRangesVietnamese();             // Default + Vietnamese characters
+    IMGUI_API const ImWchar*    GetGlyphRangesCurrencies();             // Default + 32 currency characters
+    IMGUI_API const ImWchar*    GetGlyphRangesMath();                   // Default + about 500 mathematical operator and notational symbols
 
     //-------------------------------------------
     // [BETA] Custom Rectangles/Glyphs API

--- a/imgui.h
+++ b/imgui.h
@@ -2789,7 +2789,7 @@ struct ImFontAtlas
     IMGUI_API const ImWchar*    GetGlyphRangesCyrillic();               // Default + about 400 Cyrillic characters
     IMGUI_API const ImWchar*    GetGlyphRangesThai();                   // Default + Thai characters
     IMGUI_API const ImWchar*    GetGlyphRangesVietnamese();             // Default + Vietnamese characters
-    IMGUI_API const ImWchar*    GetGlyphRangesCurrencies();             // Default + 32 currency characters
+    IMGUI_API const ImWchar*    GetGlyphRangesCurrencies();             // Default + 33 currency characters
     IMGUI_API const ImWchar*    GetGlyphRangesMath();                   // Default + about 500 mathematical operator and notational symbols
 
     //-------------------------------------------

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -3061,6 +3061,30 @@ const ImWchar*  ImFontAtlas::GetGlyphRangesVietnamese()
     return &ranges[0];
 }
 
+const ImWchar* ImFontAtlas::GetGlyphRangesCurrencies()
+{
+    static const ImWchar ranges[] =
+    {
+        0x0020, 0x00FF, // Basic Latin
+        0x20A0, 0x20C0, // Currency Symbols
+        0
+    };
+    return &ranges[0];
+}
+
+const ImWchar* ImFontAtlas::GetGlyphRangesMath()
+{
+    static const ImWchar ranges[] =
+    {
+        0x0020, 0x00FF, // Basic Latin
+        0x2070, 0x208e, // Superscripts and Subscripts
+        0x2200, 0x2300, // Mathematical Operators
+        0x2A00, 0x2AFF, // Supplemental Mathematical Operators
+        0
+    };
+    return &ranges[0];
+}
+
 //-----------------------------------------------------------------------------
 // [SECTION] ImFontGlyphRangesBuilder
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds separate built-in glyph ranges for 33 currencies and 544 mathematical symbols. Specifically, the math range includes subscript, superscript, operator, and notational symbols.
