### PR TITLE
Use DefWindowProcW in win32 examples

### DIFF
--- a/examples/example_win32_directx10/main.cpp
+++ b/examples/example_win32_directx10/main.cpp
@@ -240,5 +240,5 @@ LRESULT WINAPI WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
         ::PostQuitMessage(0);
         return 0;
     }
-    return ::DefWindowProc(hWnd, msg, wParam, lParam);
+    return ::DefWindowProcW(hWnd, msg, wParam, lParam);
 }

--- a/examples/example_win32_directx11/main.cpp
+++ b/examples/example_win32_directx11/main.cpp
@@ -244,5 +244,5 @@ LRESULT WINAPI WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
         ::PostQuitMessage(0);
         return 0;
     }
-    return ::DefWindowProc(hWnd, msg, wParam, lParam);
+    return ::DefWindowProcW(hWnd, msg, wParam, lParam);
 }

--- a/examples/example_win32_directx12/main.cpp
+++ b/examples/example_win32_directx12/main.cpp
@@ -462,5 +462,5 @@ LRESULT WINAPI WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
         ::PostQuitMessage(0);
         return 0;
     }
-    return ::DefWindowProc(hWnd, msg, wParam, lParam);
+    return ::DefWindowProcW(hWnd, msg, wParam, lParam);
 }

--- a/examples/example_win32_directx9/main.cpp
+++ b/examples/example_win32_directx9/main.cpp
@@ -234,5 +234,5 @@ LRESULT WINAPI WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
         ::PostQuitMessage(0);
         return 0;
     }
-    return ::DefWindowProc(hWnd, msg, wParam, lParam);
+    return ::DefWindowProcW(hWnd, msg, wParam, lParam);
 }


### PR DESCRIPTION
The current win32 examples will truncate the window title if you try to modify it with `Platform_SetWindowTitle`.

Before
![image](https://user-images.githubusercontent.com/814966/206033959-d4686dd4-7363-45bc-ba34-efa495dc9a6e.png)
After
![image](https://user-images.githubusercontent.com/814966/206034037-ed4d4ea1-e665-4a78-b3db-fdea2cef1e85.png)

It took me a while to figure out it was because the examples are using `DefWindowProc` instead `DefWindowProcW`.
The issue is `setWindowTextW`  sends a `WM_SETTEXT` message to `WndProc` and gets interpreted as ascii.
Maybe this fix will help others from having to debug this issue when they are getting started using the examples :)