### PR TITLE
Help users if they are reusing the same ID (Fix #7669)

### DIFF
--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -2000,8 +2000,9 @@ static void ShowDemoWindowWidgets(ImGuiDemoWindowData* demo_data)
         ImGui::SameLine();
         ImGui::SliderInt("Sample count", &display_count, 1, 400);
         float (*func)(void*, int) = (func_type == 0) ? Funcs::Sin : Funcs::Saw;
-        ImGui::PlotLines("Lines", func, NULL, display_count, 0, NULL, -1.0f, 1.0f, ImVec2(0, 80));
-        ImGui::PlotHistogram("Histogram", func, NULL, display_count, 0, NULL, -1.0f, 1.0f, ImVec2(0, 80));
+        // TRKID: imgui_demo.cpp / Widgets/Plotting: simple id fix
+        ImGui::PlotLines("Lines##2", func, NULL, display_count, 0, NULL, -1.0f, 1.0f, ImVec2(0, 80));
+        ImGui::PlotHistogram("Histogram##2", func, NULL, display_count, 0, NULL, -1.0f, 1.0f, ImVec2(0, 80));
         ImGui::Separator();
 
         ImGui::Text("Need better plotting and graphing? Consider using ImPlot:");
@@ -2596,6 +2597,10 @@ static void ShowDemoWindowWidgets(ImGuiDemoWindowData* demo_data)
         IMGUI_DEMO_MARKER("Widgets/Drag and Drop/Drag to reorder items (simple)");
         if (ImGui::TreeNode("Drag to reorder items (simple)"))
         {
+            // TRKID: Widgets/Drag and Drop/Drag to reorder items (simple) this demo will trigger a duplicated id during *one* frame (and *one* frame only)
+            // This is because it reorders items mid-flight, and may redisplay the same item in the frame where reordering happens.
+            // This is not a big issue : a red dot may flash for *one* frame (an assert may trigger if IMGUI_DEBUG_PARANOID is defined)
+
             // Simple reordering
             HelpMarker(
                 "We don't use the drag and drop api at all here! "
@@ -4225,7 +4230,8 @@ static void ShowDemoWindowLayout()
             // down by FramePadding.y ahead of time)
             ImGui::AlignTextToFramePadding();
             ImGui::Text("OK Blahblah"); ImGui::SameLine();
-            ImGui::Button("Some framed item"); ImGui::SameLine();
+            // TRKID: imgui_demo.cpp, "Layout/Text Baseline Alignment": simple ID fix
+            ImGui::Button("Some framed item##2"); ImGui::SameLine();
             HelpMarker("We call AlignTextToFramePadding() to vertically align the text baseline by +FramePadding.y");
 
             // SmallButton() uses the same vertical padding as Text
@@ -7146,6 +7152,8 @@ static void ShowDemoWindowColumns()
         ImGui::Columns(columns_count, NULL, v_borders);
         for (int i = 0; i < columns_count * lines_count; i++)
         {
+            // TRKID: imgui_demo.cpp / Columns (legacy API)/Borders: added ImGui::PushID for each cell
+            ImGui::PushID(i);
             if (h_borders && ImGui::GetColumnIndex() == 0)
                 ImGui::Separator();
             ImGui::Text("%c%c%c", 'a' + i, 'a' + i, 'a' + i);
@@ -7155,6 +7163,7 @@ static void ShowDemoWindowColumns()
             ImGui::Text("Long text that is likely to clip");
             ImGui::Button("Button", ImVec2(-FLT_MIN, 0.0f));
             ImGui::NextColumn();
+            ImGui::PopID();
         }
         ImGui::Columns(1);
         if (h_borders)

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -717,7 +717,7 @@ bool ImGui::ButtonEx(const char* label, const ImVec2& size_arg, ImGuiButtonFlags
 
     ImGuiContext& g = *GImGui;
     const ImGuiStyle& style = g.Style;
-    const ImGuiID id = window->GetID(label);
+    const ImGuiID id = window->ReserveUniqueID(label);
     const ImVec2 label_size = CalcTextSize(label, NULL, true);
 
     ImVec2 pos = window->DC.CursorPos;
@@ -778,7 +778,7 @@ bool ImGui::InvisibleButton(const char* str_id, const ImVec2& size_arg, ImGuiBut
     // Cannot use zero-size for InvisibleButton(). Unlike Button() there is not way to fallback using the label size.
     IM_ASSERT(size_arg.x != 0.0f && size_arg.y != 0.0f);
 
-    const ImGuiID id = window->GetID(str_id);
+    const ImGuiID id = window->ReserveUniqueID(str_id);
     ImVec2 size = CalcItemSize(size_arg, 0.0f, 0.0f);
     const ImRect bb(window->DC.CursorPos, window->DC.CursorPos + size);
     ItemSize(size);
@@ -799,7 +799,7 @@ bool ImGui::ArrowButtonEx(const char* str_id, ImGuiDir dir, ImVec2 size, ImGuiBu
     if (window->SkipItems)
         return false;
 
-    const ImGuiID id = window->GetID(str_id);
+    const ImGuiID id = window->ReserveUniqueID(str_id);
     const ImRect bb(window->DC.CursorPos, window->DC.CursorPos + size);
     const float default_size = GetFrameHeight();
     ItemSize(size, (size.y >= default_size) ? g.Style.FramePadding.y : -1.0f);
@@ -890,6 +890,12 @@ bool ImGui::CollapseButton(ImGuiID id, const ImVec2& pos)
     return pressed;
 }
 
+// TRKID: ReserveWindowScrollbarID will perform the ID reservation, while GetWindowScrollbarID is only a query
+ImGuiID ImGui::ReserveWindowScrollbarID(ImGuiWindow* window, ImGuiAxis axis)
+{
+    return window->ReserveUniqueID(axis == ImGuiAxis_X ? "#SCROLLX" : "#SCROLLY");
+}
+
 ImGuiID ImGui::GetWindowScrollbarID(ImGuiWindow* window, ImGuiAxis axis)
 {
     return window->GetID(axis == ImGuiAxis_X ? "#SCROLLX" : "#SCROLLY");
@@ -913,7 +919,7 @@ void ImGui::Scrollbar(ImGuiAxis axis)
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
-    const ImGuiID id = GetWindowScrollbarID(window, axis);
+    const ImGuiID id = ReserveWindowScrollbarID(window, axis);
 
     // Calculate scrollbar bounding box
     ImRect bb = GetWindowScrollbarRect(window, axis);
@@ -1103,7 +1109,7 @@ bool ImGui::ImageButton(const char* str_id, ImTextureID user_texture_id, const I
     if (window->SkipItems)
         return false;
 
-    return ImageButtonEx(window->GetID(str_id), user_texture_id, image_size, uv0, uv1, bg_col, tint_col);
+    return ImageButtonEx(window->ReserveUniqueID(str_id), user_texture_id, image_size, uv0, uv1, bg_col, tint_col);
 }
 
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
@@ -1117,6 +1123,7 @@ bool ImGui::ImageButton(ImTextureID user_texture_id, const ImVec2& size, const I
 {
     // Default to using texture ID as ID. User can still push string/integer prefixes.
     PushID((void*)(intptr_t)user_texture_id);
+    const ImGuiID id = window->GetID("#image");
     if (frame_padding >= 0)
         PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2((float)frame_padding, (float)frame_padding));
     bool ret = ImageButton("", user_texture_id, size, uv0, uv1, bg_col, tint_col);
@@ -1136,7 +1143,7 @@ bool ImGui::Checkbox(const char* label, bool* v)
 
     ImGuiContext& g = *GImGui;
     const ImGuiStyle& style = g.Style;
-    const ImGuiID id = window->GetID(label);
+    const ImGuiID id = window->ReserveUniqueID(label);
     const ImVec2 label_size = CalcTextSize(label, NULL, true);
 
     const float square_sz = GetFrameHeight();
@@ -1258,7 +1265,7 @@ bool ImGui::RadioButton(const char* label, bool active)
 
     ImGuiContext& g = *GImGui;
     const ImGuiStyle& style = g.Style;
-    const ImGuiID id = window->GetID(label);
+    const ImGuiID id = window->ReserveUniqueID(label);
     const ImVec2 label_size = CalcTextSize(label, NULL, true);
 
     const float square_sz = GetFrameHeight();
@@ -1407,7 +1414,7 @@ bool ImGui::TextLink(const char* label)
         return false;
 
     ImGuiContext& g = *GImGui;
-    const ImGuiID id = window->GetID(label);
+    const ImGuiID id = window->ReserveUniqueID(label);
     const char* label_end = FindRenderedTextEnd(label);
 
     ImVec2 pos = window->DC.CursorPos;
@@ -1821,7 +1828,7 @@ bool ImGui::BeginCombo(const char* label, const char* preview_value, ImGuiComboF
         return false;
 
     const ImGuiStyle& style = g.Style;
-    const ImGuiID id = window->GetID(label);
+    const ImGuiID id = window->ReserveUniqueID(label);
     IM_ASSERT((flags & (ImGuiComboFlags_NoArrowButton | ImGuiComboFlags_NoPreview)) != (ImGuiComboFlags_NoArrowButton | ImGuiComboFlags_NoPreview)); // Can't use both flags together
     if (flags & ImGuiComboFlags_WidthFitPreview)
         IM_ASSERT((flags & (ImGuiComboFlags_NoPreview | (ImGuiComboFlags)ImGuiComboFlags_CustomPreview)) == 0);
@@ -2581,7 +2588,7 @@ bool ImGui::DragScalar(const char* label, ImGuiDataType data_type, void* p_data,
 
     ImGuiContext& g = *GImGui;
     const ImGuiStyle& style = g.Style;
-    const ImGuiID id = window->GetID(label);
+    const ImGuiID id = window->ReserveUniqueID(label);
     const float w = CalcItemWidth();
 
     const ImVec2 label_size = CalcTextSize(label, NULL, true);
@@ -3173,7 +3180,7 @@ bool ImGui::SliderScalar(const char* label, ImGuiDataType data_type, void* p_dat
 
     ImGuiContext& g = *GImGui;
     const ImGuiStyle& style = g.Style;
-    const ImGuiID id = window->GetID(label);
+    const ImGuiID id = window->ReserveUniqueID(label);
     const float w = CalcItemWidth();
 
     const ImVec2 label_size = CalcTextSize(label, NULL, true);
@@ -3341,7 +3348,7 @@ bool ImGui::VSliderScalar(const char* label, const ImVec2& size, ImGuiDataType d
 
     ImGuiContext& g = *GImGui;
     const ImGuiStyle& style = g.Style;
-    const ImGuiID id = window->GetID(label);
+    const ImGuiID id = window->ReserveUniqueID(label);
 
     const ImVec2 label_size = CalcTextSize(label, NULL, true);
     const ImRect frame_bb(window->DC.CursorPos, window->DC.CursorPos + size);
@@ -3556,6 +3563,8 @@ bool ImGui::TempInputText(const ImRect& bb, ImGuiID id, const char* label, char*
     // On the first frame, g.TempInputTextId == 0, then on subsequent frames it becomes == id.
     // We clear ActiveID on the first frame to allow the InputText() taking it back.
     ImGuiContext& g = *GImGui;
+    // TRKID: TempInputText reuses the widget ID, so we allow it temporarily (Push)
+    ImGui::PushAllowDuplicateID();
     const bool init = (g.TempInputId != id);
     if (init)
         ClearActiveID();
@@ -3568,6 +3577,8 @@ bool ImGui::TempInputText(const ImRect& bb, ImGuiID id, const char* label, char*
         IM_ASSERT(g.ActiveId == id);
         g.TempInputId = g.ActiveId;
     }
+    // TRKID: TempInputText reuses the widget ID, so we allow it temporarily (Pop)
+    ImGui::PopAllowDuplicateID();
     return value_changed;
 }
 
@@ -4284,7 +4295,7 @@ bool ImGui::InputTextEx(const char* label, const char* hint, char* buf, int buf_
 
     if (is_multiline) // Open group before calling GetID() because groups tracks id created within their scope (including the scrollbar)
         BeginGroup();
-    const ImGuiID id = window->GetID(label);
+    const ImGuiID id = window->ReserveUniqueID(label);
     const ImVec2 label_size = CalcTextSize(label, NULL, true);
     const ImVec2 frame_size = CalcItemSize(size_arg, CalcItemWidth(), (is_multiline ? g.FontSize * 8.0f : label_size.y) + style.FramePadding.y * 2.0f); // Arbitrary default of 8 lines high for multi-line
     const ImVec2 total_size = ImVec2(frame_size.x + (label_size.x > 0.0f ? style.ItemInnerSpacing.x + label_size.x : 0.0f), frame_size.y);
@@ -5978,7 +5989,7 @@ bool ImGui::ColorButton(const char* desc_id, const ImVec4& col, ImGuiColorEditFl
         return false;
 
     ImGuiContext& g = *GImGui;
-    const ImGuiID id = window->GetID(desc_id);
+    const ImGuiID id = window->ReserveUniqueID(desc_id);
     const float default_size = GetFrameHeight();
     const ImVec2 size(size_arg.x == 0.0f ? default_size : size_arg.x, size_arg.y == 0.0f ? default_size : size_arg.y);
     const ImRect bb(window->DC.CursorPos, window->DC.CursorPos + size);
@@ -6237,8 +6248,8 @@ bool ImGui::TreeNode(const char* label)
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
         return false;
-    ImGuiID id = window->GetID(label);
-    return TreeNodeBehavior(id, ImGuiTreeNodeFlags_None, label, NULL);
+    ImGuiID id = window->ReserveUniqueID(label);
+    return TreeNodeBehavior(id, 0, label, NULL);
 }
 
 bool ImGui::TreeNodeV(const char* str_id, const char* fmt, va_list args)
@@ -6256,7 +6267,7 @@ bool ImGui::TreeNodeEx(const char* label, ImGuiTreeNodeFlags flags)
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
         return false;
-    ImGuiID id = window->GetID(label);
+    ImGuiID id = window->ReserveUniqueID(label);
     return TreeNodeBehavior(id, flags, label, NULL);
 }
 
@@ -6284,7 +6295,7 @@ bool ImGui::TreeNodeExV(const char* str_id, ImGuiTreeNodeFlags flags, const char
     if (window->SkipItems)
         return false;
 
-    ImGuiID id = window->GetID(str_id);
+    ImGuiID id = window->ReserveUniqueID(str_id);
     const char* label, *label_end;
     ImFormatStringToTempBufferV(&label, &label_end, fmt, args);
     return TreeNodeBehavior(id, flags, label, label_end);
@@ -6299,6 +6310,9 @@ bool ImGui::TreeNodeExV(const void* ptr_id, ImGuiTreeNodeFlags flags, const char
     ImGuiID id = window->GetID(ptr_id);
     const char* label, *label_end;
     ImFormatStringToTempBufferV(&label, &label_end, fmt, args);
+
+    // TRKID: ImGui::TreeNodeExV uses GetID(void *) => this is the only place where I could not ensure uniqueness
+    // (all other calls use GetID(const char *)
     return TreeNodeBehavior(id, flags, label, label_end);
 }
 
@@ -6726,7 +6740,7 @@ bool ImGui::CollapsingHeader(const char* label, ImGuiTreeNodeFlags flags)
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
         return false;
-    ImGuiID id = window->GetID(label);
+    ImGuiID id = window->ReserveUniqueID(label);
     return TreeNodeBehavior(id, flags | ImGuiTreeNodeFlags_CollapsingHeader, label);
 }
 
@@ -6743,7 +6757,7 @@ bool ImGui::CollapsingHeader(const char* label, bool* p_visible, ImGuiTreeNodeFl
     if (p_visible && !*p_visible)
         return false;
 
-    ImGuiID id = window->GetID(label);
+    ImGuiID id = window->ReserveUniqueID(label);
     flags |= ImGuiTreeNodeFlags_CollapsingHeader;
     if (p_visible)
         flags |= ImGuiTreeNodeFlags_AllowOverlap | (ImGuiTreeNodeFlags)ImGuiTreeNodeFlags_ClipLabelForTrailingButton;
@@ -6787,7 +6801,7 @@ bool ImGui::Selectable(const char* label, bool selected, ImGuiSelectableFlags fl
     const ImGuiStyle& style = g.Style;
 
     // Submit label or explicit size to ItemSize(), whereas ItemAdd() will submit a larger/spanning rectangle.
-    ImGuiID id = window->GetID(label);
+    ImGuiID id = window->ReserveUniqueID(label);
     ImVec2 label_size = CalcTextSize(label, NULL, true);
     ImVec2 size(size_arg.x != 0.0f ? size_arg.x : label_size.x, size_arg.y != 0.0f ? size_arg.y : label_size.y);
     ImVec2 pos = window->DC.CursorPos;
@@ -8224,7 +8238,7 @@ int ImGui::PlotEx(ImGuiPlotType plot_type, const char* label, float (*values_get
         return -1;
 
     const ImGuiStyle& style = g.Style;
-    const ImGuiID id = window->GetID(label);
+    const ImGuiID id = window->ReserveUniqueID(label);
 
     const ImVec2 label_size = CalcTextSize(label, NULL, true);
     const ImVec2 frame_size = CalcItemSize(size_arg, CalcItemWidth(), label_size.y + style.FramePadding.y * 2.0f);
@@ -8647,6 +8661,9 @@ bool ImGui::BeginMenuEx(const char* label, const char* icon, bool enabled)
 
     ImGuiContext& g = *GImGui;
     const ImGuiStyle& style = g.Style;
+
+    // TRKID: In BeginMenuEx, We call GetID() instead of ReserveUniqueID() because were are not "consuming" this ID, instead, we are only querying IsPopupOpen().
+    // The ID will be consumed later by calling ImGui::PushID(label) + Selectable("") (which will lead to the same ID)
     const ImGuiID id = window->GetID(label);
     bool menu_is_open = IsPopupOpen(id, ImGuiPopupFlags_None);
 
@@ -9060,7 +9077,7 @@ bool    ImGui::BeginTabBar(const char* str_id, ImGuiTabBarFlags flags)
     if (window->SkipItems)
         return false;
 
-    ImGuiID id = window->GetID(str_id);
+    ImGuiID id = window->ReserveUniqueID(str_id);
     ImGuiTabBar* tab_bar = g.TabBars.GetOrAddByKey(id);
     ImRect tab_bar_bb = ImRect(window->DC.CursorPos.x, window->DC.CursorPos.y, window->WorkRect.Max.x, window->DC.CursorPos.y + g.FontSize + g.Style.FramePadding.y * 2);
     tab_bar->ID = id;


### PR DESCRIPTION
(fix for https://github.com/ocornut/imgui/issues/7669)

There is a common user issue which is that developers may reuse the same ID, and will not understand why their widget is not responsive.

This PR will:
* detect when the same ID is used on different widgets (only if the widget is hovered, to avoid a O(n^2) search at each frame)
* display a warning tooltip to the user, with hints on how to fix the issue (e.g. use PushID, or add a ## to the label)
* allow the user to break in the debugger on any of the widgets that use the same ID
* enable to disable the warning when needed (e.g. when reusing the ID is intentional, via PushAllowDuplicateID / PopAllowDuplicateID)
* enable to debug all duplicates at once (by defining IMGUI_DEBUG_PARANOID)

**View from 10,000 feet**

1. This PR adds a distinction between

```cpp
// Same as before
ImGuiID     GetID(const char* str, const char* str_end = NULL);
 ```
and
```cpp
// returns GetID(), but may display a warning tooltip if the ID is not unique. Should be called only once per frame with a given ID stack.
ImGuiID     ReserveUniqueID(const char* str_id);
```

This distinction was applied to several widgets inside imgui_widgets.cpp which now call ReserveUniqueID instead of GetID,
when their intention is to reserve a unique ID for the widget.

2. For grepability, most of the changes are highlighted with a comment `// TRKID`.
   The only changes which are not marked with this are where GetID() was simply replace by ReserveUniqueID() inside imgui_widgets.cpp
   These `// TRKID` comments should be removed before merging, and they are only here to help reviewing the changes.

3. The full `ImGui::ShowDemoWindow()` was reviewed to make sure that no duplicated ID was used.
   Very few changes were required, and they are detailed in the PR.

4. The tooltip will look like this
![image](https://github.com/user-attachments/assets/536e1409-b127-4f92-bc99-a50b3764462b)


5.See this video for a quick overview of the feature and how it is implemented:

https://traineq.org/ImGui/ImGui_PR_Warn_reuse_ID_Explanation.mp4

----

> _Note: if desired, a compile flag (e.g. IMGUI_NO_WARN_DUPLICATE_ID or its inverse) could be added to disable the warning and make ReserveUniqueID behave like GetID()_

Summary of changes
==================

struct ImGuiContext: added fields UidIXXX (UidsThisFrame & co)
--------------------------------------------------------------

Inside imgui_internal.h / struct ImGuiContext
```cpp
struct ImGuiContext
{
    ...
    // Declaration
    ImVector<ImGuiID>       UidsThisFrame;                      // A list of item IDs submitted this frame (used to detect and warn about duplicate ID usage).
    int                     UidAllowDuplicatesStack;            // Stack depth for allowing duplicate IDs (if > 0, duplicate IDs are allowed). See PushAllowDuplicateID / PopAllowDuplicateID
    ImGuiID                 UidHighlightedDuplicate;            // Will be set if a duplicated item is hovered (all duplicated items will appear with a red dot in the top left corner on the next frame)
    int                     UidHighlightedTimestamp;            // Timestamp (FrameCount) of the highlight (which will be shown on the next frame)
    bool                    UidWasTipDisplayed;                 // Will be set to true to avoid displaying multiple times the same tooltip
    ...

    // Constructor
    ImGuiContext(ImFontAtlas* shared_font_atlas) {
        ...
        UidsThisFrame.clear();
        UidAllowDuplicatesStack = 0;
        UidHighlightedDuplicate = 0;
        UidHighlightedTimestamp = 0;
        UidWasTipDisplayed = false;
        ...
    }
};
```

struct ImGuiWindow: added ReserveUniqueID(), beside GetID()
-----------------------------------------------------------

imgui_internal.h / near GetID() existing methods
```cpp
struct ImGuiWindow {
    ...
    // ReserveUniqueID: returns GetID(), but may display a warning. Should be called only once per frame with a given ID
    ImGuiID     ReserveUniqueID(const char* str_id);
    ...
};
```

Added PushAllowDuplicateID / PopAllowDuplicateID
------------------------------------------------

imgui_internal.h  / near related ID functions (SetActiveID, GetIDWithSeed, ...)
```cpp
    ...
    IMGUI_API void          PushAllowDuplicateID();         // Disables the tooltip warning when duplicate IDs are detected.
    IMGUI_API void          PopAllowDuplicateID();          // Re-enables the tooltip warning when duplicate IDs are detected.
    ...
```

imgui.cpp:3873 / near ReserveUniqueID() implementation
```cpp
IMGUI_API void ImGui::PushAllowDuplicateID()
{
    ImGuiContext& g = *GImGui;
    g.UidAllowDuplicatesStack++;
}

IMGUI_API void ImGui::PopAllowDuplicateID()
{
    ImGuiContext& g = *GImGui;
    IM_ASSERT(g.UidAllowDuplicatesStack > 0 && "Mismatched PopAllowDuplicateID()");
    g.UidAllowDuplicatesStack--;
}
```

> _Note: doing this via ItemFlags was not feasible as many items (e.g. Button, Checkbox) do not expose flags_

Main logic: ImGui::EndFrame(), NewFrame() and ImGuiWindow::ReserveUniqueID()
----------------------------------------------------------------------------

### ImGui::NewFrame():

```cpp
    ...
    g.UidsThisFrame.resize(0);  // Empty the list of items, but keep its allocated data
    g.UidWasTipDisplayed = false;
```

### ImGui::EndFrame():
```cpp
    IM_ASSERT(g.UidAllowDuplicatesStack == 0 && "Mismatched Push/PopAllowDuplicateID");
    if (g.UidHighlightedTimestamp != ImGui::GetFrameCount())
    {
        g.UidHighlightedTimestamp = 0;
        g.UidHighlightedDuplicate = 0;
    }
```

### ImGuiWindow::ReserveUniqueID()
in imgui.cpp, at the end of "[SECTION] ID STACK".
The pseudocode below summarizes its behavior:

```cpp
IMGUI_API ImGuiID ImGuiWindow::ReserveUniqueID(const char* str_id) {
    ImGuiContext& g = *GImGui;
    ImGuiID id = GetID(str_id);

    // If PushAllowDuplicateID was called, do not check for uniqueness
    if (g.UidAllowDuplicatesStack != 0)
    return id;

    // Visual aid: a red circle in the top-left corner of all widgets that use a duplicate of the id
    if (id == g.UidHighlightedDuplicate)
        Draw Red dot on top left corner

    // Only check for uniqueness if hovered (this avoid a O(n^2) search at each frame)
    if (id == ImGui::GetHoveredID())
    {
        if (g.UidsThisFrame.contains(id) && !g.UidWasTipDisplayed)
        {
            // Prepare highlight on the next frame for widgets that use this ID
            g.UidHighlightedDuplicate = id;
            g.UidHighlightedTimestamp = ImGui::GetFrameCount();
            if (ImGui::BeginTooltip())
            {
                if (! g.DebugItemPickerActive)
                {
                    // Display tooltip showing the duplicate Id as a string
                    ...
                    // Show hints for correction (PushID, ##)
                    ...

                    ImGui::Text("    Press Ctrl-P to break in any of those items    ");
                    if Ctrl-P
                        g.DebugItemPickerActive = true;
                }
                else
                {
                    // Add additional info at the bottom of the ItemPicker tooltip
                    ImGui::Text("Click on one of the widgets which uses a duplicated item");
                }
                ImGui::EndTooltip();
            }
            g.UidWasTipDisplayed = true;
        }
    }
    g.UidsThisFrame.push_back(id);
    return id;
}
```

imgui_widgets.cpp
-----------------

**Use ReserveUniqueID, allow duplicates when needed (TempInputText, BeginMenuEx)**
I went through all the usages of window->GetID() and changed them to ReserveUniqueID when it was possible / desirable.

### Places with one-line changes

In all the places below, the change was extremely simple: I simply replaced `window->GetID` by `window->ReserveUniqueID`.

For example, in ImGui::ButtonEx
```cpp
bool ImGui::ButtonEx(const char* label, const ImVec2& size_arg, ImGuiButtonFlags flags)
    ...
    const ImGuiID id = window->ReserveUniqueID(label);  // Instead of window->GetID
```

Below is the list of all function where this simple change was applied:
```cpp
    InvisibleButton
    ArrowButtonEx
    ImageButton  (both versions)
    Checkbox
    RadioButton
    BeginCombo
    DragScalar
    SliderScalar
    VSliderScalar
    InputTextEx
    ColorButton
    CollapsingHeader
    Selectable
    PlotEx
    BeginTabBar
    TextLink
    TreeNode(const char *)
    TreeNodeEx(const char *)
    TreeNodeExV(const char *)
```

### Places where duplicates are needed

#### TempInputText

TempInputText create text input in place of another active widget (e.g. used when doing a CTRL+Click on drag/slider widgets).
It reuses the widget ID, so we allow it temporarily via PushAllowDuplicateID / PopAllowDuplicateID
```cpp
bool ImGui::TempInputText(const ImRect& bb, ImGuiID id, const char* label, char* buf, int buf_size, ImGuiInputTextFlags flags)
{
    ImGui::PushAllowDuplicateID();
    ...
    ImGui::PopAllowDuplicateID();
}

```

#### GetWindowScrollbarID
GetWindowScrollbarID had to be split in two: ReserveWindowScrollbarID will perform the ID reservation, while GetWindowScrollbarID is only a query.
Luckily, this is the only instance where this was required.

#### BeginMenuEx

In BeginMenuEx, we initially call GetID() instead of ReserveUniqueID() because were are not "consuming" this ID:
instead, we are only querying IsPopupOpen().
The ID will be consumed later by calling ImGui::PushID(label) + Selectable("") (which will lead to the same ID)

```cpp
bool ImGui::BeginMenuEx(const char* label, const char* icon, bool enabled) {
    const ImGuiID id = window->GetID(label);
    bool menu_is_open = IsPopupOpen(id, ImGuiPopupFlags_None);

    ...

    PushID(label);
    pressed = Selectable("", menu_is_open, selectable_flags, ImVec2(w, label_size.y));

    ...
}
```

### Places with no changes, but worth mentioning

* TreeNode(const void *): unchanged
`TreeNode(const void* ptr_id)` and `TreeNodeExV(const void *)` are the only instances which call `window->GetID(const void *)`.
As a consequence, they cannot use the unique id mechanism, but I think their usage is rare enough that is not a big concern.

* ImGui::TabBarCalcTabID: unchanged
It still uses window->GetID, to avoid issues when merging with the docking branch.

* BeginChild, BeginPopup and co are unchanged:
  since they use ImGui::Begin()/End() internally), I suspect they might be called multiple times with the same string,
  since it is allowed with ImGui::Begin/End.

imgui_demo.cpp: some minor changes
----------------------------------

I went through the full demo Window to look for instances where a duplicate ID might be used, and corrected them.
Very few changes were required:

* **"Layout/Text Baseline Alignment"**: simple ID fix  (Added ##)
* **"Widgets/Plotting"**: simple id fix (Added ##)
* **"Columns (legacy API)/Borders"**: added ImGui::PushID for each cell
* **"Widgets/Drag and Drop/Drag to reorder items (simple)"**: no change, but a transient duplicate ID may appear during reordering
    (for *one* frame only: see comments in the code)

Demo code in order to test this PR
==================================

Add and call this function in any imgui example. This code will trigger the warnings for duplicated IDs,
and will also enable to make sure that the fixes that had to be done are OK.

```cpp
char text1[500] = "Hello,";
char text2[500] = "world!";
char text3[500] = "Hello,";
char text4[500] = "world!";
int value = 0;
bool flag1 = false, flag2 = false;
float f1 = 0.f, f2 = 0.f, f3 = 0.f, f4 = 0.f;

void Gui()
{
    // Some widgets to show the duplicated ID warnings
    ImGui::SetNextWindowSize(ImVec2(400, 500));
    if (ImGui::Begin("Duplicated ID examples", nullptr, ImGuiWindowFlags_MenuBar))
    {
        ImGui::TextWrapped("Example of widgets using duplicated IDs");
        ImGui::Separator();

        ImGui::TextWrapped("Only the first button is clickable (same ID)");
        if (ImGui::Button("button")) printf("Button1 pressed\n");
        if (ImGui::Button("button")) printf("Button2 pressed\n");

        ImGui::Separator();

        ImGui::TextWrapped("Those text inputs will share the same value (editing one will overwrite the other)");
        ImGui::InputText("text", text1, IM_ARRAYSIZE(text1));
        ImGui::InputText("text", text2, IM_ARRAYSIZE(text2));

        ImGui::Separator();

        ImGui::TextWrapped("Those radio buttons will share the same value (selecting one will overwrite the other)");
        ImGui::RadioButton("radio", &value, 0);
        ImGui::RadioButton("radio", &value, 1);

        ImGui::Separator();

        ImGui::TextWrapped("The second checkbox cannot be toggled");
        ImGui::Checkbox("checkbox", &flag1);
        ImGui::Checkbox("checkbox", &flag2);

        ImGui::Separator();

        ImGui::TextWrapped("Those two sliders will share the same value (editing one will overwrite the other");
        ImGui::SliderFloat("slider", &f1, 0.f, 1.f);
        ImGui::SliderFloat("slider", &f2, 0.f, 1.f);

        ImGui::Separator();
    }
    ImGui::End();

    // Some widgets to test the fixes that had to be done
    ImGui::SetNextWindowSize(ImVec2(400, 400));
    if (ImGui::Begin("Regression tests", nullptr, ImGuiWindowFlags_MenuBar))
    {
        ImGui::TextWrapped("Small issues had to be fixed inside DragFloat (cf TempInputText), InputTextMultiline and BeginMenuBar.\n"
            "This window is here to test those fixes.");

        ImGui::Separator();

        if (ImGui::BeginMenuBar())
        {
            if (ImGui::BeginMenu("My Menu"))
            {
                ImGui::MenuItem("Item 1");
                ImGui::EndMenu();
            }
            ImGui::EndMenuBar();
        }

        ImGui::TextWrapped("DragFloat will reuse the Item ID when double clicking. This is allowed via Push/PopAllowDuplicateID");
        ImGui::DragFloat("dragf", &f3);

        ImGui::Separator();

        ImGui::TextWrapped("An issue was fixed with the InputTextMultiline vertical scrollbar, which trigerred a duplicate ID warning, which was fixed");
        ImGui::InputTextMultiline("multiline", text1, 500);

    }
    ImGui::End();

    // A window that is populated in several steps should still detect duplicates
    {
        ImGui::SetNextWindowSize(ImVec2(400, 200));

        ImGui::Begin("Window populated in several steps");
        ImGui::TextWrapped("This window is populated between several ImGui::Begin/ImGui::End calls (with the same window name).\n"
                           "Duplicates should be detected anyhow.");
        ImGui::Text("A first InputText");
        ImGui::InputText("TTT", text3, 500);
        ImGui::End();

        ImGui::Begin("Window populated in several steps");
        ImGui::Separator();
        ImGui::Text("The second InputText below reuses the same ID, \nin a different ImGui::Begin/ImGui::End context \n(but with the same window name)");
        ImGui::InputText("TTT", text4, 500);
        ImGui::End();
    }
}
```
