### PR TITLE
DLL Export settings in `imconfig.h`

### DIFF
--- a/imconfig.h
+++ b/imconfig.h
@@ -19,12 +19,26 @@
 //#define IM_ASSERT(_EXPR)  MyAssert(_EXPR)
 //#define IM_ASSERT(_EXPR)  ((void)(_EXPR))     // Disable asserts
 
-//---- Define attributes of all API symbols declarations, e.g. for DLL under Windows
-// Using Dear ImGui via a shared library is not recommended, because of function call overhead and because we don't guarantee backward nor forward ABI compatibility.
-// DLL users: heaps and globals are not shared across DLL boundaries! You will need to call SetCurrentContext() + SetAllocatorFunctions()
-// for each static/DLL boundary you are calling from. Read "Context and Memory Allocators" section of imgui.cpp for more details.
-//#define IMGUI_API __declspec( dllexport )
-//#define IMGUI_API __declspec( dllimport )
+//---- Define the target platform. This will select the appropriate code path for your operating system.
+// You can define one of the following manually:
+// #define _IMGUI_WINDOWS   // Use this for compiling on Windows platforms.
+// #define _IMGUI_LINUX     // Use this for compiling on Linux platforms.
+// #define _IMGUI_MACOS     // Use this for compiling on macOS platforms.
+//
+// Alternatively, you can use automatic detection by defining:
+// #define _IMGUI_AUTO      // Automatically detect the platform. 
+//
+// Ensure that only one of these macros is defined at any time to avoid conflicts.
+//#define _IMGUI_WINDOWS
+//#define _IMGUI_LINUX
+//#define _IMGUI_MACOS
+//#define _IMGUI_AUTO
+
+//---- Define attributes for all API symbols declarations
+// Using Dear ImGui through a shared library is generally not recommended due to the overhead of function calls and the lack of guaranteed backward or forward ABI compatibility.
+// If you are using a DLL, keep in mind that heaps and globals are not shared across DLL boundaries. Therefore, you need to call SetCurrentContext() and SetAllocatorFunctions()
+// for each static/DLL boundary you are working across. Refer to the "Context and Memory Allocators" section in imgui.cpp for further details.
+// #define _IMGUI_DLL
 
 //---- Don't define obsolete functions/enums/behaviors. Consider enabling from time to time after updating to clean your code of obsolete function/names.
 //#define IMGUI_DISABLE_OBSOLETE_FUNCTIONS

--- a/imgui.h
+++ b/imgui.h
@@ -74,11 +74,43 @@ Index of this file:
 #include <stddef.h>                 // ptrdiff_t, NULL
 #include <string.h>                 // memset, memmove, memcpy, strlen, strchr, strcpy, strcmp
 
-// Define attributes of all API symbols declarations (e.g. for DLL under Windows)
-// IMGUI_API is used for core imgui functions, IMGUI_IMPL_API is used for the default backends files (imgui_impl_xxx.h)
-// Using dear imgui via a shared library is not recommended: we don't guarantee backward nor forward ABI compatibility + this is a call-heavy library and function call overhead adds up.
+// Automatically select the ImGui platform if `_IMGUI_AUTO` is defined
+#ifdef _IMGUI_AUTO
+#if !defined(_IMGUI_WINDOWS) && (defined(__WIN32__) || defined(WIN32) || defined(__MINGW32__))
+#define _IMGUI_WINDOWS
+#elif !defined(_IMGUI_LINUX) && defined(__GNUC__)
+#define _IMGUI_LINUX
+#endif
+#endif
+
+// Define DLL_EXPORT to export symbols (for example, Windows DLL)
+// IMGUI_API is used for core ImGui functions, IMGUI_IMPL_API is used for the default backends files (imgui_impl_xxx.h)
+// Using Dear ImGui via a shared library is not recommended: we don't guarantee backward nor forward ABI compatibility and function call overhead adds up.
 #ifndef IMGUI_API
+#ifndef IMGUI_API
+#ifdef _IMGUI_DLL
+#ifdef _IMGUI_WINDOWS
+#ifdef _IMGUI_DLL_EXPORT
+#define IMGUI_API                   __declspec(dllexport)
+#else
+#define IMGUI_API                   __declspec(dllimport)
+#endif
+#elif defined(_IMGUI_LINUX)
+#ifdef _IMGUI_DLL_EXPORT
+#define IMGUI_API __attribute__((visibility("default")))
+#endif
+#elif defined(_IMGUI_MACOS)
+#ifdef _IMGUI_DLL_EXPORT
+#define IMGUI_API __attribute__((visibility("default")))
+#else
+#define IMGUI_API 
+#endif
+#else
+#error DLL (Shared Library) is not supported on this platform
+#endif
+#else
 #define IMGUI_API
+#endif
 #endif
 #ifndef IMGUI_IMPL_API
 #define IMGUI_IMPL_API              IMGUI_API


### PR DESCRIPTION
### Description

This PR adds support for DLL exports (`_IMGUI_DLL`).

### Why We Need It

- Ensures that Dear ImGui functions can be properly exported and imported when used in a DLL on different platforms.
- Improves flexibility for projects using ImGui as a shared library.
