### PR TITLE
imgui_stdlib: Fix warning

### DIFF
--- a/misc/cpp/imgui_stdlib.cpp
+++ b/misc/cpp/imgui_stdlib.cpp
@@ -10,6 +10,12 @@
 #include "imgui.h"
 #include "imgui_stdlib.h"
 
+// Clang warnings with -Weverything
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wsign-conversion"    // warning: implicit conversion changes signedness
+#endif
+
 struct InputTextCallback_UserData
 {
     std::string*            Str;
@@ -73,3 +79,7 @@ bool ImGui::InputTextWithHint(const char* label, const char* hint, std::string* 
     cb_user_data.ChainCallbackUserData = user_data;
     return InputTextWithHint(label, hint, (char*)str->c_str(), str->capacity() + 1, flags, InputTextCallback, &cb_user_data);
 }
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif


### PR DESCRIPTION
Based on commit 8a6911b8943748d639a99d5b07116961a645546b,
this fixes a warning in `imgui_stdlib`:
```output
-- The CXX compiler identification is Clang 17.0.0
```
```output
/imgui/misc/cpp/imgui_stdlib.cpp:29:27: warning: implicit conversion changes signedness: 'int' to 'size_type' (aka 'unsigned long') [-Wsign-conversion]
   29 |         str->resize(data->BufTextLen);
      |              ~~~~~~ ~~~~~~^~~~~~~~~~
1 warning generated.
```