### PR TITLE
Fixing vulkan buffer destruction while in use.

### DIFF
--- a/backends/imgui_impl_vulkan.cpp
+++ b/backends/imgui_impl_vulkan.cpp
@@ -397,10 +397,19 @@ static void CreateOrResizeBuffer(VkBuffer& buffer, VkDeviceMemory& buffer_memory
     ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
     ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
     VkResult err;
-    if (buffer != VK_NULL_HANDLE)
-        vkDestroyBuffer(v->Device, buffer, v->Allocator);
-    if (buffer_memory != VK_NULL_HANDLE)
-        vkFreeMemory(v->Device, buffer_memory, v->Allocator);
+
+    // Destroy resources if they existed already
+    if (buffer != VK_NULL_HANDLE || buffer_memory != VK_NULL_HANDLE)
+    {
+        //sync device to avoid deleting buffers that might be used by the gpu in a command list.
+        err = vkDeviceWaitIdle(v->Device);
+        check_vk_result(err);
+
+        if (buffer != VK_NULL_HANDLE)
+            vkDestroyBuffer(v->Device, buffer, v->Allocator);
+        if (buffer_memory != VK_NULL_HANDLE)
+            vkFreeMemory(v->Device, buffer_memory, v->Allocator);
+    }
 
     VkDeviceSize buffer_size_aligned = AlignBufferSize(IM_MAX(v->MinAllocationSize, new_size), bd->BufferMemoryAlignment);
     VkBufferCreateInfo buffer_info = {};


### PR DESCRIPTION
The function CreateOrResizeBuffer destroys vulkan buffers and memory while they could be alive and in use by the GPU.
This can  be captured if the validation layer is used. Moreover this could cause very hard to track low repro crashes.

This fix ensures the device is idle before freeing GPU resources. An alternative solution is to have fence-style syncrhonization and a destruction queue, however this might add further complexity and is likely overkill for imgui. Since buffer recreation is relatively a low frequency operation I suspect this is enough.

Tested:
* Home engine
* Built vulkan examples.