### PR TITLE
Removed column skip items assert

### DIFF
--- a/imgui_tables.cpp
+++ b/imgui_tables.cpp
@@ -1113,8 +1113,8 @@ void ImGui::TableUpdateLayout(ImGuiTable* table)
         // Mark column as SkipItems (ignoring all items/layout)
         // (table->HostSkipItems is a copy of inner_window->SkipItems before we cleared it above in Part 2)
         column->IsSkipItems = !column->IsEnabled || table->HostSkipItems;
-        if (column->IsSkipItems)
-            IM_ASSERT(!is_visible);
+        // if (column->IsSkipItems)
+        //     IM_ASSERT(!is_visible);
         if (column->IsRequestOutput && !column->IsSkipItems)
             has_at_least_one_column_requesting_output = true;
 


### PR DESCRIPTION
because IsVisibleY was changed to always be true for columns and is_visible changed to only care about the X-axis, the assert for is_visible on if the column items should be skipped is now an erroneous assert because of the case where the column is part of a table that has clipped off the top or bottom of the cliprect.  In those cases, is_visible will always be true (horizontally) but hostSkipItems will be false.