### PR TITLE
Demo: fixed resizing while maintaining aspect ratio constraint

### DIFF
--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -9117,11 +9117,33 @@ static void ShowExampleAppConstrainedResize(bool* p_open)
         static void AspectRatio(ImGuiSizeCallbackData* data)
         {
             float aspect_ratio = *(float*)data->UserData;
-            data->DesiredSize.y = (float)(int)(data->DesiredSize.x / aspect_ratio);
+            int current_cursor = ImGui::GetMouseCursor();
+            if(current_cursor == ImGuiMouseCursor_ResizeNWSE || current_cursor == ImGuiMouseCursor_ResizeNESW)
+            {
+				if(aspect_ratio > data->DesiredSize.x / data->DesiredSize.y)
+					data->DesiredSize.x = aspect_ratio * data->DesiredSize.y;
+				else
+					data->DesiredSize.y = data->DesiredSize.x / aspect_ratio;
+			}
+			else if(current_cursor == ImGuiMouseCursor_ResizeNS)
+				data->DesiredSize.x = aspect_ratio * data->DesiredSize.y;
+			else if(current_cursor == ImGuiMouseCursor_ResizeEW)
+				data->DesiredSize.y = data->DesiredSize.x / aspect_ratio;
         }
         static void Square(ImGuiSizeCallbackData* data)
         {
-            data->DesiredSize.x = data->DesiredSize.y = IM_MAX(data->DesiredSize.x, data->DesiredSize.y);
+            int current_cursor = ImGui::GetMouseCursor();
+            if(current_cursor == ImGuiMouseCursor_ResizeNWSE || current_cursor == ImGuiMouseCursor_ResizeNESW)
+            {
+				if(1.f > data->DesiredSize.x / data->DesiredSize.y)
+					data->DesiredSize.x = data->DesiredSize.y;
+				else
+					data->DesiredSize.y = data->DesiredSize.x;
+			}
+			else if(current_cursor == ImGuiMouseCursor_ResizeNS)
+				data->DesiredSize.x = data->DesiredSize.y;
+			else if(current_cursor == ImGuiMouseCursor_ResizeEW)
+				data->DesiredSize.y = data->DesiredSize.x;
         }
         static void Step(ImGuiSizeCallbackData* data)
         {


### PR DESCRIPTION
before version problem:
1. can't resize vertially with grap corner.
2. can't resize with grap top and bottom edges.
3. there is no status value to check which part of the window (corner, edge, etc.) is being used to resize the current window.

![Animation](https://github.com/user-attachments/assets/dd7dc280-7e9f-422b-b81d-34e78184119c)

my sollution is using mouse cursor status and aspect ratio of next window size

after version:

![Animation2](https://github.com/user-attachments/assets/5cf387aa-dc3f-49e5-8e3b-6c6175e9fd0c)

usage [my framebuffer viewport code](https://github.com/imdongye/imtoys/blob/bf0484815efcaca53bdafe94f57ce3cfbcbbaff0/limbrary/limbrary/model_view/viewports_and_imgui.cpp#L56)
