### PR TITLE
Fix compile error on SDL3 backend

### DIFF
--- a/backends/imgui_impl_sdl3.cpp
+++ b/backends/imgui_impl_sdl3.cpp
@@ -1053,7 +1053,7 @@ static void ImGui_ImplSDL3_InitPlatformInterface(SDL_Window* window, void* sdl_g
     vd->Window = window;
     vd->WindowID = SDL_GetWindowID(window);
     vd->WindowOwned = false;
-    vd->GLContext = sdl_gl_context;
+    vd->GLContext = (SDL_GLContext)sdl_gl_context;
     main_viewport->PlatformUserData = vd;
     main_viewport->PlatformHandle = vd->Window;
 }


### PR DESCRIPTION
This pull request fix compilation error on imgui_impl_sdl3.cpp:
imgui_impl_sdl3.cpp(1056,21): error C2440: '=': cannot convert from 'void *' to 'SDL_GLContext'

This was tested with Microsoft Visual Studio Community 2022 (64-bit) - Current Version 17.10.1

This fix the issue described on: https://github.com/ocornut/imgui/issues/7701

Thanks