### PR TITLE
Fix asset browser example window content size

### DIFF
--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -10175,7 +10175,7 @@ struct ExampleAssetsBrowser
         }
 
         ImGuiIO& io = ImGui::GetIO();
-        ImGui::SetNextWindowContentSize(ImVec2(0.0f, LayoutOuterPadding + LayoutLineCount * (LayoutItemSize.x + LayoutItemSpacing)));
+        ImGui::SetNextWindowContentSize(ImVec2(0.0f, LayoutOuterPadding + LayoutLineCount * (LayoutItemSize.y + LayoutItemSpacing)));
         if (ImGui::BeginChild("Assets", ImVec2(0.0f, -ImGui::GetTextLineHeightWithSpacing()), ImGuiChildFlags_Borders, ImGuiWindowFlags_NoMove))
         {
             ImDrawList* draw_list = ImGui::GetWindowDrawList();


### PR DESCRIPTION
Fix issue where all items are not displayed in the asset browser window when the item size is rectangular.

Unmodified (square):
![image](https://github.com/user-attachments/assets/62ae96d8-9bbb-44ab-8f2c-ebde0e9c69ea)

This issue can be reproduced by changing the LayoutItemSize so that it is not square:
` LayoutItemSize = ImVec2(floorf(IconSize), floorf(IconSize * 2));`

Before (rectangle):
![image](https://github.com/user-attachments/assets/80aca34f-eb30-4e03-ab5b-bad1f68973c0)

After (rectangle):
![image](https://github.com/user-attachments/assets/ae4ef7be-4c76-4ab8-a69a-4dbf3cc89323)



