### PR TITLE
Demo: remove incompatible ImGuiInputFlags forShortcut()

### DIFF
--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -6293,9 +6293,9 @@ static void ShowDemoWindowInputs()
             ImGui::EndDisabled();
             ImGui::Unindent();
             ImGui::RadioButton("ImGuiInputFlags_RouteAlways", &route_type, ImGuiInputFlags_RouteAlways);
-            ImGuiInputFlags flags = route_type | route_options; // Merged flags
             if (route_type != ImGuiInputFlags_RouteGlobal)
                 route_options &= ~(ImGuiInputFlags_RouteOverFocused | ImGuiInputFlags_RouteOverActive | ImGuiInputFlags_RouteUnlessBgFocused);
+            ImGuiInputFlags flags = route_type | route_options; // Merged flags
 
             ImGui::SeparatorText("Using SetNextItemShortcut()");
             ImGui::Text("Ctrl+S");


### PR DESCRIPTION
Hi!

Playing with the new `Shortcut()` in the demo window, it crashes if:
1. Select `ImGuiInputFlags_RouteGlobal`.
2. Check any of the subflags, such as `ImGuiInputFlags_RouteOverFocused`.
3. Select other flag such as `ImGuiInputFlags_RouteFocused`.

If asserts with:
```
imgui.cpp:8694: bool ImGui::SetShortcutRouting(ImGuiKeyChord, ImGuiInputFlags, ImGuiID): Assertion `flags & ImGuiInputFlags_RouteGlobal' failed.
```

In step 3 the offending flags were actually removed from the variable `route_options`, but the fixed value was not used.