### PR TITLE
Add additional ImGuiKey entry for the extra key on a non-US ISO keyboard, and add a case for it to the Win32 backend.

### DIFF
--- a/backends/imgui_impl_win32.cpp
+++ b/backends/imgui_impl_win32.cpp
@@ -531,6 +531,7 @@ static ImGuiKey ImGui_ImplWin32_VirtualKeyToImGuiKey(WPARAM wParam)
         case VK_F24: return ImGuiKey_F24;
         case VK_BROWSER_BACK: return ImGuiKey_AppBack;
         case VK_BROWSER_FORWARD: return ImGuiKey_AppForward;
+        case VK_OEM_8: return ImGuiKey_ExtraISOKey;
         default: return ImGuiKey_None;
     }
 }

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -8107,7 +8107,7 @@ static const char* const GKeyNames[] =
     "F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F9", "F10", "F11", "F12",
     "F13", "F14", "F15", "F16", "F17", "F18", "F19", "F20", "F21", "F22", "F23", "F24",
     "Apostrophe", "Comma", "Minus", "Period", "Slash", "Semicolon", "Equal", "LeftBracket",
-    "Backslash", "RightBracket", "GraveAccent", "CapsLock", "ScrollLock", "NumLock", "PrintScreen",
+    "Backslash", "RightBracket", "GraveAccent", "ExtraISOKey", "CapsLock", "ScrollLock", "NumLock", "PrintScreen",
     "Pause", "Keypad0", "Keypad1", "Keypad2", "Keypad3", "Keypad4", "Keypad5", "Keypad6",
     "Keypad7", "Keypad8", "Keypad9", "KeypadDecimal", "KeypadDivide", "KeypadMultiply",
     "KeypadSubtract", "KeypadAdd", "KeypadEnter", "KeypadEqual",

--- a/imgui.h
+++ b/imgui.h
@@ -1347,6 +1347,7 @@ enum ImGuiKey : int
     ImGuiKey_Backslash,         // \ (this text inhibit multiline comment caused by backslash)
     ImGuiKey_RightBracket,      // ]
     ImGuiKey_GraveAccent,       // `
+    ImGuiKey_ExtraISOKey,       // Extra key on an ISO-type keyboard, not present on US layout keyboards, and not necessarily reported by all backends
     ImGuiKey_CapsLock,
     ImGuiKey_ScrollLock,
     ImGuiKey_NumLock,


### PR DESCRIPTION
As ImGuiKey values are named after keys on a US keyboard, this key is not named after what's on its keycap - since US keyboards don't have it! (And the character this key produces in practice varies...)

See #7136 