### PR TITLE
Emscripten: Uses macOS behavior on macOS (using glfw contrib port) (part 2)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -527,6 +527,7 @@ jobs:
         emsdk-master/emsdk update
         emsdk-master/emsdk install latest
         emsdk-master/emsdk activate latest
+        sudo apt-get install build-essential
 
     - name: Build example_sdl2_opengl3 with Emscripten
       run: |
@@ -535,12 +536,25 @@ jobs:
         popd
         make -C examples/example_sdl2_opengl3 -f Makefile.emscripten
 
-    - name: Build example_glfw_wgpu
+    # This build compiles example_glfw_wgpu using Makefile.emscripten and Emscripten GLFW built-in implementation (-sUSE_GLFW=3)
+    # This ensures 2 things: the make build works, and the GLFW built-in implementation is tested
+    - name: Build example_glfw_wgpu with Emscripten/Makefile
       run: |
         pushd emsdk-master
         source ./emsdk_env.sh
         popd
         make -C examples/example_glfw_wgpu -f Makefile.emscripten
+
+    # This build compiles example_glfw_wgpu using CMakeLists.txt and Emscripten GLFW contrib port (--use-port=contrib.glfw3)
+    # This ensures 2 things: the CMake build works, and the GLFW contrib port is tested
+    - name: Build example_glfw_wgpu with Emscripten/CMake
+      run: |
+        pushd emsdk-master
+        source ./emsdk_env.sh
+        popd
+        emcc -v
+        emcmake cmake -B build -DCMAKE_BUILD_TYPE=Release examples/example_glfw_wgpu
+        cmake --build build
 
   Android:
     runs-on: ubuntu-24.04

--- a/examples/example_glfw_wgpu/CMakeLists.txt
+++ b/examples/example_glfw_wgpu/CMakeLists.txt
@@ -91,7 +91,6 @@ if(EMSCRIPTEN)
   if("${IMGUI_EMSCRIPTEN_GLFW3}" STREQUAL "--use-port=contrib.glfw3")
     target_compile_options(example_glfw_wgpu PUBLIC
         "${IMGUI_EMSCRIPTEN_GLFW3}"
-        "-DEMSCRIPTEN_USE_PORT_CONTRIB_GLFW3" # unnecessary beyond emscripten 3.1.59
     )
   endif()
   message(STATUS "Using ${IMGUI_EMSCRIPTEN_GLFW3} GLFW implementation")


### PR DESCRIPTION
Hi @ocornut 

This is the follow up that you requested in PR #7915 

This PR contains 2 **independent** commits for you to cherry pick:

<hr>

(1) this is the one that moves the code to use the macOS behavior to the `ImGui_ImplGlfw_Init` as you suggested. I also added comments and as I mentioned in the other PR, I created a [comprehensive documentation](https://github.com/pongasoft/emscripten-glfw/blob/master/docs/Comparison.md) to clearly explain the differences between the 2 implementations.

Note that this commit also includes a change to the `CMakeLists.txt` file as without this change you get a nasty warning and the check `#if EMSCRIPTEN_USE_PORT_CONTRIB_GLFW3 >= 34020240817` does not work

<hr>

(2) This second commit corresponds to the commit (1) in the other PR

> changed CI test to also test the CMakeLists build for `example_glfw_wgpu` and Emscripten: this tests the path when `emscripten-glfw` is used.

I still think that this is a worthwhile addition otherwise the piece of code I added in (1) is never tested in CI run...

<hr>

I paid ultra close attention to code style. I hope I got it right this time around ;)


