### PR TITLE
Bckends: GLFW: Clear emscripten's mousewheel callback before shutdown

### DIFF
--- a/backends/imgui_impl_glfw.cpp
+++ b/backends/imgui_impl_glfw.cpp
@@ -623,6 +623,9 @@ bool ImGui_ImplGlfw_InitForOther(GLFWwindow* window, bool install_callbacks)
 
 void ImGui_ImplGlfw_Shutdown()
 {
+#ifdef __EMSCRIPTEN__
+    emscripten_set_wheel_callback(EMSCRIPTEN_EVENT_TARGET_DOCUMENT, nullptr, false, nullptr);
+#endif
     ImGui_ImplGlfw_Data* bd = ImGui_ImplGlfw_GetBackendData();
     IM_ASSERT(bd != nullptr && "No platform backend to shutdown, or already shutdown?");
     ImGuiIO& io = ImGui::GetIO();


### PR DESCRIPTION
Version/Branch of Dear ImGui:

Version: v1.89.8-docking

reproduce demo without this patch: 
https://axmol.dev/wasm/cpp-tests/cpp-tests
step:
1. open `2.ImGui`
2. Goback to main manu page
3. Scroll mouse whell, will see javascript exception on console
