### PR TITLE
Fix SDL3: Set viewport's parent SDL_window only if necessary.

### DIFF
--- a/backends/imgui_impl_sdl3.cpp
+++ b/backends/imgui_impl_sdl3.cpp
@@ -956,7 +956,11 @@ static void ImGui_ImplSDL3_CreateWindow(ImGuiViewport* viewport)
     sdl_flags |= (viewport->Flags & ImGuiViewportFlags_NoTaskBarIcon) ? SDL_WINDOW_UTILITY : 0;
     sdl_flags |= (viewport->Flags & ImGuiViewportFlags_TopMost) ? SDL_WINDOW_ALWAYS_ON_TOP : 0;
     vd->Window = SDL_CreateWindow("No Title Yet", (int)viewport->Size.x, (int)viewport->Size.y, sdl_flags);
-    SDL_SetWindowParent(vd->Window, vd->ParentWindow);
+    bool use_parent_window = !!vd->ParentWindow && (viewport->Flags & (ImGuiViewportFlags_TopMost));
+    if (use_parent_window)
+    {
+        SDL_SetWindowParent(vd->Window, vd->ParentWindow);
+    }
     SDL_SetWindowPosition(vd->Window, (int)viewport->Pos.x, (int)viewport->Pos.y);
     vd->WindowOwned = true;
     if (use_opengl)


### PR DESCRIPTION
**Problem:** 
With SDL3 backend and multi-viewports, secondary viewports are always shown on top of the main window (even if the main window is focused and thus should be on top). SDL2 impl does not have this issue.

**Source of the problem:**
When creating the secondary viewport's `SDL_Window`, it got linked to a parent window every time, and the OS (Windows 11 in my case) makes it appear always on top of the parent window. 
It appears to have been introduced by #7973 through commit 484764860d26e56ef000ca51972199ffae1e64d6.

**Solution:**
Only set the parent window if necessary. 
In this fix, it is done only for `ImGuiViewportFlags_TopMost` viewport, but the criteria can be improved. 
I guess it should be done only for viewports that directly depend from a parent viewport (like popups, modals, tooltips, color pickers and combos tempory viewport, ...). Maybe there should be an explicit `ImGuiViewportFlags_UseParentWindow`? 
