### PR TITLE
Update imgui_impl_sdlrenderer3.cpp

### DIFF
--- a/backends/imgui_impl_sdlrenderer3.cpp
+++ b/backends/imgui_impl_sdlrenderer3.cpp
@@ -179,7 +179,7 @@ void ImGui_ImplSDLRenderer3_RenderDrawData(ImDrawData* draw_data)
                 const float* xy = (const float*)(const void*)((const char*)(vtx_buffer + pcmd->VtxOffset) + offsetof(ImDrawVert, pos));
                 const float* uv = (const float*)(const void*)((const char*)(vtx_buffer + pcmd->VtxOffset) + offsetof(ImDrawVert, uv));
 #if SDL_VERSION_ATLEAST(2,0,19)
-                const SDL_Color* color = (const SDL_Color*)(const void*)((const char*)(vtx_buffer + pcmd->VtxOffset) + offsetof(ImDrawVert, col)); // SDL 2.0.19+
+                const SDL_FColor* color = (const SDL_FColor*)(const void*)((const char*)(vtx_buffer + pcmd->VtxOffset) + offsetof(ImDrawVert, col)); // SDL 2.0.19+
 #else
                 const int* color = (const int*)(const void*)((const char*)(vtx_buffer + pcmd->VtxOffset) + offsetof(ImDrawVert, col)); // SDL 2.0.17 and 2.0.18
 #endif


### PR DESCRIPTION
SDL3 uses SDL_FColor for SDL_RenderGeometryRaw.
Proof: https://wiki.libsdl.org/SDL3/SDL_RenderGeometryRaw

Here is an error log (Using Clang 17.0.5):
```
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build f:/Virtual/Shared/projects/MYPROJECT/build --config Debug --target all -j 6 --
[build] [  5%] Built target SDL3_test
[build] [ 95%] Built target SDL3-shared
[build] [ 95%] Building CXX object CMakeFiles/imgui.dir/3rdparty/imgui/backends/imgui_impl_sdlrenderer3.cpp.obj
[build] F:/Virtual/Shared/projects/MYPROJECT/3rdparty/imgui/backends/imgui_impl_sdlrenderer3.cpp:212:5: error: no matching function for call to 'SDL_RenderGeometryRaw'
[build]   212 |                                 SDL_RenderGeometryRaw(bd->SDLRenderer,
[build]       |                                 ^~~~~~~~~~~~~~~~~~~~~
[build] F:/Virtual/Shared/projects/MYPROJECT/3rdparty/SDL/include\SDL3/SDL_render.h:1763:29: note: candidate function not viable: no known conversion from 'const SDL_Color *' to 'const SDL_FColor *' for 5th argument
[build]  1763 | extern DECLSPEC int SDLCALL SDL_RenderGeometryRaw(SDL_Renderer *renderer,
[build]       |                             ^
[build]  1764 |                                                SDL_Texture *texture,
[build]  1765 |                                                const float *xy, int xy_stride,
[build]  1766 |                                                const SDL_FColor *color, int color_stride,
[build]       |                                                ~~~~~~~~~~~~~~~~~~~~~~~
[build] 1 error generated.
[build] make[2]: *** [CMakeFiles/imgui.dir/build.make:167: CMakeFiles/imgui.dir/3rdparty/imgui/backends/imgui_impl_sdlrenderer3.cpp.obj] Error 1
[build] make[1]: *** [CMakeFiles/Makefile2:105: CMakeFiles/imgui.dir/all] Error 2
[build] make: *** [Makefile:91: all] Error 2
[proc] The command: "C:\Program Files\CMake\bin\cmake.EXE" --build f:/Virtual/Shared/projects/MYPROJECT/build --config Debug --target all -j 6 -- exited with code: 2
[driver] Build completed: 00:00:02.614
[build] Build finished with exit code 2
```
