### PR TITLE
Vulkan: Control secondary viewports format and present mode 

### DIFF
--- a/backends/imgui_impl_vulkan.cpp
+++ b/backends/imgui_impl_vulkan.cpp
@@ -1483,17 +1483,17 @@ bool    ImGui_ImplVulkan_Init(ImGui_ImplVulkan_InitInfo* info)
         }
         if (create_pipeline)
         {
-            ImGui_ImplVulkan_MainPipelineCreateInfo info = {};
-            info.RenderPass = v->RenderPass;
-            info.Subpass = v->Subpass;
-            info.MSAASamples = info.MSAASamples;
-            info.pDynamicRendering = p_dynamic_rendering;
-            info.ColorCorrectionMethod = v->ColorCorrectionMethod;
+            ImGui_ImplVulkan_MainPipelineCreateInfo mp_info = {};
+            mp_info.RenderPass = v->RenderPass;
+            mp_info.Subpass = v->Subpass;
+            mp_info.MSAASamples = info->MSAASamples;
+            mp_info.pDynamicRendering = p_dynamic_rendering;
+            mp_info.ColorCorrectionMethod = v->ColorCorrectionMethod;
             if(v->UseStaticColorCorrectionsParams)
             {
-                info.ColorCorrectionParams = &v->ColorCorrectionParams;
+                mp_info.ColorCorrectionParams = &v->ColorCorrectionParams;
             }
-            ImGui_ImplVulkan_ReCreateMainPipeline(info);
+            ImGui_ImplVulkan_ReCreateMainPipeline(mp_info);
         }
     }
 
@@ -1630,7 +1630,7 @@ VkSurfaceFormatKHR ImGui_ImplVulkan_GetViewportOptimalSurfaceFormat(const ImGui_
         {
             candidate_color_space = bd->DesiredViewportsSurfaceFormat.colorSpace;
         }
-        surface_format = ImGui_ImplVulkanH_SelectSurfaceFormat(v->PhysicalDevice, wd->Surface, candidate_formats + first_candidate_format, IM_ARRAYSIZE(candidate_formats) - first_candidate_format, candidate_color_space);
+        surface_format = ImGui_ImplVulkanH_SelectSurfaceFormat(v->PhysicalDevice, wd->Surface, candidate_formats + first_candidate_format, static_cast<int>(IM_ARRAYSIZE(candidate_formats) - first_candidate_format), candidate_color_space);
     }
     return surface_format;
 }
@@ -1648,7 +1648,7 @@ VkPresentModeKHR ImGui_ImplVulkan_GetViewportOptimalPresentMode(const ImGui_Impl
         {
             first_present_mode = 1;
         }
-        present_mode = ImGui_ImplVulkanH_SelectPresentMode(v->PhysicalDevice, wd->Surface, present_modes + first_present_mode, IM_ARRAYSIZE(present_modes) - first_present_mode);
+        present_mode = ImGui_ImplVulkanH_SelectPresentMode(v->PhysicalDevice, wd->Surface, present_modes + first_present_mode, static_cast<int>(IM_ARRAYSIZE(present_modes) - first_present_mode));
     }
     return present_mode;
 }

--- a/backends/imgui_impl_vulkan.h
+++ b/backends/imgui_impl_vulkan.h
@@ -85,6 +85,15 @@ struct ImGui_ImplVulkan_ColorCorrectionParameters
     // GammaAlpha: alpha channel gamma
     float param3;
     float param4;
+
+    static inline ImGui_ImplVulkan_ColorCorrectionParameters MakeGamma(float gamma, float exposure = 1.0f, float alpha_gamma = 1.0f)
+    {
+        ImGui_ImplVulkan_ColorCorrectionParameters res = {};
+        res.param1 = gamma;
+        res.param2 = exposure;
+        res.param3 = alpha_gamma;
+        return res;
+    }
 };
 
 // Initialization data, for ImGui_ImplVulkan_Init()

--- a/backends/imgui_impl_vulkan.h
+++ b/backends/imgui_impl_vulkan.h
@@ -196,11 +196,14 @@ struct ImGui_ImplVulkanH_Frame;
 struct ImGui_ImplVulkanH_Window;
 
 // Helpers
-IMGUI_IMPL_API void                 ImGui_ImplVulkanH_CreateOrResizeWindow(VkInstance instance, VkPhysicalDevice physical_device, VkDevice device, ImGui_ImplVulkanH_Window* wd, uint32_t queue_family, const VkAllocationCallbacks* allocator, int w, int h, uint32_t min_image_count);
+// To create the pipeline, ImGui_ImplVulkan_Init(...) must have been called before!
+IMGUI_IMPL_API void                 ImGui_ImplVulkanH_CreateOrResizeWindow(VkInstance instance, VkPhysicalDevice physical_device, VkDevice device, ImGui_ImplVulkanH_Window* wd, uint32_t queue_family, const VkAllocationCallbacks* allocator, int w, int h, uint32_t min_image_count, bool create_pipeline = true);
 IMGUI_IMPL_API void                 ImGui_ImplVulkanH_DestroyWindow(VkInstance instance, VkDevice device, ImGui_ImplVulkanH_Window* wd, const VkAllocationCallbacks* allocator);
 IMGUI_IMPL_API VkSurfaceFormatKHR   ImGui_ImplVulkanH_SelectSurfaceFormat(VkPhysicalDevice physical_device, VkSurfaceKHR surface, const VkFormat* request_formats, int request_formats_count, VkColorSpaceKHR request_color_space);
 IMGUI_IMPL_API VkPresentModeKHR     ImGui_ImplVulkanH_SelectPresentMode(VkPhysicalDevice physical_device, VkSurfaceKHR surface, const VkPresentModeKHR* request_modes, int request_modes_count);
 IMGUI_IMPL_API int                  ImGui_ImplVulkanH_GetMinImageCountFromPresentMode(VkPresentModeKHR present_mode);
+// Create the pipeline of wd
+IMGUI_IMPL_API void                 ImGui_ImplVulkanH_CreateViewportPipeline(ImGui_ImplVulkanH_Window* wd, VkDevice device, const VkAllocationCallbacks* allocator);
 
 // Helper structure to hold the data needed by one rendering frame
 // (Used by example's main.cpp. Used by multi-viewport features. Probably NOT used by your own engine/app.)
@@ -232,7 +235,7 @@ struct ImGui_ImplVulkanH_Window
     VkSurfaceKHR        Surface;
     VkSurfaceFormatKHR  SurfaceFormat;
     VkPresentModeKHR    PresentMode;
-    VkRenderPass        RenderPass;             // Not owned by this
+    VkRenderPass        RenderPass;             // Ownedship determined by OwnsRenderPass
     VkPipeline          Pipeline;               // Owned by this
     VkClearValue        ClearValue;
     uint32_t            FrameIndex;             // Current frame being rendered to (0 <= FrameIndex < FrameInFlightCount)
@@ -243,6 +246,9 @@ struct ImGui_ImplVulkanH_Window
     ImGui_ImplVulkanH_FrameSemaphores*  FrameSemaphores;
 
     bool                RenderPassClear;
+    bool                UseDynamicRendering;
+    bool                UseStaticColorCorrectionParams;
+    bool                OwnsRenderPass;
 
     ImGui_ImplVulkanH_Window()
     {

--- a/backends/vulkan/generate_spv.sh
+++ b/backends/vulkan/generate_spv.sh
@@ -2,5 +2,6 @@
 ## -V: create SPIR-V binary
 ## -x: save binary output as text-based 32-bit hexadecimal numbers
 ## -o: output file
-glslangValidator -V -x -o glsl_shader.frag.u32 glsl_shader.frag
+glslangValidator -V -x -DUSE_SPEC_CONSTANT_PARAMS=1 -o glsl_shader_static.frag.u32  glsl_shader.frag
+glslangValidator -V -x -DUSE_SPEC_CONSTANT_PARAMS=0 -o glsl_shader_dynamic.frag.u32 glsl_shader.frag
 glslangValidator -V -x -o glsl_shader.vert.u32 glsl_shader.vert

--- a/backends/vulkan/glsl_shader.frag
+++ b/backends/vulkan/glsl_shader.frag
@@ -1,4 +1,9 @@
 #version 450 core
+
+#ifndef USE_SPEC_CONSTANT_PARAMS
+#define USE_SPEC_CONSTANT_PARAMS 0
+#endif
+
 layout(location = 0) out vec4 fColor;
 
 layout(set=0, binding=0) uniform sampler2D sTexture;
@@ -8,7 +13,43 @@ layout(location = 0) in struct {
     vec2 UV;
 } In;
 
+layout(constant_id = 0) const int color_correction_method = 0;
+#if USE_SPEC_CONSTANT_PARAMS
+layout(constant_id = 1) const float color_correction_param1 = 1.0f;
+layout(constant_id = 2) const float color_correction_param2 = 1.0f;
+layout(constant_id = 3) const float color_correction_param3 = 1.0f;
+layout(constant_id = 4) const float color_correction_param4 = 1.0f;
+#else
+layout(push_constant) uniform uPushConstant {
+    layout(offset = 16 + 4 * 0) float color_correction_param1;
+    layout(offset = 16 + 4 * 1) float color_correction_param2;
+    layout(offset = 16 + 4 * 2) float color_correction_param3;
+    layout(offset = 16 + 4 * 3) float color_correction_param4;
+};
+#endif
+
+vec4 ApplyColorCorrection(vec4 src)
+{
+    vec4 res = src;
+    if(color_correction_method == 1 || color_correction_method == 2)
+    {
+        const float gamma = color_correction_param1;
+        const float exposure = color_correction_param2;
+        res.rgb = exposure * pow(src.rgb, gamma.xxx);
+        if(color_correction_method == 2)
+        {
+            const float alpha_gamma = color_correction_param3;
+            res.a = pow(src.a, alpha_gamma);
+        }
+    }
+    return res;
+}
+
 void main()
 {
     fColor = In.Color * texture(sTexture, In.UV.st);
+    if(color_correction_method != 0)
+    {
+        fColor = ApplyColorCorrection(fColor);
+    }
 }

--- a/examples/example_glfw_vulkan/main.cpp
+++ b/examples/example_glfw_vulkan/main.cpp
@@ -252,6 +252,7 @@ static void SetupVulkan(ImVector<const char*> instance_extensions)
 static void SetupVulkanWindow(ImGui_ImplVulkanH_Window* wd, VkSurfaceKHR surface, int width, int height)
 {
     wd->Surface = surface;
+    wd->RenderPassClear = true;
 
     // Check for WSI support
     VkBool32 res;
@@ -278,7 +279,7 @@ static void SetupVulkanWindow(ImGui_ImplVulkanH_Window* wd, VkSurfaceKHR surface
 
     // Create SwapChain, RenderPass, Framebuffer, etc.
     IM_ASSERT(g_MinImageCount >= 2);
-    ImGui_ImplVulkanH_CreateOrResizeWindow(g_Instance, g_PhysicalDevice, g_Device, wd, g_QueueFamily, g_Allocator, width, height, g_MinImageCount);
+    ImGui_ImplVulkanH_CreateOrResizeWindow(g_Instance, g_PhysicalDevice, g_Device, wd, g_QueueFamily, g_Allocator, width, height, g_MinImageCount, false);
 }
 
 static void CleanupVulkan()
@@ -464,6 +465,8 @@ int main(int, char**)
     init_info.Allocator = g_Allocator;
     init_info.CheckVkResultFn = check_vk_result;
     ImGui_ImplVulkan_Init(&init_info);
+
+    ImGui_ImplVulkanH_CreateViewportPipeline(wd, g_Device, g_Allocator);
 
     // Load Fonts
     // - If no fonts are loaded, dear imgui will use the default font. You can also load multiple fonts and use ImGui::PushFont()/PopFont() to select them.

--- a/examples/example_sdl2_vulkan/main.cpp
+++ b/examples/example_sdl2_vulkan/main.cpp
@@ -240,6 +240,7 @@ static void SetupVulkan(ImVector<const char*> instance_extensions)
 static void SetupVulkanWindow(ImGui_ImplVulkanH_Window* wd, VkSurfaceKHR surface, int width, int height)
 {
     wd->Surface = surface;
+    wd->RenderPassClear = true;
 
     // Check for WSI support
     VkBool32 res;
@@ -266,7 +267,7 @@ static void SetupVulkanWindow(ImGui_ImplVulkanH_Window* wd, VkSurfaceKHR surface
 
     // Create SwapChain, RenderPass, Framebuffer, etc.
     IM_ASSERT(g_MinImageCount >= 2);
-    ImGui_ImplVulkanH_CreateOrResizeWindow(g_Instance, g_PhysicalDevice, g_Device, wd, g_QueueFamily, g_Allocator, width, height, g_MinImageCount);
+    ImGui_ImplVulkanH_CreateOrResizeWindow(g_Instance, g_PhysicalDevice, g_Device, wd, g_QueueFamily, g_Allocator, width, height, g_MinImageCount, false);
 }
 
 static void CleanupVulkan()
@@ -464,6 +465,8 @@ int main(int, char**)
     init_info.Allocator = g_Allocator;
     init_info.CheckVkResultFn = check_vk_result;
     ImGui_ImplVulkan_Init(&init_info);
+
+    ImGui_ImplVulkanH_CreateViewportPipeline(wd, g_Device, g_Allocator);
 
     // Load Fonts
     // - If no fonts are loaded, dear imgui will use the default font. You can also load multiple fonts and use ImGui::PushFont()/PopFont() to select them.


### PR DESCRIPTION


**API changes:**
See the [pull request](https://github.com/ocornut/imgui/pull/8053) for the master branch for the changes concerning the main window pipeline re-creation and addition of color correction. This PR extends these new features to ImGui's secondary viewports. 

1. **Concerning multi view ports:**

- Secondary viewports surface format and present mode can now be controlled by the application via ImGui_ImplVulkan_RequestSecondaryViewportsChanges(...)
- Secondary viewports can also use color correction if they use the application requested format.
- Each viewport now has its own VkRenderPass and VkPipeline (cached and shared in the backed data). This fits to the fact that each viewport might have a different format (the previous code was making the (quite reasonable) assumption that they all share the same format).
- Recycle some viewport resource on swapchain recreation if possible (CommandPool, CommandBuffer, Fence, Semaphores) rather than recreating them every time.

