### PR TITLE
Update comments in ImFontAtlas::GetGlyphRangesJapanese

### DIFF
--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -2937,19 +2937,19 @@ const ImWchar*  ImFontAtlas::GetGlyphRangesJapanese()
     // 2999 ideograms code points for Japanese
     // - 2136 Joyo (meaning "for regular use" or "for common use") Kanji code points
     // - 863 Jinmeiyo (meaning "for personal name") Kanji code points
-    // - Sourced from the character information database of the Information-technology Promotion Agency, Japan
-    //   - https://mojikiban.ipa.go.jp/mji/
-    //   - Available under the terms of the Creative Commons Attribution-ShareAlike 2.1 Japan (CC BY-SA 2.1 JP).
-    //     - https://creativecommons.org/licenses/by-sa/2.1/jp/deed.en
-    //     - https://creativecommons.org/licenses/by-sa/2.1/jp/legalcode
-    //   - You can generate this code by the script at:
-    //     - https://github.com/vaiorabbit/everyday_use_kanji
+    // - Sourced from official information provided by the government agencies of Japan:
+    //   - List of Joyo Kanji by the Agency for Cultural Affairs
+    //     - https://www.bunka.go.jp/kokugo_nihongo/sisaku/joho/joho/kijun/naikaku/kanji/
+    //   - List of Jinmeiyo Kanji by the Ministry of Justice
+    //     - http://www.moj.go.jp/MINJI/minji86.html
+    //   - Available under the terms of the Creative Commons Attribution 4.0 International (CC BY 4.0).
+    //     - https://creativecommons.org/licenses/by/4.0/legalcode
+    // - You can generate this code by the script at:
+    //   - https://github.com/vaiorabbit/everyday_use_kanji
     // - References:
     //   - List of Joyo Kanji
-    //     - (Official list by the Agency for Cultural Affairs) https://www.bunka.go.jp/kokugo_nihongo/sisaku/joho/joho/kakuki/14/tosin02/index.html
     //     - (Wikipedia) https://en.wikipedia.org/wiki/List_of_j%C5%8Dy%C5%8D_kanji
     //   - List of Jinmeiyo Kanji
-    //     - (Official list by the Ministry of Justice) http://www.moj.go.jp/MINJI/minji86.html
     //     - (Wikipedia) https://en.wikipedia.org/wiki/Jinmeiy%C5%8D_kanji
     // - Missing 1 Joyo Kanji: U+20B9F (Kun'yomi: Shikaru, On'yomi: Shitsu,shichi), see https://github.com/ocornut/imgui/pull/3627 for details.
     // You can use ImFontGlyphRangesBuilder to create your own ranges derived from this, by merging existing ranges or adding new characters.


### PR DESCRIPTION
Hello! I would like to update comments in `ImFontAtlas::GetGlyphRangesJapanese`, which [I wrote in 2020](https://github.com/ocornut/imgui/pull/3627).

## What this PR do

* Updates comments in `ImFontAtlas::GetGlyphRangesJapanese` to remove old information source and replace it to new ones.
* Only comments are modified by this PR, so there's no need to check the behavior of `GetGlyphRangesJapanese`.

### Details

I noticed the character database and its API ( mojikiban.ipa.go.jp/mji/ ) I used for updating `ImFontAtlas::GetGlyphRangesJapanese` in 2020 are no longer available. So I decided to

* prepare a source of kanji character data for myself by processing other resources
* fix the updater script which can regenerate `GetGlyphRangesJapanese` with the new data source

so that we don't have to depend on the unavailable database.

And now it's done. My repository <https://github.com/vaiorabbit/everyday_use_kanji> contains lists of Joyo ("for regular use") characters and Jinmeiyo ("for personal name") characters made from new sources:
* [everyday_use_kanji/regular_use_utf8.csv](https://github.com/vaiorabbit/everyday_use_kanji/blob/719811458ff7129177ddf4214a239e10d2463b7f/regular_use_utf8.csv)
  * [src/regular_use/README.md](https://github.com/vaiorabbit/everyday_use_kanji/blob/719811458ff7129177ddf4214a239e10d2463b7f/src/regular_use/README.md)
* [everyday_use_kanji/personal_name_utf8.csv](https://github.com/vaiorabbit/everyday_use_kanji/blob/719811458ff7129177ddf4214a239e10d2463b7f/personal_name_utf8.csv)
  * [src/personal_name/README.md](https://github.com/vaiorabbit/everyday_use_kanji/blob/719811458ff7129177ddf4214a239e10d2463b7f/src/personal_name/README.md)

To prepare these lists I used resources provided by the Agency for Cultural Affairs and the Ministry of Justice of Japan, which are available under CC-BY 4.0. For more details, please see [everyday_use_kanji/LICENSE](https://github.com/vaiorabbit/everyday_use_kanji/blob/719811458ff7129177ddf4214a239e10d2463b7f/LICENSE).

After that I regenerated [the actual code of `ImFontAtlas::GetGlyphRangesJapanese`](https://github.com/vaiorabbit/everyday_use_kanji/blob/d08c013b1c7e194689b03bd1183223480105b643/imgui/GetGlyphRangesJapanese.cpp). We can say the changes made in this PR have resulted from copying and pasting this code.

Please note that there's no difference made in the offset table (`static const short accumulative_offsets_from_0x4E00`) even if we run [the updater script](https://github.com/vaiorabbit/everyday_use_kanji/blob/719811458ff7129177ddf4214a239e10d2463b7f/imgui/generate_imgui_draw_implementation.rb), because there's also no difference between characters we can get from new source I prepared and old ones from unavailable old database. As a result, the changes in this PR occurred only on the comments section.
