### PR TITLE
Backends: Vulkan: Report error when window fails to open

### DIFF
--- a/examples/example_sdl2_vulkan/main.cpp
+++ b/examples/example_sdl2_vulkan/main.cpp
@@ -386,6 +386,11 @@ int main(int, char**)
     SDL_WindowFlags window_flags = (SDL_WindowFlags)(SDL_WINDOW_VULKAN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
     SDL_Window* window = SDL_CreateWindow("Dear ImGui SDL2+Vulkan example", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 1280, 720, window_flags);
 
+    if (!window) {
+        printf("Error: %s\n", SDL_GetError());
+        return -1;
+    }
+    
     ImVector<const char*> extensions;
     uint32_t extensions_count = 0;
     SDL_Vulkan_GetInstanceExtensions(window, &extensions_count, nullptr);


### PR DESCRIPTION
When SDL is not properly configured for vulkan `SDL_CreateWindow` will return null, crashing with an exception without any detail except for a null pointer dereference. SDL_CreateWindow suggests using `SDL_GetError()` in the event something has gone wrong (much like the lines above).
