### PR TITLE
Docking filter improvement for custom window classes

### DIFF
--- a/imconfig.h
+++ b/imconfig.h
@@ -73,7 +73,7 @@
 //---- Use FreeType to build and rasterize the font atlas (instead of stb_truetype which is embedded by default in Dear ImGui)
 // Requires FreeType headers to be available in the include path. Requires program to be compiled with 'misc/freetype/imgui_freetype.cpp' (in this repository) + the FreeType library (not provided).
 // On Windows you may use vcpkg with 'vcpkg install freetype --triplet=x64-windows' + 'vcpkg integrate install'.
-//#define IMGUI_ENABLE_FREETYPE
+#define IMGUI_ENABLE_FREETYPE
 
 //---- Use stb_truetype to build and rasterize the font atlas (default)
 // The only purpose of this define is if you want force compilation of the stb_truetype backend ALONG with the FreeType backend.

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -16458,8 +16458,20 @@ static bool DockNodeIsDropAllowedOne(ImGuiWindow* payload, ImGuiWindow* host_win
 
 static bool ImGui::DockNodeIsDropAllowed(ImGuiWindow* host_window, ImGuiWindow* root_payload)
 {
-    if (root_payload->DockNodeAsHost && root_payload->DockNodeAsHost->IsSplitNode()) // FIXME-DOCK: Missing filtering
+
+    if (root_payload->DockNodeAsHost && root_payload->DockNodeAsHost->IsSplitNode()) {
+        ImGuiWindowClass* host_class = host_window->DockNodeAsHost ? &host_window->DockNodeAsHost->WindowClass : &host_window->WindowClass;
+        ImGuiWindowClass* payload_class = &root_payload->DockNodeAsHost->WindowClass;
+        if (host_class->ClassId != payload_class->ClassId)
+        {
+            if (host_class->ClassId != 0 && host_class->DockingAllowUnclassed && payload_class->ClassId == 0)
+                return true;
+            if (payload_class->ClassId != 0 && payload_class->DockingAllowUnclassed && host_class->ClassId == 0)
+                return true;
+            return false;
+        }
         return true;
+    }
 
     const int payload_count = root_payload->DockNodeAsHost ? root_payload->DockNodeAsHost->Windows.Size : 1;
     for (int payload_n = 0; payload_n < payload_count; payload_n++)

--- a/imgui.h
+++ b/imgui.h
@@ -1073,6 +1073,8 @@ enum ImGuiInputTextFlags_
     ImGuiInputTextFlags_CallbackResize      = 1 << 18,  // Callback on buffer capacity changes request (beyond 'buf_size' parameter value), allowing the string to grow. Notify when the string wants to be resized (for string types which hold a cache of their Size). You will be provided a new BufSize in the callback and NEED to honor it. (see misc/cpp/imgui_stdlib.h for an example of using this)
     ImGuiInputTextFlags_CallbackEdit        = 1 << 19,  // Callback on any edit (note that InputText() already returns true on edit, the callback is useful mainly to manipulate the underlying buffer while focus is active)
     ImGuiInputTextFlags_EscapeClearsAll     = 1 << 20,  // Escape key clears content if not empty, and deactivate otherwise (contrast to default behavior of Escape to revert)
+    ImGuiInputTextFlags_AutoScrollY         = 1 << 21,  // Automatically scroll InputTextMultiline to the bottom if the scroll at the start of this frame was already at the bottom of the container.
+    ImGuiInputTextFlags_BufferDirty         = 1 << 22,  // The input text buffer was changed by the application, reinitialise internal buffers.
 
     // Obsolete names (will be removed soon)
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
@@ -2256,6 +2258,8 @@ struct ImGuiWindowClass
     ImGuiDockNodeFlags  DockNodeFlagsOverrideSet;   // [EXPERIMENTAL] Dock node flags to set when a window of this class is hosted by a dock node (it doesn't have to be selected!)
     bool                DockingAlwaysTabBar;        // Set to true to enforce single floating windows of this class always having their own docking node (equivalent of setting the global io.ConfigDockingAlwaysTabBar)
     bool                DockingAllowUnclassed;      // Set to true to allow windows of this class to be docked/merged with an unclassed window. // FIXME-DOCK: Move to DockNodeFlags override?
+    bool                DockingAllowedClassesOnly;  // Set to true to enforce docking class filtering to allow only those windows with classes defined in the following array. This effectively disables the default 'DockingAllowUnclassed' behaviour.
+    ImVector<ImGuiID>   DockingAllowedClasses;      // An array of class IDs that are allowed to dock with this window / dockspace.
 
     ImGuiWindowClass() { memset(this, 0, sizeof(*this)); ParentViewportId = (ImGuiID)-1; DockingAllowUnclassed = true; }
 };

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -4097,6 +4097,15 @@ bool ImGui::InputTextEx(const char* label, const char* hint, char* buf, int buf_
         if (flags & ImGuiInputTextFlags_AlwaysOverwrite)
             state->Stb.insert_mode = 1; // stb field name is indeed incorrect (see #2863)
     }
+    else if ( state && (flags & ImGuiInputTextFlags_BufferDirty) ) {
+
+        // The external buffer changed, refresh our internal representation.
+        const char* buf_end = NULL;
+        state->TextW.resize(buf_size + 1);
+        state->CurLenW = ImTextStrFromUtf8(state->TextW.Data, state->TextW.Size, buf, NULL, &buf_end);
+        state->CurLenA = (int)(buf_end - buf);
+        state->CursorClamp();
+    }
 
     if (g.ActiveId != id && init_make_active)
     {
@@ -4817,6 +4826,10 @@ bool ImGui::InputTextEx(const char* label, const char* hint, char* buf, int buf_
 
     if (is_multiline)
     {
+        // Auto scroll vertically if requested.
+        if ( (flags & ImGuiInputTextFlags_AutoScrollY) && ImGui::GetScrollY() >= ImGui::GetScrollMaxY() )
+            ImGui::SetScrollY( text_size.y );
+
         // For focus requests to work on our multiline we need to ensure our child ItemAdd() call specifies the ImGuiItemFlags_Inputable (ref issue #4761)...
         Dummy(ImVec2(text_size.x, text_size.y + style.FramePadding.y));
         ImGuiItemFlags backup_item_flags = g.CurrentItemFlags;


### PR DESCRIPTION
Fixes an edge case with docking behaviours where a split node of unclassed windows could be allowed to dock with a DockSpace that explicitly disallows it.
