### PR TITLE
MacOS runtime warnings regarding access of NSView/NSWindow properties from a non-main thread

### DIFF
--- a/backends/imgui_impl_osx.mm
+++ b/backends/imgui_impl_osx.mm
@@ -81,7 +81,13 @@ struct ImGui_ImplOSX_Data
     NSTextInputContext*         InputContext;
     id                          Monitor;
 
-    ImGui_ImplOSX_Data()        { memset(this, 0, sizeof(*this)); }
+    struct {
+        NSLock                      *lock;
+        CGFloat                     backingScaleFactor;
+        CGRect                      bounds;
+    } exclusive;
+
+    ImGui_ImplOSX_Data()        { memset(this, 0, sizeof(*this)); @autoreleasepool {this->exclusive.lock = [[NSLock alloc] init]; } }
 };
 
 static ImGui_ImplOSX_Data*      ImGui_ImplOSX_CreateBackendData()   { return IM_NEW(ImGui_ImplOSX_Data)(); }

--- a/backends/imgui_impl_osx.mm
+++ b/backends/imgui_impl_osx.mm
@@ -611,8 +611,18 @@ void ImGui_ImplOSX_NewFrame(NSView* view)
     // Setup display size
     if (view)
     {
-        const float dpi = (float)[view.window backingScaleFactor];
-        io.DisplaySize = ImVec2((float)view.bounds.size.width, (float)view.bounds.size.height);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [bd->exclusive.lock lock];
+            bd->exclusive.backingScaleFactor = view.window.backingScaleFactor;
+            bd->exclusive.bounds = view.bounds;
+            [bd->exclusive.lock unlock];
+        });
+
+        [bd->exclusive.lock lock];
+        const float dpi = (float) bd->exclusive.backingScaleFactor;
+        io.DisplaySize = ImVec2((float) bd->exclusive.bounds.size.width, bd->exclusive.bounds.size.height);
+        [bd->exclusive.lock unlock];
+
         io.DisplayFramebufferScale = ImVec2(dpi, dpi);
     }
 


### PR DESCRIPTION
Xcode Version 15.3 (15E204a)


Resolve Xcode runtime warnings regarding access of NSView/NSWindow properties from a non-main thread
This issue presents when rendering from a thread that is other than the window thread, more easily reproduced when disabling vsync

This commit aims to populate the relevant data into backend_data, by way of dispatch_async (ocurring on the main thread). Those particular backend data items are protected by an NSlock

There may be more elegant ways to do this

The warnings observed are as follows:
Main Thread Checker
```
imgui/backends/imgui_impl_osx.mm:608 -[NSView window] must be used from main thread only
imgui/backends/imgui_impl_osx.mm:608 -[NSWindow backingScaleFactor] must be used from main thread only
imgui/backends/imgui_impl_osx.mm:609 -[NSView bounds] must be used from main thread only
```
