### PR TITLE
Add comment about how ImGuiKey values are named after US keyboard keys.

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -1306,6 +1306,7 @@ enum ImGuiSortDirection_
 // Since >= 1.89 we increased typing (went from int to enum), some legacy code may need a cast to ImGuiKey.
 // Read details about the 1.87 and 1.89 transition : https://github.com/ocornut/imgui/issues/4921
 // Note that "Keys" related to physical keys and are not the same concept as input "Characters", the later are submitted via io.AddInputCharacter().
+// The keyboard key enum values are named after the keys on a standard US keyboard, and on other keyboard types the keys reported may not match the keycaps.
 enum ImGuiKey : int
 {
     // Keyboard


### PR DESCRIPTION
General text input is already covered by AddInputCharacter. For scancode-based key up/down info, simplest to admit that the up/down state indexes are kind of arbitrary and may not actually map perfectly to the labels on the keys.

See #7201