### PR TITLE
GetMouseState dont calculate for scaling SDL3

### DIFF
--- a/backends/imgui_impl_sdl3.cpp
+++ b/backends/imgui_impl_sdl3.cpp
@@ -237,6 +237,9 @@ bool ImGui_ImplSDL3_ProcessEvent(const SDL_Event* event)
         case SDL_EVENT_MOUSE_MOTION:
         {
             ImVec2 mouse_pos((float)event->motion.x, (float)event->motion.y);
+            SDL_GetRenderScale(bd->Renderer, &scaleX, &scaleY);
+               mouse_pos.x *= scaleX;
+               mouse_pos.y *= scaleY;
             io.AddMouseSourceEvent(event->motion.which == SDL_TOUCH_MOUSEID ? ImGuiMouseSource_TouchScreen : ImGuiMouseSource_Mouse);
             io.AddMousePosEvent(mouse_pos.x, mouse_pos.y);
             return true;


### PR DESCRIPTION
### Problem
When using SDL3_Renderer with SDL_SetREnderScale the mouse cordinates that is recived throught `event->motion.x` and `event->motion.y` dont account for scaling offset. 

### Solution
Before `io.AddMousePosEvent` the scalefactor is applied to the mouse cordinates

### Changes
`ImGui_ImplSDL3_ProcessEvent` now fetches the scaling and apply it to the mouse cordinates. 