### PR TITLE
fix MacOS sdlrenderer example

### DIFF
--- a/examples/example_sdl_sdlrenderer/main.cpp
+++ b/examples/example_sdl_sdlrenderer/main.cpp
@@ -30,7 +30,7 @@ int main(int, char**)
     }
 
     // Setup window
-    SDL_WindowFlags window_flags = (SDL_WindowFlags)(SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
+    SDL_WindowFlags window_flags = (SDL_WindowFlags)(SDL_WINDOW_RESIZABLE);
     SDL_Window* window = SDL_CreateWindow("Dear ImGui SDL2+SDL_Renderer example", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 1280, 720, window_flags);
 
     // Setup SDL_Renderer instance


### PR DESCRIPTION
`examples/example_sdl_sdlrenderer` is unnecessarily complex and doesn't work properly on Mac. (Ventura 13.0.1) We can keep it as it is but I would like to fix the UI so that other Mac users can get ImGui easily up and running.

The `SDL_WINDOW_ALLOW_HIGHDPI` is not worth the confusion it can cause to new ImGui users. 

**Before:**

https://user-images.githubusercontent.com/14946081/204870192-670ee9f9-2c20-4ebe-bc1c-541d2b7a86ef.mp4

**After:**

https://user-images.githubusercontent.com/14946081/204870209-e9f464b0-599d-42a3-9bd1-f9ad7939e5dc.mp4


