### PR TITLE
Added usage of ImGuiTreeNodeFlags_UpsideDownArrow in frameless tree nodes

### DIFF
--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -6281,7 +6281,7 @@ bool ImGui::TreeNodeBehavior(ImGuiID id, ImGuiTreeNodeFlags flags, const char* l
         if (flags & ImGuiTreeNodeFlags_Bullet)
             RenderBullet(window->DrawList, ImVec2(text_pos.x - text_offset_x * 0.5f, text_pos.y + g.FontSize * 0.5f), text_col);
         else if (!is_leaf)
-            RenderArrow(window->DrawList, ImVec2(text_pos.x - text_offset_x + padding.x, text_pos.y + g.FontSize * 0.15f), text_col, is_open ? ImGuiDir_Down : ImGuiDir_Right, 0.70f);
+            RenderArrow(window->DrawList, ImVec2(text_pos.x - text_offset_x + padding.x, text_pos.y + g.FontSize * 0.15f), text_col, is_open ? ((flags & ImGuiTreeNodeFlags_UpsideDownArrow) ? ImGuiDir_Up : ImGuiDir_Down) : ImGuiDir_Right, 0.70f);
         if (g.LogEnabled)
             LogSetNextTextDecoration(">", NULL);
         RenderText(text_pos, label, label_end, false);


### PR DESCRIPTION
The fix added in https://github.com/ocornut/imgui/commit/d96bbf0aae984691e5a9fdcae5d4fd369100ca57 uses `ImGuiTreeNodeFlags_UpsideDownArrow` only if `ImGuiTreeNodeFlags_Framed` is also present. This PR adds identical usage for nodes without the frame. 