### PR TITLE
WGPU: initialize WGPUCompareFunction params to valid values when using depth stencil

### DIFF
--- a/backends/imgui_impl_wgpu.cpp
+++ b/backends/imgui_impl_wgpu.cpp
@@ -606,6 +606,9 @@ bool ImGui_ImplWGPU_CreateDeviceObjects()
     WGPUDepthStencilState depth_stencil_state = {};
     depth_stencil_state.format = g_depthStencilFormat;
     depth_stencil_state.depthWriteEnabled = false;
+    depth_stencil_state.depthCompare = WGPUCompareFunction_Always;
+    depth_stencil_state.stencilFront.compare = WGPUCompareFunction_Always;
+    depth_stencil_state.stencilBack.compare = WGPUCompareFunction_Always;
 
     // Configure disabled depth-stencil state
     graphics_pipeline_desc.depthStencil = g_depthStencilFormat == WGPUTextureFormat_Undefined  ? nullptr :  &depth_stencil_state;


### PR DESCRIPTION
Default initializing WGPUCompareFunction params sets them to .undefined, which triggers the following validation error:

```
error: gpu: validation error: Invalid value for WGPUCompareFunction
 - While validating depthStencil state.
 - While calling [Device].CreateRenderPipeline([RenderPipelineDescriptor]).
```

Default values defined  [here](https://www.w3.org/TR/webgpu/#depth-stencil-state) and [here](https://www.w3.org/TR/webgpu/#dictdef-gpustencilfacestate)

WGPUCompareFunction definition
https://github.com/webgpu-native/webgpu-headers/blob/main/webgpu.h#L161