### PR TITLE
Skip %+ and %# format flags for scanning

### DIFF
--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -3300,7 +3300,7 @@ void ImParseFormatSanitizeForPrinting(const char* fmt_in, char* fmt_out, size_t 
     *fmt_out = 0; // Zero-terminate
 }
 
-// - For scanning we need to remove all width and precision fields "%3.7f" -> "%f". BUT don't strip types like "%I64d" which includes digits. ! "%07I64d" -> "%I64d"
+// - For scanning we need to remove all width and precision fields and flags "%+3.7f" -> "%f". BUT don't strip types like "%I64d" which includes digits. ! "%07I64d" -> "%I64d"
 const char* ImParseFormatSanitizeForScanning(const char* fmt_in, char* fmt_out, size_t fmt_out_size)
 {
     const char* fmt_end = ImParseFormatFindEnd(fmt_in);
@@ -3311,7 +3311,7 @@ const char* ImParseFormatSanitizeForScanning(const char* fmt_in, char* fmt_out, 
     while (fmt_in < fmt_end)
     {
         char c = *fmt_in++;
-        if (!has_type && ((c >= '0' && c <= '9') || c == '.'))
+        if (!has_type && ((c >= '0' && c <= '9') || c == '.' || c == '+' || c == '#'))
             continue;
         has_type |= ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')); // Stop skipping digits
         if (c != '\'' && c != '$' && c != '_') // Custom flags provided by stb_sprintf.h. POSIX 2008 also supports '.


### PR DESCRIPTION
Fix typed in values are ignored when SliderInt's format specifier includes the + flag:

> +: the sign of signed conversions is always prepended to the result of
> the conversion (by default the result is preceded by minus only when it
> is negative)

Also skip the # flag since it seems valid to use (esp. for octal and hex):

> \# : alternative form of the conversion is performed. See the table
> below for exact effects otherwise the behavior is undefined.

There are two additional unhandled flags that only affect padding:
- and space. Formatting flags don't make sense in a SliderInt's format string, so I've omitted them.

# Test
In this example, editing the value by dragging it to +80º works but when Ctrl-clicking and typing in 10 it reverts to the previous value after hitting Enter:

```
	if (ImGui::Begin("Hello"))
	{
		static int val = 0;
		ImGui::SliderInt("Slider", &val, 0, 100, "%+dº");
		ImGui::End();
	}
```
