### PR TITLE
Provide a non-empty definition for IMGUI_DEBUG_PRINTF when disabled.

### DIFF
--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -205,7 +205,7 @@ namespace ImStb
 #ifndef IMGUI_DISABLE_DEFAULT_FORMAT_FUNCTIONS
 #define IMGUI_DEBUG_PRINTF(_FMT,...)    printf(_FMT, __VA_ARGS__)
 #else
-#define IMGUI_DEBUG_PRINTF(_FMT,...)
+#define IMGUI_DEBUG_PRINTF(_FMT,...)    do { /* no-op */ } while (0)
 #endif
 #endif
 


### PR DESCRIPTION
Fixes MSVC warning C4390 when `/W3` and `/DIMGUI_DISABLE_DEFAULT_FORMAT_FUNCTIONS` are specified. 

Minimal repro commandline:

```batch
cl /W3 -c *.cpp -DIMGUI_DISABLE_DEFAULT_FORMAT_FUNCTIONS
```

This warning is triggered when `IMGUI_DEBUG_PRINTF` is defined as empty and is called as the only statement for `if`, e.g.:

```c++
if (condition)
    IMGUI_DEBUG_PRINTF("abc");    // When IMGUI_DEBUG_PRINTF is empty, the compiler only sees the remaining semicolon.
```

This PR defines `IMGUI_DEBUG_PRINTF` as non-empty with the good old `do{}while(0)` trick.

An alternative solution is to add braces to the call-site so the if-statement becomes the following after preprocessing:

```c++
if (condition)
{
    ;    // MSVC seems content with this.
}
```

Here's a godbolt link with x64 MSVC v19.latest and /W4 that contains both solutions (just change the #define at the top to choose the solution): https://godbolt.org/z/a4TKfMPnv

Cheers and thanks for this awesome library!

MSVC version: 19.34.31933 for x64
OS: Windows 11 Pro 22H2 (22621.819)