### PR TITLE
Move some docking type definitions into header files

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -15894,68 +15894,6 @@ void ImGui::DestroyPlatformWindows()
 // - ImGuiDockContext
 //-----------------------------------------------------------------------------
 
-enum ImGuiDockRequestType
-{
-    ImGuiDockRequestType_None = 0,
-    ImGuiDockRequestType_Dock,
-    ImGuiDockRequestType_Undock,
-    ImGuiDockRequestType_Split                  // Split is the same as Dock but without a DockPayload
-};
-
-struct ImGuiDockRequest
-{
-    ImGuiDockRequestType    Type;
-    ImGuiWindow*            DockTargetWindow;   // Destination/Target Window to dock into (may be a loose window or a DockNode, might be NULL in which case DockTargetNode cannot be NULL)
-    ImGuiDockNode*          DockTargetNode;     // Destination/Target Node to dock into
-    ImGuiWindow*            DockPayload;        // Source/Payload window to dock (may be a loose window or a DockNode), [Optional]
-    ImGuiDir                DockSplitDir;
-    float                   DockSplitRatio;
-    bool                    DockSplitOuter;
-    ImGuiWindow*            UndockTargetWindow;
-    ImGuiDockNode*          UndockTargetNode;
-
-    ImGuiDockRequest()
-    {
-        Type = ImGuiDockRequestType_None;
-        DockTargetWindow = DockPayload = UndockTargetWindow = NULL;
-        DockTargetNode = UndockTargetNode = NULL;
-        DockSplitDir = ImGuiDir_None;
-        DockSplitRatio = 0.5f;
-        DockSplitOuter = false;
-    }
-};
-
-struct ImGuiDockPreviewData
-{
-    ImGuiDockNode   FutureNode;
-    bool            IsDropAllowed;
-    bool            IsCenterAvailable;
-    bool            IsSidesAvailable;           // Hold your breath, grammar freaks..
-    bool            IsSplitDirExplicit;         // Set when hovered the drop rect (vs. implicit SplitDir==None when hovered the window)
-    ImGuiDockNode*  SplitNode;
-    ImGuiDir        SplitDir;
-    float           SplitRatio;
-    ImRect          DropRectsDraw[ImGuiDir_COUNT + 1];  // May be slightly different from hit-testing drop rects used in DockNodeCalcDropRects()
-
-    ImGuiDockPreviewData() : FutureNode(0) { IsDropAllowed = IsCenterAvailable = IsSidesAvailable = IsSplitDirExplicit = false; SplitNode = NULL; SplitDir = ImGuiDir_None; SplitRatio = 0.f; for (int n = 0; n < IM_ARRAYSIZE(DropRectsDraw); n++) DropRectsDraw[n] = ImRect(+FLT_MAX, +FLT_MAX, -FLT_MAX, -FLT_MAX); }
-};
-
-// Persistent Settings data, stored contiguously in SettingsNodes (sizeof() ~32 bytes)
-struct ImGuiDockNodeSettings
-{
-    ImGuiID             ID;
-    ImGuiID             ParentNodeId;
-    ImGuiID             ParentWindowId;
-    ImGuiID             SelectedTabId;
-    signed char         SplitAxis;
-    char                Depth;
-    ImGuiDockNodeFlags  Flags;                  // NB: We save individual flags one by one in ascii format (ImGuiDockNodeFlags_SavedFlagsMask_)
-    ImVec2ih            Pos;
-    ImVec2ih            Size;
-    ImVec2ih            SizeRef;
-    ImGuiDockNodeSettings() { memset(this, 0, sizeof(*this)); SplitAxis = ImGuiAxis_None; }
-};
-
 //-----------------------------------------------------------------------------
 // Docking: Forward Declarations
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
When generating bindings for `imgui_test_engine` I ran into the issue of some of these types being declared in the headers but never defined, which caused various 'incomplete type' errors. This should be fixed by moving them from `imgui.cpp` into `imgui_internal.h`.

Example error for `ImGuiDockRequest`:
```shell-session
shell> cmake --build .                                                                                                                                                                                                                         
Consolidate compiler generated dependencies of target libImGuiTestEngine                                                                                                                                                                       
[  2%] Building CXX object CMakeFiles/libImGuiTestEngine.dir/src/JlGlobals.cxx.o                                                                                                                                                               
[  4%] Building CXX object CMakeFiles/libImGuiTestEngine.dir/src/JlImBuildInfo.cxx.o                                                                                                                                                           
[  6%] Building CXX object CMakeFiles/libImGuiTestEngine.dir/src/JlImDrawData.cxx.o                                                                                                                                                            
[  8%] Building CXX object CMakeFiles/libImGuiTestEngine.dir/src/JlImFont.cxx.o                                                                                                                                                                
[ 10%] Building CXX object CMakeFiles/libImGuiTestEngine.dir/src/JlImGuiCaptureArgs.cxx.o                                                                                                                                                      
[ 12%] Building CXX object CMakeFiles/libImGuiTestEngine.dir/src/JlImGuiCaptureContext.cxx.o                                                                                                                                                   
[ 14%] Building CXX object CMakeFiles/libImGuiTestEngine.dir/src/JlImGuiCaptureToolUI.cxx.o                                                                                                                                                    
[ 17%] Building CXX object CMakeFiles/libImGuiTestEngine.dir/src/JlImGuiContext.cxx.o                                                                                                                                                          
In file included from /home/james/git/ImGuiTestEngine.jl/gen/libImGuiTestEngine/src/jlImGuiTestEngine.h:1,                                                                                                                                     
                 from /home/james/git/ImGuiTestEngine.jl/gen/libImGuiTestEngine/src/JlImGuiContext.cxx:4:                                                                                                                                      
/home/james/.julia/artifacts/fe48f0b2aafb29660aa25ab0e55249169fabee58/include/imgui.h: In instantiation of ‘ImVector<T>& ImVector<T>::operator=(const ImVector<T>&) [with T = ImGuiDockRequest]’:                                              
/home/james/.julia/artifacts/fe48f0b2aafb29660aa25ab0e55249169fabee58/include/imgui.h:1850:97:   required from ‘ImVector<T>::ImVector(const ImVector<T>&) [with T = ImGuiDockRequest]’                                                         
/home/james/.julia/artifacts/fe48f0b2aafb29660aa25ab0e55249169fabee58/include/imgui_internal.h:1705:8:   required from ‘jlcxx::BoxedValue<T> jlcxx::create(ArgsT&& ...) [with T = ImGuiContext; bool finalize = true; ArgsT = {const ImGuiConte
xt&}]’                                                                                                                                                                                                                                         
/home/james/.julia/artifacts/287f926f4aa4d6da9d319cdcd8cf34d11fcf6486/include/jlcxx/module.hpp:755:25:   required from ‘void jlcxx::Module::add_copy_constructor(jl_datatype_t*) [with T = ImGuiContext; jl_datatype_t = _jl_datatype_t]’      
/home/james/.julia/artifacts/287f926f4aa4d6da9d319cdcd8cf34d11fcf6486/include/jlcxx/module.hpp:1320:28:   required from ‘jlcxx::TypeWrapper<T> jlcxx::Module::add_type_internal(const string&, JLSuperT*) [with T = ImGuiContext; SuperParamete
rsT = jlcxx::ParameterList<>; JLSuperT = _jl_datatype_t; std::string = std::__cxx11::basic_string<char>]’                                                                                                                                      
/home/james/.julia/artifacts/287f926f4aa4d6da9d319cdcd8cf34d11fcf6486/include/jlcxx/module.hpp:1337:48:   required from ‘jlcxx::TypeWrapper<T> jlcxx::Module::add_type(const string&, JLSuperT*) [with T = ImGuiContext; SuperParametersT = jlc
xx::ParameterList<>; JLSuperT = _jl_datatype_t; std::string = std::__cxx11::basic_string<char>]’                                                                                                                                               
/home/james/git/ImGuiTestEngine.jl/gen/libImGuiTestEngine/src/JlImGuiContext.cxx:21:74:   required from here                                                                                                                                   
/home/james/.julia/artifacts/fe48f0b2aafb29660aa25ab0e55249169fabee58/include/imgui.h:1851:142: error: invalid application of ‘sizeof’ to incomplete type ‘ImGuiDockRequest’                                                                   
 1851 |     inline ImVector<T>& operator=(const ImVector<T>& src)   { clear(); resize(src.Size); if (src.Data) memcpy(Data, src.Data, (size_t)Size * sizeof(T)); return *this; }                                                               
      |                                                                                                                                              ^~~~~~~~~                   
```
