### PR TITLE
Release allocated demo memory (property editor demo)

### DIFF
--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -371,6 +371,26 @@ struct ImGuiDemoWindowData
 
     // Other data
     ExampleTreeNode* DemoTree = NULL;
+
+    // Destructor (purge all allocated demo data)
+    ~ImGuiDemoWindowData()
+    {
+        if (DemoTree != NULL)
+        {
+            // Assume there are only 3 levels of children hierarchy.
+            for (ExampleTreeNode* node_L1 : DemoTree->Childs)
+            {
+                for (ExampleTreeNode* node_L2 : node_L1->Childs)
+                {
+                    node_L2->Childs.clear_delete(); // delete L3 nodes.
+                }
+                node_L1->Childs.clear_delete(); // delete L2 nodes.
+            }
+            DemoTree->Childs.clear_delete(); // delete L1 nodes.
+            IM_DELETE(DemoTree); // delete L0 node.
+            DemoTree = NULL;
+        }
+    }
 };
 
 // Demonstrate most Dear ImGui features (this is big function!)


### PR DESCRIPTION
Hi !  
When testing the demos, I realized there is some memory associated with the "Property Editor" demo that is never explicitely released.

More specifically, the tree of ExampleTreeNode* children.

I could see that by using this declaration in my main.cpp, that I usually keep in all my projects (seems specific to VisualStudio) :
```
// Includes :
#define _CRTDBG_MAP_ALLOC
#include <stdlib.h>
#include <crtdbg.h>

// Inside main() :
_CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
```

This PR proposes to add a destructor on the demo data, to ensure all allocated memory is explicitely released and avoid leak logs when closing the application.

Since it only affects the application release it's probably not a problem though, so it's mostly some cleaning.

PS: I am not familiar with imgui internals, so don't hesitate if you want me to change some nomenclatures or move the code elsewhere !