### PR TITLE
CI: Add manual trigger for 'workflow_run' builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
     # "scheduled" workflow, while maintaining ability to perform local CI builds.
     workflows:
       - scheduled
+      - manual
     branches:
       - master
       - docking

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -1,0 +1,12 @@
+#
+# This is a dummy workflow used to trigger full builds manually.
+#
+name: manual
+
+on: workflow_dispatch
+
+jobs:
+  manual:
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0


### PR DESCRIPTION
This adds an option for people that disabled the scheduled workflow to test out a full build in their own branch.

Example run:
https://github.com/learn-more/imgui/actions/runs/10272933298/job/28426261510

How to run it:
![image](https://github.com/user-attachments/assets/bb67832f-b70f-425c-9061-5d73a05c4c94)
