### PR TITLE
Add default case to scancodes for SDL3

### DIFF
--- a/backends/imgui_impl_sdl3.cpp
+++ b/backends/imgui_impl_sdl3.cpp
@@ -168,6 +168,7 @@ static ImGuiKey ImGui_ImplSDL3_KeyEventToImGuiKey(SDL_Keycode keycode, SDL_Scanc
         case SDL_SCANCODE_KP_PLUS: return ImGuiKey_KeypadAdd;
         case SDL_SCANCODE_KP_ENTER: return ImGuiKey_KeypadEnter;
         case SDL_SCANCODE_KP_EQUALS: return ImGuiKey_KeypadEqual;
+        default: break;
     }
     switch (keycode)
     {


### PR DESCRIPTION
Quick patch so when compiling with clang and -Werror, the compiler doesn't give a error:

```
[3/10] Building CXX object CMakeFiles/OpenGL.dir/external/imgui/backends/imgui_impl_sdl3.cpp.o
FAILED: CMakeFiles/OpenGL.dir/external/imgui/backends/imgui_impl_sdl3.cpp.o 
/sbin/clang++ -DIMGUI -D_DEBUG -I/home/me/Developer/opengl/include -I/home/me/Developer/opengl/external/imgui -g -std=c++20 -Wall -Wextra -Wpedantic -Werror -g -Og -MD -MT CMakeFiles/OpenGL.dir/external/imgui/backends/imgui_impl_sdl3.cpp.o -MF CMakeFiles/OpenGL.dir/external/imgui/backends/imgui_impl_sdl3.cpp.o.d -o CMakeFiles/OpenGL.dir/external/imgui/backends/imgui_impl_sdl3.cpp.o -c /home/me/Developer/opengl/external/imgui/backends/imgui_impl_sdl3.cpp
/home/me/Developer/opengl/external/imgui/backends/imgui_impl_sdl3.cpp:152:13: error: 232 enumeration values not handled in switch: 'SDL_SCANCODE_UNKNOWN', 'SDL_SCANCODE_A', 'SDL_SCANCODE_B'... [-Werror,-Wswitch]
  152 |     switch (scancode)
      |             ^~~~~~~~
1 error generated.
```