### PR TITLE
Input: Add per-window event handlers

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -4522,7 +4522,7 @@ void ImGui::RunEventHandlers(ImGuiWindow* window)
 
         if ((is_focused && is_hovered) || event.Type == ImGuiInputEventType_Focus)
         {
-            if (event_handler.Callback != NULL && event_handler.Callback(&event, event_handler.UserData))
+            if (event_handler.Callback != NULL && event_handler.Callback(window, &event, event_handler.UserData))
                 window->HandledEvents.push_back(event);
         }
     }

--- a/imgui.h
+++ b/imgui.h
@@ -168,6 +168,7 @@ struct ImGuiTableColumnSortSpecs;   // Sorting specification for one column of a
 struct ImGuiTextBuffer;             // Helper to hold and append into a text buffer (~string builder)
 struct ImGuiTextFilter;             // Helper to parse and apply text filters (e.g. "aaaaa[,bbbbb][,ccccc]")
 struct ImGuiViewport;               // A Platform Window (always only one in 'master' branch), in the future may represent Platform Monitor
+struct ImGuiWindow;                 // Storage for one window
 
 // Enumerations
 // - We don't use strongly typed enums much because they add constraints (can't extend in private code, can't store typed in bit fields, extra casting on iteration)
@@ -253,11 +254,11 @@ typedef ImWchar16 ImWchar;
 #endif
 
 // Callback and functions types
-typedef int     (*ImGuiInputTextCallback)(ImGuiInputTextCallbackData* data);                    // Callback function for ImGui::InputText()
-typedef void    (*ImGuiSizeCallback)(ImGuiSizeCallbackData* data);                              // Callback function for ImGui::SetNextWindowSizeConstraints()
-typedef void*   (*ImGuiMemAllocFunc)(size_t sz, void* user_data);                               // Function signature for ImGui::SetAllocatorFunctions()
-typedef void    (*ImGuiMemFreeFunc)(void* ptr, void* user_data);                                // Function signature for ImGui::SetAllocatorFunctions()
-typedef bool    (*ImGuiEventHandlerCallback)(const ImGuiInputEvent* event, void* user_data);    // Callback used for per window event handlers, and ImGui::SetNextWindowEventHandler()/SetWindowEventHandler()
+typedef int     (*ImGuiInputTextCallback)(ImGuiInputTextCallbackData* data);                                        // Callback function for ImGui::InputText()
+typedef void    (*ImGuiSizeCallback)(ImGuiSizeCallbackData* data);                                                  // Callback function for ImGui::SetNextWindowSizeConstraints()
+typedef void*   (*ImGuiMemAllocFunc)(size_t sz, void* user_data);                                                   // Function signature for ImGui::SetAllocatorFunctions()
+typedef void    (*ImGuiMemFreeFunc)(void* ptr, void* user_data);                                                    // Function signature for ImGui::SetAllocatorFunctions()
+typedef bool    (*ImGuiEventHandlerCallback)(ImGuiWindow* window, const ImGuiInputEvent* event, void* user_data);   // Callback used for per window event handlers, and ImGui::SetNextWindowEventHandler()/SetWindowEventHandler()
 
 // ImVec2: 2D vector used to store positions, sizes etc. [Compile-time configurable type]
 // This is a frequently used type in the API. Consider using IM_VEC2_CLASS_EXTRA to create implicit cast from/to our preferred type.

--- a/imgui.h
+++ b/imgui.h
@@ -183,6 +183,7 @@ typedef int ImGuiMouseCursor;       // -> enum ImGuiMouseCursor_     // Enum: A 
 typedef int ImGuiSortDirection;     // -> enum ImGuiSortDirection_   // Enum: A sorting direction (ascending or descending)
 typedef int ImGuiStyleVar;          // -> enum ImGuiStyleVar_        // Enum: A variable identifier for styling
 typedef int ImGuiTableBgTarget;     // -> enum ImGuiTableBgTarget_   // Enum: A color target for TableSetBgColor()
+typedef int ImGuiTriState;          // -> enum ImGuiTriState_        // Tri-state variable, for anything that needs three possible states.
 
 // Flags (declared as int for compatibility with old C++, to allow using as flags without overhead, and to not pollute the top of this file)
 // - Tip: Use your programming IDE navigation facilities on the names in the _central column_ below to find the actual flags/enum lists!
@@ -967,6 +968,16 @@ namespace ImGui
 //-----------------------------------------------------------------------------
 // [SECTION] Flags & Enumerations
 //-----------------------------------------------------------------------------
+
+// Tri-state variable, for anything that needs three possible states.
+enum ImGuiTriState_
+{
+    ImGuiTriState_False     = 0,
+    ImGuiTriState_True      = 1,
+    ImGuiTriState_Unknown   = 2,
+    ImGuiTriState_Default   = ImGuiTriState_Unknown,
+    ImGuiTriState_COUNT,
+};
 
 // Flags for ImGui::Begin()
 // (Those are per-window flags. There are shared flags in ImGuiIO: io.ConfigWindowsResizeFromEdges and io.ConfigWindowsMoveFromTitleBarOnly)

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -154,7 +154,6 @@ struct ImGuiTableInstanceData;      // Storage for one instance of a same table
 struct ImGuiTableTempData;          // Temporary storage for one table (one per table in the stack), shared between tables.
 struct ImGuiTableSettings;          // Storage for a table .ini settings
 struct ImGuiTableColumnsSettings;   // Storage for a column .ini settings
-struct ImGuiWindow;                 // Storage for one window
 struct ImGuiWindowTempData;         // Temporary storage for one window (that's the data which in theory we could ditch at the end of the frame, in practice we currently keep it for each window)
 struct ImGuiWindowSettings;         // Storage for a window .ini settings (we keep one of those even if the actual window wasn't instanced during this session)
 


### PR DESCRIPTION
This makes working with event driven applications much easier.

It also gives more control to the handler over whether widgets,
keyboard/gamepad navigation, etc can handle the input, or not.

It might also make more sense to add other event types, such as mouse
enter/leave, and custom user events to the event queue with this now.
