### PR TITLE
Hotfixed bizzare non-monotonically-increasing SDL_GetPerformanceCounter bug

### DIFF
--- a/backends/imgui_impl_sdl2.cpp
+++ b/backends/imgui_impl_sdl2.cpp
@@ -612,6 +612,17 @@ void ImGui_ImplSDL2_NewFrame()
     // Setup time step (we don't use SDL_GetTicks() because it is using millisecond resolution)
     static Uint64 frequency = SDL_GetPerformanceFrequency();
     Uint64 current_time = SDL_GetPerformanceCounter();
+
+    // If SDL_GetPerformanceCounter doesn't return a monotonically increasing value,
+    // "fake" the time this frame.
+    //
+    // This bizzare edge-case bug seems to happen when using the SDL backend in a VirtualBox
+    // VM, it also seems to happen in emscripten backends (#6114, #3644) - might be related to
+    // a Spectre mitigation?
+    if (current_time <= bd->Time)
+    {
+        current_time = bd->Time + 1;
+    }
     io.DeltaTime = bd->Time > 0 ? (float)((double)(current_time - bd->Time) / frequency) : (float)(1.0f / 60.0f);
     bd->Time = current_time;
 


### PR DESCRIPTION
This is a casual suggestion for hot-fixing a bug that I'm encountering when using an ImGui UI in a virtual machine. The reason I needed this hotfix is because, without it, an assertion elsewhere in ImGui (`Assertion (g.IO.DeltaTime > 0.0f || g.FrameCount == 0) && "Need a positive DeltaTime!`) will trigger and crash the application (downstream: https://github.com/ComputationalBiomechanicsLab/opensim-creator/issues/617)

This issue appears to be related to #6114 and #3644. The difference here is that I'm running ImGui in a standard x86_64 Ubuntu22 desktop environment, rather than as a wasm binary in a browser - *but* I'm running it inside a VirtualBox VM, which may trigger various hypervisor/CPU mitigations etc. that aren't enabled in a bare-metal machine.

---

# More Context

I develop [OpenSim Creator](https://github.com/ComputationalBiomechanicsLab/opensim-creator), which uses ImGui+SDL+OpenGL to render:


![screenshot](https://user-images.githubusercontent.com/4730570/220907178-301c90e6-1805-4122-9d46-2c3f86edbcb5.png)

Whenever I do a full QA pass on it (e.g. [right now, for 0.4.0](https://github.com/ComputationalBiomechanicsLab/opensim-creator/milestone/3)) I try to go through all of the documentation, new features, etc. manually on a Linux build with `NDEBUG=0`, all assertions force-enabled, `libASAN`, sometimes `valgrind` etc. to ensure that as many runtime bugs as possible are shook out before shipping (this should probably be automated :wink:).

To do that, I use a VM because it means I can mostly keep developing on my Windows machine, and it's easier to snapshot VMs, have multiple OSes, etc. - it's not that I believe my UI is likely to be used in a VM very often :-)
