### PR TITLE
Add define guards for the glfw backend

### DIFF
--- a/backends/imgui_impl_glfw.cpp
+++ b/backends/imgui_impl_glfw.cpp
@@ -85,11 +85,15 @@
 
 #ifdef _WIN32
 #undef APIENTRY
+#ifndef GLFW_EXPOSE_NATIVE_WIN32
 #define GLFW_EXPOSE_NATIVE_WIN32
+#endif
 #include <GLFW/glfw3native.h>   // for glfwGetWin32Window()
 #endif
 #ifdef __APPLE__
+#ifndef GLFW_EXPOSE_NATIVE_COCOA
 #define GLFW_EXPOSE_NATIVE_COCOA
+#endif
 #include <GLFW/glfw3native.h>   // for glfwGetCocoaWindow()
 #endif
 


### PR DESCRIPTION
This PR adds define guards for the glfw backend, namely `GLFW_EXPOSE_NATIVE_COCOA` and `GLFW_EXPOSE_NATIVE_WIN32`. This removes redefinition warnings if the glfw backend source file is include in a target where these defines where already defined.
