### PR TITLE
[wgpu backend] Avoid using the `-1u` literal

### DIFF
--- a/backends/imgui_impl_wgpu.h
+++ b/backends/imgui_impl_wgpu.h
@@ -32,7 +32,7 @@ struct ImGui_ImplWGPU_InitInfo
     ImGui_ImplWGPU_InitInfo()
     {
         PipelineMultisampleState.count = 1;
-        PipelineMultisampleState.mask = -1u;
+        PipelineMultisampleState.mask = UINT32_MAX;
         PipelineMultisampleState.alphaToCoverageEnabled = false;
     }
 };


### PR DESCRIPTION
**Problem:** The literal `-1u` raises the warning `C4146: unary minus operator applied to unsigned type, result still unsigned` on MSVC.

**Solution:** We instead use `UINT32_MAX`, like `webgpu.h` does to set all its "undefined" constants.
