### PR TITLE
Bug fix: empty INI files

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -12737,7 +12737,8 @@ void ImGui::ClearIniSettings()
 void ImGui::LoadIniSettingsFromDisk(const char* ini_filename)
 {
     size_t file_data_size = 0;
-    char* file_data = (char*)ImFileLoadToMemory(ini_filename, "rb", &file_data_size);
+    int padding_bytes = 1;
+    char* file_data = (char*)ImFileLoadToMemory(ini_filename, "rb", &file_data_size, padding_bytes);
     if (!file_data)
         return;
     if (file_data_size > 0)


### PR DESCRIPTION
This commit adds a padding byte to INI file reading, which protects against running strlen() on a non-null-terminated buffer in LoadIniSettingsFromMemory() = memory access violation.

This bug can be tripped by creating an empty INI file, causing strlen to read beyond the buffer returned by LoadIniSettingsFromDisk()/ImFileLoadToMemory().

