### PR TITLE
Text Rendering: fixed glyph Y alignment when using `ImGui::SetWindowFontScale`

### DIFF
--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -4137,8 +4137,8 @@ void ImFont::RenderText(ImDrawList* draw_list, float size, const ImVec2& pos, Im
             // We don't do a second finer clipping test on the Y axis as we've already skipped anything before clip_rect.y and exit once we pass clip_rect.w
             float x1 = x + glyph->X0 * scale;
             float x2 = x + glyph->X1 * scale;
-            float y1 = y + glyph->Y0 * scale;
-            float y2 = y + glyph->Y1 * scale;
+            float y1 = y + IM_TRUNC(glyph->Y0 * scale);
+            float y2 = y + IM_TRUNC(glyph->Y1 * scale);
             if (x1 <= clip_rect.z && x2 >= clip_rect.x)
             {
                 // Render a character


### PR DESCRIPTION
This Pull Request fixes issue #7924 by modifying two small lines in `imgui_draw.cpp`
The fix is very-very-very unlikely to conflict with any existing functionality

Here's the difference:
(No patch applied)
![image](https://github.com/user-attachments/assets/cc54200b-e9a6-4435-90b7-17d9de3544bf)

(Patch applied)
![image](https://github.com/user-attachments/assets/35f60c12-7064-4f8b-bb51-4c71f02f5913)

In the second screenshots all the glyphs are aligned correctly

