### PR TITLE
MSVC: prevent generating of unwanted dead-code logs

### DIFF
--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -205,6 +205,7 @@ namespace ImStb
 #endif
 
 // Debug Logging for ShowDebugLogWindow(). This is designed for relatively rare events so please don't spam.
+#ifndef IMGUI_DISABLE_DEBUG_TOOLS
 #define IMGUI_DEBUG_LOG(...)            ImGui::DebugLog(__VA_ARGS__)
 #define IMGUI_DEBUG_LOG_ACTIVEID(...)   do { if (g.DebugLogFlags & ImGuiDebugLogFlags_EventActiveId) IMGUI_DEBUG_LOG(__VA_ARGS__); } while (0)
 #define IMGUI_DEBUG_LOG_FOCUS(...)      do { if (g.DebugLogFlags & ImGuiDebugLogFlags_EventFocus)    IMGUI_DEBUG_LOG(__VA_ARGS__); } while (0)
@@ -212,6 +213,15 @@ namespace ImStb
 #define IMGUI_DEBUG_LOG_NAV(...)        do { if (g.DebugLogFlags & ImGuiDebugLogFlags_EventNav)      IMGUI_DEBUG_LOG(__VA_ARGS__); } while (0)
 #define IMGUI_DEBUG_LOG_CLIPPER(...)    do { if (g.DebugLogFlags & ImGuiDebugLogFlags_EventClipper)  IMGUI_DEBUG_LOG(__VA_ARGS__); } while (0)
 #define IMGUI_DEBUG_LOG_IO(...)         do { if (g.DebugLogFlags & ImGuiDebugLogFlags_EventIO)       IMGUI_DEBUG_LOG(__VA_ARGS__); } while (0)
+#else
+#define IMGUI_DEBUG_LOG(...) ((void)0)
+#define IMGUI_DEBUG_LOG_ACTIVEID(...) ((void)0)
+#define IMGUI_DEBUG_LOG_FOCUS(...) ((void)0)
+#define IMGUI_DEBUG_LOG_POPUP(...) ((void)0)
+#define IMGUI_DEBUG_LOG_NAV(...) ((void)0)
+#define IMGUI_DEBUG_LOG_CLIPPER(...) ((void)0)
+#define IMGUI_DEBUG_LOG_IO(...) ((void)0)
+#endif
 
 // Static Asserts
 #define IM_STATIC_ASSERT(_COND)         static_assert(_COND, "")


### PR DESCRIPTION
Hello, i found out that MSVC (v143) generates some dead-code on `ImGui::DebugLog` calls when `IMGUI_DISABLE_DEBUG_TOOLS` is defined (possibly because it doesn't optimize va_args).

This PR will fix that problem.



