### PR TITLE
Add DirectComposition for DX12 backend (for transparency)

### DIFF
--- a/backends/imgui_impl_dx12.cpp
+++ b/backends/imgui_impl_dx12.cpp
@@ -940,7 +940,7 @@ static void ImGui_ImplDX12_CreateWindow(ImGuiViewport* viewport)
     sd1.Stereo = FALSE;
 
     IDXGIFactory4* dxgi_factory = nullptr;
-    res = ::CreateDXGIFactory2(DXGI_CREATE_FACTORY_DEBUG, IID_PPV_ARGS(&dxgi_factory));
+    res = ::CreateDXGIFactory1(IID_PPV_ARGS(&dxgi_factory));
     IM_ASSERT(res == S_OK);
 
     IDXGISwapChain1* swap_chain = nullptr;

--- a/backends/imgui_impl_dx12.h
+++ b/backends/imgui_impl_dx12.h
@@ -42,4 +42,12 @@ IMGUI_IMPL_API void     ImGui_ImplDX12_RenderDrawData(ImDrawData* draw_data, ID3
 IMGUI_IMPL_API void     ImGui_ImplDX12_InvalidateDeviceObjects();
 IMGUI_IMPL_API bool     ImGui_ImplDX12_CreateDeviceObjects();
 
+// Extras if you want transparent backgrounds on viewport windows.
+#ifdef DCOMP
+struct IDCompositionDevice;
+
+// Call after calling ImGui_ImplDX12_Init.
+IMGUI_IMPL_API bool     ImGui_ImplDX12_InitDComp(IDCompositionDevice* device);
+#endif
+
 #endif // #ifndef IMGUI_DISABLE

--- a/backends/imgui_impl_win32.cpp
+++ b/backends/imgui_impl_win32.cpp
@@ -1013,6 +1013,12 @@ static void ImGui_ImplWin32_GetWin32StyleFromViewportFlags(ImGuiViewportFlags fl
 
     if (flags & ImGuiViewportFlags_TopMost)
         *out_ex_style |= WS_EX_TOPMOST;
+
+    // "Redirection bitmap" can be understood as a copy of painted window content held by DWM.
+    // By making DWM not hold a copy, which happens to not support transparency, this enables using
+    // transparent window contents, without having to use uniform transparency for the whole window.
+    if (flags & ImGuiViewportFlags_TransparencySupport)
+        *out_ex_style |= WS_EX_NOREDIRECTIONBITMAP;
 }
 
 static HWND ImGui_ImplWin32_GetHwndFromViewportID(ImGuiID viewport_id)

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -6485,7 +6485,7 @@ void ImGui::RenderWindowDecorations(ImGuiWindow* window, const ImRect& title_bar
                     is_docking_transparent_payload = true;
 
             ImU32 bg_col = GetColorU32(GetWindowBgColorIdx(window));
-            if (window->ViewportOwned)
+            if (window->ViewportOwned && !(g.IO.BackendFlags & ImGuiBackendFlags_RendererHasTransparentViewports))
             {
                 bg_col |= IM_COL32_A_MASK; // No alpha
                 if (is_docking_transparent_payload)
@@ -15255,7 +15255,9 @@ void ImGui::WindowSyncOwnedViewport(ImGuiWindow* window, ImGuiWindow* parent_win
     // We can also tell the backend that clearing the platform window won't be necessary,
     // as our window background is filling the viewport and we have disabled BgAlpha.
     // FIXME: Work on support for per-viewport transparency (#2766)
-    if (!(window_flags & ImGuiWindowFlags_NoBackground))
+    if (g.IO.BackendFlags & ImGuiBackendFlags_RendererHasTransparentViewports)
+        viewport_flags |= ImGuiViewportFlags_TransparencySupport;
+    else if (!(window_flags & ImGuiWindowFlags_NoBackground))
         viewport_flags |= ImGuiViewportFlags_NoRendererClear;
 
     window->Viewport->Flags = viewport_flags;

--- a/imgui.h
+++ b/imgui.h
@@ -1559,7 +1559,8 @@ enum ImGuiBackendFlags_
     // [BETA] Viewports
     ImGuiBackendFlags_PlatformHasViewports  = 1 << 10,  // Backend Platform supports multiple viewports.
     ImGuiBackendFlags_HasMouseHoveredViewport=1 << 11,  // Backend Platform supports calling io.AddMouseViewportEvent() with the viewport under the mouse. IF POSSIBLE, ignore viewports with the ImGuiViewportFlags_NoInputs flag (Win32 backend, GLFW 3.30+ backend can do this, SDL backend cannot). If this cannot be done, Dear ImGui needs to use a flawed heuristic to find the viewport under.
-    ImGuiBackendFlags_RendererHasViewports  = 1 << 12,  // Backend Renderer supports multiple viewports.
+    ImGuiBackendFlags_RendererHasViewports = 1 << 12,   // Backend Renderer supports multiple viewports.
+    ImGuiBackendFlags_RendererHasTransparentViewports = 1 << 13 // Backend Renderer supports transparent viewport content.
 };
 
 // Enumeration for PushStyleColor() / PopStyleColor()
@@ -3257,10 +3258,11 @@ enum ImGuiViewportFlags_
     ImGuiViewportFlags_NoAutoMerge              = 1 << 9,   // Platform Window: Avoid merging this window into another host window. This can only be set via ImGuiWindowClass viewport flags override (because we need to now ahead if we are going to create a viewport in the first place!).
     ImGuiViewportFlags_TopMost                  = 1 << 10,  // Platform Window: Display on top (for tooltips only).
     ImGuiViewportFlags_CanHostOtherWindows      = 1 << 11,  // Viewport can host multiple imgui windows (secondary viewports are associated to a single window). // FIXME: In practice there's still probably code making the assumption that this is always and only on the MainViewport. Will fix once we add support for "no main viewport".
+    ImGuiViewportFlags_TransparencySupport      = 1 << 12,  // Platform Window: Transparent content should be handled by system.
 
     // Output status flags (from Platform)
-    ImGuiViewportFlags_IsMinimized              = 1 << 12,  // Platform Window: Window is minimized, can skip render. When minimized we tend to avoid using the viewport pos/size for clipping window or testing if they are contained in the viewport.
-    ImGuiViewportFlags_IsFocused                = 1 << 13,  // Platform Window: Window is focused (last call to Platform_GetWindowFocus() returned true)
+    ImGuiViewportFlags_IsMinimized              = 1 << 13,  // Platform Window: Window is minimized, can skip render. When minimized we tend to avoid using the viewport pos/size for clipping window or testing if they are contained in the viewport.
+    ImGuiViewportFlags_IsFocused                = 1 << 14,  // Platform Window: Window is focused (last call to Platform_GetWindowFocus() returned true)
 };
 
 // - Currently represents the Platform Window created by the application which is hosting our Dear ImGui windows.

--- a/imgui.h
+++ b/imgui.h
@@ -1560,7 +1560,7 @@ enum ImGuiBackendFlags_
     ImGuiBackendFlags_PlatformHasViewports  = 1 << 10,  // Backend Platform supports multiple viewports.
     ImGuiBackendFlags_HasMouseHoveredViewport=1 << 11,  // Backend Platform supports calling io.AddMouseViewportEvent() with the viewport under the mouse. IF POSSIBLE, ignore viewports with the ImGuiViewportFlags_NoInputs flag (Win32 backend, GLFW 3.30+ backend can do this, SDL backend cannot). If this cannot be done, Dear ImGui needs to use a flawed heuristic to find the viewport under.
     ImGuiBackendFlags_RendererHasViewports = 1 << 12,   // Backend Renderer supports multiple viewports.
-    ImGuiBackendFlags_RendererHasTransparentViewports = 1 << 13 // Backend Renderer supports transparent viewport content.
+    ImGuiBackendFlags_RendererHasTransparentViewports = 1 << 13, // Backend Renderer supports transparent viewport content.
 };
 
 // Enumeration for PushStyleColor() / PopStyleColor()


### PR DESCRIPTION
![image](https://github.com/ocornut/imgui/assets/3614868/2ac376f6-3087-4209-ba30-a19d7d1750c6)
Note that the demo window has its window background disabled.

DirectComposition can be used to draw windows with transparent content that blend in via the desktop compositor. This PR aims to add transparency support for viewport windows using that.

`DCOMP` has to be `#define`d to check this PR in action.

Only DX12 backend has been modified to support DirectComposition, since while DX11 also supports using DC-provided swap chains, DX11 is supported on Windows 7 whereas DC is available starting from Windows 8, and I wanted to make the amount of code added minimal by omitting code that checks for supported features.

Related PR: #2766 

I thought that having `ImGuiBackendFlags_RendererHasTransparentViewports` set from backend implementation would work better than a user setting `ImGuiConfigFlags_TransparentBackbuffers` manually as needed, as it probably is more of a backend capability rather than a user-configurable thing.