### PR TITLE
[glfw] Early-out of  GLFW WndProc hook if there's no backend data

### DIFF
--- a/backends/imgui_impl_glfw.cpp
+++ b/backends/imgui_impl_glfw.cpp
@@ -483,6 +483,7 @@ static ImGuiMouseSource GetMouseSourceFromMessageExtraInfo()
 static LRESULT CALLBACK ImGui_ImplGlfw_WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
     ImGui_ImplGlfw_Data* bd = ImGui_ImplGlfw_GetBackendData();
+    if (!bd) { return DefWindowProc(hWnd, msg, wParam, lParam); }
     switch (msg)
     {
     case WM_MOUSEMOVE: case WM_NCMOUSEMOVE:


### PR DESCRIPTION
If we happen to call  `glfwTerminate`  after destroying the ImGui context, the WndProc that ImGui installs still gets triggered, but there is no backend data at that time. This is a simple one-line fix that just early-outs if `bd` is NULL for whatever reason.