### PR TITLE
SDL_GetWindowWMInfo returns 0 on success, crash fix on creating new window

### DIFF
--- a/backends/imgui_impl_sdl3.cpp
+++ b/backends/imgui_impl_sdl3.cpp
@@ -770,7 +770,7 @@ static void ImGui_ImplSDL3_CreateWindow(ImGuiViewport* viewport)
     viewport->PlatformHandle = (void*)vd->Window;
     viewport->PlatformHandleRaw = nullptr;
     SDL_SysWMinfo info;
-    if (SDL_GetWindowWMInfo(vd->Window, &info, SDL_SYSWM_CURRENT_VERSION))
+    if (SDL_GetWindowWMInfo(vd->Window, &info, SDL_SYSWM_CURRENT_VERSION) == 0)
     {
 #if defined(SDL_VIDEO_DRIVER_WINDOWS)
         viewport->PlatformHandleRaw = info.info.win.window;


### PR DESCRIPTION
SDL_GetWindowWMInfo return 0 on success so putting it into an if like that caused that if to never be entered and it caused a crash on docking branch when ImGui tried to create a new window