### PR TITLE
Arithemic operators added for ImVec2

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -257,6 +257,38 @@ struct ImVec2
     constexpr ImVec2(float _x, float _y)    : x(_x), y(_y) { }
     float  operator[] (size_t idx) const    { IM_ASSERT(idx <= 1); return (&x)[idx]; }    // We very rarely use this [] operator, the assert overhead is fine.
     float& operator[] (size_t idx)          { IM_ASSERT(idx <= 1); return (&x)[idx]; }    // We very rarely use this [] operator, the assert overhead is fine.
+    ImVec2 operator+(ImVec2 v)
+    {
+        return ImVec2(this->x + v.x, this->y + v.y);
+    }
+    ImVec2 operator-(ImVec2 v)
+    {
+        return ImVec2(this->x - v.x, this->y - v.y);
+    }
+    ImVec2 operator*(ImVec2 v)
+    {
+        return ImVec2(this->x * v.x, this->y * v.y);
+    }
+    ImVec2 operator/(ImVec2 v)
+    {
+        return ImVec2(this->x / v.x, this->y / v.y);
+    }
+    ImVec2 operator+(float c)
+    {
+        return ImVec2(this->x + c, this->y + c);
+    }
+    ImVec2 operator-(float c)
+    {
+        return ImVec2(this->x - c, this->y - c);
+    }
+    ImVec2 operator*(float c)
+    {
+        return ImVec2(this->x * c, this->y * c);
+    }
+    ImVec2 operator/(float c)
+    {
+        return ImVec2(this->x / c, this->y / c);
+    }
 #ifdef IM_VEC2_CLASS_EXTRA
     IM_VEC2_CLASS_EXTRA     // Define additional constructors and implicit cast operators in imconfig.h to convert back and forth between your math types and ImVec2.
 #endif


### PR DESCRIPTION
Instead of doing this:
``` cpp
ImVec2 vec3 = ImVec2(vec1.x + vec2.x, vec1.y + vec2.y);
ImVec2 vec3 = ImVec2(vec1.x - vec2.x, vec1.y - vec2.y);
ImVec2 vec3 = ImVec2(vec1.x * vec2.x, vec1.y * vec2.y);
ImVec2 vec3 = ImVec2(vec1.x / vec2.x, vec1.y / vec2.y);
/// OR ->>>
ImVec2 vec3 = ImVec2(vec1.x + 10, vec1.y + 10);
ImVec2 vec3 = ImVec2(vec1.x - 10, vec1.y - 10);
ImVec2 vec3 = ImVec2(vec1.x * 10, vec1.y * 10);
ImVec2 vec3 = ImVec2(vec1.x / 10, vec1.y / 10);
```
Use the operators alternative:
``` cpp
ImVec2 vec3 = vec1 + vec2;
ImVec2 vec3 = vec1 - vec2;
ImVec2 vec3 = vec1 * vec2;
ImVec2 vec3 = vec1 / vec2;
/// OR ->>>
ImVec2 vec3 = vec1 + 10;
ImVec2 vec3 = vec1 - 10;
ImVec2 vec3 = vec1 * 10;
ImVec2 vec3 = vec1 / 10;
```

