### PR TITLE
ListBox: allow using horizontal scroll bar

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -692,6 +692,7 @@ namespace ImGui
     // - The simplified/old ListBox() api are helpers over BeginListBox()/EndListBox() which are kept available for convenience purpose. This is analoguous to how Combos are created.
     // - Choose frame width:   size.x > 0.0f: custom  /  size.x < 0.0f or -FLT_MIN: right-align   /  size.x = 0.0f (default): use current ItemWidth
     // - Choose frame height:  size.y > 0.0f: custom  /  size.y < 0.0f or -FLT_MIN: bottom-align  /  size.y = 0.0f (default): arbitrary default height which can fit ~7 items
+    IMGUI_API bool          BeginListBox(const char* label, const ImVec2& size, ImGuiChildFlags child_flags, ImGuiWindowFlags window_flags);
     IMGUI_API bool          BeginListBox(const char* label, const ImVec2& size = ImVec2(0, 0)); // open a framed scrolling region
     IMGUI_API void          EndListBox();                                                       // only call EndListBox() if BeginListBox() returned true!
     IMGUI_API bool          ListBox(const char* label, int* current_item, const char* const items[], int items_count, int height_in_items = -1);

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -8159,7 +8159,7 @@ void ImGuiSelectionExternalStorage::ApplyRequests(ImGuiMultiSelectIO* ms_io)
 // This is essentially a thin wrapper to using BeginChild/EndChild with the ImGuiChildFlags_FrameStyle flag for stylistic changes + displaying a label.
 // Tip: To have a list filling the entire window width, use size.x = -FLT_MIN and pass an non-visible label e.g. "##empty"
 // Tip: If your vertical size is calculated from an item count (e.g. 10 * item_height) consider adding a fractional part to facilitate seeing scrolling boundaries (e.g. 10.25 * item_height).
-bool ImGui::BeginListBox(const char* label, const ImVec2& size_arg)
+bool ImGui::BeginListBox(const char* label, const ImVec2& size_arg, ImGuiChildFlags child_flags, ImGuiWindowFlags window_flags)
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = GetCurrentWindow();
@@ -8196,8 +8196,13 @@ bool ImGui::BeginListBox(const char* label, const ImVec2& size_arg)
         AlignTextToFramePadding();
     }
 
-    BeginChild(id, frame_bb.GetSize(), ImGuiChildFlags_FrameStyle);
+    BeginChild(id, frame_bb.GetSize(), child_flags, window_flags);
     return true;
+}
+
+bool ImGui::BeginListBox(const char* label, const ImVec2& size_arg)
+{
+    return BeginListBox(label, size_arg, ImGuiChildFlags_FrameStyle, ImGuiWindowFlags_None);
 }
 
 void ImGui::EndListBox()


### PR DESCRIPTION
Allowing passing ImGuiChildFlags and ImGuiWindowFlags parameters to ListBox. This way horizontal scroll bar (and other BeginChild options) can be enabled if needed.