### PR TITLE
Fix color is wrong in some old game with DirectX 9

### DIFF
--- a/backends/imgui_impl_dx9.cpp
+++ b/backends/imgui_impl_dx9.cpp
@@ -109,6 +109,13 @@ static void ImGui_ImplDX9_SetupRenderState(ImDrawData* draw_data)
     bd->pd3dDevice->SetRenderState(D3DRS_STENCILENABLE, FALSE);
     bd->pd3dDevice->SetRenderState(D3DRS_CLIPPING, TRUE);
     bd->pd3dDevice->SetRenderState(D3DRS_LIGHTING, FALSE);
+    
+    bd->pd3dDevice->SetRenderState(D3DRS_SRGBWRITEENABLE, FALSE); // Enable sRGB correct rendering, but alpha is wrong then
+    // Fix alpha blending
+    bd->pd3dDevice->SetTextureStageState(0, D3DTSS_ALPHAOP, D3DTOP_MODULATE);
+    bd->pd3dDevice->SetTextureStageState(0, D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
+    bd->pd3dDevice->SetTextureStageState(0, D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+    
     bd->pd3dDevice->SetTextureStageState(0, D3DTSS_COLOROP, D3DTOP_MODULATE);
     bd->pd3dDevice->SetTextureStageState(0, D3DTSS_COLORARG1, D3DTA_TEXTURE);
     bd->pd3dDevice->SetTextureStageState(0, D3DTSS_COLORARG2, D3DTA_DIFFUSE);


### PR DESCRIPTION
When I was writing the plugin for L4D2, I noticed that the color display of the imgui was a color deviation caused by some DirectX 9 properties of the game, so I went to him and fixed the sRGB and accompanying Alpha color channel exception.

