### PR TITLE
Add diagonal arrows for ArrowButton

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -1328,11 +1328,15 @@ enum ImGuiDataType_
 // A cardinal direction
 enum ImGuiDir_
 {
-    ImGuiDir_None    = -1,
-    ImGuiDir_Left    = 0,
-    ImGuiDir_Right   = 1,
-    ImGuiDir_Up      = 2,
-    ImGuiDir_Down    = 3,
+    ImGuiDir_None        = -1,
+    ImGuiDir_Left        = 0,
+    ImGuiDir_Right       = 1,
+    ImGuiDir_Up          = 2,
+    ImGuiDir_Down        = 3,
+    ImGuiDir_UpLeft      = 4,
+    ImGuiDir_UpRight     = 5,
+    ImGuiDir_DownLeft    = 6,
+    ImGuiDir_DownRight   = 7,
     ImGuiDir_COUNT
 };
 

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -3773,6 +3773,18 @@ void ImGui::RenderArrow(ImDrawList* draw_list, ImVec2 pos, ImU32 col, ImGuiDir d
         b = ImVec2(-0.750f, +0.866f) * r;
         c = ImVec2(-0.750f, -0.866f) * r;
         break;
+    case ImGuiDir_UpLeft:
+    case ImGuiDir_UpRight:    
+        a = ImVec2(-0.866f, -0.866f) * r;
+        b = ImVec2(+0.866f, -0.866f) * r;        
+        c = (dir == ImGuiDir_UpLeft) ? c = ImVec2(-0.866f, +0.866f) * r : c = ImVec2(+0.866f, +0.866f) * r;
+        break;
+    case ImGuiDir_DownLeft:
+    case ImGuiDir_DownRight:
+        a = ImVec2(+0.866f, +0.866f) * r;
+        b = ImVec2(-0.866f, +0.866f) * r;
+        c = (dir == ImGuiDir_DownLeft) ? c = ImVec2(-0.866f, -0.866f) * r : c = ImVec2(+0.866f, -0.866f) * r;        
+        break;        
     case ImGuiDir_None:
     case ImGuiDir_COUNT:
         IM_ASSERT(0);


### PR DESCRIPTION
This PR adds diagonal arrows for ImGui::ArrowButton. It is suitable for various controls with a combination of already existing arrows. Just small change.

![imgui_diagonal_arrows](https://user-images.githubusercontent.com/79196366/197360644-ff0e2d02-d8a0-417d-8061-73dd80eafb7b.png)

```
ImGui::BeginChild("ArrowButtons", {70, 70});
ImGui::Columns(3, nullptr, false);
ImGui::PushButtonRepeat(true);
for (int i = 0; i < 9; i++)
{
    switch (i)
    {
    case 0:
        if (ImGui::ArrowButton("##UpLeft", ImGuiDir_UpLeft)){}
        break;
    case 1:
        if (ImGui::ArrowButton("##Up", ImGuiDir_Up)){}
        break;
    case 2:
        if (ImGui::ArrowButton("##UpRight", ImGuiDir_UpRight)){}
        break;
    case 3:
        if (ImGui::ArrowButton("##Left", ImGuiDir_Left)){}
        break;
    case 4:
        if (ImGui::Button("C")){}
        break;
    case 5:
        if (ImGui::ArrowButton("##Right", ImGuiDir_Right)){}
        break;
    case 6:
        if (ImGui::ArrowButton("##DownLeft", ImGuiDir_DownLeft)){}
        break;
    case 7:
        if (ImGui::ArrowButton("##Down", ImGuiDir_Down)){}
        break;
    case 8:
        if (ImGui::ArrowButton("##DownRight", ImGuiDir_DownRight)){}
        break;
    }
    ImGui::NextColumn();
}
ImGui::PopButtonRepeat();
ImGui::EndChild();
```