### PR TITLE
changed SDL_SetTextInputRect to SDL_SetTextInputArea

### DIFF
--- a/backends/imgui_impl_sdl3.cpp
+++ b/backends/imgui_impl_sdl3.cpp
@@ -139,7 +139,7 @@ static void ImGui_ImplSDL3_SetPlatformImeData(ImGuiViewport* viewport, ImGuiPlat
         r.y = (int)data->InputPos.y;
         r.w = 1;
         r.h = (int)data->InputLineHeight;
-        SDL_SetTextInputRect(window, &r);
+        SDL_SetTextInputArea(window, &r, 0);
         SDL_StartTextInput(window);
         bd->ImeWindow = window;
     }


### PR DESCRIPTION
Came across an error compiling and found that SDL3 [recently changed the name of `SDL_SetTextInputRect`](https://github.com/libsdl-org/SDL/commit/bdd531986baf1c2bb1bdd4004a388b53a1993b25).

Closes #7754 