### PR TITLE
WIN32 + OpenGL 3: Allow WndProcHandler to receive contexts as argument so they do not rely in global variables and becomes thread safe

### DIFF
--- a/backends/imgui_impl_win32.h
+++ b/backends/imgui_impl_win32.h
@@ -33,7 +33,7 @@ IMGUI_IMPL_API void     ImGui_ImplWin32_NewFrame();
 // - Call from your application's message handler. Keep calling your message handler unless this function returns TRUE.
 
 #if 0
-extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
+extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam, ImGuiContext* imguiCxt);
 #endif
 
 // DPI-related helpers (optional)

--- a/examples/example_win32_opengl3/main.cpp
+++ b/examples/example_win32_opengl3/main.cpp
@@ -280,7 +280,7 @@ void CleanupDeviceWGL(HWND hWnd, WGL_WindowData* data)
 }
 
 // Forward declare message handler from imgui_impl_win32.cpp
-extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
+extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam, ImGuiContext* imguiCxt);
 
 // Win32 message handler
 // You can read the io.WantCaptureMouse, io.WantCaptureKeyboard flags to tell if dear imgui wants to use your inputs.
@@ -289,7 +289,7 @@ extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg
 // Generally you may always pass all inputs to dear imgui, and hide them from your application based on those two flags.
 LRESULT WINAPI WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
-    if (ImGui_ImplWin32_WndProcHandler(hWnd, msg, wParam, lParam))
+    if (ImGui_ImplWin32_WndProcHandler(hWnd, msg, wParam, lParam, ImGui::GetCurrentContext()))
         return true;
 
     switch (msg)


### PR DESCRIPTION
Hello,

I would like to first thank you for the hard work you've put in this very useful project.

I propose a small edit on the interfaces of the Win32 WndProc handler, to accept an arbitrary ImGui Context as input so they do not rely on the current context and it is thread safe. This allows to render multiple independent windows with their own context from one thread. This is mandatory, for example, to host ImGui windows from Windows Presentation Foundation (WPF), which results in a very powerful tool. 

Here I attach a screenshot of the resulting UI you can get by combining WPF and ImGui. It renders 4 fully independent ImGui applications, using a single auxiliary thread (e.g. a RenderThread).

I need this change to make it to work since at the time the WndProc function is called, it is possible that the RenderThread is currently drawing its frame, and the WndProc method would access an incorrect ImGuiIO or BackendData.

Thank you again.

Juan
![7EDE0972-9E82-4BAD-A121-7F5EA095F32D](https://github.com/user-attachments/assets/fcfb04bb-03d2-4cdc-a290-292aab7e77a1)
