### PR TITLE
Backends: SDL2: use SDL_Vulkan_GetDrawableSize with Vulkan instead of SDL_GL_GetDrawableSize

### DIFF
--- a/backends/imgui_impl_sdl2.cpp
+++ b/backends/imgui_impl_sdl2.cpp
@@ -112,6 +112,9 @@
 #define SDL_HAS_CAPTURE_AND_GLOBAL_MOUSE    0
 #endif
 #define SDL_HAS_VULKAN                      SDL_VERSION_ATLEAST(2,0,6)
+#if SDL_HAS_VULKAN
+extern "C" { extern DECLSPEC void SDLCALL SDL_Vulkan_GetDrawableSize(SDL_Window* window, int* w, int* h); }
+#endif
 
 // SDL Data
 struct ImGui_ImplSDL2_Data
@@ -760,6 +763,10 @@ void ImGui_ImplSDL2_NewFrame()
         w = h = 0;
     if (bd->Renderer != nullptr)
         SDL_GetRendererOutputSize(bd->Renderer, &display_w, &display_h);
+#if SDL_HAS_VULKAN
+    else if (SDL_GetWindowFlags(bd->Window) & SDL_WINDOW_VULKAN)
+        SDL_Vulkan_GetDrawableSize(bd->Window, &display_w, &display_h);
+#endif
     else
         SDL_GL_GetDrawableSize(bd->Window, &display_w, &display_h);
     io.DisplaySize = ImVec2((float)w, (float)h);


### PR DESCRIPTION
Follow-up for issue https://github.com/ocornut/imgui/pull/3190

Currently, when using Vulkan, `SDL_GL_GetDrawableSize` will call `SDL_GetWindowSizeInPixels` (since `GL_GetDrawableSize` is NULL).
This works fine except on Cocoa, KMSDRM and UiKit as they have a `Vulkan_GetDrawableSize` defined and so they don't call `SDL_GetWindowSizeInPixels`. That's why `SDL_Vulkan_GetDrawableSize` is required instead of `SDL_GL_GetDrawableSize`
```
void SDL_GL_GetDrawableSize(SDL_Window * window, int *w, int *h)
{
    CHECK_WINDOW_MAGIC(window, );

    if (_this->GL_GetDrawableSize) {
        _this->GL_GetDrawableSize(_this, window, w, h);
    } else {
        SDL_GetWindowSizeInPixels(window, w, h);
    }
}
[...]
void SDL_Vulkan_GetDrawableSize(SDL_Window *window, int *w, int *h)
{
    CHECK_WINDOW_MAGIC(window, );

    if (_this->Vulkan_GetDrawableSize) {
        _this->Vulkan_GetDrawableSize(_this, window, w, h);
    } else {
        SDL_GetWindowSizeInPixels(window, w, h);
    }
}
```

```
device->Vulkan_GetDrawableSize = UIKit_Vulkan_GetDrawableSize;

device->Vulkan_GetDrawableSize = KMSDRM_Vulkan_GetDrawableSize;

device->Vulkan_GetDrawableSize = UIKit_Vulkan_GetDrawableSize;
```
Sources:
- https://github.com/libsdl-org/SDL/blob/9519b9916cd29a14587af0507292f2bd31dd5752/src/video/SDL_video.c#L4156-L4165
- https://github.com/libsdl-org/SDL/blob/9519b9916cd29a14587af0507292f2bd31dd5752/src/video/SDL_video.c#L4743-L4752
- https://github.com/libsdl-org/SDL/blob/9519b9916cd29a14587af0507292f2bd31dd5752/src/video/uikit/SDL_uikitvideo.m#L133
- https://github.com/libsdl-org/SDL/blob/9519b9916cd29a14587af0507292f2bd31dd5752/src/video/kmsdrm/SDL_kmsdrmvideo.c#L299
- https://github.com/libsdl-org/SDL/blob/9519b9916cd29a14587af0507292f2bd31dd5752/src/video/cocoa/SDL_cocoavideo.m#L158


