### PR TITLE
Don't bring appearing host window to front unless any of the contained…

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -16712,19 +16712,28 @@ static void ImGui::DockNodeUpdate(ImGuiDockNode* node)
             node->Size = host_window->Size;
 
             // We set ImGuiWindowFlags_NoFocusOnAppearing because we don't want the host window to take full focus (e.g. steal NavWindow)
-            // But we still it bring it to the front of display unless all appearing windows have ImGuiWindowFlags_NoFocusOnAppearing set. If none of the
+            // But we still bring it to the front of display unless all appearing windows have ImGuiWindowFlags_NoFocusOnAppearing set. If none of the
             // windows wants initial focus, the host will not be brought to the front. There's no way to choose this precise behavior via window flags.
-            // One simple case to ponder if: window A has a toggle to create windows B/C/D. Dock B/C/D together, clear the toggle and enable it again.
+            // One simple case to ponder is: window A has a toggle to create windows B/C/D. Dock B/C/D together, clear the toggle and enable it again.
             // When reappearing B/C/D will request focus and be moved to the top of the display pile, but they are not linked to the dock host window
             // during the frame they appear. The dock host window would keep its old display order, and the sorting in EndFrame would move B/C/D back
             // after the dock host window, losing their top-most status.
             if (node->HostWindow->Appearing)
+            {
+                // If any of the appearing windows wants focus or any of the other windows currently has the focus, bring the host window to front.
+                // In addition to appearing windows, this handles all cases where one or multiple windows are manually docked.
                 for (ImGuiWindow* window : node->Windows)
-                    if (window->Appearing && !(window->Flags & ImGuiWindowFlags_NoFocusOnAppearing))
+                    if (window->Appearing ? !(window->Flags & ImGuiWindowFlags_NoFocusOnAppearing) : (window == g.NavWindow))
                     {
                         BringWindowToDisplayFront(node->HostWindow);
                         break;
                     }
+
+                // If the host window was not brought to the front, bring it behind the reference window to preserve its display order.
+                // This neatly handles all remaining cases of programmatically docking windows into the host window.
+                if (node->HostWindow != g.Windows.back() && ref_window)
+                    BringWindowToDisplayBehind(node->HostWindow, ref_window);
+            }
 
             node->AuthorityForPos = node->AuthorityForSize = node->AuthorityForViewport = ImGuiDataAuthority_Auto;
         }


### PR DESCRIPTION
… windows require initial focus

I took a closer look at how to implement the "officially" suggested fix for one of the problems in #7008, specifically this one:

>About Daniel's issue: seems like there's two steps for this. Making the dock node using _NoFocusOnAppearing if all just appearing windows share this flag, I think is a reasonable first move and would fix the biggest problem you have (focus stolen away from current menu), ...

The fix was surprisingly easy since all of the needed information is available right there. If the host window is appearing, instead of just bringing it to the front, it now checks its contained appearing windows first and is brought to the front only if one (or more) of the contained appearing windows has `ImGuiWindowFlags_NoFocusOnAppearing` not set (thus requiring initial focus).

This fix makes the behavior of appearing windows consistent regardless of how they may be docked. Here are some GIFs of the before and after behavior. Ctrl+Click is custom functionality through wrappers (no library change) for "sticky" menu items. They keep the menu open while appearing windows get the `ImGuiWindowFlags_NoFocusOnAppearing` flag.

Normal click closes the menu and opens the window without the flag, the behavior is not changed by the fix:
![no_focus_fix_default](https://github.com/ocornut/imgui/assets/77451134/af25b7d6-7e81-4585-9a3c-9635e0f70977)

Ctrl+Click keeps the menu open, window gets the flag, but host window gets brought to the front anyway without the fix:
![no_focus_fix_error](https://github.com/ocornut/imgui/assets/77451134/12699bfb-3bbf-40b0-8aa9-cc69d7e3a3fd)

Ctrl+Click with the fix results in the desired behavior:
![no_focus_fix_wanted](https://github.com/ocornut/imgui/assets/77451134/d6b79cd5-d86f-41d0-89a6-5876ada224d5)