### PR TITLE
Examples: Vulkan: Choose integrated GPU in vulkan demo.

### DIFF
--- a/examples/example_glfw_vulkan/main.cpp
+++ b/examples/example_glfw_vulkan/main.cpp
@@ -99,6 +99,11 @@ static VkPhysicalDevice SetupVulkan_SelectPhysicalDevice()
         if (properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU)
             return device;
     }
+
+    // Discrete GPU is not present, use first one.
+    if(!gpus.empty()){
+        return gpus[0];
+    }
     return VK_NULL_HANDLE;
 }
 

--- a/examples/example_sdl2_vulkan/main.cpp
+++ b/examples/example_sdl2_vulkan/main.cpp
@@ -87,6 +87,11 @@ static VkPhysicalDevice SetupVulkan_SelectPhysicalDevice()
         if (properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU)
             return device;
     }
+
+    // Discrete GPU is not present, use first one.
+    if(!gpus.empty()){
+        return gpus[0];
+    }
     return VK_NULL_HANDLE;
 }
 


### PR DESCRIPTION
In Vulkan's demo, only discrete GPU has been selected, making the demo unable to run on machines with only integrated GPU.

This PR will choose the first device if no discrete GPU is present.