### PR TITLE
Broken SDL3 multiviewport fix caused by fonts

### DIFF
--- a/backends/imgui_impl_sdlrenderer3.cpp
+++ b/backends/imgui_impl_sdlrenderer3.cpp
@@ -127,7 +127,7 @@ void ImGui_ImplSDLRenderer3_NewFrame()
     }
 }
 
-void ImGui_ImplSDLRenderer3_RenderDrawData(ImDrawData* draw_data, SDL_Renderer* renderer, SDL_Texture* texture)
+void ImGui_ImplSDLRenderer3_RenderDrawData(ImDrawData* draw_data, SDL_Renderer* renderer, SDL_Texture* font_texture)
 {
     ImGui_ImplSDLRenderer3_Data* bd = ImGui_ImplSDLRenderer3_GetBackendData();
 
@@ -229,10 +229,8 @@ void ImGui_ImplSDLRenderer3_RenderDrawData(ImDrawData* draw_data, SDL_Renderer* 
     
                 if (tex == bd->FontTexture)
                 {
-                    if (texture != nullptr)
-                    {
-                        tex = texture;
-                    }
+                    if (font_texture != nullptr)
+                        tex = font_texture;
                 }
 
                 SDL_RenderGeometryRaw(renderer, tex,

--- a/backends/imgui_impl_sdlrenderer3.cpp
+++ b/backends/imgui_impl_sdlrenderer3.cpp
@@ -115,16 +115,16 @@ static void ImGui_ImplSDLRenderer3_SetupRenderState(SDL_Renderer* renderer)
 
 void ImGui_ImplSDLRenderer3_NewFrame()
 {
-    ImGuiIO& io = ImGui::GetIO();
-
     ImGui_ImplSDLRenderer3_Data* bd = ImGui_ImplSDLRenderer3_GetBackendData();
     IM_ASSERT(bd != nullptr && "Context or backend not initialized! Did you call ImGui_ImplSDLRenderer3_Init()?");
 
     if (!bd->FontTexture)
-        ImGui_ImplSDLRenderer3_CreateDeviceObjects();
+    {    
+        ImGuiIO& io = ImGui::GetIO();
 
-    // Font needs to be pushed each frame
-    io.Fonts->SetTexID((ImTextureID)(intptr_t)bd->FontTexture);
+        ImGui_ImplSDLRenderer3_CreateDeviceObjects();
+        io.Fonts->SetTexID((ImTextureID)(intptr_t)bd->FontTexture);
+    }
 }
 
 void ImGui_ImplSDLRenderer3_RenderDrawData(ImDrawData* draw_data, SDL_Renderer* renderer, SDL_Texture* texture)
@@ -263,18 +263,17 @@ bool ImGui_ImplSDLRenderer3_CreateFontsTexture(SDL_Renderer* renderer, SDL_Textu
 
     // Upload texture to graphics system
     // (Bilinear sampling is required by default. Set 'io.Fonts->Flags |= ImFontAtlasFlags_NoBakedLines' or 'style.AntiAliasedLinesUseTex = false' to allow point/nearest sampling)
-
     *texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_ABGR8888, SDL_TEXTUREACCESS_STATIC, width, height);
     if (*texture == nullptr)
     {
         SDL_Log("error creating texture");
         return false;
     }
+    
     SDL_UpdateTexture(*texture, nullptr, pixels, 4 * width);
     SDL_SetTextureBlendMode(*texture, SDL_BLENDMODE_BLEND);
     SDL_SetTextureScaleMode(*texture, SDL_SCALEMODE_LINEAR);
-
-
+    
     return true;
 }
 

--- a/backends/imgui_impl_sdlrenderer3.cpp
+++ b/backends/imgui_impl_sdlrenderer3.cpp
@@ -38,7 +38,6 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wsign-conversion"    // warning: implicit conversion changes signedness
 #endif
-#include <iostream>
 
 // SDL
 #include <SDL3/SDL.h>

--- a/backends/imgui_impl_sdlrenderer3.cpp
+++ b/backends/imgui_impl_sdlrenderer3.cpp
@@ -177,17 +177,6 @@ void ImGui_ImplSDLRenderer3_RenderDrawData(ImDrawData* draw_data, SDL_Renderer* 
         {
             const ImDrawCmd* pcmd = &cmd_list->CmdBuffer[cmd_i];
 
-            // Bind texture, Draw
-            SDL_Texture* tex = (SDL_Texture*)pcmd->GetTexID();
-
-            if (tex == bd->FontTexture)
-            {
-                if (texture != nullptr)
-                {
-                    tex = texture;
-                }
-            }
-
             if (pcmd->UserCallback)
             {
                 // User callback, registered via ImDrawList::AddCallback()
@@ -234,8 +223,18 @@ void ImGui_ImplSDLRenderer3_RenderDrawData(ImDrawData* draw_data, SDL_Renderer* 
                     xy = (const float*)bd->PosBuffer.Data;
                     xy_stride = (int)sizeof(ImVec2);
                 }
+                
+                // Bind texture, Draw
+                SDL_Texture* tex = (SDL_Texture*)pcmd->GetTexID();
+    
+                if (tex == bd->FontTexture)
+                {
+                    if (texture != nullptr)
+                    {
+                        tex = texture;
+                    }
+                }
 
-            
                 SDL_RenderGeometryRaw(renderer, tex,
                     xy, xy_stride,
                     color, (int)sizeof(ImDrawVert),

--- a/backends/imgui_impl_sdlrenderer3.cpp
+++ b/backends/imgui_impl_sdlrenderer3.cpp
@@ -210,7 +210,7 @@ void ImGui_ImplSDLRenderer3_RenderDrawData(ImDrawData* draw_data, SDL_Renderer* 
                     continue;
 
                 SDL_Rect r = { (int)(clip_min.x), (int)(clip_min.y), (int)(clip_max.x - clip_min.x), (int)(clip_max.y - clip_min.y) };
-            //    SDL_SetRenderClipRect(renderer, &r);
+                SDL_SetRenderClipRect(renderer, &r);
 
                 const float* xy = (const float*)(const void*)((const char*)(vtx_buffer + pcmd->VtxOffset) + offsetof(ImDrawVert, pos));
                 int xy_stride = (int)sizeof(ImDrawVert);

--- a/backends/imgui_impl_sdlrenderer3.h
+++ b/backends/imgui_impl_sdlrenderer3.h
@@ -30,7 +30,7 @@ struct SDL_Texture;
 IMGUI_IMPL_API bool     ImGui_ImplSDLRenderer3_Init(SDL_Renderer* renderer);
 IMGUI_IMPL_API void     ImGui_ImplSDLRenderer3_Shutdown();
 IMGUI_IMPL_API void     ImGui_ImplSDLRenderer3_NewFrame();
-IMGUI_IMPL_API void     ImGui_ImplSDLRenderer3_RenderDrawData(ImDrawData* draw_data, SDL_Renderer* renderer, SDL_Texture* texture = nullptr);
+IMGUI_IMPL_API void     ImGui_ImplSDLRenderer3_RenderDrawData(ImDrawData* draw_data, SDL_Renderer* renderer, SDL_Texture* font_texture = nullptr);
 
 // Called by Init/NewFrame/Shutdown
 IMGUI_IMPL_API bool     ImGui_ImplSDLRenderer3_CreateFontsTexture(SDL_Renderer* renderer, SDL_Texture** texture);

--- a/backends/imgui_impl_sdlrenderer3.h
+++ b/backends/imgui_impl_sdlrenderer3.h
@@ -25,14 +25,15 @@
 #ifndef IMGUI_DISABLE
 
 struct SDL_Renderer;
+struct SDL_Texture;
 
 IMGUI_IMPL_API bool     ImGui_ImplSDLRenderer3_Init(SDL_Renderer* renderer);
 IMGUI_IMPL_API void     ImGui_ImplSDLRenderer3_Shutdown();
 IMGUI_IMPL_API void     ImGui_ImplSDLRenderer3_NewFrame();
-IMGUI_IMPL_API void     ImGui_ImplSDLRenderer3_RenderDrawData(ImDrawData* draw_data, SDL_Renderer* renderer);
+IMGUI_IMPL_API void     ImGui_ImplSDLRenderer3_RenderDrawData(ImDrawData* draw_data, SDL_Renderer* renderer, SDL_Texture* texture = nullptr);
 
 // Called by Init/NewFrame/Shutdown
-IMGUI_IMPL_API bool     ImGui_ImplSDLRenderer3_CreateFontsTexture();
+IMGUI_IMPL_API bool     ImGui_ImplSDLRenderer3_CreateFontsTexture(SDL_Renderer* renderer, SDL_Texture** texture);
 IMGUI_IMPL_API void     ImGui_ImplSDLRenderer3_DestroyFontsTexture();
 IMGUI_IMPL_API bool     ImGui_ImplSDLRenderer3_CreateDeviceObjects();
 IMGUI_IMPL_API void     ImGui_ImplSDLRenderer3_DestroyDeviceObjects();


### PR DESCRIPTION
Very nasty fix for SDL3 not being able to share fonts between renderers, but it works.

Though i think this needs better solution, pointer comparing isn't the best approach

```
SDL_Texture * tex = (SDL_Texture*)pcmd->GetTexID();

if (tex == bd->FontTexture)
{
    if (texture != nullptr)
    {
        tex = texture;
    }
}
```
