### PR TITLE
example_sdl2_sdlrenderer2: fix for potential typo in return code

### DIFF
--- a/examples/example_sdl2_sdlrenderer2/main.cpp
+++ b/examples/example_sdl2_sdlrenderer2/main.cpp
@@ -47,7 +47,7 @@ int main(int, char**)
     if (renderer == nullptr)
     {
         SDL_Log("Error creating SDL_Renderer!");
-        return 0;
+        return -1;
     }
     //SDL_RendererInfo info;
     //SDL_GetRendererInfo(renderer, &info);


### PR DESCRIPTION
Hi,

I noticed the return code for a failure to initialize the SDL renderer in the example returns 0, which would incorrectly indicate a successful exit. The correct return code, as used previously in the example, should most likely be -1.

Thanks