### PR TITLE
Preventing assert on accessibility monitors.

### DIFF
--- a/backends/imgui_impl_glfw.cpp
+++ b/backends/imgui_impl_glfw.cpp
@@ -906,6 +906,8 @@ static void ImGui_ImplGlfw_UpdateMonitors()
         // Warning: the validity of monitor DPI information on Windows depends on the application DPI awareness settings, which generally needs to be set in the manifest or at runtime.
         float x_scale, y_scale;
         glfwGetMonitorContentScale(glfw_monitors[n], &x_scale, &y_scale);
+        if (x_scale == 0.0f)
+            continue; // Some accessibility applications are declaring fake monitors with a DPI of 0
         monitor.DpiScale = x_scale;
 #endif
         monitor.PlatformHandle = (void*)glfw_monitors[n]; // [...] GLFW doc states: "guaranteed to be valid only until the monitor configuration changes"


### PR DESCRIPTION
This acts as both an issue and a proposal for fixing it.

Some of my users are reporting that accessibility applications are installing virtual "monitors" which have a DPI of 0. This software for instance: https://www.freedomscientific.com/products/software/jaws/

Querying all monitors using glfw when the application is installed returns the following DPI for each monitor:

```
b'Freedom Scientific Accessibility Display Driver' = 0.0, 0.0
b'Generic PnP Monitor' = 1.5, 1.5
```

This bubbles up into an assert eventually inside of ImGui: `mon.DpiScale != 0.0f`. The proposed change simply ignores monitors with a dpi scale of `0.0f`.

My guess is the monitor exists to "duplicate" the main one, and be able to capture drawing primitives for the purpose of accomplishing its work.

It's going to be difficult for me to test on other backends, given the software is expensive, and it's going to be tough to ask a visually impaired person to test many different backends, but I'm guessing other backends might want the same change.
