### PR TITLE
Vulkan backend: remove call to RemoveTexture()

### DIFF
--- a/backends/imgui_impl_vulkan.cpp
+++ b/backends/imgui_impl_vulkan.cpp
@@ -817,7 +817,6 @@ void ImGui_ImplVulkan_DestroyFontsTexture()
 
     if (bd->FontDescriptorSet)
     {
-        ImGui_ImplVulkan_RemoveTexture(bd->FontDescriptorSet);
         bd->FontDescriptorSet = VK_NULL_HANDLE;
         io.Fonts->SetTexID(0);
     }

--- a/backends/imgui_impl_vulkan.h
+++ b/backends/imgui_impl_vulkan.h
@@ -57,8 +57,7 @@
 #endif
 
 // Initialization data, for ImGui_ImplVulkan_Init()
-// - VkDescriptorPool should be created with VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT,
-//   and must contain a pool size large enough to hold an ImGui VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER descriptor.
+// - VkDescriptorPool must be created with a VkDescriptorPoolSize that includes one ImGui VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER descriptor and a VkDescriptorPoolCreateInfo where `maxSets` includes one ImGui descriptor set.
 // - When using dynamic rendering, set UseDynamicRendering=true and fill PipelineRenderingCreateInfo structure.
 // [Please zero-clear before use!]
 struct ImGui_ImplVulkan_InitInfo


### PR DESCRIPTION
`RemoveTexture()` tries to free a descriptor set on shutdown, which requires the caller to provide a descriptor pool with VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT set. If the pool does not have this set, it is a validation error. I don't think this is a restriction the backend should impose. Since it's the caller's responsibility to provide the pool, it should be the caller's responsibility to free the pool on shutdown (which frees the descriptor sets therein).

The easiest way to integrate with this Vulkan backend is to take your existing descriptor pool (used for whatever else in your application), accommodate the necessary space for what ImGui needs, and provide that. Removing the requirement for the aforementioned bitmask flag allows you to do so without having to change the characteristics of your pool.