### PR TITLE
InputTextEx: do not set WantTextInputNextFrame during the frame Input…

### DIFF
--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -4296,7 +4296,6 @@ bool ImGui::InputTextEx(const char* label, const char* hint, char* buf, int buf_
         // Although we are active we don't prevent mouse from hovering other elements unless we are interacting right now with the widget.
         // Down the line we should have a cleaner library-wide concept of Selected vs Active.
         g.ActiveIdAllowOverlap = !io.MouseDown[0];
-        g.WantTextInputNextFrame = 1;
 
         // Edit in progress
         const float mouse_x = (io.MousePos.x - frame_bb.Min.x - style.FramePadding.x) + state->ScrollX;
@@ -4734,9 +4733,14 @@ bool ImGui::InputTextEx(const char* label, const char* hint, char* buf, int buf_
         ImStrncpy(buf, apply_new_text, ImMin(apply_new_text_length + 1, buf_size));
     }
 
-    // Release active ID at the end of the function (so e.g. pressing Return still does a final application of the value)
-    if (clear_active_id && g.ActiveId == id)
-        ClearActiveID();
+    if (g.ActiveId == id)
+    {
+        // Release active ID at the end of the function (so e.g. pressing Return still does a final application of the value)
+        if (clear_active_id)
+            ClearActiveID();
+        else
+            g.WantTextInputNextFrame = 1;
+    }
 
     // Render frame
     if (!is_multiline)


### PR DESCRIPTION
…Text is deactivated

Currently, when InputText is active and is forced to be deactivated with Enter/Escape key it still requests ```WantTextInputNextFrame``` to be set for the next frame which makes ```WantTextInput``` flag to linger one frame longer than it needs to.

