### PR TITLE
Fixed memory leak of font data

### DIFF
--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -2081,6 +2081,7 @@ ImFont* ImFontAtlas::AddFont(const ImFontConfig* font_cfg)
         new_font_cfg.FontData = IM_ALLOC(new_font_cfg.FontDataSize);
         new_font_cfg.FontDataOwnedByAtlas = true;
         memcpy(new_font_cfg.FontData, font_cfg->FontData, (size_t)new_font_cfg.FontDataSize);
+        IM_FREE(font_cfg->FontData);
     }
 
     if (new_font_cfg.DstFont->EllipsisChar == (ImWchar)-1)


### PR DESCRIPTION
There is a memory leak where font data is handled.
I found it by using ``` _CrtDumpMemoryLeaks() ``` , which is available in Visual Studio.
After applying this change, no memory leak detected.

The memory leak detector reported like this:

```
Detected memory leaks!
Dumping objects ->
{491} normal block at 0x00000254A12E2070, 9527428 bytes long.
 Data: <ttcf           (> 74 74 63 66 00 02 00 00 00 00 00 04 00 00 00 28 
Object dump complete
```