### PR TITLE
Add move cursor functions

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -10045,8 +10045,10 @@ bool ImGui::ItemAdd(const ImRect& bb, ImGuiID id, const ImRect* nav_bb_arg, ImGu
 // - SameLine()
 // - GetCursorScreenPos()
 // - SetCursorScreenPos()
+// - MoveCursorScreenPos()
 // - GetCursorPos(), GetCursorPosX(), GetCursorPosY()
 // - SetCursorPos(), SetCursorPosX(), SetCursorPosY()
+// - MoveCursorPos(), MoveCursorPosX(), MoveCursorPosY()
 // - GetCursorStartPos()
 // - Indent()
 // - Unindent()
@@ -10154,6 +10156,11 @@ void ImGui::SetCursorScreenPos(const ImVec2& pos)
     window->DC.IsSetPos = true;
 }
 
+void ImGui::MoveCursorScreenPos(const ImVec2& delta_pos)
+{
+    ImGui::SetCursorScreenPos(ImGui::GetCursorScreenPos() + delta_pos);
+}
+
 // User generally sees positions in window coordinates. Internally we store CursorPos in absolute screen coordinates because it is more convenient.
 // Conversion happens as we pass the value to user, but it makes our naming convention confusing because GetCursorPos() == (DC.CursorPos - window.Pos). May want to rename 'DC.CursorPos'.
 ImVec2 ImGui::GetCursorPos()
@@ -10196,6 +10203,21 @@ void ImGui::SetCursorPosY(float y)
     window->DC.CursorPos.y = window->Pos.y - window->Scroll.y + y;
     //window->DC.CursorMaxPos.y = ImMax(window->DC.CursorMaxPos.y, window->DC.CursorPos.y);
     window->DC.IsSetPos = true;
+}
+
+void ImGui::MoveCursorPos(const ImVec2& delta_pos)
+{
+    ImGui::SetCursorPos(ImGui::GetCursorPos() + delta_pos);
+}
+
+void ImGui::MoveCursorPosX(float delta_x)
+{
+    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + delta_x);
+}
+
+void ImGui::MoveCursorPosY(float delta_y)
+{
+    ImGui::SetCursorPosY(ImGui::GetCursorPosY() + delta_y);
 }
 
 ImVec2 ImGui::GetCursorStartPos()

--- a/imgui.h
+++ b/imgui.h
@@ -465,12 +465,16 @@ namespace ImGui
     // - GetCursorScreenPos() = GetCursorPos() + GetWindowPos(). GetWindowPos() is almost only ever useful to convert from window-local to absolute coordinates.
     IMGUI_API ImVec2        GetCursorScreenPos();                                           // cursor position in absolute coordinates (prefer using this, also more useful to work with ImDrawList API).
     IMGUI_API void          SetCursorScreenPos(const ImVec2& pos);                          // cursor position in absolute coordinates
+    IMGUI_API void          MoveCursorScreenPos(const ImVec2& delta_pos);                   // cursor position in absolute coordinates
     IMGUI_API ImVec2        GetCursorPos();                                                 // [window-local] cursor position in window coordinates (relative to window position)
     IMGUI_API float         GetCursorPosX();                                                // [window-local] "
     IMGUI_API float         GetCursorPosY();                                                // [window-local] "
     IMGUI_API void          SetCursorPos(const ImVec2& local_pos);                          // [window-local] "
     IMGUI_API void          SetCursorPosX(float local_x);                                   // [window-local] "
     IMGUI_API void          SetCursorPosY(float local_y);                                   // [window-local] "
+    IMGUI_API void          MoveCursorPos(const ImVec2& delta_pos);                         // [window-local] "
+    IMGUI_API void          MoveCursorPosX(float delta_x);                                  // [window-local] "
+    IMGUI_API void          MoveCursorPosY(float delta_y);                                  // [window-local] "
     IMGUI_API ImVec2        GetCursorStartPos();                                            // [window-local] initial cursor position, in window coordinates
 
     // Other layout functions

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -2874,7 +2874,7 @@ static void ShowDemoWindowLayout()
             if (child_flags & ImGuiChildFlags_FrameStyle)
                 override_bg_color = false;
 
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + (float)offset_x);
+            ImGui::MoveCursorPosX((float)offset_x);
             if (override_bg_color)
                 ImGui::PushStyleColor(ImGuiCol_ChildBg, IM_COL32(255, 0, 0, 100));
             ImGui::BeginChild("Red", ImVec2(200, 100), child_flags, ImGuiWindowFlags_None);
@@ -4034,7 +4034,7 @@ static void EditTableSizingFlags(ImGuiTableFlags* p_flags)
             ImGui::Separator();
             ImGui::Text("%s:", policies[m].Name);
             ImGui::Separator();
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + ImGui::GetStyle().IndentSpacing * 0.5f);
+            ImGui::MoveCursorPosX(ImGui::GetStyle().IndentSpacing * 0.5f);
             ImGui::TextUnformatted(policies[m].Tooltip);
         }
         ImGui::PopTextWrapPos();


### PR DESCRIPTION
Add move cursor helper functions that reduce verbosity of a relatively common pattern of `SetCursorXXX(GetCursorXXX + ...)` and better express intent. If the trivial helpers are undesirable so as to reduce unnecessary bloat of the API surface, feel free to just directly close this PR. Thanks!

