### PR TITLE
Emscripten: Uses macOS behavior on macOS (using glfw contrib port)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -492,6 +492,7 @@ jobs:
         emsdk-master/emsdk update
         emsdk-master/emsdk install latest
         emsdk-master/emsdk activate latest
+        sudo apt-get install build-essential
 
     - name: Build example_sdl2_opengl3 with Emscripten
       run: |
@@ -500,12 +501,21 @@ jobs:
         popd
         make -C examples/example_sdl2_opengl3 -f Makefile.emscripten
 
-    - name: Build example_glfw_wgpu
+    - name: Build example_glfw_wgpu with Emscripten/Makefile
       run: |
         pushd emsdk-master
         source ./emsdk_env.sh
         popd
         make -C examples/example_glfw_wgpu -f Makefile.emscripten
+
+    - name: Build example_glfw_wgpu with Emscripten/CMake
+      run: |
+        pushd emsdk-master
+        source ./emsdk_env.sh
+        popd
+        emcc -v
+        emcmake cmake -B build -DCMAKE_BUILD_TYPE=Release examples/example_glfw_wgpu
+        cmake --build build
 
   Android:
     runs-on: ubuntu-22.04

--- a/backends/imgui_impl_glfw.cpp
+++ b/backends/imgui_impl_glfw.cpp
@@ -560,7 +560,15 @@ void ImGui_ImplGlfw_SetCallbacksChainForAllWindows(bool chain_for_all_windows)
 }
 
 #ifdef __EMSCRIPTEN__
+#if EMSCRIPTEN_USE_PORT_CONTRIB_GLFW3 >= 3'4'0'20240817
+void ImGui_ImplGlfw_EmscriptenOpenURL(char const* url)
+{
+    if(url)
+        emscripten::glfw3::OpenURL(url);
+}
+#else
 EM_JS(void, ImGui_ImplGlfw_EmscriptenOpenURL, (char const* url), { url = url ? UTF8ToString(url) : null; if (url) window.open(url, '_blank'); });
+#endif
 #endif
 
 static bool ImGui_ImplGlfw_Init(GLFWwindow* window, bool install_callbacks, GlfwClientApi client_api)

--- a/backends/imgui_impl_glfw.cpp
+++ b/backends/imgui_impl_glfw.cpp
@@ -886,10 +886,17 @@ void ImGui_ImplGlfw_InstallEmscriptenCallbacks(GLFWwindow*, const char* canvas_s
 // See https://github.com/pongasoft/emscripten-glfw/blob/master/docs/Usage.md#how-to-make-the-canvas-resizable-by-the-user for an explanation
 void ImGui_ImplGlfw_InstallEmscriptenCallbacks(GLFWwindow* window, const char* canvas_selector)
 {
-  GLFWwindow* w = (GLFWwindow*)(EM_ASM_INT({ return Module.glfwGetWindow(UTF8ToString($0)); }, canvas_selector));
-  IM_ASSERT(window == w); // Sanity check
-  IM_UNUSED(w);
-  emscripten_glfw_make_canvas_resizable(window, "window", nullptr);
+    GLFWwindow* w = (GLFWwindow*)(EM_ASM_INT({ return Module.glfwGetWindow(UTF8ToString($0)); }, canvas_selector));
+    IM_ASSERT(window == w); // Sanity check
+    IM_UNUSED(w);
+    emscripten_glfw_make_canvas_resizable(window, "window", nullptr);
+#if EMSCRIPTEN_USE_PORT_CONTRIB_GLFW3 >= 3'4'0'20240817
+    if(emscripten::glfw3::IsRuntimePlatformApple())
+    {
+        ImGui::GetIO().ConfigMacOSXBehaviors = true;
+        emscripten::glfw3::SetSuperPlusKeyTimeouts(10, 10);
+    }
+#endif
 }
 #endif // #ifdef EMSCRIPTEN_USE_PORT_CONTRIB_GLFW3
 

--- a/examples/example_glfw_wgpu/CMakeLists.txt
+++ b/examples/example_glfw_wgpu/CMakeLists.txt
@@ -91,7 +91,6 @@ if(EMSCRIPTEN)
   if("${IMGUI_EMSCRIPTEN_GLFW3}" STREQUAL "--use-port=contrib.glfw3")
     target_compile_options(example_glfw_wgpu PUBLIC
         "${IMGUI_EMSCRIPTEN_GLFW3}"
-        "-DEMSCRIPTEN_USE_PORT_CONTRIB_GLFW3" # unnecessary beyond emscripten 3.1.59
     )
   endif()
   message(STATUS "Using ${IMGUI_EMSCRIPTEN_GLFW3} GLFW implementation")

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -117,6 +117,10 @@ Index of this file:
 #include <inttypes.h>       // PRId64/PRIu64, not avail in some MinGW headers.
 #endif
 
+#ifdef __EMSCRIPTEN__
+#include <emscripten/version.h>
+#endif
+
 // Visual Studio warnings
 #ifdef _MSC_VER
 #pragma warning (disable: 4127)     // condition expression is constant
@@ -7688,6 +7692,7 @@ void ImGui::ShowAboutWindow(bool* p_open)
 #endif
 #ifdef __EMSCRIPTEN__
         ImGui::Text("define: __EMSCRIPTEN__");
+        ImGui::Text("emscripten: %d.%d.%d", __EMSCRIPTEN_major__, __EMSCRIPTEN_minor__, __EMSCRIPTEN_tiny__);
 #endif
         ImGui::Separator();
         ImGui::Text("io.BackendPlatformName: %s", io.BackendPlatformName ? io.BackendPlatformName : "NULL");


### PR DESCRIPTION
Hi @ocornut 

This is the changes for the Issue #7851: "Emscripten: Handling "external" clipboard"

What this PR contains:

1. changed CI test to also test the CMakeLists build for `example_glfw_wgpu` and emscripten: this tests the path when emscripten-glfw is used.  Here is an example output (which shows the port being retrieved as well as the version):

```text
Run pushd emsdk-master
~/work/imgui/imgui/emsdk-master ~/work/imgui/imgui
Setting up EMSDK environment (suppress these messages with EMSDK_QUIET=1)
Adding directories to PATH:
PATH += /home/runner/work/imgui/imgui/emsdk-master
PATH += /home/runner/work/imgui/imgui/emsdk-master/upstream/emscripten

Setting environment variables:
PATH = /home/runner/work/imgui/imgui/emsdk-master:/home/runner/work/imgui/imgui/emsdk-master/upstream/emscripten:/snap/bin:/home/runner/.local/bin:/opt/pipx_bin:/home/runner/.cargo/bin:/home/runner/.config/composer/vendor/bin:/usr/local/.ghcup/bin:/home/runner/.dotnet/tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
EMSDK = /home/runner/work/imgui/imgui/emsdk-master
EMSDK_NODE = /home/runner/work/imgui/imgui/emsdk-master/node/18.20.3_64bit/bin/node
~/work/imgui/imgui
emcc (Emscripten gcc/clang-like replacement + linker emulating GNU ld) 3.1.65 (7f8a05dd4e37cbd7ffde6d624f91fd545f7b52e3)
clang version 20.0.0git (https:/github.com/llvm/llvm-project 547917aebd1e79a8929b53f0ddf3b5185ee4df74)
Target: wasm32-unknown-emscripten
Thread model: posix
InstalledDir: /home/runner/work/imgui/imgui/emsdk-master/upstream/bin
configure: cmake -B build -DCMAKE_BUILD_TYPE=Release examples/example_glfw_wgpu -DCMAKE_TOOLCHAIN_FILE=/home/runner/work/imgui/imgui/emsdk-master/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake -DCMAKE_CROSSCOMPILING_EMULATOR=/home/runner/work/imgui/imgui/emsdk-master/node/18.20.3_64bit/bin/node
-- Using --use-port=contrib.glfw3 GLFW implementation
-- Configuring done (0.4s)
-- Generating done (0.0s)
-- Build files have been written to: /home/runner/work/imgui/imgui/build
[ 11%] Building CXX object CMakeFiles/example_glfw_wgpu.dir/main.cpp.o
ports:INFO: retrieving port: contrib.glfw3 from https://github.com/pongasoft/emscripten-glfw/releases/download/v3.4.0.20240817/emscripten-glfw3-3.4.0.20240817.zip
ports:INFO: unpacking port: contrib.glfw3
cache:INFO: generating port: sysroot/lib/wasm32-emscripten/lib_contrib.glfw3-O2.a... (this will be cached in "/home/runner/work/imgui/imgui/emsdk-master/upstream/emscripten/cache/sysroot/lib/wasm32-emscripten/lib_contrib.glfw3-O2.a" for subsequent builds)
system_libs:INFO: compiled 7 inputs in 5.25s
cache:INFO:  - ok
[ 22%] Building CXX object CMakeFiles/example_glfw_wgpu.dir/home/runner/work/imgui/imgui/backends/imgui_impl_glfw.cpp.o
[ 33%] Building CXX object CMakeFiles/example_glfw_wgpu.dir/home/runner/work/imgui/imgui/backends/imgui_impl_wgpu.cpp.o
[ 44%] Building CXX object CMakeFiles/example_glfw_wgpu.dir/home/runner/work/imgui/imgui/imgui.cpp.o
[ 55%] Building CXX object CMakeFiles/example_glfw_wgpu.dir/home/runner/work/imgui/imgui/imgui_draw.cpp.o
[ 66%] Building CXX object CMakeFiles/example_glfw_wgpu.dir/home/runner/work/imgui/imgui/imgui_demo.cpp.o
[ 77%] Building CXX object CMakeFiles/example_glfw_wgpu.dir/home/runner/work/imgui/imgui/imgui_tables.cpp.o
[ 88%] Building CXX object CMakeFiles/example_glfw_wgpu.dir/home/runner/work/imgui/imgui/imgui_widgets.cpp.o
[100%] Linking CXX executable index.js
cache:INFO: generating system asset: symbol_lists/0d471007c2d667e769d9b01db9c4a5c0306744ec.json... (this will be cached in "/home/runner/work/imgui/imgui/emsdk-master/upstream/emscripten/cache/symbol_lists/0d471007c2d667e769d9b01db9c4a5c0306744ec.json" for subsequent builds)
cache:INFO:  - ok
[100%] Built target example_glfw_wgpu
```

2. Added the emscripten version to "About/Config" in the demo. I feel like it is a pretty important piece of information since there was somebody recently reporting an issue with emscripten and it was due to using an old version of emscripten.

3. Use `emscripten::glfw3::OpenURL` if available. This changes fixes the "Popup blocked" message that you get with some browsers, in particular Safari when clicking on links in ImGui

4. Automatically detect the runtime platform and if Apple, sets `ImGui::GetIO().ConfigMacOSXBehaviors` to `true`. Note that due to the issues with the Meta Key and the fact that ImGui is managing key repeat internally, it is a better user experience to simply "disable" repeat for Meta + C / X / V. I personally think that it is a fine tradeoff. This changes is required IF you would like to fix the issues with Clipboard copy/paste (#7851)

With the latest version of emscripten-glfw (3.4.0.20240817) available in emscripten 3.1.65 (released yesterday), you also get:

* scrollbars now work outside the browser
* copy/paste with natural shortcuts on Windows (and on macOS if you apply the changes recommended)

I pushed a [live demo](https://pongasoft.github.io/imgui/issue-7851/) for this PR

Note that 1/2/3 and 4 are completely unrelated and I just bundled them into the same PR. If you would rather have separate PRs, I can do that.

Also if you feel like 4 is not the direction you want to go (automatically using macOS behavior), it is OK not to accept this PR at all. The changes are pretty minimal and obviously anybody can write these 2 lines after calling `ImGui_ImplGlfw_InstallEmscriptenCallbacks`