### PR TITLE
Fix blurry fonts in GLFW backend when using -ffast-math

### DIFF
--- a/backends/imgui_impl_glfw.cpp
+++ b/backends/imgui_impl_glfw.cpp
@@ -778,7 +778,7 @@ void ImGui_ImplGlfw_NewFrame()
     glfwGetFramebufferSize(bd->Window, &display_w, &display_h);
     io.DisplaySize = ImVec2((float)w, (float)h);
     if (w > 0 && h > 0)
-        io.DisplayFramebufferScale = ImVec2((float)display_w / (float)w, (float)display_h / (float)h);
+        io.DisplayFramebufferScale = ImVec2((double)display_w / (double)w, (double)display_h / (double)h);
 
     // Setup time step
     // (Accept glfwGetTime() not returning a monotonically increasing value. Seems to happens on disconnecting peripherals and probably on VMs and Emscripten, see #6491, #6189, #6114, #3644)


### PR DESCRIPTION
Issue: Fonts look blurry when using the GLFW backend with `-ffast-math`/`-Ofast`/`/fp:fast` due to a reciprocal divide optimization introducing error in the scale calculation.

Solution: Compute the scale with higher precision.

Before:
![imgui_before](https://github.com/ocornut/imgui/assets/26562606/238e62db-8b5c-45f4-8826-9cb6665950bc)

After:
![imgui_after](https://github.com/ocornut/imgui/assets/26562606/cd188e9d-b5b3-4251-a4bb-1562a1c3c6d0)

I'm not sure this is the best solution in general, but it's a lot more portable than anything else I could think of (inline asm, compiler specific optimization `#pragmas`/attributes).