### PR TITLE
Fix backends osx api version limit

### DIFF
--- a/backends/imgui_impl_osx.mm
+++ b/backends/imgui_impl_osx.mm
@@ -919,7 +919,7 @@ static void ImGui_ImplOSX_CreateWindow(ImGuiViewport* viewport)
     window.opaque = YES;
 
     KeyEventResponder* view = [[KeyEventResponder alloc] initWithFrame:rect];
-    if (floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_6)
+    if (floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_6 && ceil(NSAppKitVersionNumber) < NSAppKitVersionNumber10_15)
         [view setWantsBestResolutionOpenGLSurface:YES];
 
     window.contentView = view;


### PR DESCRIPTION
![warn](https://github.com/user-attachments/assets/ad8128a6-fd33-4109-9524-9eaa26689284)

Through the compiler warning, I found that the version of this api is limited to 10.07 to 10.14, but only the minimum version is limited in code use. So I think this place should be repaired and the maximum version should be limited to prevent calling this api in higher versions.
After reviewing Apple's official documentation, the wantsBestResolutionOpenGLSurface property is set to True by default from 10.15 onwards. ( https://developer.apple.com/documentation/appkit/nsview/1414938-wantsbestresolutionopenglsurface )
