### PR TITLE
Adding On Context Initialize Hook Feature

### DIFF
--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -2194,7 +2194,6 @@ struct ImGuiContext
     ImChunkStream<ImGuiTableSettings>   SettingsTables;         // ImGuiTable .ini settings entries
     ImVector<ImGuiContextHook>          Hooks;                  // Hooks for extensions (e.g. test engine)
     ImGuiID                             HookIdNext;             // Next available HookId
-    static ImVector<ImGuiContextHook>   InitializeHooks;        // Hooks for when a new context gets initialized
 
     // Localization
     const char*             LocalizationTable[ImGuiLocKey_COUNT];

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -1898,7 +1898,7 @@ struct ImGuiIDStackTool
 //-----------------------------------------------------------------------------
 
 typedef void (*ImGuiContextHookCallback)(ImGuiContext* ctx, ImGuiContextHook* hook);
-enum ImGuiContextHookType { ImGuiContextHookType_NewFramePre, ImGuiContextHookType_NewFramePost, ImGuiContextHookType_EndFramePre, ImGuiContextHookType_EndFramePost, ImGuiContextHookType_RenderPre, ImGuiContextHookType_RenderPost, ImGuiContextHookType_Shutdown, ImGuiContextHookType_PendingRemoval_ };
+enum ImGuiContextHookType { ImGuiContextHookType_NewFramePre, ImGuiContextHookType_NewFramePost, ImGuiContextHookType_EndFramePre, ImGuiContextHookType_EndFramePost, ImGuiContextHookType_RenderPre, ImGuiContextHookType_RenderPost, ImGuiContextHookType_Initialize, ImGuiContextHookType_Shutdown, ImGuiContextHookType_PendingRemoval_ };
 
 struct ImGuiContextHook
 {
@@ -2194,6 +2194,7 @@ struct ImGuiContext
     ImChunkStream<ImGuiTableSettings>   SettingsTables;         // ImGuiTable .ini settings entries
     ImVector<ImGuiContextHook>          Hooks;                  // Hooks for extensions (e.g. test engine)
     ImGuiID                             HookIdNext;             // Next available HookId
+    static ImVector<ImGuiContextHook>   InitializeHooks;        // Hooks for when a new context gets initialized
 
     // Localization
     const char*             LocalizationTable[ImGuiLocKey_COUNT];
@@ -3034,6 +3035,8 @@ namespace ImGui
     IMGUI_API void          UpdateMouseMovingWindowEndFrame();
 
     // Generic context hooks
+    IMGUI_API ImGuiID       AddOnContextInitializeHook(const ImGuiContextHook* hook);
+    IMGUI_API void          RemoveOnContextInitializeHook(ImGuiID hook_to_remove);
     IMGUI_API ImGuiID       AddContextHook(ImGuiContext* context, const ImGuiContextHook* hook);
     IMGUI_API void          RemoveContextHook(ImGuiContext* context, ImGuiID hook_to_remove);
     IMGUI_API void          CallContextHooks(ImGuiContext* context, ImGuiContextHookType type);


### PR DESCRIPTION
This pull request introduces a feature allowing third-party modules in multi-module applications, like games, to register and listen for context creation events. This capability is provided without requiring the third-party modules to have any knowledge of or alterations by the context manager, which could be another module entirely.
