### PR TITLE
Update imgui_impl_sdl3.cpp

### DIFF
--- a/backends/imgui_impl_sdl3.cpp
+++ b/backends/imgui_impl_sdl3.cpp
@@ -79,7 +79,7 @@ struct ImGui_ImplSDL3_Data
     SDL_Window*             Window;
     SDL_Renderer*           Renderer;
     Uint64                  Time;
-    char*                   ClipboardTextData;
+    const char*             ClipboardTextData;
 
     // IME handling
     SDL_Window*             ImeWindow;
@@ -114,7 +114,7 @@ static const char* ImGui_ImplSDL3_GetClipboardText(void*)
 {
     ImGui_ImplSDL3_Data* bd = ImGui_ImplSDL3_GetBackendData();
     if (bd->ClipboardTextData)
-        SDL_free(bd->ClipboardTextData);
+        SDL_free((void*)bd->ClipboardTextData);
     bd->ClipboardTextData = SDL_GetClipboardText();
     return bd->ClipboardTextData;
 }
@@ -507,7 +507,7 @@ void ImGui_ImplSDL3_Shutdown()
     ImGuiIO& io = ImGui::GetIO();
 
     if (bd->ClipboardTextData)
-        SDL_free(bd->ClipboardTextData);
+        SDL_free((void*)bd->ClipboardTextData);
     for (ImGuiMouseCursor cursor_n = 0; cursor_n < ImGuiMouseCursor_COUNT; cursor_n++)
         SDL_DestroyCursor(bd->MouseCursors[cursor_n]);
     ImGui_ImplSDL3_CloseGamepads();


### PR DESCRIPTION
```bash
FAILED: CMakeFiles/imgui.dir/lib/imgui/backends/imgui_impl_sdl3.cpp.o 
/usr/bin/c++  -I/home/alex/dev/sdl_learn/lib/imgui -I/home/alex/dev/sdl_learn/lib/SDL/include -I/home/alex/dev/sdl_learn/lib/imgui/backends -g -std=gnu++20 -MD -MT CMakeFiles/imgui.dir/lib/imgui/backends/imgui_impl_sdl3.cpp.o -MF CMakeFiles/imgui.dir/lib/imgui/backends/imgui_impl_sdl3.cpp.o.d -o CMakeFiles/imgui.dir/lib/imgui/backends/imgui_impl_sdl3.cpp.o -c /home/alex/dev/sdl_learn/lib/imgui/backends/imgui_impl_sdl3.cpp
/home/alex/dev/sdl_learn/lib/imgui/backends/imgui_impl_sdl3.cpp: In function ‘const char* ImGui_ImplSDL3_GetClipboardText(void*)’:
/home/alex/dev/sdl_learn/lib/imgui/backends/imgui_impl_sdl3.cpp:118:49: error: invalid conversion from ‘const char*’ to ‘char*’ [-fpermissive]
  118 |     bd->ClipboardTextData = SDL_GetClipboardText();
      |                             ~~~~~~~~~~~~~~~~~~~~^~
      |                                                 |
      |                                                 const char*
```

https://github.com/libsdl-org/SDL/commit/158fc459f181a99d3d3c993d74e5cade0bab90e7