### PR TITLE
Added '\' and '/' as word seperator

### DIFF
--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -3897,7 +3897,7 @@ static void    STB_TEXTEDIT_LAYOUTROW(StbTexteditRow* r, ImGuiInputTextState* ob
 
 static bool is_separator(unsigned int c)
 {
-    return c==',' || c==';' || c=='(' || c==')' || c=='{' || c=='}' || c=='[' || c==']' || c=='|' || c=='\n' || c=='\r' || c=='.' || c=='!';
+    return c==',' || c==';' || c=='(' || c==')' || c=='{' || c=='}' || c=='[' || c==']' || c=='|' || c=='\n' || c=='\r' || c=='.' || c=='!' || c=='\\' || c=='/';
 }
 
 static int is_word_boundary_from_right(ImGuiInputTextState* obj, int idx)


### PR DESCRIPTION
Adding those seperators means that ctrl+(left|right)-arrows and ctrl+backspace will stop at slashes, which is more inline with how most software works and generally is very convenient when dealing with paths or urls.

Relevant issue: https://github.com/ocornut/imgui/issues/7704

