### PR TITLE
Reset ImGui::GetIO().BackendPlatformName in Android and GLUT shutdown

### DIFF
--- a/backends/imgui_impl_android.cpp
+++ b/backends/imgui_impl_android.cpp
@@ -269,6 +269,9 @@ bool ImGui_ImplAndroid_Init(ANativeWindow* window)
 
 void ImGui_ImplAndroid_Shutdown()
 {
+    IM_ASSERT(ImGui::GetCurrentContext() != nullptr && "No platform backend to shutdown, or already shutdown?");
+    ImGuiIO& io = ImGui::GetIO();
+    io.BackendPlatformName = nullptr;
 }
 
 void ImGui_ImplAndroid_NewFrame()

--- a/backends/imgui_impl_android.cpp
+++ b/backends/imgui_impl_android.cpp
@@ -269,7 +269,7 @@ bool ImGui_ImplAndroid_Init(ANativeWindow* window)
 
 void ImGui_ImplAndroid_Shutdown()
 {
-    IM_ASSERT(ImGui::GetCurrentContext() != nullptr && "No platform backend to shutdown, or already shutdown?");
+    IM_ASSERT(ImGui::GetCurrentContext() != nullptr && "No platform backend to shutdown");
     ImGuiIO& io = ImGui::GetIO();
     io.BackendPlatformName = nullptr;
 }

--- a/backends/imgui_impl_glut.cpp
+++ b/backends/imgui_impl_glut.cpp
@@ -190,7 +190,7 @@ void ImGui_ImplGLUT_InstallFuncs()
 
 void ImGui_ImplGLUT_Shutdown()
 {
-    IM_ASSERT(ImGui::GetCurrentContext() != nullptr && "No platform backend to shutdown, or already shutdown?");
+    IM_ASSERT(ImGui::GetCurrentContext() != nullptr && "No platform backend to shutdown");
     ImGuiIO& io = ImGui::GetIO();
     io.BackendPlatformName = nullptr;
 }

--- a/backends/imgui_impl_glut.cpp
+++ b/backends/imgui_impl_glut.cpp
@@ -190,6 +190,9 @@ void ImGui_ImplGLUT_InstallFuncs()
 
 void ImGui_ImplGLUT_Shutdown()
 {
+    IM_ASSERT(ImGui::GetCurrentContext() != nullptr && "No platform backend to shutdown, or already shutdown?");
+    ImGuiIO& io = ImGui::GetIO();
+    io.BackendPlatformName = nullptr;
 }
 
 void ImGui_ImplGLUT_NewFrame()


### PR DESCRIPTION
Android and GLUT backends set `io.BackendPlatformName` during initialization. These backends' shutdowns have previously been no-ops and hence failed to reset `io.BackendPlatformName`. Because they don't use `io.BackendPlatformUserData` only `ImGui::GetCurrentContext()` can be checked. Other backends check for `ImGui::GetCurrentContext() != nullptr` which also fails when `ImGui::GetCurrentContext() == nullptr` and emit the same error message regardless of whether there was no context or no backend data. For this reason it's perfectly consistent to emit the same error message. Consideration about compatibility should be taken: programs may break when they relied on these backends' shutdown not failing. However arguably those could be considered misuses and additionally they'd need to have read the implementation of `ImGui_Impl*_Shutdown` to reason about the safety of calling it out-of-place or multiple times. Having done that they probably wouldn't have called the shutdown function at all (because it didn't do anything). Furthermore, if someone's program breaks due to this change all it takes to exactly restore the old behavior is to not call the shutdown function.