### PR TITLE
New function ImHashAdd() to create a new ID instead of (ID + int).

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -1907,6 +1907,11 @@ ImGuiID ImHashStr(const char* data_p, size_t data_size, ImU32 seed)
     return ~crc;
 }
 
+ImGuiID ImHashAdd(ImGuiID seed, int i)
+{
+    return ImHashData(&i, sizeof(int), seed);
+}
+
 //-----------------------------------------------------------------------------
 // [SECTION] MISC HELPERS/UTILITIES (File functions)
 //-----------------------------------------------------------------------------

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -321,6 +321,9 @@ namespace ImStb
 IMGUI_API ImGuiID       ImHashData(const void* data, size_t data_size, ImU32 seed = 0);
 IMGUI_API ImGuiID       ImHashStr(const char* data, size_t data_size = 0, ImU32 seed = 0);
 
+IMGUI_API ImGuiID       ImHashAdd(ImGuiID seed, int i);
+
+
 // Helpers: Sorting
 #ifndef ImQsort
 static inline void      ImQsort(void* base, size_t count, size_t size_of_element, int(IMGUI_CDECL *compare_func)(void const*, void const*)) { if (count > 1) qsort(base, count, size_of_element, compare_func); }

--- a/imgui_tables.cpp
+++ b/imgui_tables.cpp
@@ -333,7 +333,7 @@ bool    ImGui::BeginTableEx(const char* name, ImGuiID id, int columns_count, ImG
     // Acquire storage for the table
     ImGuiTable* table = g.Tables.GetOrAddByKey(id);
     const int instance_no = (table->LastFrameActive != g.FrameCount) ? 0 : table->InstanceCurrent + 1;
-    const ImGuiID instance_id = id + instance_no;
+    const ImGuiID instance_id = ImHashAdd(id, instance_no);
     const ImGuiTableFlags table_last_flags = table->Flags;
     if (instance_no > 0)
         IM_ASSERT(table->ColumnsCount == columns_count && "BeginTable(): Cannot change columns count mid-frame while preserving same ID");
@@ -1348,7 +1348,7 @@ void    ImGui::EndTable()
     }
 
     // Pop from id stack
-    IM_ASSERT_USER_ERROR(inner_window->IDStack.back() == table->ID + table->InstanceCurrent, "Mismatching PushID/PopID!");
+    IM_ASSERT_USER_ERROR(inner_window->IDStack.back() == ImHashAdd(table->ID, table->InstanceCurrent), "Mismatching PushID/PopID!");
     IM_ASSERT_USER_ERROR(outer_window->DC.ItemWidthStack.Size >= temp_data->HostBackupItemWidthStackSize, "Too many PopItemWidth!");
     PopID();
 


### PR DESCRIPTION
In issue #4612 there is a comment about a [hash collision][1] in the `ShowDemoWindow`, in the "Synced Tables" section. As it happens there _is_ a collision, but it is not a because of a random chance, but because of how CRC32 works and a faulty assumption in the code, that this PR tries to fix.

The issue is in `imgui_tables.cpp:336` that creates a new ID by taking the old ID and adding a number.
```
const ImGuiID instance_id = id + instance_no;
```
That looks innocent enough, the hash is different. But later, it does:
```
PushID(instance_no * 3 + column_n);
```
That basically translates to `PushID(0)`, `PushID(1)`, `PushID(2)`, `PushID(3)`... that in turn will call `ImHashData(&n, sizeof(int), instance_id);`.

Now, let's see what happens when `id` ends with an hexadecimal 0x1. On one hand we call `ImHasData(&0, sizeof(int), 0xXYZ1)`. That if we look into the CRC32 code will do this line 4 times, being `*data == 0` in all of them:
```
crc = (crc >> 8) ^ crc32_lut[(crc & 0xFF) ^ *data++]
```
Sometime later `instance_no=1` and `column_n=0` it will call `ImHashData(&3, sizeof(int), 0xXYZ2)` that will call the same crc code once with `*data==3` and three times with `*data==0`.

But if we compare the first computation of CRC in both cases:
```
/*n=0*/ crc = (0xXYZ1 >> 8) ^ crc32_lut[(0xXYZ1 & 0xFF) ^ 0];
/*n=3*/ crc = (0xXYZ2 >> 8) ^ crc32_lut[(0xXYZ2 & 0xFF) ^ 3];
```
Simplifying a bit:
```
/*n=0*/ crc = 0xXY ^ crc32_lut[0xZ1];
/*n=3*/ crc = 0xXY ^ crc32_lut[0xZ2 ^ 3];
```
But `0xZ2 ^ 3 == 0xZ1`!! And the next 3 input bytes are identical, and both functions will return the same hash!

This is not actually a weakness in CRC32 as it is not an intended use. Changing the seed using an arbitrary arithmetic operation may raise unwanted patterns in the output of the hash. The proper way to derive a new seed is to always run the CRC kernel.

So I wrote a small `ImHashAdd()` that does the moral equivalent to an addition, actually calling `ImHashData`.

I reviewed the whole Dear ImGui codebase and I only found this instance of adding a number to an ID. But maybe I skipped some, or maybe third-party code does it willy-nilly. This is why in addition to this PR I opened thos other one #6138 recommending changing the hash algorithm to a more sophisticated one.

I'm not sure that is worth it, but other option to avoid unwanted arithmetic to IDs would be to typedef it not to be an integer, a new-type pattern:
```
typedef unsigned int        ImGuiID_;
struct ImGuiID { ImGuiID_ id; };
```
Then `ImHashAdd()` could be converted into `ImGuiID::operator+(int)` and everybody would be happy.



[1]: https://github.com/ocornut/imgui/issues/4612#issuecomment-939421854