### PR TITLE
SDL3: Use SDL_CreateWindowWithProperties instead of SDL_CreateWindow

### DIFF
--- a/backends/imgui_impl_sdl3.cpp
+++ b/backends/imgui_impl_sdl3.cpp
@@ -958,6 +958,8 @@ static void ImGui_ImplSDL3_CreateWindow(ImGuiViewport* viewport)
 #endif
     SDL_SetBooleanProperty(properties, SDL_PROP_WINDOW_CREATE_ALWAYS_ON_TOP_BOOLEAN, (viewport->Flags & ImGuiViewportFlags_TopMost));
     SDL_SetStringProperty(properties, SDL_PROP_WINDOW_CREATE_TITLE_STRING, "No Title Yet");
+    SDL_SetNumberProperty(properties, SDL_PROP_WINDOW_CREATE_WIDTH_NUMBER, (int)viewport->Size.x);
+    SDL_SetNumberProperty(properties, SDL_PROP_WINDOW_CREATE_HEIGHT_NUMBER, (int)viewport->Size.y);
     SDL_SetNumberProperty(properties, SDL_PROP_WINDOW_CREATE_X_NUMBER, (int)viewport->Pos.x);
     SDL_SetNumberProperty(properties, SDL_PROP_WINDOW_CREATE_Y_NUMBER, (int)viewport->Pos.y);
     SDL_SetPointerProperty(properties, SDL_PROP_WINDOW_CREATE_PARENT_POINTER, vd->ParentWindow);


### PR DESCRIPTION
SDL3 added a new function SDL_CreateWindowWithProperties which allows specifying more options before the window is created compared to SDL_CreateWindow.

The issue I tried to fix is described here: https://github.com/ocornut/imgui/pull/7989#issuecomment-2354000789

> If you disable the NoDecoration flag and drag a window outside the main viewport, you can sometimes see the frame on the new window in the top left corner of the screen.

It kinda works. You can still sometimes see the frame, but it's smaller and less apparent than before. It's not perfect, but it's still an improvement, and it is semantically more correct because it allows the SDL to set each option as early as possible on each platform, which is desired to avoid some eventual transition breaking effects due to parameters changed after the window creation. It also makes the code easier to read imo.