### PR TITLE
Examples: Fix Android example build failed issue

### DIFF
--- a/examples/example_android_opengl3/android/app/src/main/AndroidManifest.xml
+++ b/examples/example_android_opengl3/android/app/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
             android:name="imgui.example.android.MainActivity"
             android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
             android:configChanges="orientation|keyboardHidden|screenSize"
-            android:exported="false">
+            android:exported="true">
             <meta-data android:name="android.app.lib_name"
                 android:value="ImGuiExample" />
 


### PR DESCRIPTION
set android:exported to true (IntentFilter)

## Env

- ubuntu 22.04
- gradle 8.0
- build-tools 33.0.2
- ndk 25.2.9519653
- sdk android-33

![image](https://github.com/user-attachments/assets/d15d23fe-e772-44ac-9471-82befd038a5e)

![image](https://github.com/user-attachments/assets/7f5c3f64-6051-43b1-b55a-7e9058ed8fe6)


## Log

```bash  
                  Lint found 1 errors, 2 warnings. First failure:
  
  /home/speak/workspace/github/HelloWorld/imgui_android_build/imgui/examples/example_android_opengl3/android/app/src/main/AndroidManifest.xml:14: Error: A launchable activity must be exported as of Android 12, which also makes it available to other apps. [IntentFilterExportedReceiver]
              android:exported="false">
              ~~~~~~~~~~~~~~~~~~~~~~~~
  
     Explanation for issues of type "IntentFilterExportedReceiver":
     Apps targeting Android 12 and higher are required to specify an explicit
     value for android:exported when the corresponding component has an intent
     filter defined. Otherwise, installation will fail. Set it to true to make
     this activity accessible to other apps, and false to limit it to be used
     only by this app or the OS. For launch activities, this should be set to
     true; otherwise, the app will fail to launch.
  
     Previously, android:exported for components without any intent filters
     present used to default to false, and when intent filters were present, the
     default was true. Defaults which change value based on other values are
     confusing and lead to apps accidentally exporting components as a
     side-effect of adding intent filters. This is a security risk, and we have
     made this change to avoid introducing accidental vulnerabilities.
  
     While the default without intent filters remains unchanged, it is now
     required to explicitly specify a value when intent filters are present. Any
     app failing to meet this requirement will fail to install on any Android
     version after Android 11.
  
     We recommend setting android:exported to false (even on previous versions
     of Android prior to this requirement) unless you have a good reason to
     export a particular component.
  
  
  The full lint text report is located at:
    /home/speak/workspace/github/HelloWorld/imgui_android_build/imgui/examples/example_android_opengl3/android/app/build/intermediates/lint_intermediate_text_report/debug/lint-results-debug.txt

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 1s
101 actionable tasks: 33 executed, 68 up-to-date
```

---

android:exported="false"
```
gradle assembleDebug --stacktrace # pass
gradle build # failed
```

android:exported="true"
```
gradle assembleDebug --stacktrace # pass
gradle build # pass
```
