### PR TITLE
imgui_freetype: fix nullptr to ImTextureID cast

### DIFF
--- a/misc/freetype/imgui_freetype.cpp
+++ b/misc/freetype/imgui_freetype.cpp
@@ -437,7 +437,7 @@ bool ImFontAtlasBuildWithFreeTypeEx(FT_Library ft_library, ImFontAtlas* atlas, u
     ImFontAtlasBuildInit(atlas);
 
     // Clear atlas
-    atlas->TexID = (ImTextureID)nullptr;
+    atlas->TexID = 0;
     atlas->TexWidth = atlas->TexHeight = 0;
     atlas->TexUvScale = ImVec2(0.0f, 0.0f);
     atlas->TexUvWhitePixel = ImVec2(0.0f, 0.0f);


### PR DESCRIPTION
This is a small fix for some systems where casting from void* to ImTextureID needs to be done in two steps:

On macOS, we get an error saying:

error: cast from pointer to smaller type 'int' loses information
    atlas->TexID = (ImTextureID)nullptr;
