### PR TITLE
Add `IsWindowID{Focus,Hover}ed()`

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -7307,7 +7307,7 @@ bool ImGui::IsWindowHovered(ImGuiWindow* window, ImGuiHoveredFlags flags)
     {
         const bool popup_hierarchy = (flags & ImGuiHoveredFlags_NoPopupHierarchy) == 0;
         if (flags & ImGuiHoveredFlags_RootWindow)
-            cur_window = GetCombinedRootWindow(window, popup_hierarchy);
+            window = GetCombinedRootWindow(window, popup_hierarchy);
 
         bool result;
         if (flags & ImGuiHoveredFlags_ChildWindows)
@@ -7349,12 +7349,22 @@ bool ImGui::IsWindowFocused(ImGuiWindow* window, ImGuiFocusedFlags flags)
 
     const bool popup_hierarchy = (flags & ImGuiFocusedFlags_NoPopupHierarchy) == 0;
     if (flags & ImGuiHoveredFlags_RootWindow)
-        cur_window = GetCombinedRootWindow(window, popup_hierarchy);
+        window = GetCombinedRootWindow(window, popup_hierarchy);
 
     if (flags & ImGuiHoveredFlags_ChildWindows)
         return IsWindowChildOf(ref_window, window, popup_hierarchy);
     else
         return (ref_window == window);
+}
+
+bool ImGui::IsWindowIDHovered(ImGuiID id, ImGuiHoveredFlags flags)
+{
+    return IsWindowHovered(FindWindowByID(id), flags);
+}
+
+bool ImGui::IsWindowIDFocused(ImGuiID id, ImGuiFocusedFlags flags)
+{
+    return IsWindowFocused(FindWindowByID(id), flags);
 }
 
 bool ImGui::IsWindowHovered(ImGuiHoveredFlags flags)

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -7294,28 +7294,26 @@ bool ImGui::IsWindowAbove(ImGuiWindow* potential_above, ImGuiWindow* potential_b
     return false;
 }
 
-bool ImGui::IsWindowHovered(ImGuiHoveredFlags flags)
+bool ImGui::IsWindowHovered(ImGuiWindow* window, ImGuiHoveredFlags flags)
 {
     IM_ASSERT((flags & ~ImGuiHoveredFlags_AllowedMaskForIsWindowHovered) == 0 && "Invalid flags for IsWindowHovered()!");
 
     ImGuiContext& g = *GImGui;
     ImGuiWindow* ref_window = g.HoveredWindow;
-    ImGuiWindow* cur_window = g.CurrentWindow;
-    if (ref_window == NULL)
+    if (ref_window == NULL || window == NULL)
         return false;
 
     if ((flags & ImGuiHoveredFlags_AnyWindow) == 0)
     {
-        IM_ASSERT(cur_window); // Not inside a Begin()/End()
         const bool popup_hierarchy = (flags & ImGuiHoveredFlags_NoPopupHierarchy) == 0;
         if (flags & ImGuiHoveredFlags_RootWindow)
-            cur_window = GetCombinedRootWindow(cur_window, popup_hierarchy);
+            cur_window = GetCombinedRootWindow(window, popup_hierarchy);
 
         bool result;
         if (flags & ImGuiHoveredFlags_ChildWindows)
-            result = IsWindowChildOf(ref_window, cur_window, popup_hierarchy);
+            result = IsWindowChildOf(ref_window, window, popup_hierarchy);
         else
-            result = (ref_window == cur_window);
+            result = (ref_window == window);
         if (!result)
             return false;
     }
@@ -7339,26 +7337,38 @@ bool ImGui::IsWindowHovered(ImGuiHoveredFlags flags)
     return true;
 }
 
-bool ImGui::IsWindowFocused(ImGuiFocusedFlags flags)
+bool ImGui::IsWindowFocused(ImGuiWindow* window, ImGuiFocusedFlags flags)
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* ref_window = g.NavWindow;
-    ImGuiWindow* cur_window = g.CurrentWindow;
 
-    if (ref_window == NULL)
+    if (ref_window == NULL || window == NULL)
         return false;
     if (flags & ImGuiFocusedFlags_AnyWindow)
         return true;
 
-    IM_ASSERT(cur_window); // Not inside a Begin()/End()
     const bool popup_hierarchy = (flags & ImGuiFocusedFlags_NoPopupHierarchy) == 0;
     if (flags & ImGuiHoveredFlags_RootWindow)
-        cur_window = GetCombinedRootWindow(cur_window, popup_hierarchy);
+        cur_window = GetCombinedRootWindow(window, popup_hierarchy);
 
     if (flags & ImGuiHoveredFlags_ChildWindows)
-        return IsWindowChildOf(ref_window, cur_window, popup_hierarchy);
+        return IsWindowChildOf(ref_window, window, popup_hierarchy);
     else
-        return (ref_window == cur_window);
+        return (ref_window == window);
+}
+
+bool ImGui::IsWindowHovered(ImGuiHoveredFlags flags)
+{
+    ImGuiContext& g = *GImGui;
+    IM_ASSERT(g.CurrentWindow); // Not inside a Begin()/End()
+    return IsWindowHovered(g.CurrentWindow, flags);
+}
+
+bool ImGui::IsWindowFocused(ImGuiFocusedFlags flags)
+{
+    ImGuiContext& g = *GImGui;
+    IM_ASSERT(g.CurrentWindow); // Not inside a Begin()/End()
+    return IsWindowFocused(g.CurrentWindow, flags);
 }
 
 // Can we focus this window with CTRL+TAB (or PadMenu + PadFocusPrev/PadFocusNext)

--- a/imgui.h
+++ b/imgui.h
@@ -353,13 +353,15 @@ namespace ImGui
     // - 'current window' = the window we are appending into while inside a Begin()/End() block. 'next window' = next window we will Begin() into.
     IMGUI_API bool          IsWindowAppearing();
     IMGUI_API bool          IsWindowCollapsed();
-    IMGUI_API bool          IsWindowFocused(ImGuiFocusedFlags flags=0); // is current window focused? or its root/child, depending on flags. see flags for options.
-    IMGUI_API bool          IsWindowHovered(ImGuiHoveredFlags flags=0); // is current window hovered (and typically: not blocked by a popup/modal)? see flags for options. NB: If you are trying to check whether your mouse should be dispatched to imgui or to your app, you should use the 'io.WantCaptureMouse' boolean for that! Please read the FAQ!
-    IMGUI_API ImDrawList*   GetWindowDrawList();                        // get draw list associated to the current window, to append your own drawing primitives
-    IMGUI_API ImVec2        GetWindowPos();                             // get current window position in screen space (note: it is unlikely you need to use this. Consider using current layout pos instead, GetScreenCursorPos())
-    IMGUI_API ImVec2        GetWindowSize();                            // get current window size (note: it is unlikely you need to use this. Consider using GetScreenCursorPos() and e.g. GetContentRegionAvail() instead)
-    IMGUI_API float         GetWindowWidth();                           // get current window width (shortcut for GetWindowSize().x)
-    IMGUI_API float         GetWindowHeight();                          // get current window height (shortcut for GetWindowSize().y)
+    IMGUI_API bool          IsWindowFocused(ImGuiFocusedFlags flags=0);                 // is current window focused? or its root/child, depending on flags. see flags for options.
+    IMGUI_API bool          IsWindowHovered(ImGuiHoveredFlags flags=0);                 // is current window hovered (and typically: not blocked by a popup/modal)? see flags for options. NB: If you are trying to check whether your mouse should be dispatched to imgui or to your app, you should use the 'io.WantCaptureMouse' boolean for that! Please read the FAQ!
+    IMGUI_API bool          IsWindowIDFocused(ImGuiID id, ImGuiFocusedFlags flags=0);   // is window id focused? or its root/child, depending on flags. see flags for options.
+    IMGUI_API bool          IsWindowIDHovered(ImGuiID id, ImGuiHoveredFlags flags=0);   // is window id hovered (and typically: not blocked by a popup/modal)? see flags for options.
+    IMGUI_API ImDrawList*   GetWindowDrawList();                                        // get draw list associated to the current window, to append your own drawing primitives
+    IMGUI_API ImVec2        GetWindowPos();                                             // get current window position in screen space (note: it is unlikely you need to use this. Consider using current layout pos instead, GetScreenCursorPos())
+    IMGUI_API ImVec2        GetWindowSize();                                            // get current window size (note: it is unlikely you need to use this. Consider using GetScreenCursorPos() and e.g. GetContentRegionAvail() instead)
+    IMGUI_API float         GetWindowWidth();                                           // get current window width (shortcut for GetWindowSize().x)
+    IMGUI_API float         GetWindowHeight();                                          // get current window height (shortcut for GetWindowSize().y)
 
     // Window manipulation
     // - Prefer using SetNextXXX functions (before Begin) rather that SetXXX functions (after Begin).

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -2790,6 +2790,8 @@ namespace ImGui
     IMGUI_API bool          IsWindowWithinBeginStackOf(ImGuiWindow* window, ImGuiWindow* potential_parent);
     IMGUI_API bool          IsWindowAbove(ImGuiWindow* potential_above, ImGuiWindow* potential_below);
     IMGUI_API bool          IsWindowNavFocusable(ImGuiWindow* window);
+    IMGUI_API bool          IsWindowFocused(ImGuiWindow* window, ImGuiFocusedFlags flags=0);
+    IMGUI_API bool          IsWindowHovered(ImGuiWindow* window, ImGuiHoveredFlags flags=0);
     IMGUI_API void          SetWindowPos(ImGuiWindow* window, const ImVec2& pos, ImGuiCond cond = 0);
     IMGUI_API void          SetWindowSize(ImGuiWindow* window, const ImVec2& size, ImGuiCond cond = 0);
     IMGUI_API void          SetWindowCollapsed(ImGuiWindow* window, bool collapsed, ImGuiCond cond = 0);


### PR DESCRIPTION
This allows checking if a window is focused/hovered, without a current
window. To get the window ID, you can do `ImGui::GetID("")` right after
calling `ImGui::Begin()`

Solves #6769
