### PR TITLE
Fix new window position Y coordinate calculation for OSX backend.

### DIFF
--- a/backends/imgui_impl_osx.mm
+++ b/backends/imgui_impl_osx.mm
@@ -864,7 +864,9 @@ struct ImGuiViewportDataOSX
 
 static void ConvertNSRect(NSScreen* screen, NSRect* r)
 {
-    r->origin.y = screen.frame.size.height - r->origin.y - r->size.height;
+    NSRect firstScreenFrame = NSScreen.screens[0].frame;
+    IM_ASSERT(firstScreenFrame.origin.x == 0 && firstScreenFrame.origin.y == 0);
+    r->origin.y = firstScreenFrame.size.height - r->origin.y - r->size.height;
 }
 
 static void ImGui_ImplOSX_CreateWindow(ImGuiViewport* viewport)


### PR DESCRIPTION
I believe we need to use the "first" (not the "current") screen's height to calculate Y coordinate of a window.
By "first" I mean the screen that has (0;0) coordinate at the top left for ImGui and (0;0) at the bottom left for OSX.

![Screenshot 2023-12-08 at 12 00 20](https://github.com/ocornut/imgui/assets/121183702/adbdf910-095e-44d0-a161-2cf30cb2b600)

Otherwise on secondary monitors it will behave like this:

![Screen Recording 2023-12-08 at 12 08 46](https://github.com/ocornut/imgui/assets/121183702/0905344f-a418-41f6-9aef-03afc0cb658d)

