### PR TITLE
Fix compiling when using GDK

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -1000,7 +1000,8 @@ CODE
 #else
 #include <windows.h>
 #endif
-#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP) // UWP doesn't have all Win32 functions
+#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP || WINAPI_FAMILY == WINAPI_FAMILY_GAMES)
+// The UWP and GDK Win32 API subsets don't support clipboard nor IME functions
 #define IMGUI_DISABLE_WIN32_DEFAULT_CLIPBOARD_FUNCTIONS
 #define IMGUI_DISABLE_WIN32_DEFAULT_IME_FUNCTIONS
 #endif


### PR DESCRIPTION
`WINAPI_FAMILY_GAMES` is the new Win32 partition for developing games using the GDK (Microsoft Store, Xbox). This partition discards the older Win32 desktop-specific APIs which are not useful when making games or are considered legacy.

This PR makes imgui compile out-of-the box when using the GDK.
