### PR TITLE
Style: add `ImGuiStyleVar{TabBorderSize,TableAngledHeadersAngle}`

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -3129,7 +3129,9 @@ static const ImGuiDataVarInfo GStyleVarInfo[] =
     { ImGuiDataType_Float, 1, (ImU32)offsetof(ImGuiStyle, GrabMinSize) },           // ImGuiStyleVar_GrabMinSize
     { ImGuiDataType_Float, 1, (ImU32)offsetof(ImGuiStyle, GrabRounding) },          // ImGuiStyleVar_GrabRounding
     { ImGuiDataType_Float, 1, (ImU32)offsetof(ImGuiStyle, TabRounding) },           // ImGuiStyleVar_TabRounding
+    { ImGuiDataType_Float, 1, (ImU32)offsetof(ImGuiStyle, TabBorderSize) },         // ImGuiStyleVar_TabBorderSize
     { ImGuiDataType_Float, 1, (ImU32)offsetof(ImGuiStyle, TabBarBorderSize) },      // ImGuiStyleVar_TabBarBorderSize
+    { ImGuiDataType_Float, 1, (ImU32)offsetof(ImGuiStyle, TableAngledHeadersAngle)},// ImGuiStyleVar_TableAngledHeadersAngle
     { ImGuiDataType_Float, 2, (ImU32)offsetof(ImGuiStyle, ButtonTextAlign) },       // ImGuiStyleVar_ButtonTextAlign
     { ImGuiDataType_Float, 2, (ImU32)offsetof(ImGuiStyle, SelectableTextAlign) },   // ImGuiStyleVar_SelectableTextAlign
     { ImGuiDataType_Float, 1, (ImU32)offsetof(ImGuiStyle, SeparatorTextBorderSize)},// ImGuiStyleVar_SeparatorTextBorderSize

--- a/imgui.h
+++ b/imgui.h
@@ -1576,7 +1576,9 @@ enum ImGuiStyleVar_
     ImGuiStyleVar_GrabMinSize,         // float     GrabMinSize
     ImGuiStyleVar_GrabRounding,        // float     GrabRounding
     ImGuiStyleVar_TabRounding,         // float     TabRounding
+    ImGuiStyleVar_TabBorderSize,       // float     TabBorderSize
     ImGuiStyleVar_TabBarBorderSize,    // float     TabBarBorderSize
+    ImGuiStyleVar_TableAngledHeadersAngle,// float  TableAngledHeadersAngle
     ImGuiStyleVar_ButtonTextAlign,     // ImVec2    ButtonTextAlign
     ImGuiStyleVar_SelectableTextAlign, // ImVec2    SelectableTextAlign
     ImGuiStyleVar_SeparatorTextBorderSize,// float  SeparatorTextBorderSize


### PR DESCRIPTION
These two are not accessible via the mid-frame safe `Push/PopStyleVar` API. `TabBarBorderSize` recently got its own StyleVar so it's strange that the older `TabBorderSize` doesn't have one. Temporarily overriding the new `TableAngledHeadersAngle` per-table seems useful.

The lack of StyleVar for some style fields has an impact in my custom bindings: `Push/PopStyleVar` is the only way users are allowed to edit styles mid-frame as direct memory access is not a thing in scripting languages and I limit it to "safe" APIs, obeying the comments in imgui.h:
> // You may modify the ImGui::GetStyle() main instance during initialization and before NewFrame().
> // During the frame, use ImGui::PushStyleVar(ImGuiStyleVar_XXXX)/PopStyleVar() to alter the main style values,
> // and ImGui::PushStyleColor(ImGuiCol_XXX)/PopStyleColor() for colors.

Speaking of which, and considering that comment, the new Behaviors style fields for tooltips seem a bit out of place in ImGuiStyle with direct memory access mid-frame being the only way to edit them and a comment directly contradicting the previous one:

> // (It is possible to modify those fields mid-frame if specific behavior need it, unlike e.g. configuration fields in ImGuiIO)

Yet there is no corresponding comment around ImGuiIO about mid-frame writes being no-go, and the demo happily directly writes to both ImGuiIO and ImGuiStyle mid-frame... What are the actual rules? Should I add a check in my bindings so that ImGuiIO values are only writable before a frame? Some of them are useful mid-frame, like changing `InputTextEnterKeepActive` per text field.