### PR TITLE
GLUT: remove automatic ImGui::NewFrame()

### DIFF
--- a/backends/imgui_impl_glut.cpp
+++ b/backends/imgui_impl_glut.cpp
@@ -202,9 +202,6 @@ void ImGui_ImplGLUT_NewFrame()
         delta_time_ms = 1;
     io.DeltaTime = delta_time_ms / 1000.0f;
     g_Time = current_time;
-
-    // Start the frame
-    ImGui::NewFrame();
 }
 
 static void ImGui_ImplGLUT_UpdateKeyModifiers()


### PR DESCRIPTION
Unlike all other backends' `ImGui_Impl_*_NewFrame()` functions, `ImGui_Impl_GLUT_NewFrame()` called `ImGui::NewFrame()`. This PR aims to make the GLUT backend consistent with the common interface. This is a breaking change, but possible assertion errors are easily fixable.

Maybe this behavior is intended, I was unable to find any related issues or pull requests though.