### PR TITLE
Fonts: Support for controling font rasterization density (aka. DPI)

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -2810,6 +2810,7 @@ struct ImFontConfig
     bool            MergeMode;              // false    // Merge into previous ImFont, so you can combine multiple inputs font into one ImFont (e.g. ASCII font + icons + Japanese glyphs). You may want to use GlyphOffset.y when merge font of different heights.
     unsigned int    FontBuilderFlags;       // 0        // Settings for custom font builder. THIS IS BUILDER IMPLEMENTATION DEPENDENT. Leave as zero if unsure.
     float           RasterizerMultiply;     // 1.0f     // Brighten (>1.0f) or darken (<1.0f) font output. Brightening small fonts may be a good workaround to make them more readable.
+    float           RasterizationDensity;   // 1.0f     // DPI scale for rasterization. Bigger DPI for higher quality.
     ImWchar         EllipsisChar;           // -1       // Explicitly specify unicode codepoint of ellipsis character. When fonts are being merged first specified ellipsis will be used.
 
     // [Internal]

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -2567,7 +2567,7 @@ static bool ImFontAtlasBuildWithStbTruetype(ImFontAtlas* atlas)
 
         // Convert our ranges in the format stb_truetype wants
         ImFontConfig& cfg = atlas->ConfigData[src_i];
-        src_tmp.PackRange.font_size = cfg.SizePixels;
+        src_tmp.PackRange.font_size = cfg.SizePixels * cfg.RasterizationDensity;
         src_tmp.PackRange.first_unicode_codepoint_in_range = 0;
         src_tmp.PackRange.array_of_unicode_codepoints = src_tmp.GlyphsList.Data;
         src_tmp.PackRange.num_chars = src_tmp.GlyphsList.Size;
@@ -2576,7 +2576,7 @@ static bool ImFontAtlasBuildWithStbTruetype(ImFontAtlas* atlas)
         src_tmp.PackRange.v_oversample = (unsigned char)cfg.OversampleV;
 
         // Gather the sizes of all rectangles we will need to pack (this loop is based on stbtt_PackFontRangesGatherRects)
-        const float scale = (cfg.SizePixels > 0) ? stbtt_ScaleForPixelHeight(&src_tmp.FontInfo, cfg.SizePixels) : stbtt_ScaleForMappingEmToPixels(&src_tmp.FontInfo, -cfg.SizePixels);
+        const float scale = (cfg.SizePixels > 0) ? stbtt_ScaleForPixelHeight(&src_tmp.FontInfo, cfg.SizePixels * cfg.RasterizationDensity) : stbtt_ScaleForMappingEmToPixels(&src_tmp.FontInfo, -cfg.SizePixels * cfg.RasterizationDensity);
         const int padding = atlas->TexGlyphPadding;
         for (int glyph_i = 0; glyph_i < src_tmp.GlyphsList.Size; glyph_i++)
         {
@@ -2678,6 +2678,8 @@ static bool ImFontAtlasBuildWithStbTruetype(ImFontAtlas* atlas)
         const float font_off_x = cfg.GlyphOffset.x;
         const float font_off_y = cfg.GlyphOffset.y + IM_ROUND(dst_font->Ascent);
 
+        const float inv_rasterization_scale = 1.0f / cfg.RasterizationDensity;
+
         for (int glyph_i = 0; glyph_i < src_tmp.GlyphsCount; glyph_i++)
         {
             // Register glyph
@@ -2686,7 +2688,11 @@ static bool ImFontAtlasBuildWithStbTruetype(ImFontAtlas* atlas)
             stbtt_aligned_quad q;
             float unused_x = 0.0f, unused_y = 0.0f;
             stbtt_GetPackedQuad(src_tmp.PackedChars, atlas->TexWidth, atlas->TexHeight, glyph_i, &unused_x, &unused_y, &q, 0);
-            dst_font->AddGlyph(&cfg, (ImWchar)codepoint, q.x0 + font_off_x, q.y0 + font_off_y, q.x1 + font_off_x, q.y1 + font_off_y, q.s0, q.t0, q.s1, q.t1, pc.xadvance);
+            float x0 = q.x0 * inv_rasterization_scale + font_off_x;
+            float y0 = q.y0 * inv_rasterization_scale + font_off_y;
+            float x1 = q.x1 * inv_rasterization_scale + font_off_x;
+            float y1 = q.y1 * inv_rasterization_scale + font_off_y;
+            dst_font->AddGlyph(&cfg, (ImWchar)codepoint, x0, y0, x1, y1, q.s0, q.t0, q.s1, q.t1, pc.xadvance * inv_rasterization_scale);
         }
     }
 

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -2009,6 +2009,7 @@ ImFontConfig::ImFontConfig()
     OversampleV = 1;
     GlyphMaxAdvanceX = FLT_MAX;
     RasterizerMultiply = 1.0f;
+    RasterizationDensity = 1.0f;
     EllipsisChar = (ImWchar)-1;
 }
 


### PR DESCRIPTION
This is backport of an extension that adds an ability to control font rasterization density.

Rasterization density allow to increase size of the rendered glyphs aka. their size on the atlas texture while keeping metrics intact.

I found myself redoing this a few times now, so maybe people will find that useful too.

Earlier I was hijacking OversampleH/V for that purpose, but this time I went with adding separate variable that control this behavior.

```cpp
// setup
ImFontConfig font_config;
font_config.OversampleH = 1; // FreeType does not support those, reset so stb_truetype will produce similar results
font_config.OversampleV = 1;

font_config.RasterizationDensity = 1.0f;
auto font_a = io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\segoeui.ttf", 18.0f, &font_config);
font_a->Scale = 1.0f;

font_config.RasterizationDensity = 2.0f;
auto font_b = io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\segoeui.ttf", 18.0f, &font_config);
font_b->Scale = 2.0f; // set font scale to match glyphs on atlas 1:1

font_config.RasterizationDensity = 4.0f;
auto font_c = io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\segoeui.ttf", 18.0f, &font_config);
font_c->Scale = 4.0f;

// in loop
ImGui::Text("Font: 100%");

ImGui::PushFont(font_b);
ImGui::Text("Font: 200%");
ImGui::PopFont();

ImGui::PushFont(font_c);
ImGui::Text("Font: 400%");
ImGui::PopFont();
```

Works with both FreeType and built-in stb_truetype atlas generators.

| FreeType | stb_truetype |
|-|-|
|![image](https://github.com/ocornut/imgui/assets/1197433/39528d81-2d1c-40a6-9cc2-8914b78c7a6b)|![image](https://github.com/ocornut/imgui/assets/1197433/00ebfb23-6607-4a73-8d5f-4f323bd45c56)|

---

This does aid with on form of DPI support when one utilize `io.DisplayFramebufferScale`, seting same scalle while regenerating font atlas in `ImFontConfig` remove need to touch global font scale and/or individual font scale.