### PR TITLE
Vulkan: Adding leak prevention if the fonts need to be recreated

### DIFF
--- a/backends/imgui_impl_vulkan.cpp
+++ b/backends/imgui_impl_vulkan.cpp
@@ -600,6 +600,31 @@ bool ImGui_ImplVulkan_CreateFontsTexture(VkCommandBuffer command_buffer)
 
     VkResult err;
 
+    if (bd->FontDescriptorSet) {
+        err = vkFreeDescriptorSets(v->Device, v->DescriptorPool, 1, &bd->FontDescriptorSet);
+        check_vk_result(err);
+        bd->FontDescriptorSet = VK_NULL_HANDLE;
+    }
+
+    // clean up before reallocating to avoid a resource leak
+    if (bd->FontView)
+    {
+        vkDestroyImageView(v->Device, bd->FontView, v->Allocator);
+        bd->FontView = VK_NULL_HANDLE;
+    }
+    if (bd->FontImage)
+    {
+        vkDestroyImage(v->Device, bd->FontImage, v->Allocator);
+        bd->FontImage = VK_NULL_HANDLE;
+        }
+    if (bd->FontMemory)
+    {
+        vkFreeMemory(v->Device, bd->FontMemory, v->Allocator);
+        bd->FontMemory = VK_NULL_HANDLE;
+    }
+    ImGui_ImplVulkan_DestroyFontUploadObjects();
+
+
     // Create the Image:
     {
         VkImageCreateInfo info = {};


### PR DESCRIPTION
Issue: 
I implemented support for DPI awareness in our ImGui based application by following https://github.com/ocornut/imgui/discussions/3925 .
It was adapted for Win32 and Vulkan. 

ImGui_ImplVulkan_CreateFontsTexture() needs to be called each time the DPI changes 
but I noticed that the font resources are never cleaned up creating a resource leak. 
This diff prevents the leak from occurring.

Thanks!

