### PR TITLE
webgpu example: depthSlice initialization of WGPURenderPassColorAttachment

### DIFF
--- a/examples/example_emscripten_wgpu/main.cpp
+++ b/examples/example_emscripten_wgpu/main.cpp
@@ -201,6 +201,7 @@ int main(int, char**)
         ImGui::Render();
 
         WGPURenderPassColorAttachment color_attachments = {};
+        color_attachments.depthSlice = WGPU_DEPTH_SLICE_UNDEFINED;
         color_attachments.loadOp = WGPULoadOp_Clear;
         color_attachments.storeOp = WGPUStoreOp_Store;
         color_attachments.clearValue = { clear_color.x * clear_color.w, clear_color.y * clear_color.w, clear_color.z * clear_color.w, clear_color.w };


### PR DESCRIPTION
Problem: 
The example "example_emscripten_wgpu/main.cpp"
does not work with Chromium Version 122.0.6261.69 on Linux and generates this error message:

```
depthSlice (0) is defined for a non-3D attachment ([TextureView]).
 - While validating colorAttachments[0].
 - While encoding [CommandEncoder].BeginRenderPass([null]).
```

Solution:

Initialize the `depthSlice` property of the `WGPURenderPassColorAttachment` object with `WGPU_DEPTH_SLICE_UNDEFINED`.

Mentions of the same problem in PR #7132 ( https://github.com/ocornut/imgui/pull/7132/files#r1485621741 )