### PR TITLE
Minor improvements to child window resizing behavior

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -6027,10 +6027,13 @@ static int ImGui::UpdateWindowManualResize(ImGuiWindow* window, const ImVec2& si
             border_target = ImClamp(border_target, clamp_min, clamp_max);
             if (flags & ImGuiWindowFlags_ChildWindow) // Clamp resizing of childs within parent
             {
-                if ((flags & (ImGuiWindowFlags_HorizontalScrollbar | ImGuiWindowFlags_AlwaysHorizontalScrollbar)) == 0 || (flags & ImGuiWindowFlags_NoScrollbar))
-                    border_target.x = ImClamp(border_target.x, window->ParentWindow->InnerClipRect.Min.x, window->ParentWindow->InnerClipRect.Max.x);
-                if (flags & ImGuiWindowFlags_NoScrollbar)
-                    border_target.y = ImClamp(border_target.y, window->ParentWindow->InnerClipRect.Min.y, window->ParentWindow->InnerClipRect.Max.y);
+                ImGuiWindow* parent_window = window->ParentWindow;
+                ImGuiWindowFlags parent_flags = parent_window->Flags;
+                const ImRect &parent_rect = parent_window->InnerClipRect;
+                if ((parent_flags & (ImGuiWindowFlags_HorizontalScrollbar | ImGuiWindowFlags_AlwaysHorizontalScrollbar)) == 0 || (parent_flags & ImGuiWindowFlags_NoScrollbar))
+                    border_target.x = ImClamp(border_target.x, parent_rect.Min.x, parent_rect.Max.x);
+                if (parent_flags & ImGuiWindowFlags_NoScrollbar)
+                    border_target.y = ImClamp(border_target.y, parent_rect.Min.y, parent_rect.Max.y);
             }
             if (!ignore_resize)
                 CalcResizePosSizeFromAnyCorner(window, border_target, ImMin(def.SegmentN1, def.SegmentN2), &pos_target, &size_target);

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -6029,7 +6029,7 @@ static int ImGui::UpdateWindowManualResize(ImGuiWindow* window, const ImVec2& si
             {
                 ImGuiWindow* parent_window = window->ParentWindow;
                 ImGuiWindowFlags parent_flags = parent_window->Flags;
-                const ImRect &parent_rect = parent_window->InnerClipRect;
+                const ImRect &parent_rect = parent_window->WorkRect;
                 if ((parent_flags & (ImGuiWindowFlags_HorizontalScrollbar | ImGuiWindowFlags_AlwaysHorizontalScrollbar)) == 0 || (parent_flags & ImGuiWindowFlags_NoScrollbar))
                     border_target.x = ImClamp(border_target.x, parent_rect.Min.x, parent_rect.Max.x);
                 if (parent_flags & ImGuiWindowFlags_NoScrollbar)

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -5899,7 +5899,7 @@ static int ImGui::UpdateWindowManualResize(ImGuiWindow* window, const ImVec2& si
 
     int ret_auto_fit_mask = 0x00;
     const float grip_draw_size = IM_TRUNC(ImMax(g.FontSize * 1.35f, window->WindowRounding + 1.0f + g.FontSize * 0.2f));
-    const float grip_hover_inner_size = IM_TRUNC(grip_draw_size * 0.75f);
+    const float grip_hover_inner_size = resize_grip_count > 0 ? IM_TRUNC(grip_draw_size * 0.75f) : 0.0f;
     const float grip_hover_outer_size = g.IO.ConfigWindowsResizeFromEdges ? WINDOWS_HOVER_PADDING : 0.0f;
 
     ImRect clamp_rect = visibility_rect;


### PR DESCRIPTION
Child window resizing is currently clamped to the parent window only if the child window itself has no scrollbar on that axis. It seems unintuitive to look at the child window's scrollbars rather than at the parent window's.

In a situation where the parent window is non-resizable, has scrollbars+mousewheel disabled and persistent storage enabled, that makes it very easy for end users to accidentally brick their UI until the .ini is manually cleared.

![Screencap](https://github.com/ocornut/imgui/assets/4297676/aecad2c1-071c-45f4-a93d-a3bcb6cf147a)

This PR also changes the clamp rect to take into account window padding. Currently it has half the window padding at the right side and no padding at the bottom. It's asymmetrical and makes it hard to neatly align a resizable child with other full-width items (eg. -FLT_MIN).

Lastly, this PR extends child window resize grips to cover the entire border length since childs don't have diagonal resize grips at the corners.