### PR TITLE
Fixed font ascent and descent calculation when a font hits exact integer values

### DIFF
--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -2983,8 +2983,8 @@ static bool ImFontAtlasBuildWithStbTruetype(ImFontAtlas* atlas)
         int unscaled_ascent, unscaled_descent, unscaled_line_gap;
         stbtt_GetFontVMetrics(&src_tmp.FontInfo, &unscaled_ascent, &unscaled_descent, &unscaled_line_gap);
 
-        const float ascent = ImTrunc(unscaled_ascent * font_scale + ((unscaled_ascent > 0.0f) ? +1 : -1));
-        const float descent = ImTrunc(unscaled_descent * font_scale + ((unscaled_descent > 0.0f) ? +1 : -1));
+        const float ascent = ImCeil(unscaled_ascent * font_scale);
+        const float descent = ImFloor(unscaled_descent * font_scale);
         ImFontAtlasBuildSetupFont(atlas, dst_font, &cfg, ascent, descent);
         const float font_off_x = cfg.GlyphOffset.x;
         const float font_off_y = cfg.GlyphOffset.y + IM_ROUND(dst_font->Ascent);


### PR DESCRIPTION
Here is the fix mentioned in https://github.com/ocornut/imgui/issues/7399 as a PR.

This fix doesn't affect the default font at all since it doesn't hit exact integer values, so no side effects in this regard. For custom fonts that do hit exact integer values, this fix calculates the ascent and descent with more precision and will improve the font rendering a little. If the vertical glyph offset for a custom font has been used to compensate for the imprecision before, this compensation will no longer be necessary.