### PR TITLE
Fixed Makefiles for sdl3 examples

### DIFF
--- a/examples/example_sdl3_opengl3/Makefile
+++ b/examples/example_sdl3_opengl3/Makefile
@@ -37,9 +37,9 @@ LIBS =
 
 ifeq ($(UNAME_S), Linux) #LINUX
 	ECHO_MESSAGE = "Linux"
-	LIBS += $(LINUX_GL_LIBS) -ldl `sdl3-config --libs`
+	LIBS += $(LINUX_GL_LIBS) -ldl `pkg-config sdl3 --libs`
 
-	CXXFLAGS += `sdl3-config --cflags`
+	CXXFLAGS += `pkg-config sdl3 --cflags`
 	CFLAGS = $(CXXFLAGS)
 endif
 
@@ -48,7 +48,7 @@ ifeq ($(UNAME_S), Darwin) #APPLE
 	LIBS += -framework OpenGL -framework Cocoa -framework IOKit -framework CoreVideo `sdl3-config --libs`
 	LIBS += -L/usr/local/lib -L/opt/local/lib
 
-	CXXFLAGS += `sdl3-config --cflags`
+	CXXFLAGS += `pkg-config sdl3 --cflags`
 	CXXFLAGS += -I/usr/local/include -I/opt/local/include
 	CFLAGS = $(CXXFLAGS)
 endif

--- a/examples/example_sdl3_sdlrenderer3/Makefile
+++ b/examples/example_sdl3_sdlrenderer3/Makefile
@@ -26,9 +26,9 @@ LIBS =
 
 ifeq ($(UNAME_S), Linux) #LINUX
 	ECHO_MESSAGE = "Linux"
-	LIBS += -ldl `sdl3-config --libs`
+	LIBS += -ldl `pkg-config sdl3  --libs`
 
-	CXXFLAGS += `sdl3-config --cflags`
+	CXXFLAGS += `pkg-config sdl3 --cflags`
 	CFLAGS = $(CXXFLAGS)
 endif
 
@@ -37,7 +37,7 @@ ifeq ($(UNAME_S), Darwin) #APPLE
 	LIBS += -framework OpenGL -framework Cocoa -framework IOKit -framework CoreVideo `sdl3-config --libs`
 	LIBS += -L/usr/local/lib -L/opt/local/lib
 
-	CXXFLAGS += `sdl3-config --cflags`
+	CXXFLAGS += `pkg-config sdl3 --cflags`
 	CXXFLAGS += -I/usr/local/include -I/opt/local/include
 	CFLAGS = $(CXXFLAGS)
 endif


### PR DESCRIPTION
SDL3 no longer ships `sdl3-config`, we need to use `pkg-config sdl3` instead. 
