### PR TITLE
Fix anti alias fringe position for convex polygons.

### DIFF
--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -1014,8 +1014,8 @@ void ImDrawList::AddConvexPolyFilled(const ImVec2* points, const int points_coun
             dm_y *= AA_SIZE * 0.5f;
 
             // Add vertices
-            _VtxWritePtr[0].pos.x = (points[i1].x - dm_x); _VtxWritePtr[0].pos.y = (points[i1].y - dm_y); _VtxWritePtr[0].uv = uv; _VtxWritePtr[0].col = col;        // Inner
-            _VtxWritePtr[1].pos.x = (points[i1].x + dm_x); _VtxWritePtr[1].pos.y = (points[i1].y + dm_y); _VtxWritePtr[1].uv = uv; _VtxWritePtr[1].col = col_trans;  // Outer
+            _VtxWritePtr[0].pos.x = (points[i1].x + dm_x); _VtxWritePtr[0].pos.y = (points[i1].y + dm_y); _VtxWritePtr[0].uv = uv; _VtxWritePtr[0].col = col;        // Inner
+            _VtxWritePtr[1].pos.x = (points[i1].x - dm_x); _VtxWritePtr[1].pos.y = (points[i1].y - dm_y); _VtxWritePtr[1].uv = uv; _VtxWritePtr[1].col = col_trans;  // Outer
             _VtxWritePtr += 2;
 
             // Add indexes for fringes


### PR DESCRIPTION
The following code draws a triangle using ImDrawList::AddConvexPolyFilled()
with a rather big fringe scale to be able to visualize it.
```
ImGui::PushStyleColor(ImGuiCol_WindowBg, IM_COL32(255,255,255,255));
ImGui::Begin("AddConvexPolyFilled", nullptr);
auto dl = ImGui::GetWindowDrawList();
dl->_FringeScale = 20.0;
ImVec2 triangle[] = {{250, 50}, {50, 450}, {450, 450}};
dl->AddConvexPolyFilled(triangle, 3, IM_COL32(0,0,0,255));
ImGui::End();
ImGui::PopStyleColor();
```
The resulting image follows: The fringe is not visible.
It seems that currently the fringe is directed inward instead of outward of the polygon.
![current](https://github.com/ocornut/imgui/assets/7933396/aeb1b202-2c0c-4a51-9498-af2a215df1a0)

After this fix, the fringe is now visible:
![after](https://github.com/ocornut/imgui/assets/7933396/ecaa6a05-7a5a-450f-867d-dd6e923be557)
I think this is the expected behavior, right ?
Regards.
