### PR TITLE
Menus: slack triangle for submenu opening has better fit

### DIFF
--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -7512,9 +7512,6 @@ bool ImGui::BeginMenuEx(const char* label, const char* icon, bool enabled)
             ImVec2 tb = (child_dir > 0.0f) ? next_window_rect.GetTL() : next_window_rect.GetTR();
             ImVec2 tc = (child_dir > 0.0f) ? next_window_rect.GetBL() : next_window_rect.GetBR();
             float extra = ImClamp(ImFabs(ta.x - tb.x) * 0.30f, ref_unit * 0.5f, ref_unit * 2.5f);   // add a bit of extra slack.
-            ta.x += child_dir * -0.5f;
-            tb.x += child_dir * ref_unit;
-            tc.x += child_dir * ref_unit;
             tb.y = ta.y + ImMax((tb.y - extra) - ta.y, -ref_unit * 8.0f);                           // triangle has maximum height to limit the slope and the bias toward large sub-menus
             tc.y = ta.y + ImMin((tc.y + extra) - ta.y, +ref_unit * 8.0f);
             moving_toward_child_menu = ImTriangleContainsPoint(ta, tb, tc, g.IO.MousePos);


### PR DESCRIPTION
When rolling over menus, sometimes their submenus wouldn't open correctly, particularly on the far right side of the menu item (or far left for menus opening to the left).

As reported in #6671:

![257549900-267a8420-e6a6-49ac-91a0-dca49a6e00cc](https://github.com/ocornut/imgui/assets/49529/05fa3047-3392-457f-928f-e2c967d79fa2)

## Problem context

The code for handling that behavior implements a solution like [this post](https://bjk5.com/post/44698559168/breaking-down-amazons-mega-dropdown), where it uses an imaginary triangle to define an area that the cursor can still roll into (outside of the menu item space even) before the current submenu closes and a different one opens.

However, it seems to be the current code is attempting to move the corners of this imaginary triangle unnecessarily, making it more likely it wouldn't detect the mouse had left a valid area when it did.

## Fix

My changes remove those moves, making it follow the original triangle corners more correctly, while still keeping some of its limits in place. It seems to make it feel more responsive, without making it behave incorrectly.

Capture showing how rolling over the end of the menu works, while still respecting the "slack" area that goes over other menus (without opening them):

![imguimenu](https://github.com/ocornut/imgui/assets/49529/b2429712-0e36-4163-947b-218c39e395a9)

This was tested on Windows, example_win32_directx9 example, VS Community 2022 (17.7.4), against current master (v1.89.9+), using a high-dpi monitor. However, the code seems to make it self-contained enough that I don't believe we'd have problems in other platforms, or in different DPI monitors (if anything, it *removes* a calculation that seemed to be missing DPI scaling).

Fixes #6671.