### PR TITLE
Improve width computation in multi-components widget (#7120)

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -9862,14 +9862,15 @@ void ImGui::PushMultiItemsWidths(int components, float w_full)
     ImGuiWindow* window = g.CurrentWindow;
     IM_ASSERT(components > 0);
     const ImGuiStyle& style = g.Style;
-    const float w_item_one  = ImMax(1.0f, IM_TRUNC((w_full - (style.ItemInnerSpacing.x) * (components - 1)) / (float)components));
-    const float w_item_last = ImMax(1.0f, IM_TRUNC(w_full - (w_item_one + style.ItemInnerSpacing.x) * (components - 1)));
-    window->DC.ItemWidthStack.push_back(window->DC.ItemWidth); // Backup current width
-    if (components > 1)
-        window->DC.ItemWidthStack.push_back(w_item_last);
-    for (int i = 0; i < components - 2; i++)
-        window->DC.ItemWidthStack.push_back(w_item_one);
-    window->DC.ItemWidth = (components == 1) ? w_item_last : w_item_one;
+    window->DC.ItemWidthStack.push_back(window->DC.ItemWidth);  // Backup current width
+    float w_items = w_full - style.ItemInnerSpacing.x * (components - 1);
+    float prev_split = w_items;
+    for (int i = components - 1; i > 0; i--) {
+        float next_split = IM_TRUNC(w_items * i / components);
+        window->DC.ItemWidthStack.push_back(prev_split - next_split);
+        prev_split = next_split;
+    }
+    window->DC.ItemWidth = prev_split;
     g.NextItemData.Flags &= ~ImGuiNextItemDataFlags_HasWidth;
 }
 


### PR DESCRIPTION
In the previous algorithm, all components were of the same width except for the last. That last one was using the remainder.
This meant that any error in that common width (caused by the truncation to the nearest pixel/integer), was getting accumulated and propagated into that last component.

The new algorithm avoid this issue by computing where each component should start, with the width being the difference between those locations. In essence, this spreads the errors over multiple components instead of just the last one.
