### PR TITLE
SDL3: Update ImGuiViewportFlags_NoTaskBarIcon win32 hack

### DIFF
--- a/backends/imgui_impl_sdl3.cpp
+++ b/backends/imgui_impl_sdl3.cpp
@@ -951,10 +951,7 @@ static void ImGui_ImplSDL3_CreateWindow(ImGuiViewport* viewport)
     sdl_flags |= SDL_GetWindowFlags(bd->Window);
     sdl_flags |= (viewport->Flags & ImGuiViewportFlags_NoDecoration) ? SDL_WINDOW_BORDERLESS : 0;
     sdl_flags |= (viewport->Flags & ImGuiViewportFlags_NoDecoration) ? 0 : SDL_WINDOW_RESIZABLE;
-#if !defined(_WIN32)
-    // See SDL hack in ImGui_ImplSDL3_ShowWindow().
     sdl_flags |= (viewport->Flags & ImGuiViewportFlags_NoTaskBarIcon) ? SDL_WINDOW_UTILITY : 0;
-#endif
     sdl_flags |= (viewport->Flags & ImGuiViewportFlags_TopMost) ? SDL_WINDOW_ALWAYS_ON_TOP : 0;
     vd->Window = SDL_CreateWindow("No Title Yet", (int)viewport->Size.x, (int)viewport->Size.y, sdl_flags);
     SDL_SetWindowParent(vd->Window, vd->ParentWindow);
@@ -992,13 +989,14 @@ static void ImGui_ImplSDL3_ShowWindow(ImGuiViewport* viewport)
 #if defined(_WIN32)
     HWND hwnd = (HWND)viewport->PlatformHandleRaw;
 
-    // SDL hack: Hide icon from task bar
-    // Note: SDL 3.0.0+ has a SDL_WINDOW_UTILITY flag which is supported under Windows but the way it create the window breaks our seamless transition.
-    if (viewport->Flags & ImGuiViewportFlags_NoTaskBarIcon)
+    // SDL hack: Show icon in task bar
+    // Note: SDL_WINDOW_UTILITY can be used to control task bar visibility, but on Windows, it does not affect child windows.
+    if (viewport->ParentViewportId != 0 && !(viewport->Flags & ImGuiViewportFlags_NoTaskBarIcon))
     {
         LONG ex_style = ::GetWindowLong(hwnd, GWL_EXSTYLE);
-        ex_style &= ~WS_EX_APPWINDOW;
-        ex_style |= WS_EX_TOOLWINDOW;
+        ex_style |= WS_EX_APPWINDOW;
+        ex_style &= ~WS_EX_TOOLWINDOW;
+        ::ShowWindow(hwnd, SW_HIDE);
         ::SetWindowLong(hwnd, GWL_EXSTYLE, ex_style);
     }
 #endif


### PR DESCRIPTION
This PR is a follow-up of https://github.com/ocornut/imgui/pull/7973.

It brings back full support for the ImGuiViewportFlags_NoTaskBarIcon, whether the viewport has a parent or not. If the viewport has a parent, the hack is still needed to reenable the task bar icon, because Win32 child windows aren't shown in the task bar by default and the SDL_WINDOW_UTILITY flag doesn't apply to them. On the other hand, if the viewport has no parent, the hack is not required and the SDL_WINDOW_UTILITY flag is enough.

If you wonder why I hide the window before calling SetWindowLong, it's because it's required to apply the change to the task bar.

I'm just puzzled about the comment for the SDL_WINDOW_UTILITY flag. I could not observe any adverse effect on the transition when a viewport is created, do you remember what the issue was?