### PR TITLE
Backends: Vulkan: Modifiable depth and stencil formats

### DIFF
--- a/backends/imgui_impl_vulkan.cpp
+++ b/backends/imgui_impl_vulkan.cpp
@@ -858,6 +858,8 @@ static void ImGui_ImplVulkan_CreatePipeline(VkDevice device, const VkAllocationC
     pipelineRenderingCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO_KHR;
     pipelineRenderingCreateInfo.colorAttachmentCount = 1;
     pipelineRenderingCreateInfo.pColorAttachmentFormats = &bd->VulkanInitInfo.ColorAttachmentFormat;
+    pipelineRenderingCreateInfo.depthAttachmentFormat = bd->VulkanInitInfo.DepthAttachmentFormat;
+    pipelineRenderingCreateInfo.stencilAttachmentFormat = bd->VulkanInitInfo.StencilAttachmentFormat;
     if (bd->VulkanInitInfo.UseDynamicRendering)
     {
         info.pNext = &pipelineRenderingCreateInfo;

--- a/backends/imgui_impl_vulkan.h
+++ b/backends/imgui_impl_vulkan.h
@@ -67,6 +67,8 @@ struct ImGui_ImplVulkan_InitInfo
     // Dynamic Rendering (Optional)
     bool                            UseDynamicRendering;    // Need to explicitly enable VK_KHR_dynamic_rendering extension to use this, even for Vulkan 1.3.
     VkFormat                        ColorAttachmentFormat;  // Required for dynamic rendering
+    VkFormat                        DepthAttachmentFormat; // Required for dynamic rendering
+    VkFormat                        StencilAttachmentFormat; // Required for dynamic rendering
 
     // Allocation, Debugging
     const VkAllocationCallbacks*    Allocator;


### PR DESCRIPTION
Hello, 

When using Dear ImGui with Vulkan's dynamic rendering extensions, ``depthAttachmentFormat`` and ``stencilAttachmentFormat`` are unset. This may lead to problematic errors if your depth image or stencil has differing formats.

The solution I have considered is creating a new pipeline and setting the required values, but that seems quite unnecessary for simple use of Dear ImGui. 

For users (like myself) who just want to use dynamic rendering without worrying about creating a new pipeline for ImGui, this seems like the best solution.