### PR TITLE
Fix clang not defined warning

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -14378,7 +14378,7 @@ static bool PlatformOpenInShellFn_DefaultImpl(ImGuiContext*, const char* path)
 #include <unistd.h>
 static bool PlatformOpenInShellFn_DefaultImpl(ImGuiContext*, const char* path)
 {
-#if __APPLE__
+#if defined(__APPLE__)
     const char* args[] { "open", "--", path, NULL };
 #else
     const char* args[] { "xdg-open", path, NULL };


### PR DESCRIPTION
When compiling with clang and the `-Wundef` flag, the compiler gives the following error:
```
/sbin/clang++ -DIMGUI -D_DEBUG -I/home/user/Developer/opengl/include -I/home/user/Developer/opengl/external/imgui -stdlib=libc++ -g -std=c++20 -Wall -Wextra -Wpedantic -Werror -g -Og -Wfloat-e
al -Wundef -Wshadow -Wpointer-arith -Wstrict-prototypes -Wstrict-overflow=5 -Wwrite-strings -Waggregate-return -MD -MT CMakeFiles/OpenGL.dir/external/imgui/imgui.cpp.o -MF CMakeFiles/OpenGL.di
external/imgui/imgui.cpp.o.d -o CMakeFiles/OpenGL.dir/external/imgui/imgui.cpp.o -c /home/user/Developer/opengl/external/imgui/imgui.cpp
/home/user/Developer/opengl/external/imgui/imgui.cpp:14372:5: error: '__APPLE__' is not defined, evaluates to 0 [-Werror,-Wundef]
 14372 | #if __APPLE__
       |     ^
1 error generated.
```
This is just a small pr to fix it. 