### PR TITLE
Fix OOB access in _CalcCircleAutoSegmentCount

### DIFF
--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -560,7 +560,7 @@ int ImDrawList::_CalcCircleAutoSegmentCount(float radius) const
 {
     // Automatic segment count
     const int radius_idx = (int)(radius + 0.999999f); // ceil to never reduce accuracy
-    if (radius_idx < IM_ARRAYSIZE(_Data->CircleSegmentCounts))
+    if (radius_idx >= 0 && radius_idx < IM_ARRAYSIZE(_Data->CircleSegmentCounts))
         return _Data->CircleSegmentCounts[radius_idx]; // Use cached value
     else
         return IM_DRAWLIST_CIRCLE_AUTO_SEGMENT_CALC(radius, _Data->CircleSegmentMaxError);


### PR DESCRIPTION
An OOB (out-of-bounds) access can happen inside of `ImDrawList::_CalcCircleAutoSegmentCount`, given a sufficiently large radius value (of approximately 2,147,483,584 or higher).

This will happen when attempting to index into the `CircleSegmentCounts` field using an invalid `radius_idx` value.

This bug can be reproduced by running the following code:
`DrawList->AddCircle(ImVec2(100, 100), FLT_MAX, 0xFF0000FF);`