### PR TITLE
Examples: Allegro: Fixed compilation instructions.

### DIFF
--- a/examples/example_allegro5/README.md
+++ b/examples/example_allegro5/README.md
@@ -12,7 +12,7 @@ Note that the backend supports _BOTH_ 16-bit and 32-bit indices, but 32-bit indi
 ### On Ubuntu 14.04+ and macOS
 
 ```bash
-g++ -DIMGUI_USER_CONFIG=\"examples/example_allegro5/imconfig_allegro5.h\" -I .. -I ../.. main.cpp ../../backends/imgui_impl_allegro5.cpp ../../imgui*.cpp -lallegro -lallegro_main -lallegro_primitives -o allegro5_example
+g++ -DIMGUI_USER_CONFIG=\"examples/example_allegro5/imconfig_allegro5.h\" -I .. -I ../.. -I ../../backends main.cpp ../../backends/imgui_impl_allegro5.cpp ../../imgui*.cpp -lallegro -lallegro_main -lallegro_primitives -o allegro5_example
 ```
 
 On macOS, install Allegro with homebrew: `brew install allegro`.
@@ -32,5 +32,5 @@ vcpkg integrate install						    ; register include / libs in Visual Studio
 Build:
 ```
 set ALLEGRODIR=path_to_your_allegro5_folder
-cl /Zi /MD /I %ALLEGRODIR%\include /DIMGUI_USER_CONFIG=\"examples/example_allegro5/imconfig_allegro5.h\" /I .. /I ..\.. main.cpp ..\..\backends\imgui_impl_allegro5.cpp ..\..\imgui*.cpp /link /LIBPATH:%ALLEGRODIR%\lib allegro-5.0.10-monolith-md.lib user32.lib
+cl /Zi /MD /I %ALLEGRODIR%\include /DIMGUI_USER_CONFIG=\"examples/example_allegro5/imconfig_allegro5.h\" /I .. /I ..\.. /I ..\..\backends main.cpp ..\..\backends\imgui_impl_allegro5.cpp ..\..\imgui*.cpp /link /LIBPATH:%ALLEGRODIR%\lib allegro-5.0.10-monolith-md.lib user32.lib
 ```


### PR DESCRIPTION
It looks like Allegro 5's example's compilation instructions weren't fully updated with commit a7e21fb0. All that was missing was pointing to the right backends folder for inclusion.