### PR TITLE
ComboBox flag for dynamic X resize

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -1110,6 +1110,7 @@ enum ImGuiComboFlags_
     ImGuiComboFlags_HeightLargest           = 1 << 4,   // As many fitting items as possible
     ImGuiComboFlags_NoArrowButton           = 1 << 5,   // Display on the preview box without the square arrow button
     ImGuiComboFlags_NoPreview               = 1 << 6,   // Display only a square arrow button
+    ImGuiComboFlags_WidthFitPreview         = 1 << 7,   // Dynamic width depending on current selected element
     ImGuiComboFlags_HeightMask_             = ImGuiComboFlags_HeightSmall | ImGuiComboFlags_HeightRegular | ImGuiComboFlags_HeightLarge | ImGuiComboFlags_HeightLargest,
 };
 

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -1189,6 +1189,7 @@ static void ShowDemoWindowWidgets()
         static ImGuiComboFlags flags = 0;
         ImGui::CheckboxFlags("ImGuiComboFlags_PopupAlignLeft", &flags, ImGuiComboFlags_PopupAlignLeft);
         ImGui::SameLine(); HelpMarker("Only makes a difference if the popup is larger than the combo");
+        ImGui::CheckboxFlags("ImGuiComboFlags_WidthFitPreview", &flags, ImGuiComboFlags_WidthFitPreview);
         if (ImGui::CheckboxFlags("ImGuiComboFlags_NoArrowButton", &flags, ImGuiComboFlags_NoArrowButton))
             flags &= ~ImGuiComboFlags_NoPreview;     // Clear the other flag, as we cannot combine both
         if (ImGui::CheckboxFlags("ImGuiComboFlags_NoPreview", &flags, ImGuiComboFlags_NoPreview))

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -1688,7 +1688,8 @@ bool ImGui::BeginCombo(const char* label, const char* preview_value, ImGuiComboF
 
     const float arrow_size = (flags & ImGuiComboFlags_NoArrowButton) ? 0.0f : GetFrameHeight();
     const ImVec2 label_size = CalcTextSize(label, NULL, true);
-    const float w = (flags & ImGuiComboFlags_NoPreview) ? arrow_size : CalcItemWidth();
+    const float preview_width = (preview_value != nullptr) ? CalcTextSize(preview_value, NULL, true).x : 0;
+    const float w = (flags & ImGuiComboFlags_NoPreview) ? arrow_size : ((flags & ImGuiComboFlags_WidthFitPreview) ? arrow_size + preview_width + style.ItemInnerSpacing.x * 2 : CalcItemWidth());
     const ImRect bb(window->DC.CursorPos, window->DC.CursorPos + ImVec2(w, label_size.y + style.FramePadding.y * 2.0f));
     const ImRect total_bb(bb.Min, bb.Max + ImVec2(label_size.x > 0.0f ? style.ItemInnerSpacing.x + label_size.x : 0.0f, 0.0f));
     ItemSize(total_bb, style.FramePadding.y);

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -1688,8 +1688,8 @@ bool ImGui::BeginCombo(const char* label, const char* preview_value, ImGuiComboF
 
     const float arrow_size = (flags & ImGuiComboFlags_NoArrowButton) ? 0.0f : GetFrameHeight();
     const ImVec2 label_size = CalcTextSize(label, NULL, true);
-    const float preview_width = (preview_value != nullptr) ? CalcTextSize(preview_value, NULL, true).x : 0;
-    const float w = (flags & ImGuiComboFlags_NoPreview) ? arrow_size : ((flags & ImGuiComboFlags_WidthFitPreview) ? arrow_size + preview_width + style.ItemInnerSpacing.x * 2 : CalcItemWidth());
+    const float preview_width = (preview_value != nullptr) ? CalcTextSize(preview_value, NULL, true).x : 0.0f;
+    const float w = (flags & ImGuiComboFlags_NoPreview) ? arrow_size : ((flags & ImGuiComboFlags_WidthFitPreview) ? arrow_size + preview_width + style.ItemInnerSpacing.x * 2.0f : CalcItemWidth());
     const ImRect bb(window->DC.CursorPos, window->DC.CursorPos + ImVec2(w, label_size.y + style.FramePadding.y * 2.0f));
     const ImRect total_bb(bb.Min, bb.Max + ImVec2(label_size.x > 0.0f ? style.ItemInnerSpacing.x + label_size.x : 0.0f, 0.0f));
     ItemSize(total_bb, style.FramePadding.y);


### PR DESCRIPTION
This flag might be helpful in situations when you want an empty visible label with fully visible ComboBox preview (in a limited space) or when you simply want to save unused space. Right now combobox takes up at least twice of it's label's visible width and does not check for preview width (which makes working with empty labels unbearable). 

I used this solution while working with ComboBox in tables (with ImGuiTableFlags_SizingFixedFit flag), similar example below.
![image](https://github.com/ocornut/imgui/assets/123133847/a9a9b886-8d53-46f6-a8c1-f94716d23526)
![image](https://github.com/ocornut/imgui/assets/123133847/73b0cf03-fdce-4e86-b519-126a417afe64)
