### PR TITLE
Backends: SDL2: Replace non-portable forward declaration with the actual include

### DIFF
--- a/backends/imgui_impl_sdl2.cpp
+++ b/backends/imgui_impl_sdl2.cpp
@@ -114,7 +114,7 @@
 #endif
 #define SDL_HAS_VULKAN                      SDL_VERSION_ATLEAST(2,0,6)
 #if SDL_HAS_VULKAN
-extern "C" { extern DECLSPEC void SDLCALL SDL_Vulkan_GetDrawableSize(SDL_Window* window, int* w, int* h); }
+#include <SDL_vulkan.h>
 #endif
 
 // SDL Data


### PR DESCRIPTION
In ScummVM project, we compile imgui on number of platforms.

On some platforms, the current forward declaration causes error on compilation with symbol redefinition:

```C++
In file included from backends/imgui/backends/imgui_impl_sdl2.cpp:1155:
/usr/include/SDL2/SDL_vulkan.h:204:30: error: conflicting declaration of ‘void SDL_Vulkan_GetDrawableSize(SDL_Window, int, int)’ with ‘C’ linkage
 extern DECLSPEC void SDLCALL SDL_Vulkan_GetDrawableSize(SDL_Window window,
                              ^~~~~~
backends/imgui/backends/imgui_impl_sdl2.cpp:132:30: note: previous declaration with ‘C++’ linkage
 extern DECLSPEC void SDLCALL SDL_Vulkan_GetDrawableSize(SDL_Window* window, int* w, int* h);
                              ^~~~~~
/usr/include/SDL2/SDL_vulkan.h:204:30: warning: redundant redeclaration of ‘void SDL_Vulkan_GetDrawableSize(SDL_Window, int, int)’ in same scope [-Wredundant-decls]
 extern DECLSPEC void SDLCALL SDL_Vulkan_GetDrawableSize(SDL_Window window,
                              ^~~~~~
backends/imgui/backends/imgui_impl_sdl2.cpp:132:30: note: previous declaration of ‘void SDL_Vulkan_GetDrawableSize(SDL_Window, int, int)’
 extern DECLSPEC void SDLCALL SDL_Vulkan_GetDrawableSize(SDL_Window window, int* w, int* h);

```

This patch replaces the declaration with a simple include, which makes sure there is no duplicate.

Thanks for your work on ImGui.
