### PR TITLE
Backends: Allegro: Brough back al_draw_indexed_prim.

### DIFF
--- a/backends/imgui_impl_allegro5.cpp
+++ b/backends/imgui_impl_allegro5.cpp
@@ -146,22 +146,6 @@ void ImGui_ImplAllegro5_RenderDrawData(ImDrawData* draw_data)
             dst_v->col = al_map_rgba(c[0], c[1], c[2], c[3]);
         }
 
-        const int* indices = nullptr;
-        if (sizeof(ImDrawIdx) == 2)
-        {
-            // FIXME-OPT: Unfortunately Allegro doesn't support 16-bit indices.. You can '#define ImDrawIdx int' in imconfig.h to request Dear ImGui to output 32-bit indices.
-            // Otherwise, we convert them from 16-bit to 32-bit at runtime here, which works perfectly but is a little wasteful.
-            static ImVector<int> indices_converted;
-            indices_converted.resize(cmd_list->IdxBuffer.Size);
-            for (int i = 0; i < cmd_list->IdxBuffer.Size; ++i)
-                indices_converted[i] = (int)cmd_list->IdxBuffer.Data[i];
-            indices = indices_converted.Data;
-        }
-        else if (sizeof(ImDrawIdx) == 4)
-        {
-            indices = (const int*)cmd_list->IdxBuffer.Data;
-        }
-
         // Render command lists
         ImVec2 clip_off = draw_data->DisplayPos;
         for (int cmd_i = 0; cmd_i < cmd_list->CmdBuffer.Size; cmd_i++)

--- a/backends/imgui_impl_allegro5.cpp
+++ b/backends/imgui_impl_allegro5.cpp
@@ -146,6 +146,22 @@ void ImGui_ImplAllegro5_RenderDrawData(ImDrawData* draw_data)
             dst_v->col = al_map_rgba(c[0], c[1], c[2], c[3]);
         }
 
+        const int* indices = nullptr;
+        if (sizeof(ImDrawIdx) == 2)
+        {
+            // FIXME-OPT: Unfortunately Allegro doesn't support 16-bit indices.. You can '#define ImDrawIdx int' in imconfig.h to request Dear ImGui to output 32-bit indices.
+            // Otherwise, we convert them from 16-bit to 32-bit at runtime here, which works perfectly but is a little wasteful.
+            static ImVector<int> indices_converted;
+            indices_converted.resize(cmd_list->IdxBuffer.Size);
+            for (int i = 0; i < cmd_list->IdxBuffer.Size; ++i)
+                indices_converted[i] = (int)cmd_list->IdxBuffer.Data[i];
+            indices = indices_converted.Data;
+        }
+        else if (sizeof(ImDrawIdx) == 4)
+        {
+            indices = (const int*)cmd_list->IdxBuffer.Data;
+        }
+
         // Render command lists
         ImVec2 clip_off = draw_data->DisplayPos;
         for (int cmd_i = 0; cmd_i < cmd_list->CmdBuffer.Size; cmd_i++)


### PR DESCRIPTION
**Context:**

Some time back, Allegro's DirectX implementation of al_draw_indexed_prim broke. This originated commit 185b4dd in Dear ImGui. Some time later though, version 5.2.5 (February 2019) of Allegro ended up fixing this problem.

**My changes:**

I brought back the indexed primitive logic from that Dear ImGui commit, and updated it to today's code. Not only is this more optimized since it makes use of indexing, but it also removes an annoying compilation warning `("variable ‘indices’ set but not used [-Wunused-but-set-variable]")` considering `indices` is no longer unused. One thing to note: al_draw_indexed_prim doesn't seem to like it when the num_vtx argument is 0, which Dear ImGui sometimes does. I figured if'ing that case and skipping was the best solution.

I admit I'm not 100% familiar with how that code works, but I'm confident enough to submit this PR. Basically, only the latest commit matters. But if this PR ends up being an unwanted change for some reason, then I instead propose using the first commit of the branch, which just removes the unused bit of code with the `indices` variable. Functionally, it's the same as before my PR, but with fewer compilation warnings. (That commit was made some hours ago before I realized Allegro had fixed the problem, and that I should probably try my hand at updating the backend. Oops.)

**Testing:**

I've tried running the Dear ImGui demo with my PR's branch and found absolutely no problems. Tested on my Lubuntu machine, tested DirectX on a dinky Windows 7 virtual machine, and tested OpenGL and DirectX on a Windows 10 64-bit machine.
* Linux compiler: g++ (Ubuntu 11.3.0-1ubuntu1~22.04) 11.3.0
* Windows VM compiler: Visual Studio Community 2019.
* Operating System: Lubuntu 22.04.1 LTS 64-bit