### PR TITLE
Remove Volk/ from volk.h #include directives

### DIFF
--- a/backends/imgui_impl_vulkan.h
+++ b/backends/imgui_impl_vulkan.h
@@ -55,7 +55,7 @@
 
 // Vulkan includes
 #ifdef IMGUI_IMPL_VULKAN_USE_VOLK
-#include <Volk/volk.h>
+#include <volk.h>
 #else
 #include <vulkan/vulkan.h>
 #endif

--- a/examples/example_glfw_vulkan/main.cpp
+++ b/examples/example_glfw_vulkan/main.cpp
@@ -25,7 +25,7 @@
 // Volk headers
 #ifdef IMGUI_IMPL_VULKAN_USE_VOLK
 #define VOLK_IMPLEMENTATION
-#include <Volk/volk.h>
+#include <volk.h>
 #endif
 
 // [Win32] Our example includes a copy of glfw3.lib pre-compiled with VS2010 to maximize ease of testing and compatibility with old VS compilers.

--- a/examples/example_sdl2_vulkan/main.cpp
+++ b/examples/example_sdl2_vulkan/main.cpp
@@ -24,7 +24,7 @@
 // Volk headers
 #ifdef IMGUI_IMPL_VULKAN_USE_VOLK
 #define VOLK_IMPLEMENTATION
-#include <Volk/volk.h>
+#include <volk.h>
 #endif
 
 //#define APP_USE_UNLIMITED_FRAME_RATE


### PR DESCRIPTION
Upgraded ImGUI and was happy to see recent addition of `IMGUI_IMPL_VULKAN_USE_VOLK`. However, I will continue to use `ImGui_ImplVulkan_LoadFunctions()` for a little while longer. Sending this patch to hopefully be able to use `IMGUI_IMPL_VULKAN_USE_VOLK` in next release. :)

- Capital letter in path is problematic on cases sensitive file systems.
- volk.h is also in top level directory of https://github.com/zeux/volk . Having a path before it in #include requires specifying include path to directory one level above where Volk dir is stored, which is not always wanted. If e.g. volk is stored in `third_party/volk`, prefix would require specifying `third_party` as include path to compiler and allow `#include <other_third_party_component/foo.h>`.