### PR TITLE
Fix SDL2 OpenGL3 example when compiling for WebGL2

### DIFF
--- a/backends/imgui_impl_opengl3.cpp
+++ b/backends/imgui_impl_opengl3.cpp
@@ -296,6 +296,8 @@ bool    ImGui_ImplOpenGL3_Init(const char* glsl_version)
     io.BackendRendererUserData = (void*)bd;
     io.BackendRendererName = "imgui_impl_opengl3";
 
+    const char* gl_version_str = (const char*)glGetString(GL_VERSION);
+
     // Query for GL version (e.g. 320 for GL 3.2)
 #if defined(IMGUI_IMPL_OPENGL_ES2)
     // GLES 2
@@ -303,7 +305,6 @@ bool    ImGui_ImplOpenGL3_Init(const char* glsl_version)
     bd->GlProfileIsES2 = true;
 #else
     // Desktop or GLES 3
-    const char* gl_version_str = (const char*)glGetString(GL_VERSION);
     GLint major = 0;
     GLint minor = 0;
     glGetIntegerv(GL_MAJOR_VERSION, &major);

--- a/examples/example_sdl2_opengl3/Makefile
+++ b/examples/example_sdl2_opengl3/Makefile
@@ -25,6 +25,7 @@ LINUX_GL_LIBS = -lGL
 
 CXXFLAGS = -std=c++11 -I$(IMGUI_DIR) -I$(IMGUI_DIR)/backends
 CXXFLAGS += -g -Wall -Wformat
+CXXFLAGS += -DIMGUI_IMPL_OPENGL_DEBUG
 LIBS =
 
 ##---------------------------------------------------------------------
@@ -68,6 +69,14 @@ ifeq ($(OS), Windows_NT)
     CFLAGS = $(CXXFLAGS)
 endif
 
+ifdef EMSCRIPTEN
+	ECHO_MESSAGE = "web"
+    EXE := $(EXE).html
+	CXXFLAGS += -DIMGUI_IMPL_OPENGL_ES2 # WebGL 1
+# 	CXXFLAGS += -DIMGUI_IMPL_OPENGL_ES3 # WebGL 2
+	LIBS = -s USE_SDL=2 -s MAX_WEBGL_VERSION=2
+endif
+
 ##---------------------------------------------------------------------
 ## BUILD RULES
 ##---------------------------------------------------------------------
@@ -88,4 +97,4 @@ $(EXE): $(OBJS)
 	$(CXX) -o $@ $^ $(CXXFLAGS) $(LIBS)
 
 clean:
-	rm -f $(EXE) $(OBJS)
+	rm -f $(EXE) $(EXE).html $(EXE).wasm $(EXE).js $(OBJS)

--- a/examples/example_sdl2_opengl3/main.cpp
+++ b/examples/example_sdl2_opengl3/main.cpp
@@ -35,11 +35,18 @@ int main(int, char**)
 
     // Decide GL+GLSL versions
 #if defined(IMGUI_IMPL_OPENGL_ES2)
-    // GL ES 2.0 + GLSL 100
+    // GL ES 2.0 + GLSL 100 (WebGL 1.0)
     const char* glsl_version = "#version 100";
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, 0);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
+#elif defined(IMGUI_IMPL_OPENGL_ES3)
+    // GL ES 3.0 + GLSL 300 es (WebGL 2.0)
+    const char* glsl_version = "#version 300 es";
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, 0);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
 #elif defined(__APPLE__)
     // GL 3.2 Core + GLSL 150
@@ -75,6 +82,12 @@ int main(int, char**)
     }
 
     SDL_GLContext gl_context = SDL_GL_CreateContext(window);
+    if (gl_context == nullptr)
+    {
+        printf("Error: SDL_GL_CreateContext(): %s\n", SDL_GetError());
+        return -1;
+    }
+    
     SDL_GL_MakeCurrent(window, gl_context);
     SDL_GL_SetSwapInterval(1); // Enable vsync
 


### PR DESCRIPTION
## The Issue

Attempting to build the SDL2 OpenGL3 example for WebGL 2.0 by adding the `IMGUI_IMPL_OPENGL_ES3` define resulted in a black browser window due to failing to create the GL context.

Additionally, the example would fail to compile when defining both `IMGUI_IMPL_OPENGL_DEBUG` and `IMGUI_IMPL_OPENGL_ES2`.

Tested on macOS 14.2 with an M2 chip. Browsers Safari 17.2 and Chrome Version 131.0.6778.86 (Official Build) (arm64).

## Changes in this PR

1. Add a check for successful context creation. This was helpful to diagnose my issue. Without this I got a slightly non-obvious JavaScript exception (at least to someone who doesn't use much JS).
2. Add `IMGUI_IMPL_OPENGL_ES3` case with attributes and GLSL version
	* Setting the attributes was enough to successfully create the GL context. But shader compilation failed without the GLSL version.
3. Fix a compile error when combining `IMGUI_IMPL_OPENGL_ES2` and `IMGUI_IMPL_OPENGL_DEBUG`
4. Add `-DIMGUI_IMPL_OPENGL_DEBUG` by default to the makefile. This was also helpful to diagnose my issues.
5. Add support for compiling the examples for web using `emmake make`. Invoking this way adds the `EMSCRIPTEN` define which we use to add the necessary flags. This would in theory incorrectly attempt to build for web if someone invoked `make` with an `EMSCRIPTEN` variable in their environment, but I don't know if that is a problem in practice.

After applying this fix I was able to successfully run the example with either a WebGL 1 or 2 context by defining `IMGUI_IMPL_OPENGL_ES2` or `IMGUI_IMPL_OPENGL_ES3`.

I have not tested building for ES3 on any OpenGL ES platforms, but without the `IMGUI_IMPL_OPENGL_ES3` case it's not clear to me what the expected behaviour was anyway?

## Other Info

For anyone not sure what's going on, the approach when compiling for WebGL via emscripten is to define either `IMGUI_IMPL_OPENGL_ES2` for WebGL 1 or `IMGUI_IMPL_OPENGL_ES3` for WebGL 2.

NB: to build for WebGL 2 with emscripten you also need to pass `-s MAX_WEBGL_VERSION=2` while linking (already added to the makefile in this PR).

To build the example for web you typically first source the emsdk script with `source /path/to/emscripten/install/emsdk_env.sh` then run the makefile with `emmake make`. This should create an html, js, and wasm file in the current directory.

Unfortunately you cannot just open the html file directly in your browser, you need to serve it somehow. If you have python 3 installed you can serve the current directory with `python3 -m http.server` then open the html file using the port it tells you. For me it was `localhost:8000/example_sdl2_opengl3.html`.

Related issue: https://github.com/ocornut/imgui/issues/1922

---

I hope this PR is helpful. Feel free to request changes, cherry pick, or do what you like with it.

Thanks for the awesome library!