### PR TITLE
refactor: remove redundant `#include <string.h>`

### DIFF
--- a/imstb_textedit.h
+++ b/imstb_textedit.h
@@ -387,7 +387,6 @@ typedef struct
 #ifdef STB_TEXTEDIT_IMPLEMENTATION
 
 #ifndef STB_TEXTEDIT_memmove
-#include <string.h>
 #define STB_TEXTEDIT_memmove memmove
 #endif
 


### PR DESCRIPTION
Resolves #4791 (<https://github.com/ocornut/imgui/issues/4791#issuecomment-1652638345>).

You can't compile a program using Dear ImGui with the Clang Modules feature
because of a C++ Standard library header include that appears not in the global namespace.
~~So unwrap the namespace for the `#include`.~~
So remove the redundant `#include <string.h>`.

Error log:
```output
/home/johel/Documents/C++/Forks/imgui/imstb_textedit.h:390:1: error: redundant #include of module 'std_string_h' appears within namespace 'ImStb' [-Wmodules-import-nested-redundant]
  390 | #include <string.h>
      | ^
/home/johel/Documents/C++/Forks/imgui/imgui_widgets.cpp:3691:1: note: namespace 'ImStb' begins here
 3691 | namespace ImStb
      | ^
1 error generated.
```