### PR TITLE
Add lightweight CMake setup for modular and scalable build configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ examples/example_sdl2_metal/example_sdl2_metal
 examples/example_sdl2_opengl2/example_sdl2_opengl2
 examples/example_sdl2_opengl3/example_sdl2_opengl3
 examples/example_sdl2_sdlrenderer/example_sdl2_sdlrenderer
+
+## User Playground
+playground/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(imgui)
+
+set(IMGUI_INC_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+add_library(imgui-core STATIC)
+target_sources(imgui-core PUBLIC imgui.cpp imgui_demo.cpp imgui_draw.cpp imgui_tables.cpp imgui_widgets.cpp)
+target_include_directories(imgui-core PUBLIC ${IMGUI_INC_DIR})
+
+add_subdirectory(misc)
+
+# Playground is a private space where dev might test/experiment/freestyle stuffs
+if(EXISTS playground)
+add_subdirectory(playground)
+endif()

--- a/imconfig.h
+++ b/imconfig.h
@@ -133,3 +133,8 @@ namespace ImGui
     void MyFunction(const char* name, MyMatrix44* mtx);
 }
 */
+#ifdef IMGUI_TLSCTX
+struct ImGuiContext;
+extern thread_local ImGuiContext* MyImGuiTLS;
+#define GImGui MyImGuiTLS
+#endif

--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_subdirectory(cpp)
+add_subdirectory(single_file)
+add_subdirectory(fonts)
+add_subdirectory(freetype)

--- a/misc/cpp/CMakeLists.txt
+++ b/misc/cpp/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(imgui-cpp STATIC)
+target_sources(imgui-cpp PUBLIC imgui_stdlib.cpp)
+target_include_directories(imgui-cpp PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} PRIVATE ${IMGUI_INC_DIR})

--- a/misc/fonts/CMakeLists.txt
+++ b/misc/fonts/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_executable(fonts-bin2compressed binary_to_compressed_c.cpp)

--- a/misc/freetype/CMakeLists.txt
+++ b/misc/freetype/CMakeLists.txt
@@ -1,0 +1,7 @@
+find_package(Freetype)
+if(Freetype_FOUND)
+add_library(imgui-freetype STATIC)
+target_include_directories(imgui-freetype PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} PRIVATE ${IMGUI_INC_DIR})
+target_sources(imgui-freetype PUBLIC imgui_freetype.cpp)
+target_link_libraries(imgui-freetype Freetype::Freetype)
+endif()

--- a/misc/single_file/CMakeLists.txt
+++ b/misc/single_file/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_library(imgui-jumbo INTERFACE)
+target_include_directories(imgui-jumbo INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION

This commit introduces a minimal and clean `CMake` setup aimed at maintaining the simplicity of the project. The goal is to provide a foundation for modular build configurations, allowing for future additions (e.g., `backend implementations`, `examples`) without introducing bloat.