### PR TITLE
Properly handle IMGUI_IMPL_WIN32_DISABLE_GAMEPAD

### DIFF
--- a/backends/imgui_impl_win32.cpp
+++ b/backends/imgui_impl_win32.cpp
@@ -88,10 +88,11 @@ struct ImGui_ImplWin32_Data
     INT64                       Time;
     INT64                       TicksPerSecond;
     ImGuiMouseCursor            LastMouseCursor;
+#ifndef IMGUI_IMPL_WIN32_DISABLE_GAMEPAD
     bool                        HasGamepad;
     bool                        WantUpdateHasGamepad;
 
-#ifndef IMGUI_IMPL_WIN32_DISABLE_GAMEPAD
+
     HMODULE                     XInputDLL;
     PFN_XInputGetCapabilities   XInputGetCapabilities;
     PFN_XInputGetState          XInputGetState;
@@ -129,7 +130,6 @@ bool    ImGui_ImplWin32_Init(void* hwnd)
     io.BackendFlags |= ImGuiBackendFlags_HasSetMousePos;          // We can honor io.WantSetMousePos requests (optional, rarely used)
 
     bd->hWnd = (HWND)hwnd;
-    bd->WantUpdateHasGamepad = true;
     bd->TicksPerSecond = perf_frequency;
     bd->Time = perf_counter;
     bd->LastMouseCursor = ImGuiMouseCursor_COUNT;
@@ -155,6 +155,8 @@ bool    ImGui_ImplWin32_Init(void* hwnd)
             bd->XInputGetState = (PFN_XInputGetState)::GetProcAddress(dll, "XInputGetState");
             break;
         }
+
+    bd->WantUpdateHasGamepad = true;
 #endif // IMGUI_IMPL_WIN32_DISABLE_GAMEPAD
 
     return true;
@@ -633,10 +635,12 @@ IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hwnd, UINT msg, WPARA
         if (LOWORD(lParam) == HTCLIENT && ImGui_ImplWin32_UpdateMouseCursor())
             return 1;
         return 0;
+#ifndef IMGUI_IMPL_WIN32_DISABLE_GAMEPAD
     case WM_DEVICECHANGE:
         if ((UINT)wParam == DBT_DEVNODES_CHANGED)
             bd->WantUpdateHasGamepad = true;
         return 0;
+#endif
     }
     return 0;
 }


### PR DESCRIPTION
It's not really important but `HasGamepad` and `WantUpdateHasGamepad` variables are not used anyway when `IMGUI_IMPL_WIN32_DISABLE_GAMEPAD` is defined.