### PR TITLE
Tables: Angled headers: fix border position, hit box, and overflowing contents in some cases

### DIFF
--- a/imgui_tables.cpp
+++ b/imgui_tables.cpp
@@ -3186,7 +3186,7 @@ void ImGui::TableAngledHeadersRowEx(float angle, float max_label_width)
     // Calculate our base metrics and set angled headers data _before_ the first call to TableNextRow()
     // FIXME-STYLE: Would it be better for user to submit 'max_label_width' or 'row_height' ? One can be derived from the other.
     const float header_height = g.FontSize + g.Style.CellPadding.x * 2.0f;
-    const float row_height = ImFabs(ImRotate(ImVec2(max_label_width, flip_label ? +header_height : -header_height), cos_a, sin_a).y);
+    const float row_height = ImTrunc(ImFabs(ImRotate(ImVec2(max_label_width, flip_label ? +header_height : -header_height), cos_a, sin_a).y));
     table->AngledHeadersHeight = row_height;
     table->AngledHeadersSlope = (sin_a != 0.0f) ? (cos_a / sin_a) : 0.0f;
     const ImVec2 header_angled_vector = unit_right * (row_height / -sin_a); // vector from bottom-left to top-left, and from bottom-right to top-right

--- a/imgui_tables.cpp
+++ b/imgui_tables.cpp
@@ -1240,7 +1240,7 @@ void ImGui::TableUpdateBorders(ImGuiTable* table)
     ImGuiTableInstanceData* table_instance = TableGetInstanceData(table, table->InstanceCurrent);
     const float hit_half_width = TABLE_RESIZE_SEPARATOR_HALF_THICKNESS;
     const float hit_y1 = (table->FreezeRowsCount >= 1 ? table->OuterRect.Min.y : table->WorkRect.Min.y) + table->AngledHeadersHeight;
-    const float hit_y2_body = ImMax(table->OuterRect.Max.y, hit_y1 + table_instance->LastOuterHeight);
+    const float hit_y2_body = ImMax(table->OuterRect.Max.y, hit_y1 + table_instance->LastOuterHeight - table->AngledHeadersHeight);
     const float hit_y2_head = hit_y1 + table_instance->LastTopHeadersRowHeight;
 
     for (int order_n = 0; order_n < table->ColumnsCount; order_n++)

--- a/imgui_tables.cpp
+++ b/imgui_tables.cpp
@@ -498,6 +498,7 @@ bool    ImGui::BeginTableEx(const char* name, ImGuiID id, int columns_count, ImG
     table->DeclColumnsCount = table->AngledHeadersCount = 0;
     if (previous_frame_active + 1 < g.FrameCount)
         table->IsActiveIdInTable = false;
+    table->AngledHeadersHeight = 0.0f;
     temp_data->AngledHeadersExtraWidth = 0.0f;
 
     // Using opaque colors facilitate overlapping lines of the grid, otherwise we'd need to improve TableDrawBorders()


### PR DESCRIPTION
**Bug 1:** Border hit box extends beyond non-scrollable tables. `table->AngledHeadersHeight` was added to the top and bottom coordinates instead of just the top.

![Hit box too big](https://github.com/ocornut/imgui/assets/4297676/69f6099d-c030-4a78-902a-9699e878f835)

**Bug 2:** Borders remain offset after the user stops calling `TableAngleHeadersRow`. `table->AngledHeadersHeight` was not reset.

![Border Y not reset](https://github.com/ocornut/imgui/assets/4297676/19e68a34-debe-4474-b90a-9f73ef2dac6b)

**Bug 3:** Table contents overflow the table's outer box when an angled header is used in combination with a list clipper. Angled header's row height could have a fractional part, while [this line](https://github.com/ocornut/imgui/blob/0a1f5b94e3129c1205e99eaa06f983c5abf9ac61/imgui.cpp#L9978) in `ItemSize` truncates `window->DC.CursorMaxPos.y`, leading to accumulating error at each subsequent row.

The root issue remains if the user does eg. `ImGui::TableNextRow(0, 78.396423);`, but this fixes the case with `TableAngleHeadersRow`.

![Overflowing contents](https://github.com/ocornut/imgui/assets/4297676/5d550c82-f005-4e5f-99b7-699421046dd3)

This also improves rendering quality because header row's border lines are a bit fuzzy with a fractional part.

![Before](https://github.com/ocornut/imgui/assets/4297676/2b3be731-15ad-42bd-a76e-124c393d306d) ![After](https://github.com/ocornut/imgui/assets/4297676/35c0a071-06ba-479a-9602-2f49fa8642c3)

**Duplication code**

```cpp
auto table = [] (const char *id, const bool angled, const float angle) {
  ImGuiStyle &style { ImGui::GetStyle() };
  const float oldAngle { style.TableAngledHeadersAngle };
  style.TableAngledHeadersAngle = angle * (IM_PI / 180.0f); // should be a StyleVar...
  if(!ImGui::BeginTable(id, 3, ImGuiTableFlags_Borders | ImGuiTableFlags_Resizable)) {
    style.TableAngledHeadersAngle = oldAngle;
    return;
  }
  ImGui::TableSetupColumn("Lorem Ipsum",    ImGuiTableColumnFlags_AngledHeader);
  ImGui::TableSetupColumn("Dolor Sit Amet", ImGuiTableColumnFlags_AngledHeader);
  ImGui::TableSetupColumn("Foo Bar Baz",    ImGuiTableColumnFlags_AngledHeader);
  if(angled)
    ImGui::TableAngledHeadersRow();
  ImGui::TableHeadersRow();
  for(int row = 0; row < 8; ++row) {
    ImGui::TableNextRow();
    for(int column = 0; column < 3; ++column) {
      ImGui::TableNextColumn();
      ImGui::Text("%d.%d", row, column);
    }
  }
  ImGui::EndTable();
  style.TableAngledHeadersAngle = oldAngle; // should be PopStyleVar
};

ImGui::Begin("Hello, world!");

static bool angled1 { true };
ImGui::Checkbox("Angled header##1", &angled1);
table("table1", angled1, 50.f);

static bool angled2 { true };
ImGui::Checkbox("Angled header##2", &angled2);
table(io.KeyShift ? "table1" : "table2", angled2, 35.f);

// (the following is not fixed by this PR)
if(ImGui::BeginTable("table3", 3, ImGuiTableFlags_Borders)) {
  ImGui::TableNextRow(0, 78.396423); // a possible value used by TableAngledHeadersRowEx
  ImGui::TableNextColumn();
  ImGui::Text("Foo");
  ImGuiListClipper clipper;
  clipper.Begin(32);
  while(clipper.Step()) {
    for(int row { clipper.DisplayStart }; row < clipper.DisplayEnd; ++row) {
      ImGui::TableNextRow();
      for(int column {}; column < 3; ++column) {
        ImGui::TableNextColumn();
        ImGui::Text("%.02fx%.02f", ImGui::GetCursorPosX(), ImGui::GetCursorPosY());
      }
    }
  }
  ImGui::EndTable();
}
ImGui::Text("After table");

ImGui::End();
```