### PR TITLE
Backends: SDL3 Rename QUOTE and BACKQUOTE to APOSTROPHE and GRAVE

### DIFF
--- a/backends/imgui_impl_sdl3.cpp
+++ b/backends/imgui_impl_sdl3.cpp
@@ -145,7 +145,7 @@ static ImGuiKey ImGui_ImplSDL3_KeycodeToImGuiKey(int keycode)
         case SDLK_SPACE: return ImGuiKey_Space;
         case SDLK_RETURN: return ImGuiKey_Enter;
         case SDLK_ESCAPE: return ImGuiKey_Escape;
-        case SDLK_QUOTE: return ImGuiKey_Apostrophe;
+        case SDLK_APOSTROPHE: return ImGuiKey_Apostrophe;
         case SDLK_COMMA: return ImGuiKey_Comma;
         case SDLK_MINUS: return ImGuiKey_Minus;
         case SDLK_PERIOD: return ImGuiKey_Period;
@@ -155,7 +155,7 @@ static ImGuiKey ImGui_ImplSDL3_KeycodeToImGuiKey(int keycode)
         case SDLK_LEFTBRACKET: return ImGuiKey_LeftBracket;
         case SDLK_BACKSLASH: return ImGuiKey_Backslash;
         case SDLK_RIGHTBRACKET: return ImGuiKey_RightBracket;
-        case SDLK_BACKQUOTE: return ImGuiKey_GraveAccent;
+        case SDLK_GRAVE: return ImGuiKey_GraveAccent;
         case SDLK_CAPSLOCK: return ImGuiKey_CapsLock;
         case SDLK_SCROLLLOCK: return ImGuiKey_ScrollLock;
         case SDLK_NUMLOCKCLEAR: return ImGuiKey_NumLock;


### PR DESCRIPTION


## Motivation

Currently building Dear ImGui with newest SDL3 cloned from [SDL3 github](https://github.com/libsdl-org/SDL) fails because https://github.com/libsdl-org/SDL/pull/9774 just got merged. That PR changed the APOSTROPHE and GRAVE keys as per [SDL_Keycode](https://wiki.libsdl.org/SDL3/SDL_Keycode):

```cpp
#define SDLK_APOSTROPHE  '\''
#define SDLK_GRAVE  '`'
```

## What this PR does

This tiny PR fixes the two keys by changing QUOTE and BACKQUOTE in `imgui_impl_sdl3.cpp`

```cpp
        case SDLK_QUOTE: return ImGuiKey_Apostrophe;
        case SDLK_BACKQUOTE: return ImGuiKey_GraveAccent;
```

to APOSTROPHE and GRAVE

```cpp
        case SDLK_APOSTROPHE: return ImGuiKey_Apostrophe;
        case SDLK_GRAVE: return ImGuiKey_GraveAccent;
```
       


## Result

Before this PR I get two compilation errors (below) but after making above changes the errors are fixed.


```cpp
imgui_impl_sdl3.cpp:148:14: error: use of undeclared identifier 'SDLK_QUOTE_renamed_SDLK_APOSTROPHE'
        case SDLK_QUOTE: return ImGuiKey_Apostrophe;
             ^
imgui_impl_sdl3.cpp:158:14: error: use of undeclared identifier 'SDLK_BACKQUOTE_renamed_SDLK_GRAVE'
        case SDLK_BACKQUOTE: return ImGuiKey_GraveAccent;
             ^
1 warning and 2 errors generated.
```


## Note
> [!WARNING] 
> **It might be useful to postpone merging this PR until SDL [3.1.3 Preview](https://github.com/libsdl-org/SDL/releases/tag/prerelease-3.1.3) is released.**

I don't think these key changes were included in [3.1.2 Preview](https://github.com/libsdl-org/SDL/releases/tag/prerelease-3.1.2) since they were only just merged on the SDL3 github repo. But I hope this PR is at least little bit useful for those that clone SDL3 from github and in the future when SDL 3.1.3 is officially released.


