### PR TITLE
Two bug fixes for an incorrect coordinate in `ScrollToRectEx()`, and a missing `return` keyword in `imstb_truetype`.

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -9666,7 +9666,7 @@ ImVec2 ImGui::ScrollToRectEx(ImGuiWindow* window, const ImRect& item_rect, ImGui
     else if (((flags & ImGuiScrollFlags_KeepVisibleCenterX) && !fully_visible_x) || (flags & ImGuiScrollFlags_AlwaysCenterX))
     {
         if (can_be_fully_visible_x)
-            SetScrollFromPosX(window, ImFloor((item_rect.Min.x + item_rect.Max.y) * 0.5f) - window->Pos.x, 0.5f);
+            SetScrollFromPosX(window, ImFloor((item_rect.Min.x + item_rect.Max.x) * 0.5f) - window->Pos.x, 0.5f);
         else
             SetScrollFromPosX(window, item_rect.Min.x - window->Pos.x, 0.0f);
     }

--- a/imstb_truetype.h
+++ b/imstb_truetype.h
@@ -2008,7 +2008,7 @@ static stbtt__buf stbtt__cid_get_glyph_subrs(const stbtt_fontinfo *info, int gly
          start = end;
       }
    }
-   if (fdselector == -1) stbtt__new_buf(NULL, 0);
+   if (fdselector == -1) return stbtt__new_buf(NULL, 0);
    return stbtt__get_subrs(info->cff, stbtt__cff_index_get(info->fontdicts, fdselector));
 }
 


### PR DESCRIPTION
Hi! This pull request contains fixes for two small bugs we noticed when performing static analysis on one of our projects that uses Dear ImGui.

1. In `ScrollToRectEx()`, when scrolling horizontally to center a rectangle that could be fully visible, the computation of the X scroll position averages the minimum X coordinate and the maximum Y coordinate, rather than the minimum and maximum X coordinates:

https://github.com/ocornut/imgui/blob/59b63defe5421642fb0cdcfd1fa850fc85a13791/imgui.cpp#L9669

I figure this should probably be `... (item_rect.Min.x + item_rect.Max.x) * 0.5f ...`, based on the code for centering along the Y axis later in the function:

https://github.com/ocornut/imgui/blob/59b63defe5421642fb0cdcfd1fa850fc85a13791/imgui.cpp#L9684

2. When the `stbtt__cid_get_glyph_subrs()` function of `stb_truetype` and Dear ImGui's `imstb_truetype` fork encounters an error, it constructs a null `stbtt__buf` object, but then doesn't return it (returning a null `stbtt_buf` is common in other parts of the codebase). This is a bug in the upstream version of `stb_truetype`, and we've created [a pull request](https://github.com/nothings/stb/pull/1422) there, but here's the fix applied to Dear ImGui's fork in case it saves time!

Please let me know if there's anything I can do to help integrate these; for instance, although I've combined them here (since they are small individually), I'm happy to separate them into individual branches.

Thank you!