### PR TITLE
Update imgui_impl_vulkan.h to define NOMINMAX on windows

### DIFF
--- a/backends/imgui_impl_vulkan.h
+++ b/backends/imgui_impl_vulkan.h
@@ -46,7 +46,15 @@
 #if defined(IMGUI_IMPL_VULKAN_NO_PROTOTYPES) && !defined(VK_NO_PROTOTYPES)
 #define VK_NO_PROTOTYPES
 #endif
+#if defined(VK_USE_PLATFORM_WIN32_KHR) && !defined(NOMINMAX)
+#define NOMINMAX
+#define IMGUI_IMPL_VULKAN_NOMINMAX // Only undefine NOMINMAX if it wasn't already defined to avoid side effects
+#endif
 #include <vulkan/vulkan.h>
+#ifdef IMGUI_IMPL_VULKAN_NOMINMAX 
+#undef NOMINMAX
+#undef IMGUI_IMPL_VULKAN_NOMINMAX
+#endif
 
 // Initialization data, for ImGui_ImplVulkan_Init()
 // [Please zero-clear before use!]


### PR DESCRIPTION
Issue: `#include <vulkan/vulkan.h>` includes `windows.h` if `VK_USE_PLATFORM_WIN32_KHR` is defined. `windows.h` defines `min` and `max` macros if `NOMINMAX` is not defined. `min` and `max` macros conflict with `std::numeric_limits<T>::min()` 
 and `std::numeric_limits<T>::max()`

Proposed Solution: `#define NOMINMAX` if `VK_USE_PLATFORM_WIN32_KHR` is defined then undefine it again after including `vulkan.h` only if it wasn't previously defined to avoid side effects for applications which use the windows `min` and `max` macros.

I used `IMGUI_IMPL_VULKAN_NOMINMAX ` to signal that `NOMINMAX` was defined by the backend so it can be undefined again. I am not sure if there is a better way to do this. I would love to hear of alternative solutions if they exist.
