### PR TITLE
Internals: ComboBox add additional ButtonFlags parameter

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -550,7 +550,7 @@ namespace ImGui
     // Widgets: Combo Box (Dropdown)
     // - The BeginCombo()/EndCombo() api allows you to manage your contents and selection state however you want it, by creating e.g. Selectable() items.
     // - The old Combo() api are helpers over BeginCombo()/EndCombo() which are kept available for convenience purpose. This is analogous to how ListBox are created.
-    IMGUI_API bool          BeginCombo(const char* label, const char* preview_value, ImGuiComboFlags flags = 0);
+    IMGUI_API bool          BeginCombo(const char* label, const char* preview_value, ImGuiComboFlags flags = 0, ImGuiButtonFlags button_flags = 0);
     IMGUI_API void          EndCombo(); // only call EndCombo() if BeginCombo() returns true!
     IMGUI_API bool          Combo(const char* label, int* current_item, const char* const items[], int items_count, int popup_max_height_in_items = -1);
     IMGUI_API bool          Combo(const char* label, int* current_item, const char* items_separated_by_zeros, int popup_max_height_in_items = -1);      // Separate items with \0 within a string, end item-list with \0\0. e.g. "One\0Two\0Three\0"
@@ -1596,14 +1596,21 @@ enum ImGuiStyleVar_
 // Flags for InvisibleButton() [extended in imgui_internal.h]
 enum ImGuiButtonFlags_
 {
-    ImGuiButtonFlags_None                   = 0,
-    ImGuiButtonFlags_MouseButtonLeft        = 1 << 0,   // React on left mouse button (default)
-    ImGuiButtonFlags_MouseButtonRight       = 1 << 1,   // React on right mouse button
-    ImGuiButtonFlags_MouseButtonMiddle      = 1 << 2,   // React on center mouse button
+    ImGuiButtonFlags_None                  = 0,
+    ImGuiButtonFlags_MouseButtonLeft       = 1 << 0, // React on left mouse button (default)
+    ImGuiButtonFlags_MouseButtonRight      = 1 << 1, // React on right mouse button
+    ImGuiButtonFlags_MouseButtonMiddle     = 1 << 2, // React on center mouse button
+
+    ImGuiButtonFlags_PressedOnClick        = 1 << 4, // return true on click (mouse down event)
+    ImGuiButtonFlags_PressedOnClickRelease = 1 << 5, // [Default] return true on click + release on same item <-- this is what the majority of Button are using
+    ImGuiButtonFlags_PressedOnClickReleaseAnywhere = 1 << 6, // return true on click + release even if the release event is not done while hovering the item
+    ImGuiButtonFlags_PressedOnRelease      = 1 << 7, // return true on release (default requires click+release)
+    ImGuiButtonFlags_PressedOnDoubleClick  = 1 << 8, // return true on double-click (default requires click+release)
+    ImGuiButtonFlags_PressedOnDragDropHold = 1 << 9, // return true when held into while we are drag and dropping another item (used by e.g. tree nodes, collapsing headers)
 
     // [Internal]
-    ImGuiButtonFlags_MouseButtonMask_       = ImGuiButtonFlags_MouseButtonLeft | ImGuiButtonFlags_MouseButtonRight | ImGuiButtonFlags_MouseButtonMiddle,
-    ImGuiButtonFlags_MouseButtonDefault_    = ImGuiButtonFlags_MouseButtonLeft,
+    ImGuiButtonFlags_MouseButtonMask_      = ImGuiButtonFlags_MouseButtonLeft | ImGuiButtonFlags_MouseButtonRight | ImGuiButtonFlags_MouseButtonMiddle,
+    ImGuiButtonFlags_MouseButtonDefault_   = ImGuiButtonFlags_MouseButtonLeft,
 };
 
 // Flags for ColorEdit3() / ColorEdit4() / ColorPicker3() / ColorPicker4() / ColorButton()

--- a/imgui.h
+++ b/imgui.h
@@ -1601,16 +1601,19 @@ enum ImGuiButtonFlags_
     ImGuiButtonFlags_MouseButtonRight      = 1 << 1, // React on right mouse button
     ImGuiButtonFlags_MouseButtonMiddle     = 1 << 2, // React on center mouse button
 
-    ImGuiButtonFlags_PressedOnClick        = 1 << 4, // return true on click (mouse down event)
-    ImGuiButtonFlags_PressedOnClickRelease = 1 << 5, // [Default] return true on click + release on same item <-- this is what the majority of Button are using
-    ImGuiButtonFlags_PressedOnClickReleaseAnywhere = 1 << 6, // return true on click + release even if the release event is not done while hovering the item
-    ImGuiButtonFlags_PressedOnRelease      = 1 << 7, // return true on release (default requires click+release)
-    ImGuiButtonFlags_PressedOnDoubleClick  = 1 << 8, // return true on double-click (default requires click+release)
-    ImGuiButtonFlags_PressedOnDragDropHold = 1 << 9, // return true when held into while we are drag and dropping another item (used by e.g. tree nodes, collapsing headers)
+    ImGuiButtonFlags_PressedOnClick        = 1 << 4, // React on click (mouse down event)
+    ImGuiButtonFlags_PressedOnClickRelease = 1 << 5, // [Default] React on click + release on the same item. This is default behavior for many buttons 
+    ImGuiButtonFlags_PressedOnClickReleaseAnywhere = 1 << 6, // React on click + release even if the release event is not done while hovering the item
+    ImGuiButtonFlags_PressedOnRelease      = 1 << 7, // React on release (default requires click+release)
+    ImGuiButtonFlags_PressedOnDoubleClick  = 1 << 8, // React on double-click (default requires click+release)
+    ImGuiButtonFlags_PressedOnDragDropHold = 1 << 9, // React when held into while we are drag and dropping another item (used by e.g. tree nodes, collapsing headers)
 
     // [Internal]
     ImGuiButtonFlags_MouseButtonMask_      = ImGuiButtonFlags_MouseButtonLeft | ImGuiButtonFlags_MouseButtonRight | ImGuiButtonFlags_MouseButtonMiddle,
     ImGuiButtonFlags_MouseButtonDefault_   = ImGuiButtonFlags_MouseButtonLeft,
+
+    ImGuiButtonFlags_PressedOnMask_        = ImGuiButtonFlags_PressedOnClick | ImGuiButtonFlags_PressedOnClickRelease | ImGuiButtonFlags_PressedOnClickReleaseAnywhere | ImGuiButtonFlags_PressedOnRelease | ImGuiButtonFlags_PressedOnDoubleClick | ImGuiButtonFlags_PressedOnDragDropHold,
+    ImGuiButtonFlags_PressedOnDefault_     = ImGuiButtonFlags_PressedOnClickRelease,
 };
 
 // Flags for ColorEdit3() / ColorEdit4() / ColorPicker3() / ColorPicker4() / ColorButton()

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -887,8 +887,6 @@ enum ImGuiButtonFlagsPrivate_
     ImGuiButtonFlags_NoHoveredOnFocus       = 1 << 19,  // don't report as hovered when nav focus is on this item
     ImGuiButtonFlags_NoSetKeyOwner          = 1 << 20,  // don't set key/input owner on the initial click (note: mouse buttons are keys! often, the key in question will be ImGuiKey_MouseLeft!)
     ImGuiButtonFlags_NoTestKeyOwner         = 1 << 21,  // don't test key/input owner when polling the key (note: mouse buttons are keys! often, the key in question will be ImGuiKey_MouseLeft!)
-    ImGuiButtonFlags_PressedOnMask_         = ImGuiButtonFlags_PressedOnClick | ImGuiButtonFlags_PressedOnClickRelease | ImGuiButtonFlags_PressedOnClickReleaseAnywhere | ImGuiButtonFlags_PressedOnRelease | ImGuiButtonFlags_PressedOnDoubleClick | ImGuiButtonFlags_PressedOnDragDropHold,
-    ImGuiButtonFlags_PressedOnDefault_      = ImGuiButtonFlags_PressedOnClickRelease,
 };
 
 // Extend ImGuiComboFlags_

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -875,12 +875,6 @@ enum ImGuiInputTextFlagsPrivate_
 // Extend ImGuiButtonFlags_
 enum ImGuiButtonFlagsPrivate_
 {
-    ImGuiButtonFlags_PressedOnClick         = 1 << 4,   // return true on click (mouse down event)
-    ImGuiButtonFlags_PressedOnClickRelease  = 1 << 5,   // [Default] return true on click + release on same item <-- this is what the majority of Button are using
-    ImGuiButtonFlags_PressedOnClickReleaseAnywhere = 1 << 6, // return true on click + release even if the release event is not done while hovering the item
-    ImGuiButtonFlags_PressedOnRelease       = 1 << 7,   // return true on release (default requires click+release)
-    ImGuiButtonFlags_PressedOnDoubleClick   = 1 << 8,   // return true on double-click (default requires click+release)
-    ImGuiButtonFlags_PressedOnDragDropHold  = 1 << 9,   // return true when held into while we are drag and dropping another item (used by e.g. tree nodes, collapsing headers)
     ImGuiButtonFlags_Repeat                 = 1 << 10,  // hold to repeat
     ImGuiButtonFlags_FlattenChildren        = 1 << 11,  // allow interactions even if a child window is overlapping
     ImGuiButtonFlags_AllowOverlap           = 1 << 12,  // require previous frame HoveredId to either match id or be null before being usable.

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -1698,7 +1698,7 @@ static float CalcMaxPopupHeightFromItemCount(int items_count)
     return (g.FontSize + g.Style.ItemSpacing.y) * items_count - g.Style.ItemSpacing.y + (g.Style.WindowPadding.y * 2);
 }
 
-bool ImGui::BeginCombo(const char* label, const char* preview_value, ImGuiComboFlags flags)
+bool ImGui::BeginCombo(const char* label, const char* preview_value, ImGuiComboFlags flags, ImGuiButtonFlags button_flags)
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = GetCurrentWindow();
@@ -1726,7 +1726,7 @@ bool ImGui::BeginCombo(const char* label, const char* preview_value, ImGuiComboF
 
     // Open on click
     bool hovered, held;
-    bool pressed = ButtonBehavior(bb, id, &hovered, &held);
+    bool pressed = ButtonBehavior(bb, id, &hovered, &held, button_flags);
     const ImGuiID popup_id = ImHashStr("##ComboPopup", 0, id);
     bool popup_open = IsPopupOpen(popup_id, ImGuiPopupFlags_None);
     if (pressed && !popup_open)


### PR DESCRIPTION
This change allows customization of button behavior for the ComboBox widget.

The default behavior for many buttons is to react on click + release. Now, it's possible to specify the behavior.

```cpp
static ImGuiComboFlags flags = 0;
static ImGuiButtonFlags button_flags = ImGuiButtonFlags_PressedOnClick;
if (ImGui::BeginCombo("combo 1", combo_preview_value, flags, button_flags))
{
  ...
}
```

In this example, the ComboBox reacts immediately to a mouse click event. This requires fewer frames to render the open popup window and also fixes issue #7544

Please note that we have to expose a set of `Pressed` flags to the user, which were previously internal:

- ImGuiButtonFlags_PressedOnClick 
- ImGuiButtonFlags_PressedOnClickRelease
- ImGuiButtonFlags_PressedOnClickReleaseAnywhere
- ImGuiButtonFlags_PressedOnRelease 
- ImGuiButtonFlags_PressedOnDoubleClick
- ImGuiButtonFlags_PressedOnDragDropHold