### PR TITLE
WebGPU: fix image leaks and allow reuse of WGPUTextureView

### DIFF
--- a/backends/imgui_impl_wgpu.cpp
+++ b/backends/imgui_impl_wgpu.cpp
@@ -67,7 +67,6 @@ struct RenderResources
     WGPUBuffer          Uniforms = nullptr;             // Shader uniforms
     WGPUBindGroup       CommonBindGroup = nullptr;      // Resources bind-group to bind the common resources to pipeline
     ImGuiStorage        ImageBindGroups;                // Resources bind-group to bind the font/image resources to pipeline (this is a key->value map)
-    WGPUBindGroup       ImageBindGroup = nullptr;       // Default font-resource of Dear ImGui
     WGPUBindGroupLayout ImageBindGroupLayout = nullptr; // Cache layout used for the image bind group. Avoids allocating unnecessary JS objects when working with WebASM
 };
 
@@ -241,7 +240,6 @@ static void SafeRelease(RenderResources& res)
     SafeRelease(res.Sampler);
     SafeRelease(res.Uniforms);
     SafeRelease(res.CommonBindGroup);
-    SafeRelease(res.ImageBindGroup);
     SafeRelease(res.ImageBindGroupLayout);
 };
 
@@ -715,10 +713,7 @@ bool ImGui_ImplWGPU_CreateDeviceObjects()
     common_bg_descriptor.entries = common_bg_entries;
     bd->renderResources.CommonBindGroup = wgpuDeviceCreateBindGroup(bd->wgpuDevice, &common_bg_descriptor);
 
-    WGPUBindGroup image_bind_group = ImGui_ImplWGPU_CreateImageBindGroup(bg_layouts[1], bd->renderResources.FontTextureView);
-    bd->renderResources.ImageBindGroup = image_bind_group;
     bd->renderResources.ImageBindGroupLayout = bg_layouts[1];
-    bd->renderResources.ImageBindGroups.SetVoidPtr(ImHashData(&bd->renderResources.FontTextureView, sizeof(ImTextureID)), image_bind_group);
 
     SafeRelease(vertex_shader_desc.module);
     SafeRelease(pixel_shader_desc.module);
@@ -778,7 +773,6 @@ bool ImGui_ImplWGPU_Init(ImGui_ImplWGPU_InitInfo* init_info)
     bd->renderResources.Uniforms = nullptr;
     bd->renderResources.CommonBindGroup = nullptr;
     bd->renderResources.ImageBindGroups.Data.reserve(100);
-    bd->renderResources.ImageBindGroup = nullptr;
     bd->renderResources.ImageBindGroupLayout = nullptr;
 
     // Create buffers with a default size (they will later be grown as needed)

--- a/backends/imgui_impl_wgpu.cpp
+++ b/backends/imgui_impl_wgpu.cpp
@@ -190,6 +190,15 @@ static void SafeRelease(WGPUBindGroup& res)
         wgpuBindGroupRelease(res);
     res = nullptr;
 }
+template <typename T>
+static void SafeRelease(ImGuiStorage& bind_groups_storage)
+{
+    for (int i = 0; i < bind_groups_storage.Data.size(); i++)
+    {
+        SafeRelease((T&)bind_groups_storage.Data[i].val_p);
+    }
+    bind_groups_storage.Clear();
+}
 static void SafeRelease(WGPUBuffer& res)
 {
     if (res)
@@ -816,6 +825,12 @@ void ImGui_ImplWGPU_NewFrame()
     ImGui_ImplWGPU_Data* bd = ImGui_ImplWGPU_GetBackendData();
     if (!bd->pipelineState)
         ImGui_ImplWGPU_CreateDeviceObjects();
+
+    // The user could have deallocated a stored texture, and
+    // potentially allocated a new one that has the same id as
+    // a previously registered one.
+    // To mitigate this, we release the registered bind groups.
+    SafeRelease<WGPUBindGroup>(bd->renderResources.ImageBindGroups);
 }
 
 //-----------------------------------------------------------------------------

--- a/backends/imgui_impl_wgpu.cpp
+++ b/backends/imgui_impl_wgpu.cpp
@@ -249,6 +249,7 @@ static void SafeRelease(RenderResources& res)
     SafeRelease(res.Sampler);
     SafeRelease(res.Uniforms);
     SafeRelease(res.CommonBindGroup);
+    SafeRelease<WGPUBindGroup>(res.ImageBindGroups);
     SafeRelease(res.ImageBindGroupLayout);
 };
 


### PR DESCRIPTION
Fixes https://github.com/ocornut/imgui/issues/7765 & https://github.com/ocornut/imgui/issues/8027.

A minor counterpart of removing `ImageBindGroup` is that it is now released an recreated each frame where a call to `ImGui::Image` is done to display default font texture. I'm not sure is this is really a performance issue, but it could be handled otherwise if needed.

Also I ma not sure of the pattern used for `SafeRelease<WGPUBindGroup>`. I'm not really familiar with ImGui's code style, so I am open to suggestion if you'd rather have this implemented differently.

