### PR TITLE
Fix typo in TableGetSortSpecs comment (cpp)

### DIFF
--- a/imgui_tables.cpp
+++ b/imgui_tables.cpp
@@ -2673,8 +2673,9 @@ void ImGui::TableDrawBorders(ImGuiTable* table)
 //-------------------------------------------------------------------------
 
 // Return NULL if no sort specs (most often when ImGuiTableFlags_Sortable is not set)
-// You can sort your data again when 'SpecsChanged == true'. It will be true with sorting specs have changed since
-// last call, or the first time.
+// When 'sort_specs->SpecsDirty == true' you should sort your data. It will be true when sorting specs have
+// changed since last call, or the first time. Make sure to set 'SpecsDirty = false' after sorting,
+// else you may wastefully sort your data every frame!
 // Lifetime: don't hold on this pointer over multiple frames or past any subsequent call to BeginTable()!
 ImGuiTableSortSpecs* ImGui::TableGetSortSpecs()
 {


### PR DESCRIPTION
I ended up in `imgui_tables.cpp` looking at the implementation for `TableGetSortSpecs()` and the description is a bit outdated. `SpecsChanged` is not longer part of the internal (nor external) API.

* Replaced it with an up to date piece from `imgui.h`
    https://github.com/ocornut/imgui/blob/82d177ccbd758ec24b0967fa9dfa00db9f8b97be/imgui.h#L775-L779
    * Correct `SpecsChanged` -> `sort_specs->SpecsDirty`
    * Kept the tip about making sure to set `'SpecsDirty = false'`

Feel free to edit etc...
Thanks Omar!
