### PR TITLE
refactor: avoid C++26 removed deprecated arithmetic conversion on enumerations

### DIFF
--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -1679,7 +1679,7 @@ bool ImGui::BeginCombo(const char* label, const char* preview_value, ImGuiComboF
     const ImGuiID id = window->GetID(label);
     IM_ASSERT((flags & (ImGuiComboFlags_NoArrowButton | ImGuiComboFlags_NoPreview)) != (ImGuiComboFlags_NoArrowButton | ImGuiComboFlags_NoPreview)); // Can't use both flags together
     if (flags & ImGuiComboFlags_WidthFitPreview)
-        IM_ASSERT((flags & (ImGuiComboFlags_NoPreview | ImGuiComboFlags_CustomPreview)) == 0);
+        IM_ASSERT((flags & (ImGuiComboFlags_NoPreview | (ImGuiComboFlags)ImGuiComboFlags_CustomPreview)) == 0);
 
     const float arrow_size = (flags & ImGuiComboFlags_NoArrowButton) ? 0.0f : GetFrameHeight();
     const ImVec2 label_size = CalcTextSize(label, NULL, true);
@@ -3426,7 +3426,7 @@ bool ImGui::TempInputScalar(const ImRect& bb, ImGuiID id, const char* label, ImG
     DataTypeFormatString(data_buf, IM_ARRAYSIZE(data_buf), data_type, p_data, format);
     ImStrTrimBlanks(data_buf);
 
-    ImGuiInputTextFlags flags = ImGuiInputTextFlags_AutoSelectAll | ImGuiInputTextFlags_NoMarkEdited;
+    ImGuiInputTextFlags flags = ImGuiInputTextFlags_AutoSelectAll | (ImGuiInputTextFlags)ImGuiInputTextFlags_NoMarkEdited;
     flags |= InputScalar_DefaultCharsFilter(data_type, format);
 
     bool value_changed = false;
@@ -3474,7 +3474,7 @@ bool ImGui::InputScalar(const char* label, ImGuiDataType data_type, void* p_data
     // Testing ActiveId as a minor optimization as filtering is not needed until active
     if (g.ActiveId == 0 && (flags & (ImGuiInputTextFlags_CharsDecimal | ImGuiInputTextFlags_CharsHexadecimal | ImGuiInputTextFlags_CharsScientific)) == 0)
         flags |= InputScalar_DefaultCharsFilter(data_type, format);
-    flags |= ImGuiInputTextFlags_AutoSelectAll | ImGuiInputTextFlags_NoMarkEdited; // We call MarkItemEdited() ourselves by comparing the actual data rather than the string.
+    flags |= ImGuiInputTextFlags_AutoSelectAll | (ImGuiInputTextFlags)ImGuiInputTextFlags_NoMarkEdited; // We call MarkItemEdited() ourselves by comparing the actual data rather than the string.
 
     bool value_changed = false;
     if (p_step == NULL)
@@ -6469,7 +6469,7 @@ bool ImGui::CollapsingHeader(const char* label, bool* p_visible, ImGuiTreeNodeFl
     ImGuiID id = window->GetID(label);
     flags |= ImGuiTreeNodeFlags_CollapsingHeader;
     if (p_visible)
-        flags |= ImGuiTreeNodeFlags_AllowOverlap | ImGuiTreeNodeFlags_ClipLabelForTrailingButton;
+        flags |= ImGuiTreeNodeFlags_AllowOverlap | (ImGuiTreeNodeFlags)ImGuiTreeNodeFlags_ClipLabelForTrailingButton;
     bool is_open = TreeNodeBehavior(id, flags, label);
     if (p_visible != NULL)
     {


### PR DESCRIPTION
Resolves #7088:
> C++26 will include "Removing deprecated arithmetic conversion on enumerations".
> The listed compilers already implement those (<https://en.cppreference.com/w/cpp/compiler_support#C.2B.2B26_features>):
> 
> C++26 feature | Paper(s) | GCC | Clang | MSVC | Apple Clang 
> -- | -- | -- | -- | -- | -- 
> Removing deprecated arithmetic conversion on enumerations | [P2864R2](https://wg21.link/P2864R2) |  14 |  18 | | |
> 
> While building `imgui_widgets.cpp`:
> ```
> /home/johel/Documents/C++/Forks/imgui/imgui_widgets.cpp:1682:55: error: invalid bitwise operation between different enumeration types ('ImGuiComboFlags_' and 'ImGuiComboFlagsPrivate_')
>  1682 |         IM_ASSERT((flags & (ImGuiComboFlags_NoPreview | ImGuiComboFlags_CustomPreview)) == 0);
>       |                             ~~~~~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
> /home/johel/Documents/C++/Forks/imgui/imgui.h:84:44: note: expanded from macro 'IM_ASSERT'
>    84 | #define IM_ASSERT(_EXPR)            assert(_EXPR)                               // You can override the default assert handler by editing imconfig.h
>       |                                            ^~~~~
> /usr/include/assert.h:100:27: note: expanded from macro 'assert'
>   100 |      (static_cast <bool> (expr)                                         \
>       |                           ^~~~
> /home/johel/Documents/C++/Forks/imgui/imgui_widgets.cpp:3429:67: error: invalid bitwise operation between different enumeration types ('ImGuiInputTextFlags_' and 'ImGuiInputTextFlagsPrivate_')
>  3429 |     ImGuiInputTextFlags flags = ImGuiInputTextFlags_AutoSelectAll | ImGuiInputTextFlags_NoMarkEdited;
>       |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
> /home/johel/Documents/C++/Forks/imgui/imgui_widgets.cpp:3477:48: error: invalid bitwise operation between different enumeration types ('ImGuiInputTextFlags_' and 'ImGuiInputTextFlagsPrivate_')
>  3477 |     flags |= ImGuiInputTextFlags_AutoSelectAll | ImGuiInputTextFlags_NoMarkEdited; // We call MarkItemEdited() ourselves by comparing the actual data rather than the string.
>       |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
> /home/johel/Documents/C++/Forks/imgui/imgui_widgets.cpp:6472:50: error: invalid bitwise operation between different enumeration types ('ImGuiTreeNodeFlags_' and 'ImGuiTreeNodeFlagsPrivate_')
>  6472 |         flags |= ImGuiTreeNodeFlags_AllowOverlap | ImGuiTreeNodeFlags_ClipLabelForTrailingButton;
>       |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
> 4 errors generated.
> ```
> 
> Here you can see MSVC warn, and GCC provide an opt-out flag: <https://cpp1.godbolt.org/z/Wqb5z4zjT>.