### PR TITLE
Selectable: Generate press events on right click

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -1070,6 +1070,7 @@ enum ImGuiSelectableFlags_
     ImGuiSelectableFlags_AllowDoubleClick   = 1 << 2,   // Generate press events on double clicks too
     ImGuiSelectableFlags_Disabled           = 1 << 3,   // Cannot be selected, display grayed out text
     ImGuiSelectableFlags_AllowItemOverlap   = 1 << 4,   // (WIP) Hit testing to allow subsequent widgets to overlap this one
+    ImGuiSelectableFlags_AllowRightClick    = 1 << 5,   // Generate press events on right clicks also
 };
 
 // Flags for ImGui::BeginCombo()

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -1188,7 +1188,7 @@ static void ShowDemoWindowWidgets()
         IMGUI_DEMO_MARKER("Widgets/Selectables/Basic");
         if (ImGui::TreeNode("Basic"))
         {
-            static bool selection[5] = { false, true, false, false, false };
+            static bool selection[6] = { false, true, false, false, false, false };
             ImGui::Selectable("1. I am selectable", &selection[0]);
             ImGui::Selectable("2. I am selectable", &selection[1]);
             ImGui::Text("(I am not selectable)");
@@ -1196,6 +1196,7 @@ static void ShowDemoWindowWidgets()
             if (ImGui::Selectable("5. I am double clickable", selection[4], ImGuiSelectableFlags_AllowDoubleClick))
                 if (ImGui::IsMouseDoubleClicked(0))
                     selection[4] = !selection[4];
+            ImGui::Selectable("6. I am left and right click selectable", &selection[5], ImGuiSelectableFlags_AllowRightClick);
             ImGui::TreePop();
         }
         IMGUI_DEMO_MARKER("Widgets/Selectables/Single Selection");

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -6322,7 +6322,7 @@ bool ImGui::Selectable(const char* label, bool selected, ImGuiSelectableFlags fl
     if (flags & ImGuiSelectableFlags_SelectOnRelease)   { button_flags |= ImGuiButtonFlags_PressedOnRelease; }
     if (flags & ImGuiSelectableFlags_AllowDoubleClick)  { button_flags |= ImGuiButtonFlags_PressedOnClickRelease | ImGuiButtonFlags_PressedOnDoubleClick; }
     if (flags & ImGuiSelectableFlags_AllowItemOverlap)  { button_flags |= ImGuiButtonFlags_AllowItemOverlap; }
-    if (flags & ImGuiSelectableFlags_AllowRightClick)   { button_flags |= ImGuiButtonFlags_MouseButtonLeft | ImGuiButtonFlags_MouseButtonRight | ImGuiButtonFlags_PressedOnRelease/* | ImGuiButtonFlags_PressedOnRightRelease*/; }
+    if (flags & ImGuiSelectableFlags_AllowRightClick)   { button_flags |= ImGuiButtonFlags_MouseButtonLeft | ImGuiButtonFlags_MouseButtonRight | ImGuiButtonFlags_PressedOnRelease; }
 
     const bool was_selected = selected;
     bool hovered, held;

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -6322,6 +6322,7 @@ bool ImGui::Selectable(const char* label, bool selected, ImGuiSelectableFlags fl
     if (flags & ImGuiSelectableFlags_SelectOnRelease)   { button_flags |= ImGuiButtonFlags_PressedOnRelease; }
     if (flags & ImGuiSelectableFlags_AllowDoubleClick)  { button_flags |= ImGuiButtonFlags_PressedOnClickRelease | ImGuiButtonFlags_PressedOnDoubleClick; }
     if (flags & ImGuiSelectableFlags_AllowItemOverlap)  { button_flags |= ImGuiButtonFlags_AllowItemOverlap; }
+    if (flags & ImGuiSelectableFlags_AllowRightClick)   { button_flags |= ImGuiButtonFlags_MouseButtonLeft | ImGuiButtonFlags_MouseButtonRight | ImGuiButtonFlags_PressedOnRelease/* | ImGuiButtonFlags_PressedOnRightRelease*/; }
 
     const bool was_selected = selected;
     bool hovered, held;


### PR DESCRIPTION
**Problem:**
I'm working with a table that is populated with selectables and wish to create context menus on right click events. Currently, to my knowledge, there is no way to generate a press event from a right click on a selectable.

**Solution**
I created a new selectable flag "ImGuiSelectableFlags_AllowRightClick" which leverages the button flags "ImGuiButtonFlags_MouseButtonLeft" (to maintain left click press events), "ImGuiButtonFlags_MouseButtonRight", and "ImGuiButtonFlags_PressedOnRelease" to generate the desired press event

**Example**
An example of this functionality has been provided in the DearImGui Demo under _Widgets/Selectables/Basic_

*Note. I've made the assumption that most users will mainly care about the release event and _not_ the click, as this is typical behavior in most operating systems. 
