### PR TITLE
Properly detect SSE instruction support in 32-bit MSVC build

### DIFF
--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -56,7 +56,7 @@ Index of this file:
 #include <limits.h>     // INT_MIN, INT_MAX
 
 // Enable SSE intrinsics if available
-#if (defined __SSE__ || defined __x86_64__ || defined _M_X64) && !defined(IMGUI_DISABLE_SSE)
+#if (defined __SSE__ || defined __x86_64__ || defined _M_X64 || (defined(_M_IX86_FP) && (_M_IX86_FP >= 1))) && !defined(IMGUI_DISABLE_SSE)
 #define IMGUI_ENABLE_SSE
 #include <immintrin.h>
 #endif


### PR DESCRIPTION
Currently, the condition checks for `__SSE__`, `__x86_64__`, or `_M_X64` macros, none of which are defined when building in 32-bit mode with MSVC.  The correct macros to check is `_M_IX86_FP`:

> _M_IX86_FP Defined as an integer literal value that indicates the [/arch](https://learn.microsoft.com/en-us/cpp/build/reference/arch-arm?view=msvc-170) compiler option that was set, or the default. This macro is always defined when the compilation target is an x86 processor. Otherwise, undefined. When defined, the value is:
> 
> 0 if the /arch:IA32 compiler option was set.
> 
> 1 if the /arch:SSE compiler option was set.
> 
> 2 if the /arch:SSE2, /arch:AVX, /arch:AVX2, or /arch:AVX512 compiler option was set. This value is the default if an /arch compiler option wasn't specified. When /arch:AVX is specified, the macro __AVX__ is also defined. When /arch:AVX2 is specified, both __AVX__ and __AVX2__ are also defined. When /arch:AVX512 is specified, __AVX__, __AVX2__, __AVX512BW__, __AVX512CD__, __AVX512DQ__, __AVX512F__, and __AVX512VL__ are also defined.
> 

Please refer to [this page](https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros?redirectedfrom=MSDN&view=msvc-170) for details.