### PR TITLE
Add "nop" to IM_DEBUG_BREAK macro to work around GDB bug

### DIFF
--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -304,7 +304,7 @@ namespace ImStb
 #elif defined(__GNUC__) && defined(__thumb__)
 #define IM_DEBUG_BREAK()    __asm__ volatile(".inst 0xde01")
 #elif defined(__GNUC__) && defined(__arm__) && !defined(__thumb__)
-#define IM_DEBUG_BREAK()    __asm__ volatile(".inst 0xe7f001f0");
+#define IM_DEBUG_BREAK()    __asm__ volatile(".inst 0xe7f001f0")
 #else
 #define IM_DEBUG_BREAK()    IM_ASSERT(0)    // It is expected that you define IM_DEBUG_BREAK() into something that will break nicely in a debugger!
 #endif

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -300,7 +300,7 @@ namespace ImStb
 #elif defined(__clang__)
 #define IM_DEBUG_BREAK()    __builtin_debugtrap()
 #elif defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))
-#define IM_DEBUG_BREAK()    __asm__ volatile("int $0x03")
+#define IM_DEBUG_BREAK()    __asm__ volatile("int3;nop")
 #elif defined(__GNUC__) && defined(__thumb__)
 #define IM_DEBUG_BREAK()    __asm__ volatile(".inst 0xde01")
 #elif defined(__GNUC__) && defined(__arm__) && !defined(__thumb__)


### PR DESCRIPTION
There are two issues here - first, this macro uses AT&T specific syntax with $, which is not necessary. Also, some assemblers (nasm) emit different bytes for "int 3" and "int3" (cd 03 vs cc), so it's better to use "int3" for consistency.

More importantly, GDB (as of 14.1) has some failing assertion whenever stepping after hitting a lone "int3" instruction. This makes it practically useless, as is. For some reason, putting a nop afterwards as a workaround is okay.

Related discussions:
https://sourceware.org/bugzilla/show_bug.cgi?id=31194
https://lists.sr.ht/~skeeto/public-inbox/%3C2d3d7662a361ddd049f7dc65b94cecdd%40disroot.org%3E

Also, clang's __builtin_debugtrap() runs into this same issue with GDB. I feel uncomfortable commenting the `__builtin_debugtrap()` line out, but if it's desired, I'll do so.

Of course, there's also the possibility this change is entirely undesired and can be fixed on my end by defining this macro "properly" on my own.