### PR TITLE
Support for OpenType SVG fonts

### DIFF
--- a/imconfig.h
+++ b/imconfig.h
@@ -83,7 +83,9 @@
 // Requires lunasvg headers to be available in the include path. Requires program to be compiled with the lunasvg library (not provided).
 // See https://github.com/ocornut/imgui/tree/master/misc/freetype
 // Only works in combination with IMGUI_ENABLE_FREETYPE.
- //#define IMGUI_ENABLE_FREETYPE_OTSVG
+// The implementation is based on the demo https://gitlab.freedesktop.org/freetype/freetype-demos/-/blob/master/src/rsvg-port.c
+// which is licensed under CeCILL-C Free Software License Agreement
+//#define IMGUI_ENABLE_FREETYPE_LUNASVG
 
 //---- Define constructor and implicit cast operators to convert back<>forth between your math types and ImVec2/ImVec4.
 // This will be inlined as part of ImVec2 and ImVec4 class declarations.

--- a/imconfig.h
+++ b/imconfig.h
@@ -79,6 +79,12 @@
 // The only purpose of this define is if you want force compilation of the stb_truetype backend ALONG with the FreeType backend.
 //#define IMGUI_ENABLE_STB_TRUETYPE
 
+//---- Use librsvg to render OpenType SVG fonts (SVGinOT)
+// Requires librsvg headers to be available in the include path. Requires program to be compiled with the librsvg library (not provided).
+// See https://github.com/ocornut/imgui/tree/master/misc/freetype
+// Only works in combination with IMGUI_ENABLE_FREETYPE.
+// #define IMGUI_ENABLE_FREETYPE_LIBRSVG
+
 //---- Define constructor and implicit cast operators to convert back<>forth between your math types and ImVec2/ImVec4.
 // This will be inlined as part of ImVec2 and ImVec4 class declarations.
 /*

--- a/imconfig.h
+++ b/imconfig.h
@@ -79,11 +79,11 @@
 // The only purpose of this define is if you want force compilation of the stb_truetype backend ALONG with the FreeType backend.
 //#define IMGUI_ENABLE_STB_TRUETYPE
 
-//---- Use librsvg to render OpenType SVG fonts (SVGinOT)
-// Requires librsvg headers to be available in the include path. Requires program to be compiled with the librsvg library (not provided).
+//---- Use lunasvg library to render OpenType SVG fonts (SVGinOT)
+// Requires lunasvg headers to be available in the include path. Requires program to be compiled with the lunasvg library (not provided).
 // See https://github.com/ocornut/imgui/tree/master/misc/freetype
 // Only works in combination with IMGUI_ENABLE_FREETYPE.
-// #define IMGUI_ENABLE_FREETYPE_LIBRSVG
+ //#define IMGUI_ENABLE_FREETYPE_OTSVG
 
 //---- Define constructor and implicit cast operators to convert back<>forth between your math types and ImVec2/ImVec4.
 // This will be inlined as part of ImVec2 and ImVec4 class declarations.

--- a/misc/freetype/README.md
+++ b/misc/freetype/README.md
@@ -35,3 +35,17 @@ You can use the `ImGuiFreeTypeBuilderFlags_LoadColor` flag to load certain color
 ["Using Colorful Glyphs/Emojis"](https://github.com/ocornut/imgui/blob/master/docs/FONTS.md#using-colorful-glyphsemojis) section of FONTS.md.
 
 ![colored glyphs](https://user-images.githubusercontent.com/8225057/106171241-9dc4ba80-6191-11eb-8a69-ca1467b206d1.png)
+
+
+### Using OpenType SVG fonts (SVGinOT)
+- *SVG in Open Type* is a standard by Adobe and Mozilla for color OpenType and Open Font Format fonts. It allows font creators to embed complete SVG files within a font enabling full color and even animations.
+- Popular fonts such as [twemoji](https://github.com/13rac1/twemoji-color-font) and fonts made with [scfbuild](https://github.com/13rac1/scfbuild) is SVGinOT
+- You will need to add `#define IMGUI_ENABLE_FREETYPE_LIBRSVG` in your `imconfig.h` and install [librsvg](https://github.com/GNOME/librsvg).
+- Get latest librsvg binaries or build yourself. Under Windows you may use vcpkg with: `vcpkg install freetype --triplet=x64-windows` and add the following additional include directories:
+    ```
+    $(VcpkgRoot)\installed\$(VcpkgTriplet)\include\cairo;
+    $(VcpkgRoot)\installed\$(VcpkgTriplet)\include\glib-2.0;
+    $(VcpkgRoot)\installed\$(VcpkgTriplet)\include\gdk-pixbuf-2.0;
+    $(VcpkgRoot)\installed\$(VcpkgTriplet)\lib\glib-2.0\include;
+    ```
+- Note that the vcpkg version is extremely outdated (v2.40.20 from 2016) so you may want to build the latest version instead. Be aware that the vcpkg version will use `rsvg_handle_get_dimensions` instead of the more accurate `rsvg_handle_get_intrinsic_dimensions` function which is not available in v2.40, [see more](https://gnome.pages.gitlab.gnome.org/librsvg/Rsvg-2.0/method.Handle.get_dimensions.html).

--- a/misc/freetype/README.md
+++ b/misc/freetype/README.md
@@ -40,12 +40,6 @@ You can use the `ImGuiFreeTypeBuilderFlags_LoadColor` flag to load certain color
 ### Using OpenType SVG fonts (SVGinOT)
 - *SVG in Open Type* is a standard by Adobe and Mozilla for color OpenType and Open Font Format fonts. It allows font creators to embed complete SVG files within a font enabling full color and even animations.
 - Popular fonts such as [twemoji](https://github.com/13rac1/twemoji-color-font) and fonts made with [scfbuild](https://github.com/13rac1/scfbuild) is SVGinOT
-- You will need to add `#define IMGUI_ENABLE_FREETYPE_LIBRSVG` in your `imconfig.h` and install [librsvg](https://github.com/GNOME/librsvg).
-- Get latest librsvg binaries or build yourself. Under Windows you may use vcpkg with: `vcpkg install freetype --triplet=x64-windows` and add the following additional include directories:
-    ```
-    $(VcpkgRoot)\installed\$(VcpkgTriplet)\include\cairo;
-    $(VcpkgRoot)\installed\$(VcpkgTriplet)\include\glib-2.0;
-    $(VcpkgRoot)\installed\$(VcpkgTriplet)\include\gdk-pixbuf-2.0;
-    $(VcpkgRoot)\installed\$(VcpkgTriplet)\lib\glib-2.0\include;
-    ```
-- Note that the vcpkg version is extremely outdated (v2.40.20 from 2016) so you may want to build the latest version instead. Be aware that the vcpkg version will use `rsvg_handle_get_dimensions` instead of the more accurate `rsvg_handle_get_intrinsic_dimensions` function which is not available in v2.40, [see more](https://gnome.pages.gitlab.gnome.org/librsvg/Rsvg-2.0/method.Handle.get_dimensions.html).
+- Requires: [lunasvg](https://github.com/sammycage/lunasvg) v2.3.2 and above
+    1. Add `#define IMGUI_ENABLE_FREETYPE_OTSVG` in your `imconfig.h`.
+    2. Get latest lunasvg binaries or build yourself. Under Windows you may use vcpkg with: `vcpkg install lunasvg --triplet=x64-windows`.

--- a/misc/freetype/imgui_freetype.cpp
+++ b/misc/freetype/imgui_freetype.cpp
@@ -6,7 +6,7 @@
 
 // CHANGELOG
 // (minor and older changes stripped away, please see git history for details)
-//  2023/07/12: added support for SVG fonts, enable by using '#define IMGUI_ENABLE_FREETYPE_OTSVG'
+//  2023/07/12: added support for SVG fonts, enable by using '#define IMGUI_ENABLE_FREETYPE_LUNASVG'
 //  2023/01/04: fixed a packing issue which in some occurrences would prevent large amount of glyphs from being packed correctly.
 //  2021/08/23: fixed crash when FT_Render_Glyph() fails to render a glyph and returns NULL.
 //  2021/03/05: added ImGuiFreeTypeBuilderFlags_Bitmap to load bitmap glyphs.
@@ -45,7 +45,7 @@
 #include FT_GLYPH_H             // <freetype/ftglyph.h>
 #include FT_SYNTHESIS_H         // <freetype/ftsynth.h>
 
-#ifdef IMGUI_ENABLE_FREETYPE_OTSVG
+#ifdef IMGUI_ENABLE_FREETYPE_LUNASVG
 #include FT_OTSVG_H             // <freetype/otsvg.h>
 #include FT_BBOX_H              // <freetype/ftbbox.h>
 #include <lunasvg.h>
@@ -79,7 +79,7 @@ static void  (*GImGuiFreeTypeFreeFunc)(void* ptr, void* user_data) = ImGuiFreeTy
 static void* GImGuiFreeTypeAllocatorUserData = nullptr;
 
 
-#ifdef IMGUI_ENABLE_FREETYPE_OTSVG
+#ifdef IMGUI_ENABLE_FREETYPE_LUNASVG
 FT_Error ImGuiLunasvgPortInit(FT_Pointer* state);
 void     ImGuiLunasvgPortFree(FT_Pointer* state);
 FT_Error ImGuiLunasvgPortRender(FT_GlyphSlot slot, FT_Pointer* _state);
@@ -262,21 +262,14 @@ namespace
         FT_GlyphSlot slot = Face->glyph;
 
 #if ((FREETYPE_MAJOR >= 2) && (FREETYPE_MINOR >= 12))
-#ifdef IMGUI_ENABLE_FREETYPE_OTSVG
-        IM_ASSERT(
-            slot->format == FT_GLYPH_FORMAT_OUTLINE ||
-            slot->format == FT_GLYPH_FORMAT_BITMAP  ||
-            slot->format == FT_GLYPH_FORMAT_SVG
-        );
+#ifdef IMGUI_ENABLE_FREETYPE_LUNASVG
+        IM_ASSERT(slot->format == FT_GLYPH_FORMAT_OUTLINE || slot->format == FT_GLYPH_FORMAT_BITMAP || slot->format == FT_GLYPH_FORMAT_SVG);
 #else
-        IM_ASSERT(
-            slot->format != FT_GLYPH_FORMAT_SVG &&
-            "The font contains SVG glyphs, you'll need to enable IMGUI_ENABLE_FREETYPE_OTSVG"
-            "in imconfig.h and install required libraries in order to use this font"
-        );
-
+        IM_ASSERT(slot->format != FT_GLYPH_FORMAT_SVG &&
+            "The font contains SVG glyphs, you'll need to enable IMGUI_ENABLE_FREETYPE_LUNASVG"
+            "in imconfig.h and install required libraries in order to use this font");
         IM_ASSERT(slot->format == FT_GLYPH_FORMAT_OUTLINE || slot->format == FT_GLYPH_FORMAT_BITMAP);
-#endif // IMGUI_ENABLE_FREETYPE_OTSVG
+#endif // IMGUI_ENABLE_FREETYPE_LUNASVG
 #else
         IM_ASSERT(slot->format == FT_GLYPH_FORMAT_OUTLINE || slot->format == FT_GLYPH_FORMAT_BITMAP);
 #endif // ((FREETYPE_MAJOR >= 2) && (FREETYPE_MINOR >= 12))
@@ -805,23 +798,17 @@ static bool ImFontAtlasBuildWithFreeType(ImFontAtlas* atlas)
     // If you don't call FT_Add_Default_Modules() the rest of code may work, but FreeType won't use our custom allocator.
     FT_Add_Default_Modules(ft_library);
 
-#ifdef IMGUI_ENABLE_FREETYPE_OTSVG
+#ifdef IMGUI_ENABLE_FREETYPE_LUNASVG
 #if ((FREETYPE_MAJOR >= 2) && (FREETYPE_MINOR >= 12))
     // Install svg hooks for FreeType
     // https://freetype.org/freetype2/docs/reference/ft2-properties.html#svg-hooks
     // https://freetype.org/freetype2/docs/reference/ft2-svg_fonts.html#svg_fonts
-    SVG_RendererHooks  hooks = {
-        ImGuiLunasvgPortInit,
-        ImGuiLunasvgPortFree,
-        ImGuiLunasvgPortRender,
-        ImGuiLunasvgPortPresetSlot
-    };
-
+    SVG_RendererHooks  hooks = {ImGuiLunasvgPortInit, ImGuiLunasvgPortFree, ImGuiLunasvgPortRender, ImGuiLunasvgPortPresetSlot};
     FT_Property_Set(ft_library, "ot-svg", "svg-hooks", &hooks);
 #else
-    IM_ASSERT(!"IMGUI_ENABLE_FREETYPE_OTSVG requires FreeType version >= 2.12");
+    IM_ASSERT(!"IMGUI_ENABLE_FREETYPE_LUNASVG requires FreeType version >= 2.12");
 #endif // ((FREETYPE_MAJOR >= 2) && (FREETYPE_MINOR >= 12))
-#endif // IMGUI_ENABLE_FREETYPE_OTSVG
+#endif // IMGUI_ENABLE_FREETYPE_LUNASVG
 
     bool ret = ImFontAtlasBuildWithFreeTypeEx(ft_library, atlas, atlas->FontBuilderFlags);
     FT_Done_Library(ft_library);
@@ -843,100 +830,50 @@ void ImGuiFreeType::SetAllocatorFunctions(void* (*alloc_func)(size_t sz, void* u
     GImGuiFreeTypeAllocatorUserData = user_data;
 }
 
-#ifdef IMGUI_ENABLE_FREETYPE_OTSVG
-/*
- * lunasvg-based hook functions for OT-SVG rendering in FreeType
- * based on https://gitlab.freedesktop.org/freetype/freetype-demos/-/blob/master/src/rsvg-port.c
- */
-
- /*
-  * Different hook functions can access persisting data by creating a state
-  * structure and putting its address in `library->svg_renderer_state`.
-  * Functions can then store and retrieve data from this structure.
-  */
+#ifdef IMGUI_ENABLE_FREETYPE_LUNASVG
+// For more details, see https://gitlab.freedesktop.org/freetype/freetype-demos/-/blob/master/src/rsvg-port.c
+// The original code from the demo is licensed under CeCILL-C Free Software License Agreement
+// https://gitlab.freedesktop.org/freetype/freetype/-/blob/master/LICENSE.TXT
 typedef struct  LunasvgPortState_
 {
     FT_Error err = FT_Err_Ok;
     std::unique_ptr<lunasvg::Document> svg = nullptr;
-    lunasvg::Matrix matrix;
+    lunasvg::Matrix matrix;                             // Scaled and translated matrix for rendering
 } LunasvgPortState, *PLunasvgPortState;
 
-
-/*
-  * The init hook is called when the first OT-SVG glyph is rendered.  All
-  * we do is to allocate an internal state structure and set the pointer in
-  * `library->svg_renderer_state`.  This state structure becomes very
-  * useful to cache some of the results obtained by one hook function that
-  * the other one might use.
-  */
 FT_Error ImGuiLunasvgPortInit(FT_Pointer* _state)
 {
-    /* allocate the memory upon initialization */
     *_state = new LunasvgPortState();
     return FT_Err_Ok;
 }
 
-
-/*
- * Deallocate the state structure.
- */
 void ImGuiLunasvgPortFree(FT_Pointer* _state)
 {
     delete *_state;
 }
 
-/*
- * The render hook.  The job of this hook is to simply render the glyph in
- * the buffer that has been allocated on the FreeType side.  Here we
- * simply use the recording surface by playing it back against the
- * surface.
- */
 FT_Error ImGuiLunasvgPortRender(FT_GlyphSlot slot, FT_Pointer* _state)
 {
     PLunasvgPortState state = *(PLunasvgPortState*)_state;
 
-    lunasvg::Bitmap bitmap(
-        (uint8_t*)slot->bitmap.buffer,
-        slot->bitmap.width,
-        slot->bitmap.rows, // rows is height
-        slot->bitmap.pitch // pitch (or stride) equals to width * sizeof(int32)
-    );
+    // rows is height, pitch (or stride) equals to width * sizeof(int32)
+    lunasvg::Bitmap bitmap((uint8_t*)slot->bitmap.buffer, slot->bitmap.width, slot->bitmap.rows, slot->bitmap.pitch);
 
-    // reset the svg matrix to the default value
-    state->svg->setMatrix(state->svg->matrix().identity());
-
-    // state->matrix is already scaled and translated
-    state->svg->render(bitmap, state->matrix);
+    state->svg->setMatrix(state->svg->matrix().identity()); // Reset the svg matrix to the default value
+    state->svg->render(bitmap, state->matrix);              // state->matrix is already scaled and translated
 
     return FT_Err_Ok;
 }
 
-/*
- * This hook is called at two different locations.  Firstly, it is called
- * when presetting the glyphslot when `FT_Load_Glyph` is called.
- * Secondly, it is called right before the render hook is called.  When
- * `cache` is false, it is the former, when `cache` is true, it is the
- * latter.
- *
- * The job of this function is to preset the slot setting the width,
- * height, pitch, `bitmap.left`, and `bitmap.top`.  These are all
- * necessary for appropriate memory allocation, as well as ultimately
- * compositing the glyph later on by client applications.
- */
 FT_Error ImGuiLunasvgPortPresetSlot(FT_GlyphSlot slot, FT_Bool cache, FT_Pointer* _state)
 {
-    
     FT_SVG_Document   document = (FT_SVG_Document)slot->other;
     PLunasvgPortState state = *(PLunasvgPortState*)_state;
     FT_Size_Metrics&  metrics = document->metrics;
 
     if (cache) return state->err;
 
-    state->svg = lunasvg::Document::loadFromData(
-        (const char*)document->svg_document,
-        document->svg_document_length
-    );
-
+    state->svg = lunasvg::Document::loadFromData((const char*)document->svg_document, document->svg_document_length);
     if (state->svg == nullptr)
     {
         state->err = FT_Err_Invalid_SVG_Document;
@@ -946,55 +883,49 @@ FT_Error ImGuiLunasvgPortPresetSlot(FT_GlyphSlot slot, FT_Bool cache, FT_Pointer
     lunasvg::Box box = state->svg->box();
 
     double scale = std::min(metrics.x_ppem / box.w, metrics.y_ppem / box.h);
-
     double xx = (double)document->transform.xx / (1 << 16);
     double xy = -(double)document->transform.xy / (1 << 16);
     double yx = -(double)document->transform.yx / (1 << 16);
     double yy = (double)document->transform.yy / (1 << 16);
-
     double x0 = (double)document->delta.x / 64 * box.w / metrics.x_ppem;
     double y0 = -(double)document->delta.y / 64 * box.h / metrics.y_ppem;
 
-    // this reset the matrix to default value
+    // This reset the matrix to its default value
     state->matrix.identity();
 
+    // Scale and transform, we don't translate the svg yet
     state->matrix.scale(scale, scale);
     state->matrix.transform(xx, xy, yx, yy, x0, y0);
     state->svg->setMatrix(state->matrix);
 
-    // don't translate the svg yet, leave this for the rendering step
+    // Pre-translate the matrix for the rendering step
     state->matrix.translate(-box.x, -box.y);
 
-    // get the box again after the transformation
+    // Get the box again after the transformation
     box = state->svg->box();
 
-    /* Preset the values. */
-    slot->bitmap_left = FT_Int(box.x);  /* XXX rounding? */
+    // Calculate the bitmap size
+    slot->bitmap_left = FT_Int(box.x);
     slot->bitmap_top = FT_Int(-box.y);
-
     slot->bitmap.rows = unsigned int(ceil(box.h));
     slot->bitmap.width = unsigned int(ceil(box.w));
-
     slot->bitmap.pitch = slot->bitmap.width * 4;
     slot->bitmap.pixel_mode = FT_PIXEL_MODE_BGRA;
 
-    /* Compute all the bearings and set them correctly.  The outline is */
-    /* scaled already, we just need to use the bounding box.            */
+    // Compute all the bearings and set them correctly. The outline is
+    // scaled already, we just need to use the bounding box.
     double metrics_width = box.w;
     double metrics_height = box.h;
-
     double horiBearingX = box.x;
     double horiBearingY = -box.y;
 
-    double vertBearingX = slot->metrics.horiBearingX / 64.0 -
-        slot->metrics.horiAdvance / 64.0 / 2.0;
-    double vertBearingY = (slot->metrics.vertAdvance / 64.0 -
-        slot->metrics.height / 64.0) / 2.0; /* XXX parentheses correct? */
+    double vertBearingX = slot->metrics.horiBearingX / 64.0 - slot->metrics.horiAdvance / 64.0 / 2.0;
+    double vertBearingY = (slot->metrics.vertAdvance / 64.0 - slot->metrics.height / 64.0) / 2.0;
 
-    slot->metrics.width = FT_Pos(round(metrics_width * 64));
-    slot->metrics.height = FT_Pos(round(metrics_height * 64));
+    slot->metrics.width = FT_Pos(round(metrics_width * 64.0));
+    slot->metrics.height = FT_Pos(round(metrics_height * 64.0));
 
-    slot->metrics.horiBearingX = FT_Pos(horiBearingX * 64); /* XXX rounding? */
+    slot->metrics.horiBearingX = FT_Pos(horiBearingX * 64);
     slot->metrics.horiBearingY = FT_Pos(horiBearingY * 64);
     slot->metrics.vertBearingX = FT_Pos(vertBearingX * 64);
     slot->metrics.vertBearingY = FT_Pos(vertBearingY * 64);
@@ -1005,7 +936,7 @@ FT_Error ImGuiLunasvgPortPresetSlot(FT_GlyphSlot slot, FT_Bool cache, FT_Pointer
     state->err = FT_Err_Ok;
     return state->err;
 }
-#endif // !IMGUI_ENABLE_FREETYPE_OTSVG
+#endif // !IMGUI_ENABLE_FREETYPE_LUNASVG
 //-----------------------------------------------------------------------------
 
 #ifdef __GNUC__

--- a/misc/freetype/imgui_freetype.cpp
+++ b/misc/freetype/imgui_freetype.cpp
@@ -6,6 +6,7 @@
 
 // CHANGELOG
 // (minor and older changes stripped away, please see git history for details)
+//  2023/07/10: added support for SVG fonts, enable by using '#define IMGUI_ENABLE_FREETYPE_LIBRSVG'
 //  2023/01/04: fixed a packing issue which in some occurrences would prevent large amount of glyphs from being packed correctly.
 //  2021/08/23: fixed crash when FT_Render_Glyph() fails to render a glyph and returns NULL.
 //  2021/03/05: added ImGuiFreeTypeBuilderFlags_Bitmap to load bitmap glyphs.
@@ -42,6 +43,13 @@
 #include FT_GLYPH_H             // <freetype/ftglyph.h>
 #include FT_SYNTHESIS_H         // <freetype/ftsynth.h>
 
+#ifdef IMGUI_ENABLE_FREETYPE_LIBRSVG
+#include FT_OTSVG_H             // <freetype/otsvg.h>
+#include FT_BBOX_H              // <freetype/ftbbox.h>
+#include <librsvg/rsvg.h>
+#include <cairo/cairo.h>
+#endif
+
 #ifdef _MSC_VER
 #pragma warning (push)
 #pragma warning (disable: 4505)     // unreferenced local function has been removed (stb stuff)
@@ -67,6 +75,15 @@ static void  ImGuiFreeTypeDefaultFreeFunc(void* ptr, void* user_data) { IM_UNUSE
 static void* (*GImGuiFreeTypeAllocFunc)(size_t size, void* user_data) = ImGuiFreeTypeDefaultAllocFunc;
 static void  (*GImGuiFreeTypeFreeFunc)(void* ptr, void* user_data) = ImGuiFreeTypeDefaultFreeFunc;
 static void* GImGuiFreeTypeAllocatorUserData = nullptr;
+
+
+#ifdef IMGUI_ENABLE_FREETYPE_LIBRSVG
+// librsvg hooks
+FT_Error ImGuiRsvgPortInit(FT_Pointer* state);
+void     ImGuiRsvgPortFree(FT_Pointer* state);
+FT_Error ImGuiRsvgPortRender(FT_GlyphSlot slot, FT_Pointer* _state);
+FT_Error ImGuiRsvgPortPresetSlot(FT_GlyphSlot slot, FT_Bool cache, FT_Pointer* _state);
+#endif
 
 //-------------------------------------------------------------------------
 // Code
@@ -242,7 +259,22 @@ namespace
 
         // Need an outline for this to work
         FT_GlyphSlot slot = Face->glyph;
+
+#ifdef IMGUI_ENABLE_FREETYPE_LIBRSVG
+        IM_ASSERT(
+            slot->format == FT_GLYPH_FORMAT_OUTLINE ||
+            slot->format == FT_GLYPH_FORMAT_BITMAP  ||
+            slot->format == FT_GLYPH_FORMAT_SVG
+        );
+#else
+        IM_ASSERT(
+            slot->format != FT_GLYPH_FORMAT_SVG &&
+            "The font contains SVG glyphs, you'll need to enable IMGUI_ENABLE_FREETYPE_LIBRSVG"
+            "in imconfig.h and install required libraries in order to use this font"
+        );
+
         IM_ASSERT(slot->format == FT_GLYPH_FORMAT_OUTLINE || slot->format == FT_GLYPH_FORMAT_BITMAP);
+#endif
 
         // Apply convenience transform (this is not picking from real "Bold"/"Italic" fonts! Merely applying FreeType helper transform. Oblique == Slanting)
         if (UserFlags & ImGuiFreeTypeBuilderFlags_Bold)
@@ -768,6 +800,20 @@ static bool ImFontAtlasBuildWithFreeType(ImFontAtlas* atlas)
     // If you don't call FT_Add_Default_Modules() the rest of code may work, but FreeType won't use our custom allocator.
     FT_Add_Default_Modules(ft_library);
 
+#ifdef IMGUI_ENABLE_FREETYPE_LIBRSVG
+    // Install svg hooks for FreeType
+    // https://freetype.org/freetype2/docs/reference/ft2-properties.html#svg-hooks
+    // https://freetype.org/freetype2/docs/reference/ft2-svg_fonts.html#svg_fonts
+    SVG_RendererHooks  hooks = {
+        ImGuiRsvgPortInit,
+        ImGuiRsvgPortFree,
+        ImGuiRsvgPortRender,
+        ImGuiRsvgPortPresetSlot
+    };
+
+    FT_Property_Set(ft_library, "ot-svg", "svg-hooks", &hooks);
+#endif
+
     bool ret = ImFontAtlasBuildWithFreeTypeEx(ft_library, atlas, atlas->FontBuilderFlags);
     FT_Done_Library(ft_library);
 
@@ -787,6 +833,439 @@ void ImGuiFreeType::SetAllocatorFunctions(void* (*alloc_func)(size_t sz, void* u
     GImGuiFreeTypeFreeFunc = free_func;
     GImGuiFreeTypeAllocatorUserData = user_data;
 }
+
+#ifdef IMGUI_ENABLE_FREETYPE_LIBRSVG
+/*
+ * Librsvg-based hook functions for OT-SVG rendering in FreeType
+ * https://gitlab.freedesktop.org/freetype/freetype-demos/-/blob/master/src/rsvg-port.c
+ */
+
+ /*
+  * Different hook functions can access persisting data by creating a state
+  * structure and putting its address in `library->svg_renderer_state`.
+  * Functions can then store and retrieve data from this structure.
+  */
+typedef struct  Rsvg_Port_StateRec_
+{
+    cairo_surface_t* rec_surface;
+
+    double  x;
+    double  y;
+
+} Rsvg_Port_StateRec;
+
+typedef struct Rsvg_Port_StateRec_* Rsvg_Port_State;
+
+
+/*
+  * The init hook is called when the first OT-SVG glyph is rendered.  All
+  * we do is to allocate an internal state structure and set the pointer in
+  * `library->svg_renderer_state`.  This state structure becomes very
+  * useful to cache some of the results obtained by one hook function that
+  * the other one might use.
+  */
+FT_Error
+ImGuiRsvgPortInit(FT_Pointer* state)
+{
+    /* allocate the memory upon initialization */
+    *state = malloc(sizeof(Rsvg_Port_StateRec)); /* XXX error handling */
+
+    return FT_Err_Ok;
+}
+
+
+/*
+ * Deallocate the state structure.
+ */
+void
+ImGuiRsvgPortFree(FT_Pointer* state)
+{
+    free(*state);
+}
+
+
+/*
+ * The render hook.  The job of this hook is to simply render the glyph in
+ * the buffer that has been allocated on the FreeType side.  Here we
+ * simply use the recording surface by playing it back against the
+ * surface.
+ */
+FT_Error
+ImGuiRsvgPortRender(FT_GlyphSlot  slot,
+    FT_Pointer* _state)
+{
+    FT_Error  error = FT_Err_Ok;
+
+    Rsvg_Port_State   state;
+    cairo_status_t    status;
+    cairo_t* cr;
+    cairo_surface_t* surface;
+
+
+    state = *(Rsvg_Port_State*)_state;
+
+    /* Create an image surface to store the rendered image.  However,   */
+    /* don't allocate memory; instead use the space already provided in */
+    /* `slot->bitmap.buffer`.                                           */
+    surface = cairo_image_surface_create_for_data(slot->bitmap.buffer,
+        CAIRO_FORMAT_ARGB32,
+        (int)slot->bitmap.width,
+        (int)slot->bitmap.rows,
+        slot->bitmap.pitch);
+    status = cairo_surface_status(surface);
+
+    if (status != CAIRO_STATUS_SUCCESS)
+    {
+        if (status == CAIRO_STATUS_NO_MEMORY)
+            return FT_Err_Out_Of_Memory;
+        else
+            return FT_Err_Invalid_Outline;
+    }
+
+    cr = cairo_create(surface);
+    status = cairo_status(cr);
+
+    if (status != CAIRO_STATUS_SUCCESS)
+    {
+        if (status == CAIRO_STATUS_NO_MEMORY)
+            return FT_Err_Out_Of_Memory;
+        else
+            return FT_Err_Invalid_Outline;
+    }
+
+    /* Set a translate transform that translates the points in such a way */
+    /* that we get a tight rendering with least redundant white spac.     */
+    cairo_translate(cr, -state->x, -state->y);
+
+    /* Replay from the recorded surface.  This saves us from parsing the */
+    /* document again and redoing what was already done in the preset    */
+    /* hook.                                                             */
+    cairo_set_source_surface(cr, state->rec_surface, 0.0, 0.0);
+    cairo_paint(cr);
+
+    cairo_surface_flush(surface);
+
+    slot->bitmap.pixel_mode = FT_PIXEL_MODE_BGRA;
+    slot->bitmap.num_grays = 256;
+    slot->format = FT_GLYPH_FORMAT_BITMAP;
+
+    /* Clean up everything. */
+    cairo_surface_destroy(surface);
+    cairo_destroy(cr);
+    cairo_surface_destroy(state->rec_surface);
+
+    return error;
+}
+
+/*
+ * This hook is called at two different locations.  Firstly, it is called
+ * when presetting the glyphslot when `FT_Load_Glyph` is called.
+ * Secondly, it is called right before the render hook is called.  When
+ * `cache` is false, it is the former, when `cache` is true, it is the
+ * latter.
+ *
+ * The job of this function is to preset the slot setting the width,
+ * height, pitch, `bitmap.left`, and `bitmap.top`.  These are all
+ * necessary for appropriate memory allocation, as well as ultimately
+ * compositing the glyph later on by client applications.
+ */
+FT_Error
+ImGuiRsvgPortPresetSlot(FT_GlyphSlot  slot,
+    FT_Bool       cache,
+    FT_Pointer* _state)
+{
+    /* FreeType variables. */
+    FT_Error  error = FT_Err_Ok;
+
+    FT_SVG_Document  document = (FT_SVG_Document)slot->other;
+    FT_Size_Metrics  metrics = document->metrics;
+
+    FT_UShort  units_per_EM = document->units_per_EM;
+    FT_UShort  end_glyph_id = document->end_glyph_id;
+    FT_UShort  start_glyph_id = document->start_glyph_id;
+
+    /* Librsvg variables. */
+    GError* gerror = NULL;
+    gboolean  ret;
+
+    gboolean  out_has_width;
+    gboolean  out_has_height;
+    gboolean  out_has_viewbox;
+
+    RsvgHandle* handle;
+    RsvgDimensionData  dimension_svg;
+
+    cairo_t* rec_cr;
+    cairo_matrix_t  transform_matrix;
+
+    /* Rendering port's state. */
+    Rsvg_Port_State     state;
+    Rsvg_Port_StateRec  state_dummy;
+
+    /* General variables. */
+    double  x, y;
+    double  xx, xy, yx, yy;
+    double  x0, y0;
+    double  width, height;
+    double  x_svg_to_out, y_svg_to_out;
+    double  tmpd;
+
+    float metrics_width, metrics_height;
+    float horiBearingX, horiBearingY;
+    float vertBearingX, vertBearingY;
+    float tmpf;
+
+    char* id;
+    char  str[32];
+
+
+    /* If `cache` is `TRUE` we store calculations in the actual port */
+    /* state variable, otherwise we just create a dummy variable and */
+    /* store there.  This saves us from too many 'if' statements.    */
+    if (cache)
+        state = *(Rsvg_Port_State*)_state;
+    else
+        state = &state_dummy;
+
+    /* Form an `RsvgHandle` by loading the SVG document. */
+    handle = rsvg_handle_new_from_data(document->svg_document,
+        document->svg_document_length,
+        &gerror);
+    if (handle == NULL)
+    {
+        error = FT_Err_Invalid_SVG_Document;
+        goto CleanLibrsvg;
+    }
+
+#if (defined(RSVG_VERSION_H) && (LIBRSVG_MAJOR_VERSION >= 2) && (LIBRSVG_MINOR_VERSION >= 46))
+
+    RsvgLength         out_width;
+    RsvgLength         out_height;
+    RsvgRectangle      out_viewbox;
+
+    /* Get attributes like `viewBox` and `width`/`height`. */
+    rsvg_handle_get_intrinsic_dimensions(handle,
+        &out_has_width,
+        &out_width,
+        &out_has_height,
+        &out_height,
+        &out_has_viewbox,
+        &out_viewbox);
+
+    /*
+     * Figure out the units in the EM square in the SVG document.  This is
+     * specified by the `ViewBox` or the `width`/`height` attributes, if
+     * present, otherwise it should be assumed that the units in the EM
+     * square are the same as in the TTF/CFF outlines.
+     *
+     * TODO: I'm not sure what the standard says about the situation if
+     * `ViewBox` as well as `width`/`height` are present; however, I've
+     * never seen that situation in real fonts.
+     */
+    if (out_has_viewbox == TRUE)
+    {
+        dimension_svg.width = (int)out_viewbox.width; /* XXX rounding? */
+        dimension_svg.height = (int)out_viewbox.height;
+    }
+    else if (out_has_width == TRUE && out_has_height == TRUE)
+    {
+        dimension_svg.width = (int)out_width.length; /* XXX rounding? */
+        dimension_svg.height = (int)out_height.length;
+
+        /*
+         * librsvg 2.53+ behavior, on SVG doc without explicit width/height.
+         * See `rsvg_handle_get_intrinsic_dimensions` section in
+         * the `librsvg/rsvg.h` header file.
+         */
+        if (out_width.length == 1 &&
+            out_height.length == 1)
+        {
+            dimension_svg.width = units_per_EM;
+            dimension_svg.height = units_per_EM;
+        }
+    }
+    else
+    {
+        /*
+         * If neither `ViewBox` nor `width`/`height` are present, the
+         * `units_per_EM` in SVG coordinates must be the same as
+         * `units_per_EM` of the TTF/CFF outlines.
+         *
+         * librsvg up to 2.52 behavior, on SVG doc without explicit
+         * width/height.
+         */
+        dimension_svg.width = units_per_EM;
+        dimension_svg.height = units_per_EM;
+    }
+#else
+    // Workaround for librsvg <= v2.46 doesn't have the rsvg_handle_get_intrinsic_dimensions function
+    // See the problem with rsvg_handle_get_dimensions here:
+    // https://gnome.pages.gitlab.gnome.org/librsvg/Rsvg-2.0/method.Handle.get_dimensions.html
+    rsvg_handle_get_dimensions(handle, &dimension_svg);
+#endif // (defined(RSVG_VERSION_H) && (LIBRSVG_MAJOR_VERSION >= 2) && (LIBRSVG_MINOR_VERSION >= 46))
+
+    /* Scale factors from SVG coordinates to the needed output size. */
+    x_svg_to_out = (double)metrics.x_ppem / dimension_svg.width;
+    y_svg_to_out = (double)metrics.y_ppem / dimension_svg.height;
+
+    /*
+     * Create a cairo recording surface.  This is done for two reasons.
+     * Firstly, it is required to get the bounding box of the final drawing
+     * so we can use an appropriate translate transform to get a tight
+     * rendering.  Secondly, if `cache` is true, we can save this surface
+     * and later replay it against an image surface for the final rendering.
+     * This saves us from loading and parsing the document again.
+     */
+    state->rec_surface =
+        cairo_recording_surface_create(CAIRO_CONTENT_COLOR_ALPHA, NULL);
+
+    rec_cr = cairo_create(state->rec_surface);
+
+    /*
+     * We need to take into account any transformations applied.  The end
+     * user who applied the transformation doesn't know the internal details
+     * of the SVG document.  Thus, we expect that the end user should just
+     * write the transformation as if the glyph is a traditional one.  We
+     * then do some maths on this to get the equivalent transformation in
+     * SVG coordinates.
+     */
+    xx = (double)document->transform.xx / (1 << 16);
+    xy = -(double)document->transform.xy / (1 << 16);
+    yx = -(double)document->transform.yx / (1 << 16);
+    yy = (double)document->transform.yy / (1 << 16);
+
+    x0 = (double)document->delta.x / 64 *
+        dimension_svg.width / metrics.x_ppem;
+    y0 = -(double)document->delta.y / 64 *
+        dimension_svg.height / metrics.y_ppem;
+
+    /* Cairo stores both transformation and translation in one matrix. */
+    transform_matrix.xx = xx;
+    transform_matrix.yx = yx;
+    transform_matrix.xy = xy;
+    transform_matrix.yy = yy;
+    transform_matrix.x0 = x0;
+    transform_matrix.y0 = y0;
+
+    /* Set up a scale transformation to scale up the document to the */
+    /* required output size.                                         */
+    cairo_scale(rec_cr, x_svg_to_out, y_svg_to_out);
+    /* Set up a transformation matrix. */
+    cairo_transform(rec_cr, &transform_matrix);
+
+    /* If the document contains only one glyph, `start_glyph_id` and */
+    /* `end_glyph_id` have the same value.  Otherwise `end_glyph_id` */
+    /* is larger.                                                    */
+    if (start_glyph_id < end_glyph_id)
+    {
+        /* Render only the element with its ID equal to `glyph<ID>`. */
+        sprintf(str, "#glyph%u", slot->glyph_index);
+        id = str;
+    }
+    else
+    {
+        /* NULL = Render the whole document */
+        id = NULL;
+    }
+
+#if LIBRSVG_CHECK_VERSION( 2, 52, 0 )
+    {
+        RsvgRectangle  viewport =
+        {
+          .x = 0,
+          .y = 0,
+          .width = (double)dimension_svg.width,
+          .height = (double)dimension_svg.height,
+        };
+
+
+        ret = rsvg_handle_render_layer(handle,
+            rec_cr,
+            id,
+            &viewport,
+            NULL);
+    }
+#else
+    ret = rsvg_handle_render_cairo_sub(handle, rec_cr, id);
+#endif
+
+    if (ret == FALSE)
+    {
+        error = FT_Err_Invalid_SVG_Document;
+        goto CleanCairo;
+    }
+
+    /* Get the bounding box of the drawing. */
+    cairo_recording_surface_ink_extents(state->rec_surface, &x, &y,
+        &width, &height);
+
+    /* We store the bounding box's `x` and `y` values so that the render */
+    /* hook can apply a translation to get a tight rendering.            */
+    state->x = x;
+    state->y = y;
+
+    /* Preset the values. */
+    slot->bitmap_left = (FT_Int)state->x;  /* XXX rounding? */
+    slot->bitmap_top = (FT_Int)-state->y;
+
+    /* Do conversion in two steps to avoid 'bad function cast' warning. */
+    tmpd = ceil(height);
+    slot->bitmap.rows = (unsigned int)tmpd;
+    tmpd = ceil(width);
+    slot->bitmap.width = (unsigned int)tmpd;
+
+    slot->bitmap.pitch = (int)slot->bitmap.width * 4;
+
+    slot->bitmap.pixel_mode = FT_PIXEL_MODE_BGRA;
+
+    /* Compute all the bearings and set them correctly.  The outline is */
+    /* scaled already, we just need to use the bounding box.            */
+    metrics_width = (float)width;
+    metrics_height = (float)height;
+
+    horiBearingX = (float)state->x;
+    horiBearingY = (float)-state->y;
+
+    vertBearingX = slot->metrics.horiBearingX / 64.0f -
+        slot->metrics.horiAdvance / 64.0f / 2;
+    vertBearingY = (slot->metrics.vertAdvance / 64.0f -
+        slot->metrics.height / 64.0f) / 2; /* XXX parentheses correct? */
+
+    /* Do conversion in two steps to avoid 'bad function cast' warning. */
+    tmpf = roundf(metrics_width * 64);
+    slot->metrics.width = (FT_Pos)tmpf;
+    tmpf = roundf(metrics_height * 64);
+    slot->metrics.height = (FT_Pos)tmpf;
+
+    slot->metrics.horiBearingX = (FT_Pos)(horiBearingX * 64); /* XXX rounding? */
+    slot->metrics.horiBearingY = (FT_Pos)(horiBearingY * 64);
+    slot->metrics.vertBearingX = (FT_Pos)(vertBearingX * 64);
+    slot->metrics.vertBearingY = (FT_Pos)(vertBearingY * 64);
+
+    if (slot->metrics.vertAdvance == 0)
+        slot->metrics.vertAdvance = (FT_Pos)(metrics_height * 1.2f * 64);
+
+    /* If a render call is to follow, just destroy the context for the */
+    /* recording surface since no more drawing will be done on it.     */
+    /* However, keep the surface itself for use by the render hook.    */
+    if (cache == TRUE)
+    {
+        cairo_destroy(rec_cr);
+        goto CleanLibrsvg;
+    }
+
+    /* Destroy the recording surface as well as the context. */
+CleanCairo:
+    cairo_surface_destroy(state->rec_surface);
+    cairo_destroy(rec_cr);
+
+CleanLibrsvg:
+    /* Destroy the handle. */
+    g_object_unref(handle);
+
+    return error;
+}
+#endif // !IMGUI_ENABLE_FREETYPE_LIBRSVG
 
 #ifdef __GNUC__
 #pragma GCC diagnostic pop

--- a/misc/freetype/imgui_freetype.cpp
+++ b/misc/freetype/imgui_freetype.cpp
@@ -6,7 +6,7 @@
 
 // CHANGELOG
 // (minor and older changes stripped away, please see git history for details)
-//  2023/07/10: added support for SVG fonts, enable by using '#define IMGUI_ENABLE_FREETYPE_LIBRSVG'
+//  2023/07/12: added support for SVG fonts, enable by using '#define IMGUI_ENABLE_FREETYPE_OTSVG'
 //  2023/01/04: fixed a packing issue which in some occurrences would prevent large amount of glyphs from being packed correctly.
 //  2021/08/23: fixed crash when FT_Render_Glyph() fails to render a glyph and returns NULL.
 //  2021/03/05: added ImGuiFreeTypeBuilderFlags_Bitmap to load bitmap glyphs.
@@ -43,11 +43,11 @@
 #include FT_GLYPH_H             // <freetype/ftglyph.h>
 #include FT_SYNTHESIS_H         // <freetype/ftsynth.h>
 
-#ifdef IMGUI_ENABLE_FREETYPE_LIBRSVG
+#ifdef IMGUI_ENABLE_FREETYPE_OTSVG
 #include FT_OTSVG_H             // <freetype/otsvg.h>
 #include FT_BBOX_H              // <freetype/ftbbox.h>
-#include <librsvg/rsvg.h>
-#include <cairo/cairo.h>
+#include <lunasvg.h>
+#include <memory>
 #endif
 
 #ifdef _MSC_VER
@@ -77,12 +77,11 @@ static void  (*GImGuiFreeTypeFreeFunc)(void* ptr, void* user_data) = ImGuiFreeTy
 static void* GImGuiFreeTypeAllocatorUserData = nullptr;
 
 
-#ifdef IMGUI_ENABLE_FREETYPE_LIBRSVG
-// librsvg hooks
-FT_Error ImGuiRsvgPortInit(FT_Pointer* state);
-void     ImGuiRsvgPortFree(FT_Pointer* state);
-FT_Error ImGuiRsvgPortRender(FT_GlyphSlot slot, FT_Pointer* _state);
-FT_Error ImGuiRsvgPortPresetSlot(FT_GlyphSlot slot, FT_Bool cache, FT_Pointer* _state);
+#ifdef IMGUI_ENABLE_FREETYPE_OTSVG
+FT_Error ImGuiLunasvgPortInit(FT_Pointer* state);
+void     ImGuiLunasvgPortFree(FT_Pointer* state);
+FT_Error ImGuiLunasvgPortRender(FT_GlyphSlot slot, FT_Pointer* _state);
+FT_Error ImGuiLunasvgPortPresetSlot(FT_GlyphSlot slot, FT_Bool cache, FT_Pointer* _state);
 #endif
 
 //-------------------------------------------------------------------------
@@ -261,7 +260,7 @@ namespace
         FT_GlyphSlot slot = Face->glyph;
 
 #if ((FREETYPE_MAJOR >= 2) && (FREETYPE_MINOR >= 12))
-#ifdef IMGUI_ENABLE_FREETYPE_LIBRSVG
+#ifdef IMGUI_ENABLE_FREETYPE_OTSVG
         IM_ASSERT(
             slot->format == FT_GLYPH_FORMAT_OUTLINE ||
             slot->format == FT_GLYPH_FORMAT_BITMAP  ||
@@ -270,12 +269,12 @@ namespace
 #else
         IM_ASSERT(
             slot->format != FT_GLYPH_FORMAT_SVG &&
-            "The font contains SVG glyphs, you'll need to enable IMGUI_ENABLE_FREETYPE_LIBRSVG"
+            "The font contains SVG glyphs, you'll need to enable IMGUI_ENABLE_FREETYPE_OTSVG"
             "in imconfig.h and install required libraries in order to use this font"
         );
 
         IM_ASSERT(slot->format == FT_GLYPH_FORMAT_OUTLINE || slot->format == FT_GLYPH_FORMAT_BITMAP);
-#endif // IMGUI_ENABLE_FREETYPE_LIBRSVG
+#endif // IMGUI_ENABLE_FREETYPE_OTSVG
 #else
         IM_ASSERT(slot->format == FT_GLYPH_FORMAT_OUTLINE || slot->format == FT_GLYPH_FORMAT_BITMAP);
 #endif // ((FREETYPE_MAJOR >= 2) && (FREETYPE_MINOR >= 12))
@@ -804,23 +803,23 @@ static bool ImFontAtlasBuildWithFreeType(ImFontAtlas* atlas)
     // If you don't call FT_Add_Default_Modules() the rest of code may work, but FreeType won't use our custom allocator.
     FT_Add_Default_Modules(ft_library);
 
-#ifdef IMGUI_ENABLE_FREETYPE_LIBRSVG
+#ifdef IMGUI_ENABLE_FREETYPE_OTSVG
 #if ((FREETYPE_MAJOR >= 2) && (FREETYPE_MINOR >= 12))
     // Install svg hooks for FreeType
     // https://freetype.org/freetype2/docs/reference/ft2-properties.html#svg-hooks
     // https://freetype.org/freetype2/docs/reference/ft2-svg_fonts.html#svg_fonts
     SVG_RendererHooks  hooks = {
-        ImGuiRsvgPortInit,
-        ImGuiRsvgPortFree,
-        ImGuiRsvgPortRender,
-        ImGuiRsvgPortPresetSlot
+        ImGuiLunasvgPortInit,
+        ImGuiLunasvgPortFree,
+        ImGuiLunasvgPortRender,
+        ImGuiLunasvgPortPresetSlot
     };
 
     FT_Property_Set(ft_library, "ot-svg", "svg-hooks", &hooks);
 #else
-    IM_ASSERT(!"IMGUI_ENABLE_FREETYPE_LIBRSVG requires FreeType version >= 2.12");
+    IM_ASSERT(!"IMGUI_ENABLE_FREETYPE_OTSVG requires FreeType version >= 2.12");
 #endif // ((FREETYPE_MAJOR >= 2) && (FREETYPE_MINOR >= 12))
-#endif // IMGUI_ENABLE_FREETYPE_LIBRSVG
+#endif // IMGUI_ENABLE_FREETYPE_OTSVG
 
     bool ret = ImFontAtlasBuildWithFreeTypeEx(ft_library, atlas, atlas->FontBuilderFlags);
     FT_Done_Library(ft_library);
@@ -842,10 +841,10 @@ void ImGuiFreeType::SetAllocatorFunctions(void* (*alloc_func)(size_t sz, void* u
     GImGuiFreeTypeAllocatorUserData = user_data;
 }
 
-#ifdef IMGUI_ENABLE_FREETYPE_LIBRSVG
+#ifdef IMGUI_ENABLE_FREETYPE_OTSVG
 /*
- * Librsvg-based hook functions for OT-SVG rendering in FreeType
- * https://gitlab.freedesktop.org/freetype/freetype-demos/-/blob/master/src/rsvg-port.c
+ * lunasvg-based hook functions for OT-SVG rendering in FreeType
+ * based on https://gitlab.freedesktop.org/freetype/freetype-demos/-/blob/master/src/rsvg-port.c
  */
 
  /*
@@ -853,16 +852,12 @@ void ImGuiFreeType::SetAllocatorFunctions(void* (*alloc_func)(size_t sz, void* u
   * structure and putting its address in `library->svg_renderer_state`.
   * Functions can then store and retrieve data from this structure.
   */
-typedef struct  Rsvg_Port_StateRec_
+typedef struct  LunasvgPortState_
 {
-    cairo_surface_t* rec_surface;
-
-    double  x;
-    double  y;
-
-} Rsvg_Port_StateRec;
-
-typedef struct Rsvg_Port_StateRec_* Rsvg_Port_State;
+    FT_Error err = FT_Err_Ok;
+    std::unique_ptr<lunasvg::Document> svg = nullptr;
+    lunasvg::Matrix matrix;
+} LunasvgPortState, *PLunasvgPortState;
 
 
 /*
@@ -872,12 +867,10 @@ typedef struct Rsvg_Port_StateRec_* Rsvg_Port_State;
   * useful to cache some of the results obtained by one hook function that
   * the other one might use.
   */
-FT_Error
-ImGuiRsvgPortInit(FT_Pointer* state)
+FT_Error ImGuiLunasvgPortInit(FT_Pointer* _state)
 {
     /* allocate the memory upon initialization */
-    *state = malloc(sizeof(Rsvg_Port_StateRec)); /* XXX error handling */
-
+    *_state = new LunasvgPortState();
     return FT_Err_Ok;
 }
 
@@ -885,12 +878,10 @@ ImGuiRsvgPortInit(FT_Pointer* state)
 /*
  * Deallocate the state structure.
  */
-void
-ImGuiRsvgPortFree(FT_Pointer* state)
+void ImGuiLunasvgPortFree(FT_Pointer* _state)
 {
-    free(*state);
+    delete *_state;
 }
-
 
 /*
  * The render hook.  The job of this hook is to simply render the glyph in
@@ -898,71 +889,24 @@ ImGuiRsvgPortFree(FT_Pointer* state)
  * simply use the recording surface by playing it back against the
  * surface.
  */
-FT_Error
-ImGuiRsvgPortRender(FT_GlyphSlot  slot,
-    FT_Pointer* _state)
+FT_Error ImGuiLunasvgPortRender(FT_GlyphSlot slot, FT_Pointer* _state)
 {
-    FT_Error  error = FT_Err_Ok;
+    PLunasvgPortState state = *(PLunasvgPortState*)_state;
 
-    Rsvg_Port_State   state;
-    cairo_status_t    status;
-    cairo_t* cr;
-    cairo_surface_t* surface;
+    lunasvg::Bitmap bitmap(
+        (uint8_t*)slot->bitmap.buffer,
+        slot->bitmap.width,
+        slot->bitmap.rows, // rows is height
+        slot->bitmap.pitch // pitch (or stride) equals to width * sizeof(int32)
+    );
 
+    // reset the svg matrix to the default value
+    state->svg->setMatrix(state->svg->matrix().identity());
 
-    state = *(Rsvg_Port_State*)_state;
+    // state->matrix is already scaled and translated
+    state->svg->render(bitmap, state->matrix);
 
-    /* Create an image surface to store the rendered image.  However,   */
-    /* don't allocate memory; instead use the space already provided in */
-    /* `slot->bitmap.buffer`.                                           */
-    surface = cairo_image_surface_create_for_data(slot->bitmap.buffer,
-        CAIRO_FORMAT_ARGB32,
-        (int)slot->bitmap.width,
-        (int)slot->bitmap.rows,
-        slot->bitmap.pitch);
-    status = cairo_surface_status(surface);
-
-    if (status != CAIRO_STATUS_SUCCESS)
-    {
-        if (status == CAIRO_STATUS_NO_MEMORY)
-            return FT_Err_Out_Of_Memory;
-        else
-            return FT_Err_Invalid_Outline;
-    }
-
-    cr = cairo_create(surface);
-    status = cairo_status(cr);
-
-    if (status != CAIRO_STATUS_SUCCESS)
-    {
-        if (status == CAIRO_STATUS_NO_MEMORY)
-            return FT_Err_Out_Of_Memory;
-        else
-            return FT_Err_Invalid_Outline;
-    }
-
-    /* Set a translate transform that translates the points in such a way */
-    /* that we get a tight rendering with least redundant white spac.     */
-    cairo_translate(cr, -state->x, -state->y);
-
-    /* Replay from the recorded surface.  This saves us from parsing the */
-    /* document again and redoing what was already done in the preset    */
-    /* hook.                                                             */
-    cairo_set_source_surface(cr, state->rec_surface, 0.0, 0.0);
-    cairo_paint(cr);
-
-    cairo_surface_flush(surface);
-
-    slot->bitmap.pixel_mode = FT_PIXEL_MODE_BGRA;
-    slot->bitmap.num_grays = 256;
-    slot->format = FT_GLYPH_FORMAT_BITMAP;
-
-    /* Clean up everything. */
-    cairo_surface_destroy(surface);
-    cairo_destroy(cr);
-    cairo_surface_destroy(state->rec_surface);
-
-    return error;
+    return FT_Err_Ok;
 }
 
 /*
@@ -977,303 +921,89 @@ ImGuiRsvgPortRender(FT_GlyphSlot  slot,
  * necessary for appropriate memory allocation, as well as ultimately
  * compositing the glyph later on by client applications.
  */
-FT_Error
-ImGuiRsvgPortPresetSlot(FT_GlyphSlot  slot,
-    FT_Bool       cache,
-    FT_Pointer* _state)
+FT_Error ImGuiLunasvgPortPresetSlot(FT_GlyphSlot slot, FT_Bool cache, FT_Pointer* _state)
 {
-    /* FreeType variables. */
-    FT_Error  error = FT_Err_Ok;
+    
+    FT_SVG_Document   document = (FT_SVG_Document)slot->other;
+    PLunasvgPortState state = *(PLunasvgPortState*)_state;
+    FT_Size_Metrics&  metrics = document->metrics;
 
-    FT_SVG_Document  document = (FT_SVG_Document)slot->other;
-    FT_Size_Metrics  metrics = document->metrics;
+    if (cache) return state->err;
 
-    FT_UShort  units_per_EM = document->units_per_EM;
-    FT_UShort  end_glyph_id = document->end_glyph_id;
-    FT_UShort  start_glyph_id = document->start_glyph_id;
+    state->svg = lunasvg::Document::loadFromData(
+        (const char*)document->svg_document,
+        document->svg_document_length
+    );
 
-    /* Librsvg variables. */
-    GError* gerror = NULL;
-    gboolean  ret;
-
-    gboolean  out_has_width;
-    gboolean  out_has_height;
-    gboolean  out_has_viewbox;
-
-    RsvgHandle* handle;
-    RsvgDimensionData  dimension_svg;
-
-    cairo_t* rec_cr;
-    cairo_matrix_t  transform_matrix;
-
-    /* Rendering port's state. */
-    Rsvg_Port_State     state;
-    Rsvg_Port_StateRec  state_dummy;
-
-    /* General variables. */
-    double  x, y;
-    double  xx, xy, yx, yy;
-    double  x0, y0;
-    double  width, height;
-    double  x_svg_to_out, y_svg_to_out;
-    double  tmpd;
-
-    float metrics_width, metrics_height;
-    float horiBearingX, horiBearingY;
-    float vertBearingX, vertBearingY;
-    float tmpf;
-
-    char* id;
-    char  str[32];
-
-
-    /* If `cache` is `TRUE` we store calculations in the actual port */
-    /* state variable, otherwise we just create a dummy variable and */
-    /* store there.  This saves us from too many 'if' statements.    */
-    if (cache)
-        state = *(Rsvg_Port_State*)_state;
-    else
-        state = &state_dummy;
-
-    /* Form an `RsvgHandle` by loading the SVG document. */
-    handle = rsvg_handle_new_from_data(document->svg_document,
-        document->svg_document_length,
-        &gerror);
-    if (handle == NULL)
+    if (state->svg == nullptr)
     {
-        error = FT_Err_Invalid_SVG_Document;
-        goto CleanLibrsvg;
+        state->err = FT_Err_Invalid_SVG_Document;
+        return state->err;
     }
 
-#if LIBRSVG_CHECK_VERSION(2, 46, 0)
+    lunasvg::Box box = state->svg->box();
 
-    RsvgLength         out_width;
-    RsvgLength         out_height;
-    RsvgRectangle      out_viewbox;
+    double scale = std::min(metrics.x_ppem / box.w, metrics.y_ppem / box.h);
 
-    /* Get attributes like `viewBox` and `width`/`height`. */
-    rsvg_handle_get_intrinsic_dimensions(handle,
-        &out_has_width,
-        &out_width,
-        &out_has_height,
-        &out_height,
-        &out_has_viewbox,
-        &out_viewbox);
+    double xx = (double)document->transform.xx / (1 << 16);
+    double xy = -(double)document->transform.xy / (1 << 16);
+    double yx = -(double)document->transform.yx / (1 << 16);
+    double yy = (double)document->transform.yy / (1 << 16);
 
-    /*
-     * Figure out the units in the EM square in the SVG document.  This is
-     * specified by the `ViewBox` or the `width`/`height` attributes, if
-     * present, otherwise it should be assumed that the units in the EM
-     * square are the same as in the TTF/CFF outlines.
-     *
-     * TODO: I'm not sure what the standard says about the situation if
-     * `ViewBox` as well as `width`/`height` are present; however, I've
-     * never seen that situation in real fonts.
-     */
-    if (out_has_viewbox == TRUE)
-    {
-        dimension_svg.width = (int)out_viewbox.width; /* XXX rounding? */
-        dimension_svg.height = (int)out_viewbox.height;
-    }
-    else if (out_has_width == TRUE && out_has_height == TRUE)
-    {
-        dimension_svg.width = (int)out_width.length; /* XXX rounding? */
-        dimension_svg.height = (int)out_height.length;
+    double x0 = (double)document->delta.x / 64 * box.w / metrics.x_ppem;
+    double y0 = -(double)document->delta.y / 64 * box.h / metrics.y_ppem;
 
-        /*
-         * librsvg 2.53+ behavior, on SVG doc without explicit width/height.
-         * See `rsvg_handle_get_intrinsic_dimensions` section in
-         * the `librsvg/rsvg.h` header file.
-         */
-        if (out_width.length == 1 &&
-            out_height.length == 1)
-        {
-            dimension_svg.width = units_per_EM;
-            dimension_svg.height = units_per_EM;
-        }
-    }
-    else
-    {
-        /*
-         * If neither `ViewBox` nor `width`/`height` are present, the
-         * `units_per_EM` in SVG coordinates must be the same as
-         * `units_per_EM` of the TTF/CFF outlines.
-         *
-         * librsvg up to 2.52 behavior, on SVG doc without explicit
-         * width/height.
-         */
-        dimension_svg.width = units_per_EM;
-        dimension_svg.height = units_per_EM;
-    }
-#else
-    // Workaround for librsvg <= v2.46 doesn't have the rsvg_handle_get_intrinsic_dimensions function
-    // See the problem with rsvg_handle_get_dimensions here:
-    // https://gnome.pages.gitlab.gnome.org/librsvg/Rsvg-2.0/method.Handle.get_dimensions.html
-    rsvg_handle_get_dimensions(handle, &dimension_svg);
-#endif // (defined(RSVG_VERSION_H) && (LIBRSVG_MAJOR_VERSION >= 2) && (LIBRSVG_MINOR_VERSION >= 46))
+    // this reset the matrix to default value
+    state->matrix.identity();
 
-    /* Scale factors from SVG coordinates to the needed output size. */
-    x_svg_to_out = (double)metrics.x_ppem / dimension_svg.width;
-    y_svg_to_out = (double)metrics.y_ppem / dimension_svg.height;
+    state->matrix.scale(scale, scale);
+    state->matrix.transform(xx, xy, yx, yy, x0, y0);
+    state->svg->setMatrix(state->matrix);
 
-    /*
-     * Create a cairo recording surface.  This is done for two reasons.
-     * Firstly, it is required to get the bounding box of the final drawing
-     * so we can use an appropriate translate transform to get a tight
-     * rendering.  Secondly, if `cache` is true, we can save this surface
-     * and later replay it against an image surface for the final rendering.
-     * This saves us from loading and parsing the document again.
-     */
-    state->rec_surface =
-        cairo_recording_surface_create(CAIRO_CONTENT_COLOR_ALPHA, NULL);
+    // don't translate the svg yet, leave this for the rendering step
+    state->matrix.translate(-box.x, -box.y);
 
-    rec_cr = cairo_create(state->rec_surface);
-
-    /*
-     * We need to take into account any transformations applied.  The end
-     * user who applied the transformation doesn't know the internal details
-     * of the SVG document.  Thus, we expect that the end user should just
-     * write the transformation as if the glyph is a traditional one.  We
-     * then do some maths on this to get the equivalent transformation in
-     * SVG coordinates.
-     */
-    xx = (double)document->transform.xx / (1 << 16);
-    xy = -(double)document->transform.xy / (1 << 16);
-    yx = -(double)document->transform.yx / (1 << 16);
-    yy = (double)document->transform.yy / (1 << 16);
-
-    x0 = (double)document->delta.x / 64 *
-        dimension_svg.width / metrics.x_ppem;
-    y0 = -(double)document->delta.y / 64 *
-        dimension_svg.height / metrics.y_ppem;
-
-    /* Cairo stores both transformation and translation in one matrix. */
-    transform_matrix.xx = xx;
-    transform_matrix.yx = yx;
-    transform_matrix.xy = xy;
-    transform_matrix.yy = yy;
-    transform_matrix.x0 = x0;
-    transform_matrix.y0 = y0;
-
-    /* Set up a scale transformation to scale up the document to the */
-    /* required output size.                                         */
-    cairo_scale(rec_cr, x_svg_to_out, y_svg_to_out);
-    /* Set up a transformation matrix. */
-    cairo_transform(rec_cr, &transform_matrix);
-
-    /* If the document contains only one glyph, `start_glyph_id` and */
-    /* `end_glyph_id` have the same value.  Otherwise `end_glyph_id` */
-    /* is larger.                                                    */
-    if (start_glyph_id < end_glyph_id)
-    {
-        /* Render only the element with its ID equal to `glyph<ID>`. */
-        sprintf(str, "#glyph%u", slot->glyph_index);
-        id = str;
-    }
-    else
-    {
-        /* NULL = Render the whole document */
-        id = NULL;
-    }
-
-#if LIBRSVG_CHECK_VERSION( 2, 52, 0 )
-    {
-        RsvgRectangle  viewport =
-        {
-          .x = 0,
-          .y = 0,
-          .width = (double)dimension_svg.width,
-          .height = (double)dimension_svg.height,
-        };
-
-
-        ret = rsvg_handle_render_layer(handle,
-            rec_cr,
-            id,
-            &viewport,
-            NULL);
-    }
-#else
-    ret = rsvg_handle_render_cairo_sub(handle, rec_cr, id);
-#endif
-
-    if (ret == FALSE)
-    {
-        error = FT_Err_Invalid_SVG_Document;
-        goto CleanCairo;
-    }
-
-    /* Get the bounding box of the drawing. */
-    cairo_recording_surface_ink_extents(state->rec_surface, &x, &y,
-        &width, &height);
-
-    /* We store the bounding box's `x` and `y` values so that the render */
-    /* hook can apply a translation to get a tight rendering.            */
-    state->x = x;
-    state->y = y;
+    // get the box again after the transformation
+    box = state->svg->box();
 
     /* Preset the values. */
-    slot->bitmap_left = (FT_Int)state->x;  /* XXX rounding? */
-    slot->bitmap_top = (FT_Int)-state->y;
+    slot->bitmap_left = FT_Int(box.x);  /* XXX rounding? */
+    slot->bitmap_top = FT_Int(-box.y);
 
-    /* Do conversion in two steps to avoid 'bad function cast' warning. */
-    tmpd = ceil(height);
-    slot->bitmap.rows = (unsigned int)tmpd;
-    tmpd = ceil(width);
-    slot->bitmap.width = (unsigned int)tmpd;
+    slot->bitmap.rows = unsigned int(ceil(box.h));
+    slot->bitmap.width = unsigned int(ceil(box.w));
 
-    slot->bitmap.pitch = (int)slot->bitmap.width * 4;
-
+    slot->bitmap.pitch = slot->bitmap.width * 4;
     slot->bitmap.pixel_mode = FT_PIXEL_MODE_BGRA;
 
     /* Compute all the bearings and set them correctly.  The outline is */
     /* scaled already, we just need to use the bounding box.            */
-    metrics_width = (float)width;
-    metrics_height = (float)height;
+    double metrics_width = box.w;
+    double metrics_height = box.h;
 
-    horiBearingX = (float)state->x;
-    horiBearingY = (float)-state->y;
+    double horiBearingX = box.x;
+    double horiBearingY = -box.y;
 
-    vertBearingX = slot->metrics.horiBearingX / 64.0f -
-        slot->metrics.horiAdvance / 64.0f / 2;
-    vertBearingY = (slot->metrics.vertAdvance / 64.0f -
-        slot->metrics.height / 64.0f) / 2; /* XXX parentheses correct? */
+    double vertBearingX = slot->metrics.horiBearingX / 64.0 -
+        slot->metrics.horiAdvance / 64.0 / 2.0;
+    double vertBearingY = (slot->metrics.vertAdvance / 64.0 -
+        slot->metrics.height / 64.0) / 2.0; /* XXX parentheses correct? */
 
-    /* Do conversion in two steps to avoid 'bad function cast' warning. */
-    tmpf = roundf(metrics_width * 64);
-    slot->metrics.width = (FT_Pos)tmpf;
-    tmpf = roundf(metrics_height * 64);
-    slot->metrics.height = (FT_Pos)tmpf;
+    slot->metrics.width = FT_Pos(round(metrics_width * 64));
+    slot->metrics.height = FT_Pos(round(metrics_height * 64));
 
-    slot->metrics.horiBearingX = (FT_Pos)(horiBearingX * 64); /* XXX rounding? */
-    slot->metrics.horiBearingY = (FT_Pos)(horiBearingY * 64);
-    slot->metrics.vertBearingX = (FT_Pos)(vertBearingX * 64);
-    slot->metrics.vertBearingY = (FT_Pos)(vertBearingY * 64);
+    slot->metrics.horiBearingX = FT_Pos(horiBearingX * 64); /* XXX rounding? */
+    slot->metrics.horiBearingY = FT_Pos(horiBearingY * 64);
+    slot->metrics.vertBearingX = FT_Pos(vertBearingX * 64);
+    slot->metrics.vertBearingY = FT_Pos(vertBearingY * 64);
 
     if (slot->metrics.vertAdvance == 0)
-        slot->metrics.vertAdvance = (FT_Pos)(metrics_height * 1.2f * 64);
+        slot->metrics.vertAdvance = FT_Pos(metrics_height * 1.2 * 64.0);
 
-    /* If a render call is to follow, just destroy the context for the */
-    /* recording surface since no more drawing will be done on it.     */
-    /* However, keep the surface itself for use by the render hook.    */
-    if (cache == TRUE)
-    {
-        cairo_destroy(rec_cr);
-        goto CleanLibrsvg;
-    }
-
-    /* Destroy the recording surface as well as the context. */
-CleanCairo:
-    cairo_surface_destroy(state->rec_surface);
-    cairo_destroy(rec_cr);
-
-CleanLibrsvg:
-    /* Destroy the handle. */
-    g_object_unref(handle);
-
-    return error;
+    state->err = FT_Err_Ok;
+    return state->err;
 }
-#endif // !IMGUI_ENABLE_FREETYPE_LIBRSVG
+#endif // !IMGUI_ENABLE_FREETYPE_OTSVG
 
 #ifdef __GNUC__
 #pragma GCC diagnostic pop

--- a/misc/freetype/imgui_freetype.cpp
+++ b/misc/freetype/imgui_freetype.cpp
@@ -260,6 +260,7 @@ namespace
         // Need an outline for this to work
         FT_GlyphSlot slot = Face->glyph;
 
+#if ((FREETYPE_MAJOR >= 2) && (FREETYPE_MINOR >= 12))
 #ifdef IMGUI_ENABLE_FREETYPE_LIBRSVG
         IM_ASSERT(
             slot->format == FT_GLYPH_FORMAT_OUTLINE ||
@@ -274,7 +275,10 @@ namespace
         );
 
         IM_ASSERT(slot->format == FT_GLYPH_FORMAT_OUTLINE || slot->format == FT_GLYPH_FORMAT_BITMAP);
-#endif
+#endif // IMGUI_ENABLE_FREETYPE_LIBRSVG
+#else
+        IM_ASSERT(slot->format == FT_GLYPH_FORMAT_OUTLINE || slot->format == FT_GLYPH_FORMAT_BITMAP);
+#endif // ((FREETYPE_MAJOR >= 2) && (FREETYPE_MINOR >= 12))
 
         // Apply convenience transform (this is not picking from real "Bold"/"Italic" fonts! Merely applying FreeType helper transform. Oblique == Slanting)
         if (UserFlags & ImGuiFreeTypeBuilderFlags_Bold)
@@ -801,6 +805,7 @@ static bool ImFontAtlasBuildWithFreeType(ImFontAtlas* atlas)
     FT_Add_Default_Modules(ft_library);
 
 #ifdef IMGUI_ENABLE_FREETYPE_LIBRSVG
+#if ((FREETYPE_MAJOR >= 2) && (FREETYPE_MINOR >= 12))
     // Install svg hooks for FreeType
     // https://freetype.org/freetype2/docs/reference/ft2-properties.html#svg-hooks
     // https://freetype.org/freetype2/docs/reference/ft2-svg_fonts.html#svg_fonts
@@ -812,7 +817,10 @@ static bool ImFontAtlasBuildWithFreeType(ImFontAtlas* atlas)
     };
 
     FT_Property_Set(ft_library, "ot-svg", "svg-hooks", &hooks);
-#endif
+#else
+    IM_ASSERT(!"IMGUI_ENABLE_FREETYPE_LIBRSVG requires FreeType version >= 2.12");
+#endif // ((FREETYPE_MAJOR >= 2) && (FREETYPE_MINOR >= 12))
+#endif // IMGUI_ENABLE_FREETYPE_LIBRSVG
 
     bool ret = ImFontAtlasBuildWithFreeTypeEx(ft_library, atlas, atlas->FontBuilderFlags);
     FT_Done_Library(ft_library);
@@ -1037,7 +1045,7 @@ ImGuiRsvgPortPresetSlot(FT_GlyphSlot  slot,
         goto CleanLibrsvg;
     }
 
-#if (defined(RSVG_VERSION_H) && (LIBRSVG_MAJOR_VERSION >= 2) && (LIBRSVG_MINOR_VERSION >= 46))
+#if LIBRSVG_CHECK_VERSION(2, 46, 0)
 
     RsvgLength         out_width;
     RsvgLength         out_height;

--- a/misc/freetype/imgui_freetype.cpp
+++ b/misc/freetype/imgui_freetype.cpp
@@ -917,8 +917,8 @@ FT_Error ImGuiLunasvgPortPresetSlot(FT_GlyphSlot slot, FT_Bool cache, FT_Pointer
     // Calculate the bitmap size
     slot->bitmap_left = FT_Int(box.x);
     slot->bitmap_top = FT_Int(-box.y);
-    slot->bitmap.rows = unsigned int(ceil(box.h));
-    slot->bitmap.width = unsigned int(ceil(box.w));
+    slot->bitmap.rows = (unsigned int)(ceil(box.h));
+    slot->bitmap.width = (unsigned int)(ceil(box.w));
     slot->bitmap.pitch = slot->bitmap.width * 4;
     slot->bitmap.pixel_mode = FT_PIXEL_MODE_BGRA;
 


### PR DESCRIPTION
## Support for OpenType SVG fonts (SVGinOT)
### Motivation
- *SVG in Open Type* is a standard by Adobe and Mozilla for color OpenType and Open Font Format fonts. It allows font creators to embed complete SVG files within a font enabling full color and even animations.
- Popular SVGinOT fonts such as [twemoji](https://github.com/13rac1/twemoji-color-font) and (a build of) [noto-emoji](https://github.com/googlefonts/color-fonts/blob/main/fonts/noto-untouchedsvg.ttf) are currently not supported by dear imgui.
- Using tools like [nanoemoji](https://github.com/googlefonts/nanoemoji) and [scfbuild](https://github.com/13rac1/scfbuild), we can easily make our own custom colorful fonts from SVGs instead of having to [use custom glyphs](https://github.com/ocornut/imgui/blob/master/docs/FONTS.md#using-custom-colorful-icons) and deal with bitmap and scaling.

### How it works
- FreeType provides a way to hook SVG rendering: [svg-hooks](https://freetype.org/freetype2/docs/reference/ft2-properties.html#svg-hooks), [svg-fonts](https://freetype.org/freetype2/docs/reference/ft2-svg_fonts.html#svg_fonts)
- Example code can be found in [freetype-demos/src/rsvg-port.c](https://gitlab.freedesktop.org/freetype/freetype-demos/-/blob/master/src/rsvg-port.c).

### Enable SVG support and install required libraries
1. Enable FreeType, follow the instructions [here](https://github.com/ocornut/imgui/tree/master/misc/freetype#usage), requires v2.12 and above.
2. Add `#define IMGUI_ENABLE_FREETYPE_OTSVG` in your `imconfig.h`.
3. Install [lunasvg](https://github.com/sammycage/lunasvg) v2.3.2 and above. Get the latest lunasvg binaries or build yourself. Under Windows, you may use vcpkg with: `vcpkg install lunasvg --triplet=x64-windows`.

### Preview
- Here is a preview of twemoji rendered in dear imgui:
    ![image](https://github.com/ocornut/imgui/assets/136492105/2f2619fd-3fe1-41fb-b138-b3e5352bc3ab)

