### PR TITLE
Fix Android example build for Gradle 8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -504,4 +504,4 @@ jobs:
     - name: Build example_android_opengl3
       run: |
         cd examples/example_android_opengl3/android
-        gradle assembleDebug
+        gradle assembleDebug --stacktrace

--- a/examples/example_android_opengl3/android/app/build.gradle
+++ b/examples/example_android_opengl3/android/app/build.gradle
@@ -2,13 +2,15 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "30.0.3"
-    ndkVersion "21.4.7075529"
+    compileSdkVersion 33
+    buildToolsVersion "33.0.2"
+    ndkVersion "25.2.9519653"
+
     defaultConfig {
         applicationId "imgui.example.android"
-        minSdkVersion 23
-        targetSdkVersion 29
+        namespace "imgui.example.android"
+        minSdkVersion 24
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
     }
@@ -20,9 +22,19 @@ android {
         }
     }
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
+    }
+
+    kotlinOptions {
+        jvmTarget="11"
+    }
+
     externalNativeBuild {
         cmake {
             path "../../CMakeLists.txt"
+            version '3.22.1'
         }
     }
 }

--- a/examples/example_android_opengl3/android/app/src/main/AndroidManifest.xml
+++ b/examples/example_android_opengl3/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="imgui.example.android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:label="ImGuiExample"
@@ -11,7 +10,8 @@
         <activity
             android:name="imgui.example.android.MainActivity"
             android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
-            android:configChanges="orientation|keyboardHidden|screenSize">
+            android:configChanges="orientation|keyboardHidden|screenSize"
+            android:exported="false">
             <meta-data android:name="android.app.lib_name"
                 android:value="ImGuiExample" />
 

--- a/examples/example_android_opengl3/android/build.gradle
+++ b/examples/example_android_opengl3/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.4.31'
+    ext.kotlin_version = '1.8.0'
     repositories {
         google()
         mavenCentral()
 
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.4.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
     }


### PR DESCRIPTION
This PR fixes the Android build, which was broken since using Gradle 8.x (which is now the default on the ubuntu-22.04 Actions runner).

Details:
- Updated the Gradle files to use recent versions of the NDK, Android Gradle plugin, etc.
- Removed deprecation warning regarding the package name in `AndroidManifest.xml`
- Added `--stacktrace` to the `gradle assembleDebug` command to see future errors early in the log