### PR TITLE
Optional optimisation in OpenGL3 impl: don't save and restore state

### DIFF
--- a/backends/imgui_impl_opengl3.cpp
+++ b/backends/imgui_impl_opengl3.cpp
@@ -182,6 +182,11 @@
 #define IMGUI_IMPL_OPENGL_MAY_HAVE_EXTENSIONS
 #endif
 
+// Optional performance improvement: don't restore any previous state after drawing
+#ifndef IMGUI_IMPL_OPENGL_NO_RESTORE_STATE
+#define IMGUI_IMPL_RESTORE_STATE
+#endif // IMGUI_IMPL_OPENGL_NO_RESTORE_STATE
+
 // [Debugging]
 //#define IMGUI_IMPL_OPENGL_DEBUG
 #ifdef IMGUI_IMPL_OPENGL_DEBUG
@@ -445,9 +450,12 @@ void    ImGui_ImplOpenGL3_RenderDrawData(ImDrawData* draw_data)
 
     ImGui_ImplOpenGL3_Data* bd = ImGui_ImplOpenGL3_GetBackendData();
 
+#ifdef IMGUI_IMPL_RESTORE_STATE
     // Backup GL state
     GLenum last_active_texture; glGetIntegerv(GL_ACTIVE_TEXTURE, (GLint*)&last_active_texture);
+#endif // IMGUI_IMPL_RESTORE_STATE
     glActiveTexture(GL_TEXTURE0);
+#ifdef IMGUI_IMPL_RESTORE_STATE
     GLuint last_program; glGetIntegerv(GL_CURRENT_PROGRAM, (GLint*)&last_program);
     GLuint last_texture; glGetIntegerv(GL_TEXTURE_BINDING_2D, (GLint*)&last_texture);
 #ifdef IMGUI_IMPL_OPENGL_MAY_HAVE_BIND_SAMPLER
@@ -475,6 +483,7 @@ void    ImGui_ImplOpenGL3_RenderDrawData(ImDrawData* draw_data)
     GLenum last_blend_dst_alpha; glGetIntegerv(GL_BLEND_DST_ALPHA, (GLint*)&last_blend_dst_alpha);
     GLenum last_blend_equation_rgb; glGetIntegerv(GL_BLEND_EQUATION_RGB, (GLint*)&last_blend_equation_rgb);
     GLenum last_blend_equation_alpha; glGetIntegerv(GL_BLEND_EQUATION_ALPHA, (GLint*)&last_blend_equation_alpha);
+#endif // IMGUI_IMPL_RESTORE_STATE
     GLboolean last_enable_blend = glIsEnabled(GL_BLEND);
     GLboolean last_enable_cull_face = glIsEnabled(GL_CULL_FACE);
     GLboolean last_enable_depth_test = glIsEnabled(GL_DEPTH_TEST);
@@ -573,6 +582,7 @@ void    ImGui_ImplOpenGL3_RenderDrawData(ImDrawData* draw_data)
     GL_CALL(glDeleteVertexArrays(1, &vertex_array_object));
 #endif
 
+ifdef IMGUI_IMPL_RESTORE_STATE
     // Restore modified GL state
     glUseProgram(last_program);
     glBindTexture(GL_TEXTURE_2D, last_texture);
@@ -593,6 +603,7 @@ void    ImGui_ImplOpenGL3_RenderDrawData(ImDrawData* draw_data)
 #endif
     glBlendEquationSeparate(last_blend_equation_rgb, last_blend_equation_alpha);
     glBlendFuncSeparate(last_blend_src_rgb, last_blend_dst_rgb, last_blend_src_alpha, last_blend_dst_alpha);
+#endif // IMGUI_IMPL_RESTORE_STATE
     if (last_enable_blend) glEnable(GL_BLEND); else glDisable(GL_BLEND);
     if (last_enable_cull_face) glEnable(GL_CULL_FACE); else glDisable(GL_CULL_FACE);
     if (last_enable_depth_test) glEnable(GL_DEPTH_TEST); else glDisable(GL_DEPTH_TEST);
@@ -602,11 +613,13 @@ void    ImGui_ImplOpenGL3_RenderDrawData(ImDrawData* draw_data)
     if (bd->GlVersion >= 310) { if (last_enable_primitive_restart) glEnable(GL_PRIMITIVE_RESTART); else glDisable(GL_PRIMITIVE_RESTART); }
 #endif
 
+#ifdef IMGUI_IMPL_RESTORE_STATE
 #ifdef IMGUI_IMPL_HAS_POLYGON_MODE
     glPolygonMode(GL_FRONT_AND_BACK, (GLenum)last_polygon_mode[0]);
 #endif
     glViewport(last_viewport[0], last_viewport[1], (GLsizei)last_viewport[2], (GLsizei)last_viewport[3]);
     glScissor(last_scissor_box[0], last_scissor_box[1], (GLsizei)last_scissor_box[2], (GLsizei)last_scissor_box[3]);
+#endif // IMGUI_IMPL_RESTORE_STATE
     (void)bd; // Not all compilation paths use this
 }
 


### PR DESCRIPTION
After profiling an ImGUI application running in the browser, compiled to WASM built with Emscripten, rendering WebGL using the OpenGL3 backend, I observed surprisingly slow performance - the majority of frame time is spent in expensive `glGetIntegerv` calls from `ImGui_ImplOpenGL3_RenderDrawData()`:

![image](https://user-images.githubusercontent.com/649131/212546842-04b0de04-69a6-4954-8101-0cfa2d4633d1.png)
![image](https://user-images.githubusercontent.com/649131/212546847-592bf1a6-5bce-408e-a99c-6a7ac7aac2f7.png)

Over 60ms is spent just querying OpenGL state every frame.

## Analysis

These calls are made when querying the existing OpenGL state each frame, which is then saved and restored at the end of the function.  For many applications, this is simply unnecessary - in some cases the application already sets up its state from scratch each frame, and in other cases the state set by the implementation may already coincide with the application's desired state.

In any case, it may often be desirable to manually set only those parts of the state which diverge from the application's desired state, after calling `ImGui_ImplOpenGL3_RenderDrawData()`, thus avoiding incurring the expensive `glGetIntegerv` calls.

The specific cost in this case comes from `glGetIntegerv` calls which in turn call `emscriptenWebGLGet`, producing an expensive WebGL call to [`getParameter`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/getParameter).  Calls to `getParameter` produce synchronous stalls on the calling thread, and the general advice is they should be avoided (https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_best_practices#avoid_blocking_api_calls_in_production).

## This PR's changes

This PR makes the following changes to backends/imgui_impl_opengl3.cpp:

- Gate expensive OpenGL state query and subsequent restore behind a new define, `IMGUI_IMPL_RESTORE_STATE`.  This is set by default.
- Accept an optional define `IMGUI_IMPL_OPENGL_NO_RESTORE_STATE` - if this is defined, it unsets `IMGUI_IMPL_RESTORE_STATE`, and OpenGL states are not saved and loaded.

## Results

After making this change, and defining IMGUI_IMPL_OPENGL_NO_RESTORE_STATE in my project, my profile for a single frame looks like this:

![image](https://user-images.githubusercontent.com/649131/212547193-fe07f560-a2e7-4706-9ce8-f5e7e0cd18f7.png)
![image](https://user-images.githubusercontent.com/649131/212547211-b1a27e79-74e8-45f5-b6f5-78cb86a73781.png)

Total time spent in `ImGui_ImplOpenGL3_RenderDrawData()` each frame went from 62.9ms to <0.1ms - a speedup of over 600x.  For reference, this benchmark is on Chromium 108.0.5359.124 64bit on Linux, GPU is Nvidia RTX 2070 Super.

I recognise that the cost of `glGetIntegerv` here is disproportionately higher in a WebGL context than it may be for other users of the implementation, but I believe this change will be of some use to non-WebGL users also.