### PR TITLE
remove pointless ternary

### DIFF
--- a/backends/imgui_impl_win32.cpp
+++ b/backends/imgui_impl_win32.cpp
@@ -733,7 +733,7 @@ static BOOL _IsWindowsVersionOrGreater(WORD major, WORD minor, WORD)
 	versionInfo.dwMinorVersion = minor;
 	VER_SET_CONDITION(conditionMask, VER_MAJORVERSION, VER_GREATER_EQUAL);
 	VER_SET_CONDITION(conditionMask, VER_MINORVERSION, VER_GREATER_EQUAL);
-	return (RtlVerifyVersionInfoFn(&versionInfo, VER_MAJORVERSION | VER_MINORVERSION, conditionMask) == 0) ? TRUE : FALSE;
+	return RtlVerifyVersionInfoFn(&versionInfo, VER_MAJORVERSION | VER_MINORVERSION, conditionMask) == 0;
 }
 
 #define _IsWindowsVistaOrGreater()   _IsWindowsVersionOrGreater(HIBYTE(0x0600), LOBYTE(0x0600), 0) // _WIN32_WINNT_VISTA


### PR DESCRIPTION
This changes exactly one thing in one line: a ternary operator that was set up to return true if the function's result was zero. I realized that using a ternary on a keyword that returns a straightforward boolean answer was completely pointless. This fixes that.
