### PR TITLE
Fix member name changes in SDL_KeyboardEvent and pass SDL_Window* to functions

### DIFF
--- a/backends/imgui_impl_sdl3.cpp
+++ b/backends/imgui_impl_sdl3.cpp
@@ -130,6 +130,8 @@ static void ImGui_ImplSDL3_SetClipboardText(void*, const char* text)
 
 static void ImGui_ImplSDL3_SetPlatformImeData(ImGuiViewport* viewport, ImGuiPlatformImeData* data)
 {
+    ImGui_ImplSDL3_GetBackendData* bd = ImGui_ImplSDL3_GetBackendData();
+
     if (data->WantVisible)
     {
         SDL_Rect r;
@@ -137,12 +139,12 @@ static void ImGui_ImplSDL3_SetPlatformImeData(ImGuiViewport* viewport, ImGuiPlat
         r.y = (int)(data->InputPos.y - viewport->Pos.y + data->InputLineHeight);
         r.w = 1;
         r.h = (int)data->InputLineHeight;
-        SDL_SetTextInputRect(&r);
-        SDL_StartTextInput();
+        SDL_SetTextInputRect(bd->window, &r);
+        SDL_StartTextInput(bd->window);
     }
     else
     {
-        SDL_StopTextInput();
+        SDL_StopTextInput(bd->window);
     }
 }
 
@@ -345,10 +347,10 @@ bool ImGui_ImplSDL3_ProcessEvent(const SDL_Event* event)
         case SDL_EVENT_KEY_DOWN:
         case SDL_EVENT_KEY_UP:
         {
-            ImGui_ImplSDL3_UpdateKeyModifiers((SDL_Keymod)event->key.keysym.mod);
-            ImGuiKey key = ImGui_ImplSDL3_KeycodeToImGuiKey(event->key.keysym.sym);
+            ImGui_ImplSDL3_UpdateKeyModifiers((SDL_Keymod)event->key.mod);
+            ImGuiKey key = ImGui_ImplSDL3_KeycodeToImGuiKey(event->key.key);
             io.AddKeyEvent(key, (event->type == SDL_EVENT_KEY_DOWN));
-            io.SetKeyEventNativeData(key, event->key.keysym.sym, event->key.keysym.scancode, event->key.keysym.scancode); // To support legacy indexing (<1.87 user code). Legacy backend uses SDLK_*** as indices to IsKeyXXX() functions.
+            io.SetKeyEventNativeData(key, event->key.key, event->key.scancode, event->key.scancode); // To support legacy indexing (<1.87 user code). Legacy backend uses SDLK_*** as indices to IsKeyXXX() functions.
             return true;
         }
         case SDL_EVENT_DISPLAY_ORIENTATION:


### PR DESCRIPTION
In recent updates on the main branch of SDL, the `SDL_Keysym` member was removed from `SDL_KeyboardEvent`, with its members moved directly into `SDL_KeyboardEvent` and subsequently renamed. Additionally, some functions now require an additional `SDL_Window*` parameter.

Since I don't use the main branch, I can only confirm that this error occurs on the docking branch. If there are any further questions, please let me know.

