### PR TITLE
Configurable Linear or Nearest filtering in webgpu backend.

### DIFF
--- a/backends/imgui_impl_wgpu.cpp
+++ b/backends/imgui_impl_wgpu.cpp
@@ -505,11 +505,18 @@ static void ImGui_ImplWGPU_CreateFontsTexture()
 
     // Create the associated sampler
     // (Bilinear sampling is required by default. Set 'io.Fonts->Flags |= ImFontAtlasFlags_NoBakedLines' or 'style.AntiAliasedLinesUseTex = false' to allow point/nearest sampling)
+
     {
         WGPUSamplerDescriptor sampler_desc = {};
-        sampler_desc.minFilter = WGPUFilterMode_Linear;
-        sampler_desc.magFilter = WGPUFilterMode_Linear;
-        sampler_desc.mipmapFilter = WGPUFilterMode_Linear;
+        WGPUFilterMode filter_mode;
+        if ((io.Fonts->Flags & ImFontAtlasFlags_NoBakedLines) || !(ImGui::GetStyle().AntiAliasedLinesUseTex))
+            filter_mode = WGPUFilterMode_Nearest;
+        else
+            filter_mode = WGPUFilterMode_Linear;
+            
+        sampler_desc.minFilter = filter_mode;
+        sampler_desc.magFilter = filter_mode;
+        sampler_desc.mipmapFilter = filter_mode;
         sampler_desc.addressModeU = WGPUAddressMode_Repeat;
         sampler_desc.addressModeV = WGPUAddressMode_Repeat;
         sampler_desc.addressModeW = WGPUAddressMode_Repeat;


### PR DESCRIPTION
Changed hardcoded linear filtering, to being configurable by `ImFontAtlasFlags_NoBakedLines` or `style.AntiAliasedLinesUseTex.` When enabling the flags above, the textures still had linear filtering, but this new change allows the user to change the texture filtering for ImGui textures. for webgpu backends. 

NOTE: It also changes the image supplied to `ImGui::Image` to use the filtering specified.

When `io.Fonts->Flags |= ImFontAtlasFlags_NoBakedLines` or `ImGui::GetStyle().AntiAliasedLinesUseTex = false`:
![image](https://user-images.githubusercontent.com/65868911/195179384-2d3262ed-3cea-4f0a-b54b-2b85b31eb110.png)

When `ImFontAtlasFlags_NoBakedLines` not set or `ImGui::GetStyle().AntiAliasedLinesUseTex = true`:
![image](https://user-images.githubusercontent.com/65868911/195179581-682c7cd5-202f-46af-bc13-fb34bd438c4b.png)
