### PR TITLE
Demo: Fixed typo in comment

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,13 +2,13 @@
 
 ## Index
 
-- [Getting Started & General Advices](#getting-started--general-advices)
+- [Getting Started & General Advice](#getting-started--general-advice)
 - [Issues vs Discussions](#issues-vs-discussions)
 - [How to open an Issue](#how-to-open-an-issue)
 - [How to open a Pull Request](#how-to-open-a-pull-request)
 - [Copyright / Contributor License Agreement](#copyright--contributor-license-agreement)
 
-## Getting Started & General Advices
+## Getting Started & General Advice
 
 - Article: [How To Ask Good Questions](https://bit.ly/3nwRnx1).
 - Please browse the [Wiki](https://github.com/ocornut/imgui/wiki) to find code snippets, links and other resources (e.g. [Useful extensions](https://github.com/ocornut/imgui/wiki/Useful-Extensions)).

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -7443,7 +7443,7 @@ static void ShowExampleAppFullscreen(bool* p_open)
     static ImGuiWindowFlags flags = ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoSavedSettings;
 
     // We demonstrate using the full viewport area or the work area (without menu-bars, task-bars etc.)
-    // Based on your use case you may want one of the other.
+    // Based on your use case you may want one or the other.
     const ImGuiViewport* viewport = ImGui::GetMainViewport();
     ImGui::SetNextWindowPos(use_work_area ? viewport->WorkPos : viewport->Pos);
     ImGui::SetNextWindowSize(use_work_area ? viewport->WorkSize : viewport->Size);


### PR DESCRIPTION
This is a port of https://github.com/cfillion/reaimgui/commit/da31e74cdd29986a75185c149d9b21533c631085

FWIW I also noticed "General Advices" should be "General Advice" in the contributing guideline, but it might break an internal link so I left it alone.