### PR TITLE
Examples: Emscripten+WebGPU: Remove use of deprecated and removed ObjectBase<...>::Release in favor of ::MoveToCHandle

### DIFF
--- a/examples/example_emscripten_wgpu/main.cpp
+++ b/examples/example_emscripten_wgpu/main.cpp
@@ -128,7 +128,7 @@ static bool InitWGPU()
     wgpu::Surface surface = instance.CreateSurface(&surface_desc);
     wgpu::Adapter adapter = {};
     wgpu_preferred_fmt = (WGPUTextureFormat)surface.GetPreferredFormat(adapter);
-    wgpu_surface = surface.Release();
+    wgpu_surface = surface.MoveToCHandle();
 
     return true;
 }


### PR DESCRIPTION
Latest emsdk 3.1.52 released 19 Jan 2024 contains updated WebGPU headers, where `Release()` function on objects was removed.

Diff with 3.1.51 does show this change:
<img width="739" alt="image" src="https://github.com/ocornut/imgui/assets/1197433/9e834c05-0203-467d-ba4c-f2b92a9af52d">

PR replace use of now removed `Release()` with `MoveToCHandle()` which appear to be same function with more descriptive name.

Issue is limited to `webgpu_cpp.h`, which is generated header in Chromium codebase AFAIK.