### PR TITLE
Added support to render OpenType SVG fonts using plutosvg as an alternative to lunasvg (fix #7187)

### DIFF
--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -66,7 +66,9 @@ Breaking changes:
    - new ImageButton() always use style.FramePadding, which you can freely override with PushStyleVar()/PopStyleVar().
 
 Other changes:
-
+- Fonts, imgui_freetype: Added support to render OpenType SVG fonts using plutosvg as an alternative to lunasvg
+  Requires enabling IMGUI_ENABLE_FREETYPE_PLUTOSVG along with IMGUI_ENABLE_FREETYPE,
+  and providing headers/libraries for plutosvg + plutovg
 - IO: Added GetPlatformIO() and ImGuiPlatformIO, pulled from 'docking' branch, which
   is a centralized spot to connect os/platform/renderer related functions.
   Clipboard, IME and OpenInShell hooks are moved here. (#7660)

--- a/imconfig.h
+++ b/imconfig.h
@@ -83,10 +83,13 @@
 // On Windows you may use vcpkg with 'vcpkg install freetype --triplet=x64-windows' + 'vcpkg integrate install'.
 //#define IMGUI_ENABLE_FREETYPE
 
-//---- Use FreeType+lunasvg library to render OpenType SVG fonts (SVGinOT)
-// Requires lunasvg headers to be available in the include path + program to be linked with the lunasvg library (not provided).
+//---- render OpenType SVG fonts (SVGinOT) via plutosvg or lunasvg
+// Two alternatives are possible to render SVG fonts: either use lunasvg (added 2023/11), or use plutosvg (added in 2024)
+// (plutosvg will support more fonts and may load them faster)
+// Both alternatives require the headers to be available in the include path + program to be linked with the lunasvg or plutosvg library (not provided).
 // Only works in combination with IMGUI_ENABLE_FREETYPE.
-// (implementation is based on Freetype's rsvg-port.c which is licensed under CeCILL-C Free Software License Agreement)
+// (lunasvg implementation is based on Freetype's rsvg-port.c which is licensed under CeCILL-C Free Software License Agreement)
+//#define IMGUI_ENABLE_FREETYPE_PLUTOSVG
 //#define IMGUI_ENABLE_FREETYPE_LUNASVG
 
 //---- Use stb_truetype to build and rasterize the font atlas (default)

--- a/misc/freetype/README.md
+++ b/misc/freetype/README.md
@@ -38,7 +38,25 @@ You can use the `ImGuiFreeTypeBuilderFlags_LoadColor` flag to load certain color
 
 ### Using OpenType SVG fonts (SVGinOT)
 - *SVG in Open Type* is a standard by Adobe and Mozilla for color OpenType and Open Font Format fonts. It allows font creators to embed complete SVG files within a font enabling full color and even animations.
-- Popular fonts such as [twemoji](https://github.com/13rac1/twemoji-color-font) and fonts made with [scfbuild](https://github.com/13rac1/scfbuild) is SVGinOT
+- Popular fonts such as [twemoji](https://github.com/13rac1/twemoji-color-font) and fonts made with [scfbuild](https://github.com/13rac1/scfbuild) is SVGinOT 
+- Two alternatives are possible to render SVG fonts: either use lunasvg (support added in november 2023), or use "plutosvg" (support added late 2024). plutosvg will support some more fonts (for example NotoColorEmoji-Regular) and may load them faster.
+
+#### Using lunasvg
 - Requires: [lunasvg](https://github.com/sammycage/lunasvg) v2.3.2 and above
     1. Add `#define IMGUI_ENABLE_FREETYPE_LUNASVG` in your `imconfig.h`.
     2. Get latest lunasvg binaries or build yourself. Under Windows you may use vcpkg with: `vcpkg install lunasvg --triplet=x64-windows`.
+
+#### Using plutosvg (and plutovg)
+1. Add `#define IMGUI_ENABLE_FREETYPE_PLUTOSVG` in your `imconfig.h`.
+2. Compile and link with plutosvg *and* plutovg (which is required by plutosvg)
+
+_Compilation hints for plutovg_
+- Compile all source files in `plutovg/source/*.c`
+- Add include directory: `plutovg/include` + `plutovg/stb`
+
+_Compilation hints for plutosvg_
+- Compile `plutosvg/source/plutosvg.c`
+- Add include directory: `plutosvg/source`
+- Add define: `PLUTOSVG_HAS_FREETYPE`
+- Link with: plutovg, freetype
+

--- a/misc/freetype/imgui_freetype.cpp
+++ b/misc/freetype/imgui_freetype.cpp
@@ -6,6 +6,7 @@
 
 // CHANGELOG
 // (minor and older changes stripped away, please see git history for details)
+//  2024/08/27: improved support for SVG Fonts, by providing IMGUI_ENABLE_FREETYPE_PLUTOSVG, as an alternative to IMGUI_ENABLE_FREETYPE_LUNASVG
 //  2023/11/13: added support for ImFontConfig::RasterizationDensity field for scaling render density without scaling metrics.
 //  2023/08/01: added support for SVG fonts, enable by using '#define IMGUI_ENABLE_FREETYPE_LUNASVG' (#6591)
 //  2023/01/04: fixed a packing issue which in some occurrences would prevent large amount of glyphs from being packed correctly.
@@ -45,12 +46,21 @@
 #include FT_GLYPH_H             // <freetype/ftglyph.h>
 #include FT_SYNTHESIS_H         // <freetype/ftsynth.h>
 
-#ifdef IMGUI_ENABLE_FREETYPE_LUNASVG
+// Handle LunaSVG and PlutoSVG
+#if defined(IMGUI_ENABLE_FREETYPE_LUNASVG) && defined(IMGUI_ENABLE_FREETYPE_PLUTOSVG)
+#error "Cannot enable both IMGUI_ENABLE_FREETYPE_LUNASVG and IMGUI_ENABLE_FREETYPE_PLUTOSVG"
+#endif
+#ifdef  IMGUI_ENABLE_FREETYPE_LUNASVG
 #include FT_OTSVG_H             // <freetype/otsvg.h>
 #include FT_BBOX_H              // <freetype/ftbbox.h>
 #include <lunasvg.h>
+#endif
+#ifdef  IMGUI_ENABLE_FREETYPE_PLUTOSVG
+#include <plutosvg.h>
+#endif
+#if defined(IMGUI_ENABLE_FREETYPE_LUNASVG) || defined (IMGUI_ENABLE_FREETYPE_PLUTOSVG)
 #if !((FREETYPE_MAJOR >= 2) && (FREETYPE_MINOR >= 12))
-#error IMGUI_ENABLE_FREETYPE_LUNASVG requires FreeType version >= 2.12
+#error IMGUI_ENABLE_FREETYPE_PLUTOSVG or IMGUI_ENABLE_FREETYPE_LUNASVG requires FreeType version >= 2.12
 #endif
 #endif
 
@@ -269,11 +279,11 @@ namespace
 
         // Need an outline for this to work
         FT_GlyphSlot slot = Face->glyph;
-#ifdef IMGUI_ENABLE_FREETYPE_LUNASVG
+#if defined(IMGUI_ENABLE_FREETYPE_LUNASVG) || defined(IMGUI_ENABLE_FREETYPE_PLUTOSVG)
         IM_ASSERT(slot->format == FT_GLYPH_FORMAT_OUTLINE || slot->format == FT_GLYPH_FORMAT_BITMAP || slot->format == FT_GLYPH_FORMAT_SVG);
 #else
 #if ((FREETYPE_MAJOR >= 2) && (FREETYPE_MINOR >= 12))
-        IM_ASSERT(slot->format != FT_GLYPH_FORMAT_SVG && "The font contains SVG glyphs, you'll need to enable IMGUI_ENABLE_FREETYPE_LUNASVG in imconfig.h and install required libraries in order to use this font");
+        IM_ASSERT(slot->format != FT_GLYPH_FORMAT_SVG && "The font contains SVG glyphs, you'll need to enable IMGUI_ENABLE_FREETYPE_PLUTOSVG or IMGUI_ENABLE_FREETYPE_LUNASVG in imconfig.h and install required libraries in order to use this font");
 #endif
         IM_ASSERT(slot->format == FT_GLYPH_FORMAT_OUTLINE || slot->format == FT_GLYPH_FORMAT_BITMAP);
 #endif // IMGUI_ENABLE_FREETYPE_LUNASVG
@@ -810,6 +820,10 @@ static bool ImFontAtlasBuildWithFreeType(ImFontAtlas* atlas)
     SVG_RendererHooks hooks = { ImGuiLunasvgPortInit, ImGuiLunasvgPortFree, ImGuiLunasvgPortRender, ImGuiLunasvgPortPresetSlot };
     FT_Property_Set(ft_library, "ot-svg", "svg-hooks", &hooks);
 #endif // IMGUI_ENABLE_FREETYPE_LUNASVG
+#ifdef IMGUI_ENABLE_FREETYPE_PLUTOSVG
+    // With plutosvg, use provided hooks
+    FT_Property_Set(ft_library, "ot-svg", "svg-hooks", plutosvg_ft_svg_hooks());
+#endif // IMGUI_ENABLE_FREETYPE_PLUTOSVG
 
     bool ret = ImFontAtlasBuildWithFreeTypeEx(ft_library, atlas, atlas->FontBuilderFlags);
     FT_Done_Library(ft_library);


### PR DESCRIPTION
Bonjour Omar, 

This is a follow up to these related issues:
- https://github.com/ocornut/imgui/issues/7187 (which may need to be reopened, since there is a real rendering issue in ImGui)
- https://github.com/sammycage/lunasvg/issues/150

----
SVG Fonts include a set of SVG documents. As per the [OpenType specification](https://learn.microsoft.com/en-us/typography/opentype/spec/svg#glyph-identifiers), some SVG fonts (such as NotoColorEmoji) may group several glyphs in a common svg document (by selecting a subset of the elements in this document).

LunaSvg does support fonts where each glyph is associated to a distinct document. Unfortunately, it is not able to render a subset of a svg document, and will likely not be able to do so in the future.

Its cousin project [plutosvg](https://github.com/sammycage/plutosvg) (by the same author):
* is able to do it
* provides ready to use freetype hooks
* is faster according to its author
* will likely be required by the next version of lunasvg

Example: https://github.com/sammycage/lunasvg/issues/150 shows an example where a single svg document included in the font may contains thousands of glyphs (each glyph is a subset of the svg document).

Pros and Cons
-------------
Since this commit may add some complexity in the build process here is a study of the pros and cons:

Pros:
- plutosvg is faster than lunasvg
- freetype hooks are provided by plutosvg (no need to provide them in imgui_freetype.cpp)
- popular font such as NotoColorEmoji are supported

Cons:
- the compilation setup for plutosvg is a bit more complex than for lunasvg (requires [plutovg](https://github.com/sammycage/plutovg) + [plutosvg](https://github.com/sammycage/plutosvg))
- no offical release is available yet for plutosvg. No vcpkg package available yet.
- having two competing compilation flags is not ideal (IMGUI_ENABLE_FREETYPE_LUNASVG vs IMGUI_ENABLE_FREETYPE_PLUTOSVG) (it may be possible to remove IMGUI_ENABLE_FREETYPE_LUNASVG in the future, at the cost of breaking some users build upon upgrade)

Compilation hints for plutovg/plutosvg
--------------------------------------
_Compilation hints for plutovg_
- Compile all source files in `plutovg/source/*.c`
- Add include directory: `plutovg/include` + `plutovg/stb`

_Compilation hints for plutosvg_
- Compile `plutosvg/source/plutosvg.c`
- Add include directory: `plutosvg/source`
- Add define: `PLUTOSVG_HAS_FREETYPE`
- Link with: plutovg, freetype

Demonstration repository
-------------------------
https://github.com/pthom/lunasvg_perf_issue
(a demo repro which can renders all the glyphs of NotoColorEmoji using plutosvg)

