### PR TITLE
Added missing prototype to ImGui_ImplGlfw_KeyToImGuiKey

### DIFF
--- a/backends/imgui_impl_glfw.cpp
+++ b/backends/imgui_impl_glfw.cpp
@@ -216,6 +216,9 @@ static void ImGui_ImplGlfw_ShutdownMultiViewportSupport();
 
 // Functions
 
+//Prototype to avoid -Werror=missing-declarations warning
+ImGuiKey ImGui_ImplGlfw_KeyToImGuiKey(int keycode, int scancode);
+
 // Not static to allow third-party code to use that if they want to (but undocumented)
 ImGuiKey ImGui_ImplGlfw_KeyToImGuiKey(int keycode, int scancode)
 {


### PR DESCRIPTION
Latest imgui has a -Wmissing-declarations warning so I added a prototype.

This PR adds the prototype to the .cpp rather than the .h as it appears the intent was for this to not be too public a function.

