### PR TITLE
do not clear ImGuiIO::NavInputs in ImGui_ImplOSX_UpdateGamepads 

### DIFF
--- a/backends/imgui_impl_osx.mm
+++ b/backends/imgui_impl_osx.mm
@@ -534,7 +534,6 @@ static void ImGui_ImplOSX_UpdateMouseCursor()
 static void ImGui_ImplOSX_UpdateGamepads()
 {
     ImGuiIO& io = ImGui::GetIO();
-    memset(io.NavInputs, 0, sizeof(io.NavInputs));
     if ((io.ConfigFlags & ImGuiConfigFlags_NavEnableGamepad) == 0) // FIXME: Technically feeding gamepad shouldn't depend on this now that they are regular inputs.
         return;
 


### PR DESCRIPTION
If we define `IMGUI_DISABLE_OBSOLETE_KEYIO` or `IMGUI_DISABLE_OBSOLETE_FUNCTIONS` then `ImGuiIO::NavInputs` is not available, so `ImGui_ImplOSX_UpdateGamepads` should account for that when calling `memset(io.NavInputs, 0, sizeof(io.NavInputs));`