### PR TITLE
Client specifies window bgcolor

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -3722,6 +3722,7 @@ ImGuiWindow::ImGuiWindow(ImGuiContext* context, const char* name) : DrawListInst
     DrawList = &DrawListInst;
     DrawList->_Data = &context->DrawListSharedData;
     DrawList->_OwnerName = Name;
+    bUseCustomBgColor = false;
     IM_PLACEMENT_NEW(&WindowClass) ImGuiWindowClass();
 }
 

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -6108,6 +6108,12 @@ void ImGui::RenderWindowDecorations(ImGuiWindow* window, const ImRect& title_bar
                     is_docking_transparent_payload = true;
 
             ImU32 bg_col = GetColorU32(GetWindowBgColorIdx(window));
+
+            if (window->bUseCustomBgColor)
+            {
+                bg_col = window->BgColor;
+            }
+
             if (window->ViewportOwned)
             {
                 bg_col |= IM_COL32_A_MASK; // No alpha

--- a/imgui.h
+++ b/imgui.h
@@ -2717,6 +2717,9 @@ struct ImDrawList
     IMGUI_API void  AddImageQuad(ImTextureID user_texture_id, const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, const ImVec2& uv1 = ImVec2(0, 0), const ImVec2& uv2 = ImVec2(1, 0), const ImVec2& uv3 = ImVec2(1, 1), const ImVec2& uv4 = ImVec2(0, 1), ImU32 col = IM_COL32_WHITE);
     IMGUI_API void  AddImageRounded(ImTextureID user_texture_id, const ImVec2& p_min, const ImVec2& p_max, const ImVec2& uv_min, const ImVec2& uv_max, ImU32 col, float rounding, ImDrawFlags flags = 0);
 
+    // Add custom background color to a window
+    IMGUI_API void SetWindowBackgroundColor(ImVec4 bgColor);
+
     // Stateful path API, add points then finish with PathFillConvex() or PathStroke()
     // - Filled shapes must always use clockwise winding order. The anti-aliasing fringe depends on it. Counter-clockwise shapes will have "inward" anti-aliasing.
     inline    void  PathClear()                                                 { _Path.Size = 0; }

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -1665,6 +1665,18 @@ void ImDrawList::AddImageRounded(ImTextureID user_texture_id, const ImVec2& p_mi
         PopTextureID();
 }
 
+void ImDrawList::SetWindowBackgroundColor(ImVec4 bgColor)
+{
+    ImGuiWindow* window = ImGui::GetCurrentWindow();
+    if (window->SkipItems || (window->Size.x <= window->TitleBarRect().GetSize().x && window->Size.y <= window->TitleBarRect().GetSize().y))
+    {
+        return;
+    }
+
+    window->bUseCustomBgColor = true;
+    window->BgColor = ImGui::GetColorU32(bgColor);
+
+}
 
 //-----------------------------------------------------------------------------
 // [SECTION] ImDrawListSplitter

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -2436,6 +2436,7 @@ struct IMGUI_API ImGuiWindow
     ImVec2                  ContentSizeIdeal;
     ImVec2                  ContentSizeExplicit;                // Size of contents/scrollable client area explicitly request by the user via SetNextWindowContentSize().
     ImVec2                  WindowPadding;                      // Window padding at the time of Begin().
+    ImU32                   BgColor;                            // Client specified window background color
     float                   WindowRounding;                     // Window rounding at the time of Begin(). May be clamped lower to avoid rendering artifacts with title bar, menu bar etc.
     float                   WindowBorderSize;                   // Window border size at the time of Begin().
     float                   DecoOuterSizeX1, DecoOuterSizeY1;   // Left/Up offsets. Sum of non-scrolling outer decorations (X1 generally == 0.0f. Y1 generally = TitleBarHeight + MenuBarHeight). Locked during Begin().
@@ -2451,6 +2452,7 @@ struct IMGUI_API ImGuiWindow
     ImVec2                  ScrollTargetCenterRatio;            // 0.0f = scroll so that target position is at top, 0.5f = scroll so that target position is centered
     ImVec2                  ScrollTargetEdgeSnapDist;           // 0.0f = no snapping, >0.0f snapping threshold
     ImVec2                  ScrollbarSizes;                     // Size taken by each scrollbars on their smaller axis. Pay attention! ScrollbarSizes.x == width of the vertical scrollbar, ScrollbarSizes.y = height of the horizontal scrollbar.
+    bool                    bUseCustomBgColor;                  // Shoule we use custom (client specified) bg color for window?
     bool                    ScrollbarX, ScrollbarY;             // Are scrollbars visible?
     bool                    ViewportOwned;
     bool                    Active;                             // Set to true on Begin(), unless Collapsed


### PR DESCRIPTION
Often I have felt the need for specifying the bg color for specific Dear ImGui windows. Since I couldn't find the feature, I have added one myself and therefore creating a PR.

Usage
```C++
ImGui::SetNextWindowSize(ImVec2(400, 400), ImGuiCond_FirstUseEver);
ImGui::Begin("3D Exhibitor");

ImVec4 bgColor;
bgColor.x = 1.0f;
bgColor.y = 0.75f;
bgColor.z = 0.80f;
bgColor.w = 1.0f;

ImGui::GetCurrentWindow()->DrawList->SetWindowBackgroundColor(bgColor);

ImGui::End();
```
The result is like so

![image](https://user-images.githubusercontent.com/2173654/210289611-be15aac5-08a6-4397-80e5-2945b94968f2.png)
