### PR TITLE
fix impl_sdl compile on winrt

### DIFF
--- a/backends/imgui_impl_sdl.cpp
+++ b/backends/imgui_impl_sdl.cpp
@@ -359,7 +359,7 @@ static bool ImGui_ImplSDL2_Init(SDL_Window* window, SDL_Renderer* renderer)
     bd->MouseCursors[ImGuiMouseCursor_NotAllowed] = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_NO);
 
     // Set platform dependent data in viewport
-#ifdef _WIN32
+#if defined(SDL_VIDEO_DRIVER_WINDOWS)
     SDL_SysWMinfo info;
     SDL_VERSION(&info.version);
     if (SDL_GetWindowWMInfo(window, &info))


### PR DESCRIPTION
sdl uses it's own set of macros for the fields in SDL_SysWMinfo. For windows, it uses `SDL_VIDEO_DRIVER_WINDOWS`.

On winrt however, `SDL_VIDEO_DRIVER_WINRT` is defined instead.

this breaks the sdl backend when used for winrt