### PR TITLE
Fix rendering errors caused by dragging the window across monitors with different DPI scaling.

### DIFF
--- a/backends/imgui_impl_glfw.cpp
+++ b/backends/imgui_impl_glfw.cpp
@@ -190,6 +190,7 @@ static ImGui_ImplGlfw_Data* ImGui_ImplGlfw_GetBackendData()
 
 // Forward Declarations
 static void ImGui_ImplGlfw_UpdateMonitors();
+static void ImGui_ImplGlfw_UpdateViewports();
 static void ImGui_ImplGlfw_InitPlatformInterface();
 static void ImGui_ImplGlfw_ShutdownPlatformInterface();
 
@@ -924,6 +925,7 @@ void ImGui_ImplGlfw_NewFrame()
     io.DeltaTime = bd->Time > 0.0 ? (float)(current_time - bd->Time) : (float)(1.0f / 60.0f);
     bd->Time = current_time;
 
+	ImGui_ImplGlfw_UpdateViewports();
     ImGui_ImplGlfw_UpdateMouseData();
     ImGui_ImplGlfw_UpdateMouseCursor();
 
@@ -979,6 +981,7 @@ struct ImGui_ImplGlfw_ViewportData
 {
     GLFWwindow* Window;
     bool        WindowOwned;
+	bool 		PlatformRequestResizeNextFrame;
     int         IgnoreWindowPosEventFrame;
     int         IgnoreWindowSizeEventFrame;
 #ifdef _WIN32
@@ -988,6 +991,25 @@ struct ImGui_ImplGlfw_ViewportData
     ImGui_ImplGlfw_ViewportData()  { memset(this, 0, sizeof(*this)); IgnoreWindowSizeEventFrame = IgnoreWindowPosEventFrame = -1; }
     ~ImGui_ImplGlfw_ViewportData() { IM_ASSERT(Window == nullptr); }
 };
+
+static void ImGui_ImplGlfw_UpdateViewports()
+{
+	ImGuiPlatformIO& platform_io = ImGui::GetPlatformIO();
+	for (int n = 0; n < platform_io.Viewports.Size; n++)
+	{
+		ImGuiViewport* viewport = platform_io.Viewports[n];
+		if (ImGui_ImplGlfw_ViewportData* vd = (ImGui_ImplGlfw_ViewportData*)viewport->PlatformUserData){
+			if(vd->PlatformRequestResizeNextFrame){
+				// The previous frame's windowSizeCallback was invoked when glfwSetWindowPos was used, not triggered by glfwPollEvent.
+				// At this point, some critical operations that depend on PlatformRequestResize have already been completed.
+				// The PlatformRequestResize flag is cleared at the end of the frame,
+				// so we delay the operation to the current frame to ensure that the PlatformRequestResize behavior is fully completed.
+				viewport->PlatformRequestResize = true;
+				vd->PlatformRequestResizeNextFrame = false;
+			}
+		}
+	}
+}
 
 static void ImGui_ImplGlfw_WindowCloseCallback(GLFWwindow* window)
 {
@@ -1026,6 +1048,15 @@ static void ImGui_ImplGlfw_WindowSizeCallback(GLFWwindow* window, int, int)
             //data->IgnoreWindowSizeEventFrame = -1;
             if (ignore_event)
                 return;
+
+			bool delay_to_next_frame = (ImGui::GetFrameCount() <= vd->IgnoreWindowPosEventFrame + 1);
+
+			if(delay_to_next_frame){
+				// glfwSetWindowPos and glfwSetWindowSizeCallback are called in the same frame
+				// we should not process the resize event in this frame
+				vd->PlatformRequestResizeNextFrame = true;
+				return;
+			}
         }
         viewport->PlatformRequestResize = true;
     }


### PR DESCRIPTION
When I create a window using the docking branch and enable the following settings, some rendering issues occur when dragging between monitors with different DPI scaling.

	io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
	io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;
	io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
	io.ConfigFlags |= ImGuiConfigFlags_ViewportsEnable;

	io.ConfigViewportsNoAutoMerge = true;
	io.ConfigViewportsNoTaskBarIcon = false;
	io.ConfigViewportsNoDefaultParent = true;
	io.ConfigViewportsNoDecoration = true;

I found that dragging in NoDecoration mode relies on using glfwSetWindowPos, and the window triggers a resize when crossing monitors. However, the resize triggered by glfwSetWindowPos occurs immediately in the current frame, which means some operations depending on PlatformRequestResize might have already completed. Additionally, the PlatformRequestResize flag is cleared at the end of the frame. Therefore, we need to consider delaying the resize triggered by glfwSetWindowPos to the next frame to ensure that operations related to PlatformRequestResize are fully executed.

I only handled the related issue in GLFW, but other backends might have similar problems. Perhaps other window events could also have similar issues (triggered in the current frame but not fully processed before being cleared).

The related issues:

#7689 #6444 
