### PR TITLE
Backends: add glBindSampler for GL ES 3.0

### DIFF
--- a/backends/imgui_impl_opengl3.cpp
+++ b/backends/imgui_impl_opengl3.cpp
@@ -176,8 +176,8 @@
 #define IMGUI_IMPL_OPENGL_MAY_HAVE_VTX_OFFSET
 #endif
 
-// Desktop GL 3.3+ has glBindSampler()
-#if !defined(IMGUI_IMPL_OPENGL_ES2) && !defined(IMGUI_IMPL_OPENGL_ES3) && defined(GL_VERSION_3_3)
+// Desktop GL 3.3+ and GL ES 3.0+ have glBindSampler()
+#if !defined(IMGUI_IMPL_OPENGL_ES2) && (defined(IMGUI_IMPL_OPENGL_ES3) || defined(GL_VERSION_3_3))
 #define IMGUI_IMPL_OPENGL_MAY_HAVE_BIND_SAMPLER
 #endif
 
@@ -428,8 +428,13 @@ static void ImGui_ImplOpenGL3_SetupRenderState(ImDrawData* draw_data, int fb_wid
     glUniformMatrix4fv(bd->AttribLocationProjMtx, 1, GL_FALSE, &ortho_projection[0][0]);
 
 #ifdef IMGUI_IMPL_OPENGL_MAY_HAVE_BIND_SAMPLER
+    // We use combined texture/sampler state. Applications using GL 3.3 and GL ES 3.0 may set that otherwise.
+#ifdef IMGUI_IMPL_OPENGL_ES3
+    glBindSampler(0, 0);
+#else
     if (bd->GlVersion >= 330)
-        glBindSampler(0, 0); // We use combined texture/sampler state. Applications using GL 3.3 may set that otherwise.
+        glBindSampler(0, 0);
+#endif
 #endif
 
     (void)vertex_array_object;
@@ -467,7 +472,12 @@ void    ImGui_ImplOpenGL3_RenderDrawData(ImDrawData* draw_data)
     GLuint last_program; glGetIntegerv(GL_CURRENT_PROGRAM, (GLint*)&last_program);
     GLuint last_texture; glGetIntegerv(GL_TEXTURE_BINDING_2D, (GLint*)&last_texture);
 #ifdef IMGUI_IMPL_OPENGL_MAY_HAVE_BIND_SAMPLER
-    GLuint last_sampler; if (bd->GlVersion >= 330) { glGetIntegerv(GL_SAMPLER_BINDING, (GLint*)&last_sampler); } else { last_sampler = 0; }
+    GLuint last_sampler;
+#ifdef IMGUI_IMPL_OPENGL_ES3
+    glGetIntegerv(GL_SAMPLER_BINDING, (GLint*)&last_sampler);
+#else
+    if (bd->GlVersion >= 330) { glGetIntegerv(GL_SAMPLER_BINDING, (GLint*)&last_sampler); } else { last_sampler = 0; }
+#endif
 #endif
     GLuint last_array_buffer; glGetIntegerv(GL_ARRAY_BUFFER_BINDING, (GLint*)&last_array_buffer);
 #ifndef IMGUI_IMPL_OPENGL_USE_VERTEX_ARRAY
@@ -594,8 +604,12 @@ void    ImGui_ImplOpenGL3_RenderDrawData(ImDrawData* draw_data)
     if (last_program == 0 || glIsProgram(last_program)) glUseProgram(last_program);
     glBindTexture(GL_TEXTURE_2D, last_texture);
 #ifdef IMGUI_IMPL_OPENGL_MAY_HAVE_BIND_SAMPLER
+#ifdef IMGUI_IMPL_OPENGL_ES3
+    glBindSampler(0, last_sampler);
+#else
     if (bd->GlVersion >= 330)
         glBindSampler(0, last_sampler);
+#endif
 #endif
     glActiveTexture(last_active_texture);
 #ifdef IMGUI_IMPL_OPENGL_USE_VERTEX_ARRAY


### PR DESCRIPTION
Visual Pinball uses ImGui to display it's Live UI. 

While working on the cross platform port, we were getting a random flicker anytime the Live UI was visible on Android, iOS, and tvOS. The versions all use GL ES 3.0. 

After using RenderDoc, we noticed the sampler was different between both frames. 

![Screenshot 2023-04-26 at 11 57 56 AM](https://user-images.githubusercontent.com/1197137/234633260-c95243b0-9b59-4805-a37c-2c44b506636b.jpg)

`glBindSampler` is supported on [GL ES 3.0+](https://registry.khronos.org/OpenGL-Refpages/es3/html/glBindSampler.xhtml).

I've updated the code to enable `IMGUI_IMPL_OPENGL_MAY_HAVE_BIND_SAMPLER` when GL ES 3, and then handle it when `IMGUI_IMPL_OPENGL_ES3`

This PR can be reworked accordingly as I wasn't sure how to check for ES in `bd->GlVersion`
