### PR TITLE
Add wgpu multiviewport support

### DIFF
--- a/backends/imgui_impl_wgpu.cpp
+++ b/backends/imgui_impl_wgpu.cpp
@@ -932,6 +932,7 @@ static void ImGui_ImplWGPU_RenderWindow(ImGuiViewport* viewport, void*)
     WGPUQueue queue = wgpuDeviceGetQueue(bd->wgpuDevice);
     wgpuQueueSubmit(queue, 1, &cmd_buffer);
 
+    SafeRelease(surfaceTexture.texture);
     SafeRelease(color_attachments.view);
     SafeRelease(pass);
     SafeRelease(encoder);

--- a/backends/imgui_impl_wgpu.cpp
+++ b/backends/imgui_impl_wgpu.cpp
@@ -808,7 +808,7 @@ bool ImGui_ImplWGPU_Init(ImGui_ImplWGPU_InitInfo* init_info)
     if (io.ConfigFlags & ImGuiConfigFlags_ViewportsEnable)
     {
         IM_ASSERT(init_info->CreateViewportWindowFn != nullptr && "Window creation callback required for multi viewport!");
-        IM_ASSERT(init_info->ViewportPresentMode != 0 && "WGPUPresentMode required to be set for multi viewport!");
+        IM_ASSERT(init_info->ViewportPresentMode != ~0 && "WGPUPresentMode required to be set for multi viewport!");
         ImGui_ImplWGPU_InitPlatformInterface();
     }
 
@@ -877,7 +877,6 @@ static void ImGui_ImplWGPU_DestroyWindow(ImGuiViewport* viewport)
 {
     if (ImGui_ImplWGPU_ViewportData* vd = (ImGui_ImplWGPU_ViewportData*)viewport->RendererUserData)
     {
-        wgpuSurfaceUnconfigure(vd->wgpu_surface);
         SafeRelease(vd->wgpu_surface);
         IM_DELETE(vd);
     }

--- a/backends/imgui_impl_wgpu.h
+++ b/backends/imgui_impl_wgpu.h
@@ -25,13 +25,13 @@
 // Initialization data, for ImGui_ImplWGPU_Init()
 struct ImGui_ImplWGPU_InitInfo
 {
-    WGPUInstance            Instance;
     WGPUDevice              Device;
     int                     NumFramesInFlight = 3;
     WGPUTextureFormat       RenderTargetFormat = WGPUTextureFormat_Undefined;
     WGPUTextureFormat       DepthStencilFormat = WGPUTextureFormat_Undefined;
     WGPUMultisampleState    PipelineMultisampleState = {};
     WGPUPresentMode         ViewportPresentMode = {};
+    WGPUSurface             (*CreateViewportWindowFn)(ImGuiViewport* viewport) = nullptr;
 
     ImGui_ImplWGPU_InitInfo()
     {

--- a/backends/imgui_impl_wgpu.h
+++ b/backends/imgui_impl_wgpu.h
@@ -25,11 +25,13 @@
 // Initialization data, for ImGui_ImplWGPU_Init()
 struct ImGui_ImplWGPU_InitInfo
 {
+    WGPUInstance            Instance;
     WGPUDevice              Device;
     int                     NumFramesInFlight = 3;
     WGPUTextureFormat       RenderTargetFormat = WGPUTextureFormat_Undefined;
     WGPUTextureFormat       DepthStencilFormat = WGPUTextureFormat_Undefined;
     WGPUMultisampleState    PipelineMultisampleState = {};
+    WGPUPresentMode         ViewportPresentMode = {};
 
     ImGui_ImplWGPU_InitInfo()
     {

--- a/examples/example_glfw_wgpu/main.cpp
+++ b/examples/example_glfw_wgpu/main.cpp
@@ -35,6 +35,7 @@ static WGPUInstance      wgpu_instance = nullptr;
 static WGPUDevice        wgpu_device = nullptr;
 static WGPUSurface       wgpu_surface = nullptr;
 static WGPUTextureFormat wgpu_preferred_fmt = WGPUTextureFormat_RGBA8Unorm;
+static WGPUPresentMode   wgpu_present_mode = WGPUPresentMode_Fifo;
 static WGPUSwapChain     wgpu_swap_chain = nullptr;
 static int               wgpu_swap_chain_width = 1280;
 static int               wgpu_swap_chain_height = 720;
@@ -93,6 +94,8 @@ int main(int, char**)
     ImGuiIO& io = ImGui::GetIO(); (void)io;
     io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;     // Enable Keyboard Controls
     io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;      // Enable Gamepad Controls
+    io.ConfigFlags |= ImGuiConfigFlags_ViewportsEnable;
+    io.ConfigFlags |= ImGuiConfigFlags_DockingEnable; 
 
     // Setup Dear ImGui style
     ImGui::StyleColorsDark();
@@ -108,6 +111,10 @@ int main(int, char**)
     init_info.NumFramesInFlight = 3;
     init_info.RenderTargetFormat = wgpu_preferred_fmt;
     init_info.DepthStencilFormat = WGPUTextureFormat_Undefined;
+    init_info.ViewportPresentMode = wgpu_present_mode;
+    init_info.CreateViewportWindowFn = [](ImGuiViewport* viewport) {
+        return wgpu::glfw::CreateSurfaceForWindow(wgpu_instance, (GLFWwindow*) viewport->PlatformHandle).MoveToCHandle();
+    };
     ImGui_ImplWGPU_Init(&init_info);
 
     // Load Fonts
@@ -236,6 +243,12 @@ int main(int, char**)
         WGPUQueue queue = wgpuDeviceGetQueue(wgpu_device);
         wgpuQueueSubmit(queue, 1, &cmd_buffer);
 
+        if (ImGui::GetIO().ConfigFlags & ImGuiConfigFlags_ViewportsEnable)
+        {
+            ImGui::UpdatePlatformWindows();
+            ImGui::RenderPlatformWindowsDefault();
+        }
+
 #ifndef __EMSCRIPTEN__
         wgpuSwapChainPresent(wgpu_swap_chain);
 #endif
@@ -269,7 +282,7 @@ static WGPUAdapter RequestAdapter(WGPUInstance instance)
             *(WGPUAdapter*)(pUserData) = adapter;
         else
             printf("Could not get WebGPU adapter: %s\n", message);
-};
+    };
     WGPUAdapter adapter;
     wgpuInstanceRequestAdapter(instance, nullptr, onAdapterRequestEnded, (void*)&adapter);
     return adapter;
@@ -318,7 +331,10 @@ static bool InitWGPU(GLFWwindow* window)
     wgpu::Surface surface = wgpu::glfw::CreateSurfaceForWindow(instance, window);
     if (!surface)
         return false;
-    wgpu_preferred_fmt = WGPUTextureFormat_BGRA8Unorm;
+    wgpu::SurfaceCapabilities capabilities;
+    surface.GetCapabilities(adapter, &capabilities);
+    wgpu_preferred_fmt = (WGPUTextureFormat) capabilities.formats[0];
+    wgpu_present_mode = (WGPUPresentMode) capabilities.presentModes[0];
 #endif
 
     wgpu_instance = instance.MoveToCHandle();


### PR DESCRIPTION
Supersedes https://github.com/ocornut/imgui/pull/7132

Add Multiviewport support to the WebGPU backend and example.

Tasks outstanding:
- [x] Have user defined callback for creating a surface when create window is called
- [x] Remove wgpu_instance & headers needed for surface creation
- [ ] Change the format and presentation mode better (select preferred rather than first available but fall back to first available)
- [x] Fix present mode assert to use ~0 not 0

> [!Note]
> Linux users(using Dawn):
> ~~Due to an [intel bug](https://issues.chromium.org/issues/42241486) on linux/vulkan, the Mailbox present mode is the only thing available using vulkan backend. This disables Vsync. Using both AMD/Nvidia seems fine to edit dawn's code directly but that isn't a solution.~~
> ~~The old manual swapchain creation and usage and selecting FiFo is still working.~~
Fixed with this commit:
https://dawn.googlesource.com/dawn/+/780bbd6fce6b8e81569406fdb4b490613d158733%5E%21/#F2