### PR TITLE
WebGPU: Use ClampToEdge instead of Repeat for the texture sampler

### DIFF
--- a/backends/imgui_impl_wgpu.cpp
+++ b/backends/imgui_impl_wgpu.cpp
@@ -536,9 +536,9 @@ static void ImGui_ImplWGPU_CreateFontsTexture()
         sampler_desc.minFilter = WGPUFilterMode_Linear;
         sampler_desc.magFilter = WGPUFilterMode_Linear;
         sampler_desc.mipmapFilter = WGPUMipmapFilterMode_Linear;
-        sampler_desc.addressModeU = WGPUAddressMode_Repeat;
-        sampler_desc.addressModeV = WGPUAddressMode_Repeat;
-        sampler_desc.addressModeW = WGPUAddressMode_Repeat;
+        sampler_desc.addressModeU = WGPUAddressMode_ClampToEdge;
+        sampler_desc.addressModeV = WGPUAddressMode_ClampToEdge;
+        sampler_desc.addressModeW = WGPUAddressMode_ClampToEdge;
         sampler_desc.maxAnisotropy = 1;
         bd->renderResources.Sampler = wgpuDeviceCreateSampler(bd->wgpuDevice, &sampler_desc);
     }


### PR DESCRIPTION
The sampler is currently set to use Repeat, which can cause unexpected behavior when using `ImGui::Image()`. For some image sizes and positions, UVs can go slightly bigger than 1, causing the sampler to kick in. For example this can produce this thin line of red pixels at the top of the image:
![image](https://github.com/ocornut/imgui/assets/45451201/cdbe0e36-d8b1-4138-83ff-58787d18eac3)

With the proposed changes, the red line disappears:
![image](https://github.com/ocornut/imgui/assets/45451201/970bf218-8665-457b-a6c6-0cdd928dc71e)

**NB:** if there was a reason to use Repeat for the font texture, maybe we could create two samplers, one for the Font texture, and one for user-provided textures.