### PR TITLE
Backends: SDL3: Fix leak of SDL_GetGamepads() return value

### DIFF
--- a/backends/imgui_impl_sdl3.cpp
+++ b/backends/imgui_impl_sdl3.cpp
@@ -609,6 +609,7 @@ static void ImGui_ImplSDL3_UpdateGamepads()
                 if (bd->GamepadMode == ImGui_ImplSDL3_GamepadMode_AutoFirst)
                     break;
             }
+        SDL_free(sdl_gamepads);
         bd->WantUpdateGamepadsList = false;
     }
 


### PR DESCRIPTION
According to the SDL3 documentation, SDL_GetGamepads() can fail and return NULL, or return an array that must be freed with SDL_free().

See: https://github.com/libsdl-org/SDL/blob/76defc5c82204707e1d11a53a561a789d3f1e769/include/SDL3/SDL_gamepad.h#L389-L401

This commit updates ImGui_ImplSDL3_UpdateGamepads() to check the return value of SDL_GetGamepads() and free the return value if non-NULL.

Without this commit, I get the following AddressSanitizer error:

    Direct leak of 4 byte(s) in 1 object(s) allocated from:
        #0 0x7f5773ef3bd7 in malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
        #1 0x7f5771f7b5be in SDL_malloc_REAL /home/runner/work/vacon/vacon/sdl/src/stdlib/SDL_malloc.c:5287
        #2 0x7f5771f340d2 in SDL_GetJoysticks_REAL /home/runner/work/vacon/vacon/sdl/src/joystick/SDL_joystick.c:697
        #3 0x7f5771f3173a in SDL_GetGamepads_REAL /home/runner/work/vacon/vacon/sdl/src/joystick/SDL_gamepad.c:2326
        #4 0x5575624084c3 in ImGui_ImplSDL3_UpdateGamepads ../subprojects/imgui/backends/imgui_impl_sdl3.cpp:604
        #5 0x5575624084c3 in ImGui_ImplSDL3_NewFrame() ../subprojects/imgui/backends/imgui_impl_sdl3.cpp:688
        #6 0x5575621c2700 in vacon::App::RenderFrame() ../src/ui.cpp:243
        #7 0x557561fda588 in vacon::App::AppIterate() ../src/app.cpp:204
        #8 0x7f5771f3d8b0 in SDL_IterateMainCallbacks /home/runner/work/vacon/vacon/sdl/src/main/SDL_main_callbacks.c:124
        #9 0x7f57720235fe in SDL_EnterAppMainCallbacks_REAL /home/runner/work/vacon/vacon/sdl/src/main/generic/SDL_sysmain_callbacks.c:48
        #10 0x7f5771d076c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

Thanks!