### PR TITLE
added default move ctor/operator= (to compile with vc2022)

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -2483,6 +2483,8 @@ struct ImGuiListClipper
     // items_count: Use INT_MAX if you don't know how many items you have (in which case the cursor won't be advanced in the final step)
     // items_height: Use -1.0f to be calculated automatically on first step. Otherwise pass in the distance between your items, typically GetTextLineHeightWithSpacing() or GetFrameHeightWithSpacing().
     IMGUI_API ImGuiListClipper();
+    ImGuiListClipper(ImGuiListClipper&&) = default;
+    ImGuiListClipper& operator=(ImGuiListClipper&&) = default;
     IMGUI_API ~ImGuiListClipper();
     IMGUI_API void  Begin(int items_count, float items_height = -1.0f);
     IMGUI_API void  End();             // Automatically called on the last call of Step() that returns false.
@@ -2662,6 +2664,8 @@ struct ImDrawListSplitter
     ImVector<ImDrawChannel>     _Channels;   // Draw channels (not resized down so _Count might be < Channels.Size)
 
     inline ImDrawListSplitter()  { memset(this, 0, sizeof(*this)); }
+    ImDrawListSplitter(ImDrawListSplitter&&) = default;
+    ImDrawListSplitter& operator=(ImDrawListSplitter&&) = default;
     inline ~ImDrawListSplitter() { ClearFreeMemory(); }
     inline void                 Clear() { _Current = 0; _Count = 1; } // Do not clear Channels[] so our allocations are reused next frame
     IMGUI_API void              ClearFreeMemory();
@@ -2733,6 +2737,8 @@ struct ImDrawList
 
     // If you want to create ImDrawList instances, pass them ImGui::GetDrawListSharedData() or create and use your own ImDrawListSharedData (so you can use ImDrawList without ImGui)
     ImDrawList(ImDrawListSharedData* shared_data) { memset(this, 0, sizeof(*this)); _Data = shared_data; }
+    ImDrawList(ImDrawList&&) = default;
+    ImDrawList& operator=(ImDrawList&&) = default;
 
     ~ImDrawList() { _ClearFreeMemory(); }
     IMGUI_API void  PushClipRect(const ImVec2& clip_rect_min, const ImVec2& clip_rect_max, bool intersect_with_current_clip_rect = false);  // Render-level scissoring. This is passed down to your render function but not used for CPU-side coarse clipping. Prefer using higher-level ImGui::PushClipRect() to affect logic (hit-testing and widget culling)
@@ -2972,6 +2978,8 @@ enum ImFontAtlasFlags_
 struct ImFontAtlas
 {
     IMGUI_API ImFontAtlas();
+    ImFontAtlas(ImFontAtlas&&) = default;
+    ImFontAtlas& operator=(ImFontAtlas&&) = default;
     IMGUI_API ~ImFontAtlas();
     IMGUI_API ImFont*           AddFont(const ImFontConfig* font_cfg);
     IMGUI_API ImFont*           AddFontDefault(const ImFontConfig* font_cfg = NULL);
@@ -3102,6 +3110,8 @@ struct ImFont
 
     // Methods
     IMGUI_API ImFont();
+    ImFont(ImFont&&) = default;
+    ImFont& operator=(ImFont&&) = default;
     IMGUI_API ~ImFont();
     IMGUI_API const ImFontGlyph*FindGlyph(ImWchar c) const;
     IMGUI_API const ImFontGlyph*FindGlyphNoFallback(ImWchar c) const;


### PR DESCRIPTION
 with C5267 warning turned on, needed due to explicit dtor