### PR TITLE
Backends: Vulkan: Add support for dynamic rendering

### DIFF
--- a/backends/imgui_impl_vulkan.h
+++ b/backends/imgui_impl_vulkan.h
@@ -59,6 +59,8 @@ struct ImGui_ImplVulkan_InitInfo
     uint32_t                        MinImageCount;          // >= 2
     uint32_t                        ImageCount;             // >= MinImageCount
     VkSampleCountFlagBits           MSAASamples;            // >= VK_SAMPLE_COUNT_1_BIT (0 -> default to VK_SAMPLE_COUNT_1_BIT)
+    VkFormat                        ColorFormat;            // Only needed if render pass passed at initialization was VK_NULL_HANDLE
+    VkFormat                        DepthFormat;            // Only needed if render pass passed at initialization was VK_NULL_HANDLE
     const VkAllocationCallbacks*    Allocator;
     void                            (*CheckVkResultFn)(VkResult err);
 };


### PR DESCRIPTION
This adds support for rendering without a render pass in the Vulkan backend. Some engines use a feature called dynamic rendering which eliminates the need for a render pass and framebuffers and allows you to just specify the required info at the time of rendering. When trying to use this backend with dynamic rendering you run into a problem, that the backend expects you to provide a render pass which is not a thing in the before mentioned example.

NOTE: This code will not work out of the box on the docking branch and requires further changes there, should I create a separate pull request for that branch?