### PR TITLE
Correct Integer Division to Prevent Precision Loss

### DIFF
--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -6061,7 +6061,7 @@ static void ShowDemoWindowTables()
             ImGui::TableHeadersRow();
             for (int column = 0; column < column_count; column++)
                 column_flags_out[column] = ImGui::TableGetColumnFlags(column);
-            float indent_step = (float)((int)TEXT_BASE_WIDTH / 2);
+            float indent_step = (float)((float)TEXT_BASE_WIDTH / 2);
             for (int row = 0; row < 8; row++)
             {
                 // Add some indentation to demonstrate usage of per-column IndentEnable/IndentDisable flags.
@@ -10646,7 +10646,7 @@ struct ExampleAssetsBrowser
                     // Manipulate scroll to that we will land at the same Y location of currently hovered item.
                     // - Calculate next frame position of item under mouse
                     // - Set new scroll position to be used in next ImGui::BeginChild() call.
-                    float hovered_item_rel_pos_y = ((float)(hovered_item_idx / LayoutColumnCount) + fmodf(hovered_item_ny, 1.0f)) * LayoutItemStep.y;
+                    float hovered_item_rel_pos_y = ((int)(hovered_item_idx / LayoutColumnCount) + fmodf(hovered_item_ny, 1.0f)) * LayoutItemStep.y;
                     hovered_item_rel_pos_y += ImGui::GetStyle().WindowPadding.y;
                     float mouse_local_y = io.MousePos.y - ImGui::GetWindowPos().y;
                     ImGui::SetScrollY(hovered_item_rel_pos_y - mouse_local_y);


### PR DESCRIPTION
### Description of Changes
- Fixed warning: "Result of integer division used in a floating point context; possible loss of precision."
- Changed integer division to ensure proper float handling.

### Development Environment
- **IDE**: Zed IDE
- **Compiler**: g++ version 13.2.0
- **Platform**: Linux 6.8.0-45-generic

### Warning Context
- The warning appeared in Zed IDE at lines 6064 and 10649.


