### PR TITLE
Backends: SDL3: Fix gamepad memory leak

### DIFF
--- a/backends/imgui_impl_sdl3.cpp
+++ b/backends/imgui_impl_sdl3.cpp
@@ -640,7 +640,7 @@ static void ImGui_ImplSDL3_UpdateGamepads()
     {
         ImGui_ImplSDL3_CloseGamepads();
         int sdl_gamepads_count = 0;
-        const SDL_JoystickID* sdl_gamepads = SDL_GetGamepads(&sdl_gamepads_count);
+        SDL_JoystickID* sdl_gamepads = SDL_GetGamepads(&sdl_gamepads_count);
         for (int n = 0; n < sdl_gamepads_count; n++)
             if (SDL_Gamepad* gamepad = SDL_OpenGamepad(sdl_gamepads[n]))
             {
@@ -649,6 +649,7 @@ static void ImGui_ImplSDL3_UpdateGamepads()
                     break;
             }
         bd->WantUpdateGamepadsList = false;
+        SDL_free(sdl_gamepads);
     }
 
     // FIXME: Technically feeding gamepad shouldn't depend on this now that they are regular inputs.


### PR DESCRIPTION
The pointer returned by `SDL_GetGamepads` should be freed (See: https://wiki.libsdl.org/SDL3/SDL_GetGamepads)

Leak Sanitizer log:
```
Direct leak of 4 byte(s) in 1 object(s) allocated from:
    #0 0x10479f848 in malloc+0x58 (libclang_rt.lsan_osx_dynamic.dylib:x86_64h+0x33848)
    #1 0x1028887a4 in real_malloc+0x14 (libSDL3.0.dylib:x86_64+0x1037a4)
    #2 0x1028889fb in SDL_malloc_REAL+0x2b (libSDL3.0.dylib:x86_64+0x1039fb)
    #3 0x1027ff5ab in SDL_GetJoysticks_REAL+0x6b (libSDL3.0.dylib:x86_64+0x7a5ab)
    #4 0x1027f9312 in SDL_GetGamepads_REAL+0x22 (libSDL3.0.dylib:x86_64+0x74312)
    #5 0x1027bae08 in SDL_GetGamepads+0x18 (libSDL3.0.dylib:x86_64+0x35e08)
    #6 0x101fee382 in ImGui_ImplSDL3_UpdateGamepads() imgui_impl_sdl3.cpp:643
    #7 0x101fee067 in ImGui_ImplSDL3_NewFrame() imgui_impl_sdl3.cpp:727
    #8 0x101d04c9d in Game::gui() game.cpp:243
    #9 0x101d04afa in Game::iterate() game.cpp:157
    #10 0x101d03114 in SDL_AppIterate main.cpp:79
    #11 0x10280e107 in SDL_IterateMainCallbacks+0x47 (libSDL3.0.dylib:x86_64+0x89107)
    #12 0x102a1efb0 in SDL_EnterAppMainCallbacks_REAL+0xa0 (libSDL3.0.dylib:x86_64+0x299fb0)
    #13 0x1027b972e in SDL_EnterAppMainCallbacks+0x3e (libSDL3.0.dylib:x86_64+0x3472e)
    #14 0x101d02de8 in SDL_main SDL_main_impl.h:59
    #15 0x10280e350 in SDL_RunApp_REAL+0x40 (libSDL3.0.dylib:x86_64+0x89350)
    #16 0x1027d0a03 in SDL_RunApp_DEFAULT+0x33 (libSDL3.0.dylib:x86_64+0x4ba03)
    #17 0x1027beb9e in SDL_RunApp+0x2e (libSDL3.0.dylib:x86_64+0x39b9e)
    #18 0x101d0343e in main SDL_main_impl.h:208
    #19 0x7fff20471f3c in start+0x0 (libdyld.dylib:x86_64+0x15f3c)
its<char>, std::__1::allocator<char> > const&>, std::__1::tuple<> >(std::__1::basic_string<char, std
```

PS. Maybe the pointer should be cast to a non-const pointer when invoking `SDL_free`? 