### PR TITLE
Backends: avoid null dereference in metal and osx shutdown

### DIFF
--- a/backends/imgui_impl_metal.mm
+++ b/backends/imgui_impl_metal.mm
@@ -137,12 +137,13 @@ void ImGui_ImplMetal_Shutdown()
 {
     ImGui_ImplMetal_Data* bd = ImGui_ImplMetal_GetBackendData();
     IM_ASSERT(bd != nullptr && "No renderer backend to shutdown, or already shutdown?");
+    ImGui_ImplMetal_DestroyDeviceObjects();
+    ImGui_ImplMetal_DestroyBackendData();
+
     ImGuiIO& io = ImGui::GetIO();
     io.BackendRendererName = nullptr;
     io.BackendRendererUserData = nullptr;
     io.BackendFlags &= ~ImGuiBackendFlags_RendererHasVtxOffset;
-    ImGui_ImplMetal_DestroyDeviceObjects();
-    ImGui_ImplMetal_DestroyBackendData();
 }
 
 void ImGui_ImplMetal_NewFrame(MTLRenderPassDescriptor* renderPassDescriptor)

--- a/backends/imgui_impl_osx.mm
+++ b/backends/imgui_impl_osx.mm
@@ -477,7 +477,6 @@ void ImGui_ImplOSX_Shutdown()
 {
     ImGui_ImplOSX_Data* bd = ImGui_ImplOSX_GetBackendData();
     IM_ASSERT(bd != nullptr && "No platform backend to shutdown, or already shutdown?");
-    ImGuiIO& io = ImGui::GetIO();
 
     bd->Observer = nullptr;
     if (bd->Monitor != nullptr)
@@ -486,10 +485,12 @@ void ImGui_ImplOSX_Shutdown()
         bd->Monitor = nullptr;
     }
 
+    ImGui_ImplOSX_DestroyBackendData();
+
+    ImGuiIO& io = ImGui::GetIO();
     io.BackendPlatformName = nullptr;
     io.BackendPlatformUserData = nullptr;
     io.BackendFlags &= ~(ImGuiBackendFlags_HasMouseCursors | ImGuiBackendFlags_HasGamepad);
-    ImGui_ImplOSX_DestroyBackendData();
 }
 
 static void ImGui_ImplOSX_UpdateMouseCursor()


### PR DESCRIPTION
A recent change (7d40dd4c8c1f9482546fd64d8b963c8888fc6d44) is causing a null pointer dereference on shutdown in the metal backend. This is because `ImGui_ImplMetal_DestroyDeviceObjects` tries to access `BackendRendererUserData`, which is set to `nullptr` before its execution. This PR changes the order so that the objects are destroyed before the pointer is set to null. Similarly, this PR fixes a memory leak on shutdown in the osx backend, where the pointer is also set to null before `IM_DELETE` is called. I have looked whether 7d40dd4c8c1f9482546fd64d8b963c8888fc6d44 introduces issues in other backends as well, but metal and osx seem to be the only ones affected. Thanks!