### PR TITLE
Properly honor GLFW_CURSOR_DISABLED

### DIFF
--- a/backends/imgui_impl_glfw.cpp
+++ b/backends/imgui_impl_glfw.cpp
@@ -386,8 +386,6 @@ void ImGui_ImplGlfw_CursorPosCallback(GLFWwindow* window, double x, double y)
     ImGui_ImplGlfw_Data* bd = ImGui_ImplGlfw_GetBackendData();
     if (bd->PrevUserCallbackCursorPos != nullptr && ImGui_ImplGlfw_ShouldChainCallback(window))
         bd->PrevUserCallbackCursorPos(window, x, y);
-    if (glfwGetInputMode(window, GLFW_CURSOR) == GLFW_CURSOR_DISABLED)
-        return;
 
     ImGuiIO& io = ImGui::GetIO();
     io.AddMousePosEvent((float)x, (float)y);
@@ -401,8 +399,6 @@ void ImGui_ImplGlfw_CursorEnterCallback(GLFWwindow* window, int entered)
     ImGui_ImplGlfw_Data* bd = ImGui_ImplGlfw_GetBackendData();
     if (bd->PrevUserCallbackCursorEnter != nullptr && ImGui_ImplGlfw_ShouldChainCallback(window))
         bd->PrevUserCallbackCursorEnter(window, entered);
-    if (glfwGetInputMode(window, GLFW_CURSOR) == GLFW_CURSOR_DISABLED)
-        return;
 
     ImGuiIO& io = ImGui::GetIO();
     if (entered)
@@ -654,11 +650,6 @@ static void ImGui_ImplGlfw_UpdateMouseData()
     ImGui_ImplGlfw_Data* bd = ImGui_ImplGlfw_GetBackendData();
     ImGuiIO& io = ImGui::GetIO();
 
-    if (glfwGetInputMode(bd->Window, GLFW_CURSOR) == GLFW_CURSOR_DISABLED)
-    {
-        io.AddMousePosEvent(-FLT_MAX, -FLT_MAX);
-        return;
-    }
 
     // (those braces are here to reduce diff with multi-viewports support in 'docking' branch)
     {

--- a/backends/imgui_impl_glfw.cpp
+++ b/backends/imgui_impl_glfw.cpp
@@ -121,7 +121,6 @@ struct ImGui_ImplGlfw_Data
     ImVec2                  LastValidMousePos;
     bool                    InstalledCallbacks;
     bool                    CallbacksChainForAllWindows;
-    bool                    ClearNoMouse;
 
     // Chain GLFW callbacks: our callbacks will call the user's previously installed callbacks, if any.
     GLFWwindowfocusfun      PrevUserCallbackWindowFocus;
@@ -653,15 +652,11 @@ static void ImGui_ImplGlfw_UpdateMouseData()
 
     if (glfwGetInputMode(bd->Window, GLFW_CURSOR) == GLFW_CURSOR_DISABLED)
     {
-        // Store whether we should clear the "NoMouse" flag when the cursor is set to normal again
-        bd->ClearNoMouse = !(io.ConfigFlags & ImGuiConfigFlags_NoMouse);
-        io.ConfigFlags |= ImGuiConfigFlags_NoMouse;
+        io.BackendFlags |= ImGuiBackendFlags_CursorDisabled;
     }
-    else if (bd->ClearNoMouse)
+    else
     {
-        // Cursor isn't disabled anymore and the user didn't set "NoMouse" manually. Clear the flag
-        io.ConfigFlags &= ~ImGuiConfigFlags_NoMouse;
-        bd->ClearNoMouse = false;
+        io.BackendFlags &= ~ImGuiBackendFlags_CursorDisabled;
     }
 
     // (those braces are here to reduce diff with multi-viewports support in 'docking' branch)

--- a/backends/imgui_impl_glfw.cpp
+++ b/backends/imgui_impl_glfw.cpp
@@ -121,6 +121,7 @@ struct ImGui_ImplGlfw_Data
     ImVec2                  LastValidMousePos;
     bool                    InstalledCallbacks;
     bool                    CallbacksChainForAllWindows;
+    bool                    ClearNoMouse;
 
     // Chain GLFW callbacks: our callbacks will call the user's previously installed callbacks, if any.
     GLFWwindowfocusfun      PrevUserCallbackWindowFocus;
@@ -650,6 +651,18 @@ static void ImGui_ImplGlfw_UpdateMouseData()
     ImGui_ImplGlfw_Data* bd = ImGui_ImplGlfw_GetBackendData();
     ImGuiIO& io = ImGui::GetIO();
 
+    if (glfwGetInputMode(bd->Window, GLFW_CURSOR) == GLFW_CURSOR_DISABLED)
+    {
+        // Store whether we should clear the "NoMouse" flag when the cursor is set to normal again
+        bd->ClearNoMouse = !(io.ConfigFlags & ImGuiConfigFlags_NoMouse);
+        io.ConfigFlags |= ImGuiConfigFlags_NoMouse;
+    }
+    else if (bd->ClearNoMouse)
+    {
+        // Cursor isn't disabled anymore and the user didn't set "NoMouse" manually. Clear the flag
+        io.ConfigFlags &= ~ImGuiConfigFlags_NoMouse;
+        bd->ClearNoMouse = false;
+    }
 
     // (those braces are here to reduce diff with multi-viewports support in 'docking' branch)
     {

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -4444,7 +4444,7 @@ void ImGui::UpdateHoveredWindowAndCaptureFlags()
         clear_hovered_windows = true;
 
     // Disabled mouse?
-    if (io.ConfigFlags & ImGuiConfigFlags_NoMouse)
+    if (io.ConfigFlags & ImGuiConfigFlags_NoMouse || io.BackendFlags & ImGuiBackendFlags_CursorDisabled)
         clear_hovered_windows = true;
 
     // We track click ownership. When clicked outside of a window the click is owned by the application and

--- a/imgui.h
+++ b/imgui.h
@@ -1550,6 +1550,7 @@ enum ImGuiBackendFlags_
     ImGuiBackendFlags_HasMouseCursors       = 1 << 1,   // Backend Platform supports honoring GetMouseCursor() value to change the OS cursor shape.
     ImGuiBackendFlags_HasSetMousePos        = 1 << 2,   // Backend Platform supports io.WantSetMousePos requests to reposition the OS mouse position (only used if ImGuiConfigFlags_NavEnableSetMousePos is set).
     ImGuiBackendFlags_RendererHasVtxOffset  = 1 << 3,   // Backend Renderer supports ImDrawCmd::VtxOffset. This enables output of large meshes (64K+ vertices) while still using 16-bit indices.
+    ImGuiBackendFlags_CursorDisabled        = 1 << 4,   // The backend disabled the cursor. Anologous to ImGuiConfigFlags_NoMouse.
 };
 
 // Enumeration for PushStyleColor() / PopStyleColor()


### PR DESCRIPTION
This PR does 2 things:
1. Reverts #5625
2. Implements #5625 properly

By setting an analogous backend flag to ```ImGuiConfigFlag_NoMouse``` when ```GLFW_CURSOR_DISABLED``` is set, ImGui won't hover items with the virtual cursor, while also providing up-to-date cursor positions (https://github.com/ocornut/imgui/pull/5625#issuecomment-1628600363). 
I opted to add a backend flag instead of just using ```ImGuiConfigFlag_NoMouse``` to avoid interfering with the user setting this flag (See also the commit message for da049f3). A version that just uses ```ImGuiConfigFlag_NoMouse``` can be found at the commit c7013bd though.