### PR TITLE
Add #define config for "imgui_user.h" path

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -3276,7 +3276,11 @@ enum ImGuiModFlags_ { ImGuiModFlags_None = 0, ImGuiModFlags_Ctrl = ImGuiMod_Ctrl
 
 // Include imgui_user.h at the end of imgui.h (convenient for user to only explicitly include vanilla imgui.h)
 #ifdef IMGUI_INCLUDE_IMGUI_USER_H
+#ifdef IMGUI_USER_H_PATH
+#include IMGUI_USER_H_PATH
+#else
 #include "imgui_user.h"
+#endif
 #endif
 
 #endif // #ifndef IMGUI_DISABLE


### PR DESCRIPTION
My project has a nested include structure, where `#include "imgui_user.h"` isn't available (think `#include "some/path/to/imgui_user.h"` instead).

It's obviously possible to get around this by setting `-Isome/path/to`, but that has to be set both when compiling imgui code and user code, and somewhat defeats the point of the nested include structure.

Open to bikeshedding on the name of the `#define`. The closest parallel to base the name off of was `IMGUI_USER_CONFIG`, but I had to keep the default behavior of `#define IMGUI_INCLUDE_USER_H` -> `#include "imgui_user.h"`