### PR TITLE
Fixed copy/paste error in DebugModeWindow()

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -16351,7 +16351,7 @@ void ImGui::DebugNodeWindow(ImGuiWindow* window, const char* label)
     for (int layer = 0; layer < ImGuiNavLayer_COUNT; layer++)
     {
         ImRect r = window->NavRectRel[layer];
-        if (r.Min.x >= r.Max.y && r.Min.y >= r.Max.y)
+        if (r.Min.x >= r.Max.x && r.Min.y >= r.Max.y)
             BulletText("NavLastIds[%d]: 0x%08X", layer, window->NavLastIds[layer]);
         else
             BulletText("NavLastIds[%d]: 0x%08X at +(%.1f,%.1f)(%.1f,%.1f)", layer, window->NavLastIds[layer], r.Min.x, r.Min.y, r.Max.x, r.Max.y);


### PR DESCRIPTION
It is an obvious copy/paste error in computing the condition for showing debug text.

It was discovered by a static analysis tool Coverity.

