### PR TITLE
Feature Smooth Scrolling

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -1578,6 +1578,7 @@ enum ImGuiStyleVar_
     ImGuiStyleVar_SeparatorTextBorderSize,// float  SeparatorTextBorderSize
     ImGuiStyleVar_SeparatorTextAlign,  // ImVec2    SeparatorTextAlign
     ImGuiStyleVar_SeparatorTextPadding,// ImVec2    SeparatorTextPadding
+    ImGuiStyleVar_ScrollSmooth,        // float     ScrollSmooth
     ImGuiStyleVar_COUNT
 };
 
@@ -2029,6 +2030,8 @@ struct ImGuiStyle
     float             HoverDelayNormal;         // Delay for IsItemHovered(ImGuiHoveredFlags_DelayNormal). "
     ImGuiHoveredFlags HoverFlagsForTooltipMouse;// Default flags when using IsItemHovered(ImGuiHoveredFlags_ForTooltip) or BeginItemTooltip()/SetItemTooltip() while using mouse.
     ImGuiHoveredFlags HoverFlagsForTooltipNav;  // Default flags when using IsItemHovered(ImGuiHoveredFlags_ForTooltip) or BeginItemTooltip()/SetItemTooltip() while using keyboard/gamepad.
+
+    float             ScrollSmooth;             // Smooth scrolling amount: 1.0f no smoothing. Anything above 1.0f will make the scroll delta more smooth.
 
     IMGUI_API ImGuiStyle();
     IMGUI_API void ScaleAllSizes(float scale_factor);

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -3279,6 +3279,50 @@ static void ShowDemoWindowLayout()
         }
         ImGui::PopID();
 
+        // Smooth scroll functions
+        IMGUI_DEMO_MARKER("Smooth Scrolling");
+        HelpMarker("Use ImGuiStyleVar_ScrollSmooth to enable and define the amount of smooth scrolling. Move the scrolls with the same controls as the previous example to check the difference.");
+
+        ImGui::PushStyleVar(ImGuiStyleVar_ScrollSmooth,20.0f);
+        ImGui::PushID("##SmoothScrolling");
+        for (int i = 0; i < 5; i++) {
+            if (i > 0) ImGui::SameLine();
+            ImGui::BeginGroup();
+            const char* names[] = { "Top", "25%", "Center", "75%", "Bottom" };
+            ImGui::TextUnformatted(names[i]);
+
+            const ImGuiWindowFlags child_flags = enable_extra_decorations ? ImGuiWindowFlags_MenuBar : 0;
+            const ImGuiID child_id = ImGui::GetID((void*)(intptr_t)i);
+            const bool child_is_visible = ImGui::BeginChild(child_id, ImVec2(child_w, 200.0f), ImGuiChildFlags_Border, child_flags);
+            if (ImGui::BeginMenuBar()) {
+                ImGui::TextUnformatted("abc");
+                ImGui::EndMenuBar();
+            }
+            if (scroll_to_off)
+                ImGui::SetScrollY(scroll_to_off_px);
+            if (scroll_to_pos)
+                ImGui::SetScrollFromPosY(ImGui::GetCursorStartPos().y + scroll_to_pos_px, i * 0.25f);
+            if (child_is_visible) // Avoid calling SetScrollHereY when running with culled items
+            {
+                for (int item = 0; item < 100; item++) {
+                    if (enable_track && item == track_item) {
+                        ImGui::TextColored(ImVec4(1, 1, 0, 1), "Item %d", item);
+                        ImGui::SetScrollHereY(i * 0.25f); // 0.0f:top, 0.5f:center, 1.0f:bottom
+                    } else {
+                        ImGui::Text("Item %d", item);
+                    }
+                }
+            }
+            float scroll_y = ImGui::GetScrollY();
+            float scroll_max_y = ImGui::GetScrollMaxY();
+            ImGui::EndChild();
+            ImGui::Text("%.0f/%.0f", scroll_y, scroll_max_y);
+            ImGui::EndGroup();
+        }
+        ImGui::PopID();
+        ImGui::PopStyleVar();
+
+
         // Horizontal scroll functions
         IMGUI_DEMO_MARKER("Layout/Scrolling/Horizontal");
         ImGui::Spacing();

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -2515,7 +2515,8 @@ struct IMGUI_API ImGuiWindow
     int                     NameBufLen;                         // Size of buffer storing Name. May be larger than strlen(Name)!
     ImGuiID                 MoveId;                             // == window->GetID("#MOVE")
     ImGuiID                 ChildId;                            // ID of corresponding item in parent window (for navigation to return from child window to parent window)
-    ImVec2                  Scroll;
+    ImVec2                  Scroll;                             // Current Visible Scroll position
+    ImVec2                  ScrollExpected;                     // Current Expected Scroll position   
     ImVec2                  ScrollMax;
     ImVec2                  ScrollTarget;                       // target scroll position. stored as cursor position with scrolling canceled out, so the highest point is always 0.0f. (FLT_MAX for no change)
     ImVec2                  ScrollTargetCenterRatio;            // 0.0f = scroll so that target position is at top, 0.5f = scroll so that target position is centered

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -915,9 +915,9 @@ void ImGui::Scrollbar(ImGuiAxis axis)
     }
     float size_avail = window->InnerRect.Max[axis] - window->InnerRect.Min[axis];
     float size_contents = window->ContentSize[axis] + window->WindowPadding[axis] * 2.0f;
-    ImS64 scroll = (ImS64)window->Scroll[axis];
+    ImS64 scroll = (ImS64)window->ScrollExpected[axis];
     ScrollbarEx(bb, id, axis, &scroll, (ImS64)size_avail, (ImS64)size_contents, rounding_corners);
-    window->Scroll[axis] = (float)scroll;
+    window->ScrollExpected[axis] = (float)scroll;
 }
 
 // Vertical/Horizontal scrollbar


### PR DESCRIPTION

ImGuiStyleVar_ScrollSmouth float added.
Default value: 1.0 = means no smooth scrolling
Values over 1.0 = starts to smooth the scroll.

Code in the demo added. Same example as the verticaller scrollers but with smooth activated.

MouseWheel and others like SetScrollHereY continue setting ScrollTarget
SetScrollX/SetScrollY/GetScrollX/GetScrollY and scroll bar widget works against a new value in ImWindow "ScrollExpected" 

Function CalcNextScrollFromScrollTargetAndClamp now applies the smooth scrolling no matter if it comes from "ScrollExpected" or "ScrollTarget".

The formula is pretty simple. Is frame bounded and no time bounded but as counter part it is only one new style var and one new var in ImWindow, nothing else. Simple and small change.