### PR TITLE
To avoid the default hidden window to save setting.ini 

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -4813,7 +4813,8 @@ void ImGui::NewFrame()
     // This fallback is particularly important as it prevents ImGui:: calls from crashing.
     g.WithinFrameScopeWithImplicitWindow = true;
     SetNextWindowSize(ImVec2(400, 400), ImGuiCond_FirstUseEver);
-    Begin("Debug##Default");
+    //To avoid the default hide window to save setting.ini when whenever we open our application
+    Begin("Debug##Default",(bool *)false, ImGuiWindowFlags_NoSavedSettings);
     IM_ASSERT(g.CurrentWindow->IsFallbackWindow == true);
 
     // [DEBUG] When io.ConfigDebugBeginReturnValue is set, we make Begin()/BeginChild() return false at different level of the window-stack,


### PR DESCRIPTION
it's often weird to see that even if all the window is set to `noSavedSetting` flags there is a setting.ini that still appear

