### PR TITLE
Fonts: added IMGUI_DISABLE_DEFAULT_FONTS macro.

### DIFF
--- a/imconfig.h
+++ b/imconfig.h
@@ -49,6 +49,7 @@
 //#define IMGUI_DISABLE_DEFAULT_FILE_FUNCTIONS              // Don't implement ImFileOpen/ImFileClose/ImFileRead/ImFileWrite and ImFileHandle so you can implement them yourself if you don't want to link with fopen/fclose/fread/fwrite. This will also disable the LogToTTY() function.
 //#define IMGUI_DISABLE_DEFAULT_ALLOCATORS                  // Don't implement default allocators calling malloc()/free() to avoid linking with them. You will need to call ImGui::SetAllocatorFunctions().
 //#define IMGUI_DISABLE_SSE                                 // Disable use of SSE intrinsics even if available
+//#define IMGUI_DISABLE_DEFAULT_FONTS                       // Disable default font (ProggyClean.ttf) 
 
 //---- Enable Test Engine / Automation features.
 //#define IMGUI_ENABLE_TEST_ENGINE                          // Enable imgui_test_engine hooks. Generally set automatically by include "imgui_te_config.h", see Test Engine for details.

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -2560,7 +2560,9 @@ ImFont* ImFontAtlas::AddFont(const ImFontConfig* font_cfg)
 // Default font TTF is compressed with stb_compress then base85 encoded (see misc/fonts/binary_to_compressed_c.cpp for encoder)
 static unsigned int stb_decompress_length(const unsigned char* input);
 static unsigned int stb_decompress(unsigned char* output, const unsigned char* input, unsigned int length);
+#ifndef IMGUI_DISABLE_DEFAULT_FONTS
 static const char*  GetDefaultCompressedFontDataTTFBase85();
+#endif // #ifndef IMGUI_DISABLE_DEFAULT_FONTS
 static unsigned int Decode85Byte(char c)                                    { return c >= '\\' ? c-36 : c-35; }
 static void         Decode85(const unsigned char* src, unsigned char* dst)
 {
@@ -2576,6 +2578,7 @@ static void         Decode85(const unsigned char* src, unsigned char* dst)
 // Load embedded ProggyClean.ttf at size 13, disable oversampling
 ImFont* ImFontAtlas::AddFontDefault(const ImFontConfig* font_cfg_template)
 {
+#ifndef IMGUI_DISABLE_DEFAULT_FONTS
     ImFontConfig font_cfg = font_cfg_template ? *font_cfg_template : ImFontConfig();
     if (!font_cfg_template)
     {
@@ -2593,6 +2596,11 @@ ImFont* ImFontAtlas::AddFontDefault(const ImFontConfig* font_cfg_template)
     const ImWchar* glyph_ranges = font_cfg.GlyphRanges != NULL ? font_cfg.GlyphRanges : GetGlyphRangesDefault();
     ImFont* font = AddFontFromMemoryCompressedBase85TTF(ttf_compressed_base85, font_cfg.SizePixels, &font_cfg, glyph_ranges);
     return font;
+#else
+    IM_ASSERT(!"Default font disabled");
+    IM_UNUSED(font_cfg_template);
+    return nullptr;
+#endif // #ifndef IMGUI_DISABLE_DEFAULT_FONTS
 }
 
 ImFont* ImFontAtlas::AddFontFromFileTTF(const char* filename, float size_pixels, const ImFontConfig* font_cfg_template, const ImWchar* glyph_ranges)
@@ -2717,9 +2725,11 @@ bool    ImFontAtlas::Build()
 {
     IM_ASSERT(!Locked && "Cannot modify a locked ImFontAtlas between NewFrame() and EndFrame/Render()!");
 
+#ifndef IMGUI_DISABLE_DEFAULT_FONTS
     // Default font is none are specified
     if (ConfigData.Size == 0)
         AddFontDefault();
+#endif // #ifndef IMGUI_DISABLE_DEFAULT_FONTS
 
     // Select builder
     // - Note that we do not reassign to atlas->FontBuilderIO, since it is likely to point to static data which
@@ -4578,6 +4588,8 @@ static unsigned int stb_decompress(unsigned char *output, const unsigned char *i
 // Exported using misc/fonts/binary_to_compressed_c.cpp (with compression + base85 string encoding).
 // The purpose of encoding as base85 instead of "0x00,0x01,..." style is only save on _source code_ size.
 //-----------------------------------------------------------------------------
+
+#ifndef IMGUI_DISABLE_DEFAULT_FONTS
 static const char proggy_clean_ttf_compressed_data_base85[11980 + 1] =
     "7])#######hV0qs'/###[),##/l:$#Q6>##5[n42>c-TH`->>#/e>11NNV=Bv(*:.F?uu#(gRU.o0XGH`$vhLG1hxt9?W`#,5LsCp#-i>.r$<$6pD>Lb';9Crc6tgXmKVeU2cD4Eo3R/"
     "2*>]b(MC;$jPfY.;h^`IWM9<Lh2TlS+f-s$o6Q<BWH`YiU.xfLq$N;$0iR/GX:U(jcW2p/W*q?-qmnUCI;jHSAiFWM.R*kU@C=GH?a9wp8f$e.-4^Qg1)Q-GL(lf(r/7GrRgwV%MS=C#"
@@ -4670,5 +4682,6 @@ static const char* GetDefaultCompressedFontDataTTFBase85()
 {
     return proggy_clean_ttf_compressed_data_base85;
 }
+#endif // #ifndef IMGUI_DISABLE_DEFAULT_FONTS
 
 #endif // #ifndef IMGUI_DISABLE


### PR DESCRIPTION
## Summary

As of now, we can disable the demo (`IMGUI_DISABLE_DEMO_WINDOWS`) and debugging tools (`IMGUI_DISABLE_DEBUG_TOOLS`) to reduce executable size.

I noticed that it's common to load high-quality vector fonts from the OS font library. Default font (ProggyClean) performs best at 13px and gets blurry at other sizes. So we can add a macro `IMGUI_DISABLE_DEFAULT_FONTS` to disable it.

## Test

Tested with example_win32_directx11.

`IMGUI_DISABLE_DEMO_WINDOWS` and `IMGUI_DISABLE_DEBUG_TOOLS` are defined.

|`IMGUI_DISABLE_DEFAULT_FONTS` defined|size (in bytes)|
|---|---|
|NO|214,016 (100.0%)|
|YES|200,192 (93.54%)|

<details>
<summary>dir</summary>
<pre><code>D:\imgui\build\Release&gt;dir
 驱动器 D 中的卷是 Data
 卷的序列号是 C0C4-4173

 D:\imgui\build\Release 的目录

2024/11/19  03:20    &lt;DIR&gt;          .
2024/11/19  02:37    &lt;DIR&gt;          ..
2024/11/19  02:30           214,016 example_win32_d3d11.with.exe
2024/11/19  02:31           200,192 example_win32_d3d11.without.exe</code></pre>
</details>
