### PR TITLE
Font texture styling - demo window and metric/debug

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -13170,7 +13170,7 @@ void ImGui::ShowFontAtlas(ImFontAtlas* atlas)
     }
     if (TreeNode("Atlas texture", "Atlas texture (%dx%d pixels)", atlas->TexWidth, atlas->TexHeight))
     {
-        ImVec4 tint_col = ImVec4(1.0f, 1.0f, 1.0f, 1.0f);
+        ImVec4 tint_col = ImGui::GetStyleColorVec4(ImGuiCol_Text); //tint - style text colour
         ImVec4 border_col = ImVec4(1.0f, 1.0f, 1.0f, 0.5f);
         Image(atlas->TexID, ImVec2((float)atlas->TexWidth, (float)atlas->TexHeight), ImVec2(0.0f, 0.0f), ImVec2(1.0f, 1.0f), tint_col, border_col);
         TreePop();

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -1028,7 +1028,7 @@ static void ShowDemoWindowWidgets()
             ImVec2 pos = ImGui::GetCursorScreenPos();
             ImVec2 uv_min = ImVec2(0.0f, 0.0f);                 // Top-left
             ImVec2 uv_max = ImVec2(1.0f, 1.0f);                 // Lower-right
-            ImVec4 tint_col = ImVec4(1.0f, 1.0f, 1.0f, 1.0f);   // No tint
+            ImVec4 tint_col = ImGui::GetStyleColorVec4(ImGuiCol_Text); //style text colour tint
             ImVec4 border_col = ImVec4(1.0f, 1.0f, 1.0f, 0.5f); // 50% opaque white
             ImGui::Image(my_tex_id, ImVec2(my_tex_w, my_tex_h), uv_min, uv_max, tint_col, border_col);
             if (ImGui::IsItemHovered())


### PR DESCRIPTION
When using the Light style, the font texture displayed in the demo window (Widgets/Images) and the Metrics/Debug window is white on a light background and nearly unreadable (especially the magnified part under the mouse cursor)

![font-texture-white-tint](https://user-images.githubusercontent.com/5308037/215549964-faf86407-a88c-40e8-a564-1b2cbe5873e2.png)

![metric-debug-white-tint](https://user-images.githubusercontent.com/5308037/215550011-2d8b2c59-d3a5-4ecd-93ae-69250a057402.png)

This is caused by a fixed white tint being applied to the font texture image which is fine for the Dark and Classic styles but is not suitable for the Light style.

`ImVec4 tint_col = ImVec4(1.0f, 1.0f, 1.0f, 1.0f);`

Changing the tint_col to use the styles text colour fixes the image display for the Light style and leaves the Dark and Classic styles unchanged as their font colour is light

`ImVec4 tint_col = ImGui::GetStyleColorVec4(ImGuiCol_Text);`

Result with fixed applied

![font-texture-style-tint](https://user-images.githubusercontent.com/5308037/215551213-3f72b24e-cb10-4e83-bec5-f4eab76fd9c9.png)

![metric-debug-style-tint](https://user-images.githubusercontent.com/5308037/215551279-1e7e20d8-de49-472a-9753-18e79c3f9ebc.png)

Dark style unaffected - before -

![dark-style-white-tint](https://user-images.githubusercontent.com/5308037/215551403-87076085-22ec-418d-9ed7-2d49a5b72bc9.png)

After -

![dark-style-use-style-tint](https://user-images.githubusercontent.com/5308037/215551447-af3ecd15-5018-4a39-b782-b9ebbd695821.png)




