### PR TITLE
Fonts: Fix clang compiling warning&error with freetype&lunasvg

### DIFF
--- a/misc/freetype/imgui_freetype.cpp
+++ b/misc/freetype/imgui_freetype.cpp
@@ -63,7 +63,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpragmas"                  // warning: unknown option after '#pragma GCC diagnostic' kind
 #pragma GCC diagnostic ignored "-Wunused-function"          // warning: 'xxxx' defined but not used
+#ifndef __clang__
 #pragma GCC diagnostic ignored "-Wsubobject-linkage"        // warning: 'xxxx' has a field 'xxxx' whose type uses the anonymous namespace
+#endif
 #endif
 
 //-------------------------------------------------------------------------
@@ -840,7 +842,7 @@ static FT_Error ImGuiLunasvgPortInit(FT_Pointer* _state)
 
 static void ImGuiLunasvgPortFree(FT_Pointer* _state)
 {
-    IM_DELETE(*(LunasvgPortState*)_state);
+    IM_DELETE(*(LunasvgPortState**)_state);
 }
 
 static FT_Error ImGuiLunasvgPortRender(FT_GlyphSlot slot, FT_Pointer* _state)


### PR DESCRIPTION
clang-16 is complaining about gcc-specific options and wrong template type.

```
[build] /some/path/imgui/misc/freetype/imgui_freetype.cpp:845:5: error: no matching function for call to 'IM_DELETE'
[build]     IM_DELETE(*(LunasvgPortState*)_state);
[build]     ^~~~~~~~~
[build] /some/path/imgui/imgui.h:1798:27: note: candidate template ignored: could not match 'T *' against 'LunasvgPortState'
[build] template<typename T> void IM_DELETE(T* p)   { if (p) { p->~T(); ImGui::MemFree(p); } }
[build]                           ^
[build] 1 error generated.
[build] ninja: build stopped: subcommand failed.
```

Checkout PR commit for details.