### PR TITLE
Backends: Vulkan: Create a custom pipeline for viewports

### DIFF
--- a/backends/imgui_impl_vulkan.cpp
+++ b/backends/imgui_impl_vulkan.cpp
@@ -1630,6 +1630,9 @@ static void ImGui_ImplVulkan_RenderWindow(ImGuiViewport* viewport, void*)
         }
     }
 
+    if (wd->Pipeline == VK_NULL_HANDLE)
+        ImGui_ImplVulkan_CreatePipeline(v->Device, v->Allocator, VK_NULL_HANDLE, wd->RenderPass, VK_SAMPLE_COUNT_1_BIT, &wd->Pipeline, 0);
+
     ImGui_ImplVulkan_RenderDrawData(viewport->DrawData, fd->CommandBuffer, wd->Pipeline);
 
     {

--- a/backends/imgui_impl_vulkan.cpp
+++ b/backends/imgui_impl_vulkan.cpp
@@ -1286,8 +1286,10 @@ void ImGui_ImplVulkanH_CreateWindowSwapChain(VkPhysicalDevice physical_device, V
     wd->ImageCount = 0;
     if (wd->RenderPass)
         vkDestroyRenderPass(device, wd->RenderPass, allocator);
-    if (wd->Pipeline)
+    if (wd->Pipeline) {
         vkDestroyPipeline(device, wd->Pipeline, allocator);
+        wd->Pipeline = nullptr;
+    }
 
     // If min image count was not specified, request different count of images dependent on selected present mode
     if (min_image_count == 0)


### PR DESCRIPTION
The main render pass may have a different configuration than the viewport window render pass. Vulkan can reuse the pipeline between different render passes only if the render pass configuration is the same. To fix it, when it's time to RenderDrawData for the viewport window and a pipeline is not yet available, a new pipeline is created for that window to be sure that is compatible with the render pass.

This is related to the issue #6305 
