### PR TITLE
MSVC: Initialize last_pixel_unpack_buffer in opengl3 backend

### DIFF
--- a/backends/imgui_impl_opengl3.cpp
+++ b/backends/imgui_impl_opengl3.cpp
@@ -750,7 +750,7 @@ bool    ImGui_ImplOpenGL3_CreateDeviceObjects()
     glGetIntegerv(GL_TEXTURE_BINDING_2D, &last_texture);
     glGetIntegerv(GL_ARRAY_BUFFER_BINDING, &last_array_buffer);
 #ifdef IMGUI_IMPL_OPENGL_MAY_HAVE_BIND_BUFFER_PIXEL_UNPACK
-    GLint last_pixel_unpack_buffer;
+    GLint last_pixel_unpack_buffer = 0;
     if (bd->GlVersion >= 210) { glGetIntegerv(GL_PIXEL_UNPACK_BUFFER_BINDING, &last_pixel_unpack_buffer); glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0); }
 #endif
 #ifdef IMGUI_IMPL_OPENGL_USE_VERTEX_ARRAY


### PR DESCRIPTION

This pull request fixes compiler warning regarding uninitialized variable on latest MSVC (and most likely older versions too) in opengl3 backend

**MSVC**: 19.39.33523.0
**MSBuild**: 17.9.8

```ps
  imgui_draw.cpp
  imgui_demo.cpp
  imgui_tables.cpp
  imgui_widgets.cpp
  imgui_impl_glfw.cpp
  imgui_impl_opengl3.cpp
  Generating Code...
D:\a\b\imgui\backends\imgui_impl_opengl3.cpp(929,1): error C2220: the following warning is treated as an error [D:\a\b\b.vcxproj]
D:\a\b\imgui\backends\imgui_impl_opengl3.cpp(929,1): warning C4701: potentially uninitialized local variable 'last_pixel_unpack_buffer' used [D:\a\b\b.vcxproj]
```