### PR TITLE
Add small checkboxes

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -506,6 +506,7 @@ namespace ImGui
     IMGUI_API bool          Checkbox(const char* label, bool* v);
     IMGUI_API bool          CheckboxFlags(const char* label, int* flags, int flags_value);
     IMGUI_API bool          CheckboxFlags(const char* label, unsigned int* flags, unsigned int flags_value);
+    IMGUI_API bool          SmallCheckbox(const char* label, bool* v);
     IMGUI_API bool          RadioButton(const char* label, bool active);                    // use with e.g. if (RadioButton("one", my_value==1)) { my_value = 1; }
     IMGUI_API bool          RadioButton(const char* label, int* v, int v_button);           // shortcut to handle the above pattern when value is an integer
     IMGUI_API void          ProgressBar(float fraction, const ImVec2& size_arg = ImVec2(-FLT_MIN, 0), const char* overlay = NULL);

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -2766,6 +2766,12 @@ static void ShowDemoWindowLayout()
         ImGui::Checkbox("Is", &c3); ImGui::SameLine();
         ImGui::Checkbox("Rich", &c4);
 
+        // Checkbox
+        static bool c5 = false;
+        ImGui::Text("Small"); ImGui::SameLine();
+        ImGui::SmallCheckbox("checkboxes", &c5); ImGui::SameLine();
+        ImGui::Text("exist too.");
+
         // Various
         static float f0 = 1.0f, f1 = 2.0f, f2 = 3.0f;
         ImGui::PushItemWidth(80);

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -420,6 +420,7 @@ void ImGui::BulletTextV(const char* fmt, va_list args)
 // - Checkbox()
 // - CheckboxFlagsT() [Internal]
 // - CheckboxFlags()
+// - SmallCheckbox()
 // - RadioButton()
 // - ProgressBar()
 // - Bullet()
@@ -1206,6 +1207,17 @@ bool ImGui::CheckboxFlags(const char* label, ImS64* flags, ImS64 flags_value)
 bool ImGui::CheckboxFlags(const char* label, ImU64* flags, ImU64 flags_value)
 {
     return CheckboxFlagsT(label, flags, flags_value);
+}
+
+// Like small buttons, small checkboxes fit within text without additional vertical spacing.
+bool ImGui::SmallCheckbox(const char* label, bool* v)
+{
+    ImGuiContext& g = *GImGui;
+    float backup_padding_y = g.Style.FramePadding.y;
+    g.Style.FramePadding.y = 0.0f;
+    bool pressed = Checkbox(label, v);
+    g.Style.FramePadding.y = backup_padding_y;
+    return pressed;
 }
 
 bool ImGui::RadioButton(const char* label, bool active)


### PR DESCRIPTION
I recently ran into a use case where I wanted a checkbox, but the vertical size needed messed with the space between lines. I looked around the demo and found `ImGui::SmallButton()` covered a similar case, so I reused its code to make a smaller checkbox.

My usecase in a very WIP debugger window showing what a `SmallCheckbox()` looks like compared to a `Checkbox()`.
![Screenshot 2023-06-16 183041](https://github.com/ocornut/imgui/assets/86537480/8812840c-2b1a-4de0-9454-64d6cf07c0eb)

In the middle of text as shown in the demo window.
![Screenshot 2023-06-16 184127](https://github.com/ocornut/imgui/assets/86537480/e6db6e5f-5ab5-4f95-949e-8ce2b1cb1017)

I understand if the need for this is too rare to justify a new widget and PR. Feel free to reject it.