### PR TITLE
Backends: Vulkan: Custom window surface format with dynamic rendering

### DIFF
--- a/backends/imgui_impl_vulkan.cpp
+++ b/backends/imgui_impl_vulkan.cpp
@@ -1653,7 +1653,11 @@ static void ImGui_ImplVulkan_CreateWindow(ImGuiViewport* viewport)
     }
 
     // Select Surface Format
-    const VkFormat requestSurfaceImageFormat[] = { VK_FORMAT_B8G8R8A8_UNORM, VK_FORMAT_R8G8B8A8_UNORM, VK_FORMAT_B8G8R8_UNORM, VK_FORMAT_R8G8B8_UNORM };
+    const VkFormat requestSurfaceImageFormat[] = {
+#if defined(IMGUI_IMPL_VULKAN_HAS_DYNAMIC_RENDERING)
+        bd->VulkanInitInfo.ColorAttachmentFormat,
+#endif
+        VK_FORMAT_B8G8R8A8_UNORM, VK_FORMAT_R8G8B8A8_UNORM, VK_FORMAT_B8G8R8_UNORM, VK_FORMAT_R8G8B8_UNORM };
     const VkColorSpaceKHR requestSurfaceColorSpace = VK_COLORSPACE_SRGB_NONLINEAR_KHR;
     wd->SurfaceFormat = ImGui_ImplVulkanH_SelectSurfaceFormat(v->PhysicalDevice, wd->Surface, requestSurfaceImageFormat, (size_t)IM_ARRAYSIZE(requestSurfaceImageFormat), requestSurfaceColorSpace);
 

--- a/backends/imgui_impl_vulkan.cpp
+++ b/backends/imgui_impl_vulkan.cpp
@@ -1655,7 +1655,7 @@ static void ImGui_ImplVulkan_CreateWindow(ImGuiViewport* viewport)
     // Select Surface Format
     const VkFormat requestSurfaceImageFormat[] = {
 #if defined(IMGUI_IMPL_VULKAN_HAS_DYNAMIC_RENDERING)
-        bd->VulkanInitInfo.ColorAttachmentFormat,
+        v->UseDynamicRendering && v->ColorAttachmentFormat ? v->ColorAttachmentFormat : VK_FORMAT_B8G8R8A8_UNORM,
 #endif
         VK_FORMAT_B8G8R8A8_UNORM, VK_FORMAT_R8G8B8A8_UNORM, VK_FORMAT_B8G8R8_UNORM, VK_FORMAT_R8G8B8_UNORM };
     const VkColorSpaceKHR requestSurfaceColorSpace = VK_COLORSPACE_SRGB_NONLINEAR_KHR;


### PR DESCRIPTION
## Background

`ImGui_ImplVulkan_CreateWindow` currently selects one out of four formats from `VK_FORMAT_B8G8R8A8_UNORM, VK_FORMAT_R8G8B8A8_UNORM, VK_FORMAT_B8G8R8_UNORM, VK_FORMAT_R8G8B8_UNORM`. The selected `wd->SurfaceFormat` is later used to create the swapchain and the frame's `BackbufferView`.

The backbuffer view is used in the `VkRenderingAttachmentInfo` when using dynamic rendering. If the selected surface format does not match the format set on the VkPipelineRenderingCreateInfoKHR, a validation error is triggered:
```
Message: Validation Error: [ VUID-vkCmdDrawIndexed-colorAttachmentCount-06180 ] VkRenderingInfo::pColorAttachments[0].imageView format (VK_FORMAT_B8G8R8A8_UNORM) must match corresponding format in VkPipelineRenderingCreateInfo::pColorAttachmentFormats[0] (VK_FORMAT_B8G8R8A8_SRGB) The Vulkan spec states: If the current render pass instance was begun with vkCmdBeginRendering and VkRenderingInfo::colorAttachmentCount greater than 0, then each element of the VkRenderingInfo::pColorAttachments array with a imageView not equal to VK_NULL_HANDLE must have been created with a VkFormat equal to the corresponding element of VkPipelineRenderingCreateInfo::pColorAttachmentFormats used to create the currently bound graphics pipeline
```

In my case, I use `VK_FORMAT_B8G8R8A8_SRGB` as `ColorAttachmentFormat` when creating the pipeline, and the `BackbufferView` defaults to `VK_FORMAT_B8G8R8A8_UNORM`, which is invalid.

## Proposal

To solve this, I propose using the `ColorAttachmentFormat` as the primary requestSurfaceImageFormat when dynamic rendering is enabled, which will cause both the swapchain and the BackbufferView to have the same format as we create the pipeline with.