### PR TITLE
Handle IsSameLine in Separator()

### DIFF
--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -1465,15 +1465,20 @@ void ImGui::Separator()
     if (window->SkipItems)
         return;
 
+    bool same_line = window->DC.IsSameLine;
+
     // Those flags should eventually be configurable by the user
     // FIXME: We cannot g.Style.SeparatorTextBorderSize for thickness as it relates to SeparatorText() which is a decorated separator, not defaulting to 1.0f.
-    ImGuiSeparatorFlags flags = (window->DC.LayoutType == ImGuiLayoutType_Horizontal) ? ImGuiSeparatorFlags_Vertical : ImGuiSeparatorFlags_Horizontal;
+    ImGuiSeparatorFlags flags = (window->DC.LayoutType == ImGuiLayoutType_Horizontal || same_line) ? ImGuiSeparatorFlags_Vertical : ImGuiSeparatorFlags_Horizontal;
 
     // Only applies to legacy Columns() api as they relied on Separator() a lot.
     if (window->DC.CurrentColumns)
         flags |= ImGuiSeparatorFlags_SpanAllColumns;
 
     SeparatorEx(flags, 1.0f);
+
+    if (same_line)
+        SameLine ();
 }
 
 void ImGui::SeparatorTextEx(ImGuiID id, const char* label, const char* label_end, float extra_w)


### PR DESCRIPTION
This is a simple one, but I can't find any reason IsSameLine shouldn't be handled in Separator.

One thing I am not sure about is the SameLine() call at the end of Separator if we used SameLine() before. Although I don't see a practical reason to not restore IsSameLine state, it feels weird that specifically Separator wants to keep things on the same line even though all the other widgets do not (that I am aware of).

I haven't tested this in weird cases, are there edge cases maybe that I should be aware of?