### PR TITLE
Combo: Flip arrow icon when active

### DIFF
--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -1652,7 +1652,7 @@ bool ImGui::BeginCombo(const char* label, const char* preview_value, ImGuiComboF
         ImU32 text_col = GetColorU32(ImGuiCol_Text);
         window->DrawList->AddRectFilled(ImVec2(value_x2, bb.Min.y), bb.Max, bg_col, style.FrameRounding, (w <= arrow_size) ? ImDrawFlags_RoundCornersAll : ImDrawFlags_RoundCornersRight);
         if (value_x2 + arrow_size - style.FramePadding.x <= bb.Max.x)
-            RenderArrow(window->DrawList, ImVec2(value_x2 + style.FramePadding.y, bb.Min.y + style.FramePadding.y), text_col, ImGuiDir_Down, 1.0f);
+            RenderArrow(window->DrawList, ImVec2(value_x2 + style.FramePadding.y, bb.Min.y + style.FramePadding.y), text_col, popup_open ? ImGuiDir_Up : ImGuiDir_Down, 1.0f);
     }
     RenderFrameBorder(bb.Min, bb.Max, style.FrameRounding);
 


### PR DESCRIPTION
I think it would be a great idea to show more feedback when the combo box is active. This flips the arrow on the right side of the combo box when it is active (just like in treenodes, collapsing headers, etc.)

Before:

![Before](https://cdn.discordapp.com/attachments/783966433641365504/1064610812829900800/before.gif)

After:

![After](https://cdn.discordapp.com/attachments/783966433641365504/1064610813152870511/after.gif)