### PR TITLE
Add PopAllStyleColors

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -3038,6 +3038,17 @@ void ImGui::PopStyleColor(int count)
     }
 }
 
+void ImGui::PopAllStyleColors()
+{
+    ImGuiContext& g = *GImGui;
+    while (!g.ColorStack.empty())
+    {
+        ImGuiColorMod& backup = g.ColorStack.back();
+        g.Style.Colors[backup.Col] = backup.BackupValue;
+        g.ColorStack.pop_back();
+    }
+}
+
 static const ImGuiDataVarInfo GStyleVarInfo[] =
 {
     { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImGuiStyle, Alpha) },               // ImGuiStyleVar_Alpha

--- a/imgui.h
+++ b/imgui.h
@@ -406,6 +406,7 @@ namespace ImGui
     IMGUI_API void          PushStyleVar(ImGuiStyleVar idx, float val);                     // modify a style float variable. always use this if you modify the style after NewFrame().
     IMGUI_API void          PushStyleVar(ImGuiStyleVar idx, const ImVec2& val);             // modify a style ImVec2 variable. always use this if you modify the style after NewFrame().
     IMGUI_API void          PopStyleVar(int count = 1);
+    IMGUI_API void          PopAllStyleColors();                                            // pop all style colors pushed within the current window
     IMGUI_API void          PushTabStop(bool tab_stop);                                     // == tab stop enable. Allow focusing using TAB/Shift-TAB, enabled by default but you can disable it for certain widgets
     IMGUI_API void          PopTabStop();
     IMGUI_API void          PushButtonRepeat(bool repeat);                                  // in 'repeat' mode, Button*() functions return repeated true in a typematic manner (using io.KeyRepeatDelay/io.KeyRepeatRate setting). Note that you can call IsItemActive() after any Button() to tell if the button is held in the current frame.


### PR DESCRIPTION
This PR adds the function PopAllStyleColors, which essentially is a version of PopStyleColor() where you do not have to specify the number styles you want to pop. 

This is specially useful when the count of styles can vary and it helps in a way so you don't have to worry about the "count" parameter with extra code. Instead, user can just focus in popping all styles in the color stack.

Example of a code that shows a gray button when the option is off and a default color button when the option is on:
```cpp
	if (ImGui::TreeNode("Opciones del Builder"))
	{
		auto grayColor = IM_COL32(97, 97, 97, 255);

		static bool gridSnapIsActive = false;
		static std::string gridSnapLabel = "GRID SNAP OFF";
		if (!gridSnapIsActive)
		{
			ImGui::PushStyleColor(ImGuiCol_Button, grayColor);
			ImGui::PushStyleColor(ImGuiCol_ButtonHovered, grayColor);
			ImGui::PushStyleColor(ImGuiCol_ButtonActive, grayColor);
		}

		if (ImGui::Button(gridSnapLabel.c_str()))
		{
			gridSnapIsActive = !gridSnapIsActive;
			gridSnapLabel = (gridSnapIsActive) ? "GRID SNAP ON" : "GRID SNAP OFF";

			mGraphics->GetGraph()->SetSnapToGrid(gridSnapIsActive);
		}
		ImGui::PopAllStyleColors();


		static bool smartGuideIsActive = true;
		static std::string smartGuideLabel = "SMART GUIDES ON";
		if (!smartGuideIsActive)
		{
			ImGui::PushStyleColor(ImGuiCol_Button, grayColor);
			ImGui::PushStyleColor(ImGuiCol_ButtonHovered, grayColor);
			ImGui::PushStyleColor(ImGuiCol_ButtonActive, grayColor);
		}

		if (ImGui::Button(smartGuideLabel.c_str()))
		{
			smartGuideIsActive = !smartGuideIsActive;
			smartGuideLabel = (smartGuideIsActive) ? "SMART GUIDES ON" : "SMART GUIDES OFF";

			mGraphics->GetGraph()->SetSnapToSmartGuides(smartGuideIsActive);
		}
		ImGui::PopAllStyleColors();

		ImGui::TreePop();
    }
```
![image](https://user-images.githubusercontent.com/89319333/236602457-59e5335e-35c0-42cb-a33f-509fde0f3cc4.png)

Alternatively, another option would be that if you don't pass any parameter, all style colors would be deleted by default.