### PR TITLE
Added exclusion from groups as a feature and used it to fix activatio…

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -837,6 +837,13 @@ namespace ImGui
     IMGUI_API void          BeginDisabled(bool disabled = true);
     IMGUI_API void          EndDisabled();
 
+    // Excluding from group
+    // - Don't collect activation, deactivation and edit information into surrounding groups.
+    // - Those can be nested but it cannot be used to include an already excluded section (a single BeginExcludedFromGroup(true) in the stack is enough to keep everything excluded)
+    // - BeginExcludedFromGroup(false) essentially does nothing useful but is provided to facilitate use of boolean expressions. If you can avoid calling BeginExcludedFromGroup(False)/EndExcludedFromGroup() best to avoid it.
+    IMGUI_API void          BeginExcludedFromGroup(bool excluded = true);
+    IMGUI_API void          EndExcludedFromGroup();
+
     // Clipping
     // - Mouse hovering is affected by ImGui::PushClipRect() calls, unlike direct calls to ImDrawList::PushClipRect() which are render only.
     IMGUI_API void          PushClipRect(const ImVec2& clip_rect_min, const ImVec2& clip_rect_max, bool intersect_with_current_clip_rect);

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -5128,7 +5128,11 @@ bool ImGui::ColorEdit4(const char* label, float col[4], ImGuiColorEditFlags flag
 
     // Context menu: display and modify options (before defaults are applied)
     if (!(flags & ImGuiColorEditFlags_NoOptions))
+    {
+        BeginExcludedFromGroup();
         ColorEditOptionsPopup(col, flags);
+        EndExcludedFromGroup();
+    }
 
     // Read stored options
     if (!(flags & ImGuiColorEditFlags_DisplayMask_))
@@ -5393,7 +5397,11 @@ bool ImGui::ColorPicker4(const char* label, float col[4], ImGuiColorEditFlags fl
 
     // Context menu: display and store options.
     if (!(flags & ImGuiColorEditFlags_NoOptions))
+    {
+        BeginExcludedFromGroup();
         ColorPickerOptionsPopup(col, flags);
+        EndExcludedFromGroup();
+    }
 
     // Read stored options
     if (!(flags & ImGuiColorEditFlags_PickerMask_))


### PR DESCRIPTION
…n/deactivation and editing reports for color widgets and color pickers.

Hi, I found a working solution (and I think a rather elegant one) to #6722.

Based on `BeginDisabled()`/`EndDisabled()` I added `BeginExcludedFromGroup()`/`EndExcludedFromGroup()`, and used them to fix the various interaction reports fired by the display mode changing context menu for color widgets and pickers. With this exclusion, item interactions don't collect in surrounding groups. Corner cases like a group inside of an excluded popup are handled correctly.

The new feature required for the fix also comes in handy for custom widgets.