### PR TITLE
Features/treenode span only text

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -1059,7 +1059,7 @@ enum ImGuiTreeNodeFlags_
     ImGuiTreeNodeFlags_SpanFullWidth        = 1 << 12,  // Extend hit box to the left-most and right-most edges (bypass the indented area).
     ImGuiTreeNodeFlags_SpanAllColumns       = 1 << 13,  // Frame will span all columns of its container table (text will still fit in current column)
     ImGuiTreeNodeFlags_NavLeftJumpsBackHere = 1 << 14,  // (WIP) Nav: left direction may move to this TreeNode() from any of its child (items submitted between TreeNode and TreePop)
-    ImGuiTreeNodeFlags_SpanOnlyText         = 1 << 15,  // Hovering highlight will only cover the label text and reduces the hitbox to wrap the text tighter (0.5f style.ItemSpacing.x instead of regular 2.0f). Does nothing when the following flags are set: ImGuiTreeNodeFlags_Framed, ImGuiTreeNodeFlags_SpanAvailWidth, ImGuiTreeNodeFlags_SpanFullWidth, ImGuiTreeNodeFlags_SpanAllColumns.
+    ImGuiTreeNodeFlags_SpanOnlyText         = 1 << 15,  // Hovering highlight will only cover the label text and reduces the hitbox to wrap the text tighter (0.5f style.ItemSpacing.x instead of regular 2.0f). Does nothing when any of the following flags is set: ImGuiTreeNodeFlags_Framed, ImGuiTreeNodeFlags_SpanAvailWidth, ImGuiTreeNodeFlags_SpanFullWidth, ImGuiTreeNodeFlags_SpanAllColumns.
     //ImGuiTreeNodeFlags_NoScrollOnOpen     = 1 << 16,  // FIXME: TODO: Disable automatic scroll on TreePop() if node got just open and contents is not visible
     ImGuiTreeNodeFlags_CollapsingHeader     = ImGuiTreeNodeFlags_Framed | ImGuiTreeNodeFlags_NoTreePushOnOpen | ImGuiTreeNodeFlags_NoAutoOpenOnLog,
 

--- a/imgui.h
+++ b/imgui.h
@@ -1059,7 +1059,8 @@ enum ImGuiTreeNodeFlags_
     ImGuiTreeNodeFlags_SpanFullWidth        = 1 << 12,  // Extend hit box to the left-most and right-most edges (bypass the indented area).
     ImGuiTreeNodeFlags_SpanAllColumns       = 1 << 13,  // Frame will span all columns of its container table (text will still fit in current column)
     ImGuiTreeNodeFlags_NavLeftJumpsBackHere = 1 << 14,  // (WIP) Nav: left direction may move to this TreeNode() from any of its child (items submitted between TreeNode and TreePop)
-    //ImGuiTreeNodeFlags_NoScrollOnOpen     = 1 << 14,  // FIXME: TODO: Disable automatic scroll on TreePop() if node got just open and contents is not visible
+    ImGuiTreeNodeFlags_SpanOnlyText         = 1 << 15,  // Hovering highlight will only cover the label text and reduces the hitbox to wrap the text tighter (0.5f style.ItemSpacing.x instead of regular 2.0f). Does nothing when the following flags are set: ImGuiTreeNodeFlags_Framed, ImGuiTreeNodeFlags_SpanAvailWidth, ImGuiTreeNodeFlags_SpanFullWidth, ImGuiTreeNodeFlags_SpanAllColumns.
+    //ImGuiTreeNodeFlags_NoScrollOnOpen     = 1 << 16,  // FIXME: TODO: Disable automatic scroll on TreePop() if node got just open and contents is not visible
     ImGuiTreeNodeFlags_CollapsingHeader     = ImGuiTreeNodeFlags_Framed | ImGuiTreeNodeFlags_NoTreePushOnOpen | ImGuiTreeNodeFlags_NoAutoOpenOnLog,
 
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -920,7 +920,8 @@ static void ShowDemoWindowWidgets()
             ImGui::CheckboxFlags("ImGuiTreeNodeFlags_SpanAvailWidth",    &base_flags, ImGuiTreeNodeFlags_SpanAvailWidth); ImGui::SameLine(); HelpMarker("Extend hit area to all available width instead of allowing more items to be laid out after the node.");
             ImGui::CheckboxFlags("ImGuiTreeNodeFlags_SpanFullWidth",     &base_flags, ImGuiTreeNodeFlags_SpanFullWidth);
             ImGui::CheckboxFlags("ImGuiTreeNodeFlags_SpanAllColumns",    &base_flags, ImGuiTreeNodeFlags_SpanAllColumns); ImGui::SameLine(); HelpMarker("For use in Tables only.");
-            ImGui::CheckboxFlags("ImGuiTreeNodeFlags_SpanOnlyText",      &base_flags, ImGuiTreeNodeFlags_SpanOnlyText); ImGui::SameLine(); HelpMarker("Reduce hit area to the text label and bit of margin.");
+            ImGui::CheckboxFlags("ImGuiTreeNodeFlags_SpanOnlyText",      &base_flags, ImGuiTreeNodeFlags_SpanOnlyText);   ImGui::SameLine(); HelpMarker("Reduce hit area to the text label and bit of margin.");
+            ImGui::CheckboxFlags("ImGuiTreeNodeFlags_Framed",            &base_flags, ImGuiTreeNodeFlags_Framed);         ImGui::SameLine(); HelpMarker("Draw frame with background (e.g. for CollapsingHeader)");
             ImGui::Checkbox("Align label with current X position", &align_label_with_current_x_position);
             ImGui::Checkbox("Test tree node as drag source", &test_drag_and_drop);
             ImGui::Text("Hello!");

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -888,7 +888,14 @@ static void ShowDemoWindowWidgets()
                 if (i == 0)
                     ImGui::SetNextItemOpen(true, ImGuiCond_Once);
 
-                if (ImGui::TreeNode((void*)(intptr_t)i, "Child %d", i))
+                bool node_open = ImGui::TreeNode((void*)(intptr_t)i, "Child %d", i);
+
+                // Item 2 has an additional inline button
+                if (i == 2) {
+                    ImGui::SameLine();
+                    if (ImGui::SmallButton("button")) {}
+                }
+                if (node_open)
                 {
                     ImGui::Text("blah blah");
                     ImGui::SameLine();
@@ -945,6 +952,11 @@ static void ShowDemoWindowWidgets()
                         ImGui::SetDragDropPayload("_TREENODE", NULL, 0);
                         ImGui::Text("This is a drag and drop source");
                         ImGui::EndDragDropSource();
+                    }
+                    // Item 2 has an additional inline button
+                    if (i == 2) {
+                        ImGui::SameLine();
+                        if (ImGui::SmallButton("button")) {}
                     }
                     if (node_open)
                     {

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -913,6 +913,7 @@ static void ShowDemoWindowWidgets()
             ImGui::CheckboxFlags("ImGuiTreeNodeFlags_SpanAvailWidth",    &base_flags, ImGuiTreeNodeFlags_SpanAvailWidth); ImGui::SameLine(); HelpMarker("Extend hit area to all available width instead of allowing more items to be laid out after the node.");
             ImGui::CheckboxFlags("ImGuiTreeNodeFlags_SpanFullWidth",     &base_flags, ImGuiTreeNodeFlags_SpanFullWidth);
             ImGui::CheckboxFlags("ImGuiTreeNodeFlags_SpanAllColumns",    &base_flags, ImGuiTreeNodeFlags_SpanAllColumns); ImGui::SameLine(); HelpMarker("For use in Tables only.");
+            ImGui::CheckboxFlags("ImGuiTreeNodeFlags_SpanOnlyText",      &base_flags, ImGuiTreeNodeFlags_SpanOnlyText); ImGui::SameLine(); HelpMarker("Reduce hit area to the text label and bit of margin.");
             ImGui::Checkbox("Align label with current X position", &align_label_with_current_x_position);
             ImGui::Checkbox("Test tree node as drag source", &test_drag_and_drop);
             ImGui::Text("Hello!");
@@ -5028,8 +5029,9 @@ static void ShowDemoWindowTables()
         static ImGuiTableFlags flags = ImGuiTableFlags_BordersV | ImGuiTableFlags_BordersOuterH | ImGuiTableFlags_Resizable | ImGuiTableFlags_RowBg | ImGuiTableFlags_NoBordersInBody;
 
         static ImGuiTreeNodeFlags tree_node_flags = ImGuiTreeNodeFlags_SpanAllColumns;
-        ImGui::CheckboxFlags("ImGuiTreeNodeFlags_SpanFullWidth", &tree_node_flags, ImGuiTreeNodeFlags_SpanFullWidth);
+        ImGui::CheckboxFlags("ImGuiTreeNodeFlags_SpanFullWidth",  &tree_node_flags, ImGuiTreeNodeFlags_SpanFullWidth);
         ImGui::CheckboxFlags("ImGuiTreeNodeFlags_SpanAllColumns", &tree_node_flags, ImGuiTreeNodeFlags_SpanAllColumns);
+        ImGui::CheckboxFlags("ImGuiTreeNodeFlags_SpanOnlyText",   &tree_node_flags, ImGuiTreeNodeFlags_SpanOnlyText);
 
         if (ImGui::BeginTable("3ways", 3, flags))
         {


### PR DESCRIPTION
Hello Omar!

Sometimes I use elements in the same line as treenodes, e.g. buttons or checkboxes.
But I find it a bit distractive how the tree hovering highlight overlaps with these.
Related to https://github.com/ocornut/imgui/issues/6574, how selectable covering buttons seems intuitive.

![2023-10-18_(093928)_viewer](https://github.com/ocornut/imgui/assets/26868611/37992201-4fbd-4dd9-b3a2-490effb9d84a)

So, I wanted to add a simple flag to treenodes to make the highlight limited to the text label.
After a while using it, I polished it and also updated to master branch.
Thought you might find it interesting for a merge :)

![2023-10-18_(094029)_viewer](https://github.com/ocornut/imgui/assets/26868611/8e0f3bab-a21e-447f-85ad-7d349bb6a337)

![2023-10-18_(094213)_viewer](https://github.com/ocornut/imgui/assets/26868611/09618e9b-802e-4d57-8151-c11674d35aff)

I named it, `ImGuiTreeNodeFlags_SpanOnlyText`, in line with the other span related flags `ImGuiTreeNodeFlags_SpanAvailWidth` and `ImGuiTreeNodeFlags_SpanFullWidth`

***As described in imgui.h***: Hovering highlight will only cover the label text and reduces the hitbox to wrap the text tighter (0.5f `style.ItemSpacing.x` instead of regular 2.0f). Does nothing when any of the following flags is set: `ImGuiTreeNodeFlags_Framed`, `ImGuiTreeNodeFlags_SpanAvailWidth`, `ImGuiTreeNodeFlags_SpanFullWidth`, `ImGuiTreeNodeFlags_SpanAllColumns`.

Rationale:
* Tighter hitbox feels more intuitive when the highlight also wraps the text tightly, it also helps to avoid clicking on inline widgets.
* Does not make much sense to allow smaller framed nodes, but opinionated.
* There are more and older flags that increase span, so seems to make to give them preference

**I added a few lines to the demo to add some inline buttons and showcase the flags.**

> Ofc, feel free to edit or suggest anything, thanks!