### PR TITLE
korean packing rect size multiply 2

### DIFF
--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -2630,7 +2630,11 @@ void ImFontAtlasBuildPackCustomRects(ImFontAtlas* atlas, void* stbrp_context_opa
         {
             user_rects[i].X = (unsigned short)pack_rects[i].x;
             user_rects[i].Y = (unsigned short)pack_rects[i].y;
+#ifdef IMGUI_FREETYPE_KOREAN
+            IM_ASSERT(pack_rects[i].w == user_rects[i].Width * 2 && pack_rects[i].h == user_rects[i].Height);
+#else
             IM_ASSERT(pack_rects[i].w == user_rects[i].Width && pack_rects[i].h == user_rects[i].Height);
+#endif // IMGUI_FREETYPE_KOREAN
             atlas->TexHeight = ImMax(atlas->TexHeight, pack_rects[i].y + pack_rects[i].h);
         }
 }

--- a/imstb_rectpack.h
+++ b/imstb_rectpack.h
@@ -550,6 +550,9 @@ STBRP_DEF int stbrp_pack_rects(stbrp_context *context, stbrp_rect *rects, int nu
    // we use the 'was_packed' field internally to allow sorting/unsorting
    for (i=0; i < num_rects; ++i) {
       rects[i].was_packed = i;
+#ifdef IMGUI_FREETYPE_KOREAN
+      rects[i].w *= 2;
+#endif
    }
 
    // sort according to heuristic


### PR DESCRIPTION
Some koreans seems to be a little bigger.  
So if we use freetype, it is necessary to increase the width of the correct when packing.

Changes:

-    When you start freetype packing, rects[i].w *= 2 

[NanumSquareB_ttf.zip](https://github.com/ocornut/imgui/files/9806907/NanumSquareB_ttf.zip)
