### PR TITLE
Implement SetPlatformImeDataFn for SDL backend to locate IME at caret while typing.

### DIFF
--- a/backends/imgui_impl_sdl.cpp
+++ b/backends/imgui_impl_sdl.cpp
@@ -79,6 +79,7 @@
 #define SDL_HAS_CAPTURE_AND_GLOBAL_MOUSE    0
 #endif
 #define SDL_HAS_VULKAN                      SDL_VERSION_ATLEAST(2,0,6)
+#define SDL_HAS_SET_TEXT_INPUT_RECT         SDL_VERSION_ATLEAST(2,0,0)
 
 // SDL Data
 struct ImGui_ImplSDL2_Data
@@ -316,6 +317,27 @@ bool ImGui_ImplSDL2_ProcessEvent(const SDL_Event* event)
     return false;
 }
 
+#if SDL_HAS_SET_TEXT_INPUT_RECT
+static void ImGui_ImplSDL2_SetPlatformImeData(ImGuiViewport* viewport, ImGuiPlatformImeData* data)
+{
+    (void)viewport;
+    if (data->WantVisible)
+    {
+        SDL_Rect r;
+        r.x = (int)data->InputPos.x;
+        r.y = (int)data->InputPos.y;
+        r.w = 1;
+        r.h = (int)data->InputLineHeight;
+        SDL_SetTextInputRect(&r);
+        SDL_StartTextInput();
+    }
+    else
+    {
+        SDL_StopTextInput();
+    }
+}
+#endif
+
 static bool ImGui_ImplSDL2_Init(SDL_Window* window, SDL_Renderer* renderer)
 {
     ImGuiIO& io = ImGui::GetIO();
@@ -346,6 +368,10 @@ static bool ImGui_ImplSDL2_Init(SDL_Window* window, SDL_Renderer* renderer)
     io.SetClipboardTextFn = ImGui_ImplSDL2_SetClipboardText;
     io.GetClipboardTextFn = ImGui_ImplSDL2_GetClipboardText;
     io.ClipboardUserData = nullptr;
+
+#if SDL_HAS_SET_TEXT_INPUT_RECT
+    io.SetPlatformImeDataFn = ImGui_ImplSDL2_SetPlatformImeData;
+#endif
 
     // Load mouse cursors
     bd->MouseCursors[ImGuiMouseCursor_Arrow] = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_ARROW);


### PR DESCRIPTION
Implement SetPlatformImeDataFn for SDL backend to properly locate IME candidate panel while typing in utf-8 enabled `ImGui::InputText`.

From SDL Wiki:
> SDL supports "on-the-spot" mode.
> 
> One important thing to notice is that the application can enable and disable text input arbitrarily with [SDL_StartTextInput](https://wiki.libsdl.org/SDL2/SDL_StartTextInput)() and [SDL_StopTextInput](https://wiki.libsdl.org/SDL2/SDL_StopTextInput)(). [SDL_SetTextInputRect](https://wiki.libsdl.org/SDL2/SDL_SetTextInputRect)() controls where the [Candidate List](https://wiki.libsdl.org/SDL2/Tutorials-TextInput#candidatelist) will open, if supported.

# Screenshots
Before patch:
![before_patch](https://user-images.githubusercontent.com/5917425/212046863-841c1b0e-a49b-44e2-8b73-122a5ec3967b.png)

After patch:
![after_patch](https://user-images.githubusercontent.com/5917425/212046885-58313c11-ae1d-483e-9c31-fae4753ec20e.png)

# Tests
Tested `example_sdl_sdlrenderer`, `example_sdl_opengl2`, `example_sdl_opengl3` on Ubuntu 16.04(X11 + IBus)

> CJK text will only appear if the font was loaded with the appropriate CJK character ranges. 

For testing, I use the following code to load a Chinese TTF font:
```
io.Fonts->AddFontFromFileTTF("/usr/share/fonts/truetype/wqy/wqy-microhei.ttc", 18.0f, NULL, io.Fonts->GetGlyphRangesChineseFull());
```
 