### PR TITLE
Don't try to use SSE4.2 CRC intrinsics under Emscripten

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -2150,7 +2150,7 @@ void ImFormatStringToTempBufferV(const char** out_buf, const char** out_buf_end,
     }
 }
 
-#ifndef IMGUI_ENABLE_SSE4_2
+#if (!defined(IMGUI_ENABLE_SSE4_2)) || defined(EMSCRIPTEN)
 // CRC32 needs a 1KB lookup table (not cache friendly)
 // Although the code to generate the table is simple and shorter than the table itself, using a const table allows us to easily:
 // - avoid an unnecessary branch/memory tap, - keep the ImHashXXX functions usable by static constructors, - make it thread-safe.
@@ -2184,7 +2184,8 @@ ImGuiID ImHashData(const void* data_p, size_t data_size, ImGuiID seed)
     ImU32 crc = ~seed;
     const unsigned char* data = (const unsigned char*)data_p;
     const unsigned char *data_end = (const unsigned char*)data_p + data_size;
-#ifndef IMGUI_ENABLE_SSE4_2
+#if (!defined(IMGUI_ENABLE_SSE4_2)) || defined(EMSCRIPTEN)
+// _mm_crc32_u32 is not available on Emscripten: https://emscripten.org/docs/porting/simd.html#id11
     const ImU32* crc32_lut = GCrc32LookupTable;
     while (data < data_end)
         crc = (crc >> 8) ^ crc32_lut[(crc & 0xFF) ^ *data++];
@@ -2212,7 +2213,7 @@ ImGuiID ImHashStr(const char* data_p, size_t data_size, ImGuiID seed)
     seed = ~seed;
     ImU32 crc = seed;
     const unsigned char* data = (const unsigned char*)data_p;
-#ifndef IMGUI_ENABLE_SSE4_2
+#if (!defined(IMGUI_ENABLE_SSE4_2)) || defined(EMSCRIPTEN)
     const ImU32* crc32_lut = GCrc32LookupTable;
 #endif
     if (data_size != 0)
@@ -2222,7 +2223,8 @@ ImGuiID ImHashStr(const char* data_p, size_t data_size, ImGuiID seed)
             unsigned char c = *data++;
             if (c == '#' && data_size >= 2 && data[0] == '#' && data[1] == '#')
                 crc = seed;
-#ifndef IMGUI_ENABLE_SSE4_2
+#if (!defined(IMGUI_ENABLE_SSE4_2)) || defined(EMSCRIPTEN)
+// _mm_crc32_u8 is not available on Emscripten
             crc = (crc >> 8) ^ crc32_lut[(crc & 0xFF) ^ c];
 #else
             crc = _mm_crc32_u8(crc, c);
@@ -2235,7 +2237,8 @@ ImGuiID ImHashStr(const char* data_p, size_t data_size, ImGuiID seed)
         {
             if (c == '#' && data[0] == '#' && data[1] == '#')
                 crc = seed;
-#ifndef IMGUI_ENABLE_SSE4_2
+#if (!defined(IMGUI_ENABLE_SSE4_2)) || defined(EMSCRIPTEN)
+// _mm_crc32_u8 is not available on Emscripten
             crc = (crc >> 8) ^ crc32_lut[(crc & 0xFF) ^ c];
 #else
             crc = _mm_crc32_u8(crc, c);

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -61,7 +61,7 @@ Index of this file:
 #if (defined __SSE__ || defined __x86_64__ || defined _M_X64 || (defined(_M_IX86_FP) && (_M_IX86_FP >= 1))) && !defined(IMGUI_DISABLE_SSE)
 #define IMGUI_ENABLE_SSE
 #include <immintrin.h>
-#if (defined __AVX__ || defined __SSE4_2__) && !defined(EMSCRIPTEN)
+#if (defined __AVX__ || defined __SSE4_2__)
 #define IMGUI_ENABLE_SSE4_2
 #include <nmmintrin.h>
 #endif

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -61,7 +61,7 @@ Index of this file:
 #if (defined __SSE__ || defined __x86_64__ || defined _M_X64 || (defined(_M_IX86_FP) && (_M_IX86_FP >= 1))) && !defined(IMGUI_DISABLE_SSE)
 #define IMGUI_ENABLE_SSE
 #include <immintrin.h>
-#if (defined __AVX__ || defined __SSE4_2__)
+#if (defined __AVX__ || defined __SSE4_2__) && !defined(EMSCRIPTEN)
 #define IMGUI_ENABLE_SSE4_2
 #include <nmmintrin.h>
 #endif


### PR DESCRIPTION
A very simple change to avoid enabling SSE4 under Emscripten.

This is a workaround, as the latest changes in this WIP branch don't work with Emscripten when SSE4.2 is enabled.

It is possible to build Emscripten projects with SSE4.2 (see https://emscripten.org/docs/porting/simd.html) by passing flags `-msse4.2` and `-msimd128`, which will define `__SSE4_2__`.  However, symbols used here such as `_mm_crc32_u32` are not available.  Instead, Emscripten exposes a different set of [WebAssembly SIMD intrinsics](https://emscripten.org/docs/porting/simd.html#webassembly-simd-intrinsics).

This PR is just a workaround for now - an ideal solution would be to have `#ifdef EMSCRIPTEN` branches for each place that uses SIMD intrinsics, and provide WASM intrinsic equivalent in those places, as described in the article above.