### PR TITLE
Backends: Win32: Uninitialized context crash fix

### DIFF
--- a/backends/imgui_impl_win32.cpp
+++ b/backends/imgui_impl_win32.cpp
@@ -513,6 +513,8 @@ IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hwnd, UINT msg, WPARA
 
     ImGuiIO& io = ImGui::GetIO();
     ImGui_ImplWin32_Data* bd = ImGui_ImplWin32_GetBackendData();
+    if (bd == nullptr)
+        return 0;
 
     switch (msg)
     {


### PR DESCRIPTION
Ignoring the window procedure handler for contexts that havn't been initialized yet will prevent this from crashing when the backend data is being accessed, for example on line 526.

In my situation contexts(2) are being created before the window. Then when the window is created and starts sending messages i havn't had a chance yet to initialize each context. I'm thinking this early out will just discard messages for such contexts, similar to as-if there isn't an active context yet.

