### PR TITLE
On OSX backend, the mouse cursor has an offset when it first comes to focus

### DIFF
--- a/backends/imgui_impl_osx.mm
+++ b/backends/imgui_impl_osx.mm
@@ -631,6 +631,9 @@ static bool ImGui_ImplOSX_HandleEvent(NSEvent* event, NSView* view)
     if (event.type == NSEventTypeMouseMoved || event.type == NSEventTypeLeftMouseDragged || event.type == NSEventTypeRightMouseDragged || event.type == NSEventTypeOtherMouseDragged)
     {
         NSPoint mousePoint = event.locationInWindow;
+        if (event.window == nil){
+          mousePoint = [[view window] convertPointFromScreen:mousePoint];
+        }
         mousePoint = [view convertPoint:mousePoint fromView:nil];
         if ([view isFlipped])
             mousePoint = NSMakePoint(mousePoint.x, mousePoint.y);


### PR DESCRIPTION
## Issue
On macos (12.6 running on M1), 
when the window comes into focus, the reported mouse cursor position has an offset.
Once the user clicks somewhere in the window the offset is gone.

It seems that before the user clicks somewhere in the window, imgui reports the screen coordinate instead of the window coordinate.
<img width="1201" alt="imgui-issue" src="https://user-images.githubusercontent.com/20865091/199295801-357dfdd3-31cf-41c8-9730-c85906ee9fc5.png">


## How to reproduce the problem
Build and run `example_apple_metal_macos`.  Unless the window is placed at the top-left, the highlighted UI element will be offset relative to the cursor initially.  Once the user clicks somewhere inside the window, the UI element under the mouse cursor will be selected.

## Reason
NSEvent's `locationInWindow` property is used to retrieve the window coordinate of the cursor when handling mouse events in `ImGui_ImplOSX_HandleEvent` of `imgui_impl_osx.mm` backend, but according to the [reference](https://developer.apple.com/documentation/appkit/nsevent/1529068-locationinwindow), this property may contain the screen coordinate, if the NSEvent's `.window` property is nil.

## Fix
Check the `.window` property of the NSEvent.  If null, convert from screen coordinate to the window coordinate associated with the view