### PR TITLE
Update MouseViewport on the same frame as AddMouseViewportEvent is processed

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -4666,8 +4666,6 @@ void ImGui::NewFrame()
     g.FramerateSecPerFrameCount = ImMin(g.FramerateSecPerFrameCount + 1, IM_ARRAYSIZE(g.FramerateSecPerFrame));
     g.IO.Framerate = (g.FramerateSecPerFrameAccum > 0.0f) ? (1.0f / (g.FramerateSecPerFrameAccum / (float)g.FramerateSecPerFrameCount)) : FLT_MAX;
 
-    UpdateViewportsNewFrame();
-
     // Setup current font and draw list shared data
     // FIXME-VIEWPORT: the concept of a single ClipRectFullscreen is not ideal!
     g.IO.Fonts->Locked = true;
@@ -4791,6 +4789,9 @@ void ImGui::NewFrame()
     // Process input queue (trickle as many events as possible)
     g.InputEventsTrail.resize(0);
     UpdateInputEvents(g.IO.ConfigInputTrickleEventQueue);
+
+    // After processing ImGuiInputEventType_MouseViewport
+    UpdateViewportsNewFrame();
 
     // Update keyboard input state
     UpdateKeyboardInputs();


### PR DESCRIPTION
Version: 1.88 (issue bisected to e278277d53c961b6b345388b79644187bd0d0339, v1.87)
Branch: docking
Backends: imgui_impl_win32.cpp (and custom)

**My Issue:**

`IsWindowHovered` returns true for one frame in the window under the viewport under the mouse when releasing the left mouse button.

This happens only if the backend uses the new `io.AddMouseViewportEvent` instead of directly setting `io.MouseHoveredViewport`.

`NewFrame` calls `UpdateViewportsNewFrame` before `UpdateInputEvents`, so there is a one frame delay before the former sees the new `io.MouseHoveredViewport` set by the latter.

**Screenshot/Video**

![Video](https://user-images.githubusercontent.com/4297676/198856607-2ca49f6e-158b-46d1-bdff-8e12530279ac.gif)
