### PR TITLE
Tables: do not show empty tooltip when user submits TableHeader with …

### DIFF
--- a/imgui_tables.cpp
+++ b/imgui_tables.cpp
@@ -3007,7 +3007,7 @@ void ImGui::TableHeader(const char* label)
     }
 
     // Sort order arrow
-    const float ellipsis_max = cell_r.Max.x - w_arrow - w_sort_text;
+    const float ellipsis_max = ImMax(cell_r.Max.x - w_arrow - w_sort_text, label_pos.x);
     if ((table->Flags & ImGuiTableFlags_Sortable) && !(column->Flags & ImGuiTableColumnFlags_NoSort))
     {
         if (column->SortOrder != -1)


### PR DESCRIPTION
…no label to display

When building custom table header with sorting enabled:

```
        if ( ImGui::BeginTable( "##test", 2, ImGuiTableFlags_Sortable | ImGuiTableFlags_SizingStretchSame, { 600.0f, 300.0f } ) )
        {
            ImGui::TableSetupColumn( "Column1", ImGuiTableColumnFlags_WidthFixed, 110.0f );
            ImGui::TableSetupColumn( "Column2" );

            ImGui::TableNextRow( ImGuiTableRowFlags_Headers );
            if ( ImGui::TableSetColumnIndex( 0 ) )
            {
                ImGui::Button( ICON_FA_ARROW_DOWN_A_Z );

                ImGui::SameLine();

                const char * column_name = ImGui::TableGetColumnName( 0 );
                ImGui::AlignTextToFramePadding();
                ImGui::Text( column_name );

                ImGui::SameLine( 0.0f, 0.0f );

                //! use TableHeader here so we still retain table header highlight and context menu support
                ImGui::TableHeader( "##column" );
            }

            if ( ImGui::TableSetColumnIndex( 1 ) )
                ImGui::TableHeader( ImGui::TableGetColumnName( 1 ) );

            ImGui::TableNextRow();

            ImGui::EndTable();
        }
 ```
I am calling  ```ImGui::TableHeader( "##column" );```  so I still retain native table header highlight and context menu support.

But submitting label with no text to display, causes empty tooltip to be shown when the cell is hovered:
<img width="482" alt="image" src="https://user-images.githubusercontent.com/48881/232611001-369e0cb9-4171-4923-8ce9-28be4a76b69a.png">

The issue is caused by the calculation of ellipsis_max:

```
    const float ellipsis_max = cell_r.Max.x - w_arrow - w_sort_text;
```
which goes below label_pos.x:

<img width="1011" alt="image" src="https://user-images.githubusercontent.com/48881/232611639-6b95054f-1b6b-4a7b-933b-035ed8a95d7a.png">

and makes condition of:
```
    const bool text_clipped = label_size.x > (ellipsis_max - label_pos.x);
```
wrongly positive.

This PR forces an assumption that the ellipsis position can not go below the min x position of the label.
