### PR TITLE
Dpi: add EmVec2() and EmSize() / terse way for DPI independent layout

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -7360,6 +7360,16 @@ float ImGui::GetFontSize()
     return GImGui->FontSize;
 }
 
+ImVec2 ImGui::EmVec2(float x, float y)
+{
+    return ImVec2(GetFontSize() * x, GetFontSize() * y);
+}
+
+float ImGui::EmSize(float v)
+{
+    return GetFontSize() * v;
+}
+
 ImVec2 ImGui::GetFontTexUvWhitePixel()
 {
     return GImGui->DrawListSharedData.TexUvWhitePixel;

--- a/imgui.h
+++ b/imgui.h
@@ -249,6 +249,7 @@ typedef void    (*ImGuiMemFreeFunc)(void* ptr, void* user_data);                
 
 // ImVec2: 2D vector used to store positions, sizes etc. [Compile-time configurable type]
 // This is a frequently used type in the API. Consider using IM_VEC2_CLASS_EXTRA to create implicit cast from/to our preferred type.
+// (in order to scale and position your widgets in a DPI independent way, you can use ImGui::EmVec2(x, y))
 IM_MSVC_RUNTIME_CHECKS_OFF
 struct ImVec2
 {
@@ -309,6 +310,10 @@ namespace ImGui
     IMGUI_API void          ShowFontSelector(const char* label);        // add font selector block (not a window), essentially a combo listing the loaded fonts.
     IMGUI_API void          ShowUserGuide();                            // add basic help/info block (not a window): how to manipulate ImGui as an end-user (mouse/keyboard controls).
     IMGUI_API const char*   GetVersion();                               // get the compiled version string e.g. "1.80 WIP" (essentially the value for IMGUI_VERSION from the compiled version of imgui.cpp)
+
+    // DPI aware sizing and positioning, by using the standard "em" typography unit (see https://en.wikipedia.org/wiki/Em_(typography) )
+    IMGUI_API ImVec2        EmVec2(float x, float y);                   // Returns a ImVec2 whose values are computed in multiples of ImGui::GetFontSize()
+    IMGUI_API float         EmSize(float v = 1.f);                      // Returns ImGui::GetFontSize() * v
 
     // Styles
     IMGUI_API void          StyleColorsDark(ImGuiStyle* dst = NULL);    // new, recommended style (default)


### PR DESCRIPTION
This PR is here in order to facilitate a discussion about the question: how to facilitate the development of DPI independent apps, and how to make the related API obvious, or even impossible to miss?


### Content:

Technically, this is a super simple PR, which adds utilities based on the standard ["em" typography unit](https://en.wikipedia.org/wiki/Em_(typography))

Added:
```cpp
    IMGUI_API ImVec2        EmVec2(float x, float y);                   // Returns a ImVec2 whose values are computed in multiples of ImGui::GetFontSize()
    IMGUI_API float         EmSize(float v = 1.f);                      // Returns ImGui::GetFontSize() * v
```




### Context
When working on Dear ImGui Bundle, I had to adapt quite a lot of third parties which were either not handling the DPI scale, or for which it was attempted, but with an error.

[ImGuizmo](https://github.com/pthom/ImGuizmo/commit/9e5061cfe09fabfaa789ea5a1591c9899f4e8f79)
[imgui-tex-inspect](https://github.com/pthom/imgui_tex_inspect/commit/42418195793e9cb44e7e5c57c940a73f7b88f986)
[imgui-knobs](https://github.com/pthom/imgui-knobs/commit/d78f95e6929e520890914d6b74c375505638f06b) 
[imgui-toggle](https://github.com/pthom/imgui_toggle/commit/49f2eb4b5ee3f0dd270d8e2d9f2b9334aa2746da)

I am absolutely not blaming them! On the contrary, I think that a more "obvious" API inside `imgui.h` could have helped, hence this PR.


---

### (Unrelated to this PR) More context on DPI handling

When developing ImGui Bundle, I had to battle in order to render correctly on Mac, Windows, Linux and emscripten. 
DPI handling is a hard subject, especially because it depends on the plaform.

I took some time to write a FAQ about the issues I encountered. 
I put it here: [html version](https://pthom.github.io/imgui_bundle/faq.html) and [markdown version](https://github.com/pthom/imgui_bundle/blob/doc/bindings/imgui_bundle/doc/imgui_bundle_demo_parts/ibd_faq.adoc.md). May be some part of it (especially related to windows and emscripten) could be ported to the [ImGui FAQ](https://github.com/ocornut/imgui/blob/master/docs/FAQ.md#q-how-should-i-handle-dpi-in-my-application)