### PR TITLE
Update outdated Pseudo-code in FONTS.md

### DIFF
--- a/docs/FONTS.md
+++ b/docs/FONTS.md
@@ -277,8 +277,8 @@ io.Fonts->GetTexDataAsRGBA32(&tex_pixels, &tex_width, &tex_height);
 
 for (int rect_n = 0; rect_n < IM_ARRAYSIZE(rect_ids); rect_n++)
 {
-    int rect_id = rects_ids[rect_n];
-    if (const ImFontAtlas::CustomRect* rect = io.Fonts->GetCustomRectByIndex(rect_id))
+    int rect_id = rect_ids[rect_n];
+    if (const ImFontAtlasCustomRect* rect = io.Fonts->GetCustomRectByIndex(rect_id))
     {
         // Fill the custom rectangle with red pixels (in reality you would draw/copy your bitmap data here!)
         for (int y = 0; y < rect->Height; y++)


### PR DESCRIPTION
`ImFontAtlas::CustomRect` was renamed to `ImFontAtlasCustomRect` on 2022/01/01 (1.87).
`rects_ids[rect_n]` seems to be a mistake, fixed as `rect_ids[rect_n]`
```diff --git a/docs/FONTS.md b/docs/FONTS.md

 for (int rect_n = 0; rect_n < IM_ARRAYSIZE(rect_ids); rect_n++)
 {
-    int rect_id = rects_ids[rect_n];
-    if (const ImFontAtlas::CustomRect* rect = io.Fonts->GetCustomRectByIndex(rect_id))
+    int rect_id = rect_ids[rect_n];
+    if (const ImFontAtlasCustomRect* rect = io.Fonts->GetCustomRectByIndex(rect_id))
     {
         // Fill the custom rectangle with red pixels (in reality you would draw/copy your bitmap data here!)
         for (int y = 0; y < rect->Height; y++)
```