### PR TITLE
Bug with clamping values in DragScalar if limits the same

### DIFF
--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -2296,7 +2296,7 @@ bool ImGui::DataTypeApplyFromText(const char* buf, ImGuiDataType data_type, void
 template<typename T>
 static int DataTypeCompareT(const T* lhs, const T* rhs)
 {
-    if (*lhs < *rhs) return -1;
+    if (*lhs <= *rhs) return -1;
     if (*lhs > *rhs) return +1;
     return 0;
 }
@@ -2408,7 +2408,7 @@ bool ImGui::DragBehaviorT(ImGuiDataType data_type, TYPE* v, float v_speed, const
 {
     ImGuiContext& g = *GImGui;
     const ImGuiAxis axis = (flags & ImGuiSliderFlags_Vertical) ? ImGuiAxis_Y : ImGuiAxis_X;
-    const bool is_bounded = (v_min < v_max);
+    const bool is_bounded = (v_min <= v_max);
     const bool is_wrapped = is_bounded && (flags & ImGuiSliderFlags_WrapAround);
     const bool is_logarithmic = (flags & ImGuiSliderFlags_Logarithmic) != 0;
     const bool is_floating_point = (data_type == ImGuiDataType_Float) || (data_type == ImGuiDataType_Double);

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -2296,7 +2296,7 @@ bool ImGui::DataTypeApplyFromText(const char* buf, ImGuiDataType data_type, void
 template<typename T>
 static int DataTypeCompareT(const T* lhs, const T* rhs)
 {
-    if (*lhs <= *rhs) return -1;
+    if (*lhs < *rhs) return -1;
     if (*lhs > *rhs) return +1;
     return 0;
 }
@@ -2632,7 +2632,7 @@ bool ImGui::DragScalar(const char* label, ImGuiDataType data_type, void* p_data,
     if (temp_input_is_active)
     {
         // Only clamp CTRL+Click input when ImGuiSliderFlags_AlwaysClamp is set
-        const bool is_clamp_input = (flags & ImGuiSliderFlags_AlwaysClamp) != 0 && (p_min == NULL || p_max == NULL || DataTypeCompare(data_type, p_min, p_max) < 0);
+        const bool is_clamp_input = (flags & ImGuiSliderFlags_AlwaysClamp) != 0 && (p_min == NULL || p_max == NULL || DataTypeCompare(data_type, p_min, p_max) <= 0);
         return TempInputScalar(frame_bb, id, label, data_type, p_data, format, is_clamp_input ? p_min : NULL, is_clamp_input ? p_max : NULL);
     }
 


### PR DESCRIPTION
```
float minValue = -180.0f;
float maxValue = 1.0f;

{
    ImGui::Begin("Test DragScalar");

    ImGui::DragFloat("Min Limit", &minValue, 1.0f, -180.0f, maxValue, "%.3f", ImGuiSliderFlags_AlwaysClamp);
    ImGui::DragFloat("Max Limit", &maxValue, 1.0f, minValue, 180.0f, "%.3f", ImGuiSliderFlags_AlwaysClamp);

    ImGui::End();
}

```

If you change "Max Limit" to -180 then you can make "Min Limit" lower than -180, so PR fix this problem
