### PR TITLE
Backends: DX12: let the user specifies the DepthStencilView format.

### DIFF
--- a/backends/imgui_impl_dx12.cpp
+++ b/backends/imgui_impl_dx12.cpp
@@ -72,6 +72,7 @@ struct ImGui_ImplDX12_Data
     ID3D12RootSignature*        pRootSignature;
     ID3D12PipelineState*        pPipelineState;
     DXGI_FORMAT                 RTVFormat;
+    DXGI_FORMAT                 DSVFormat;
     ID3D12DescriptorHeap*       pd3dSrvDescHeap;
     UINT                        numFramesInFlight;
 
@@ -569,6 +570,7 @@ bool    ImGui_ImplDX12_CreateDeviceObjects()
     psoDesc.SampleMask = UINT_MAX;
     psoDesc.NumRenderTargets = 1;
     psoDesc.RTVFormats[0] = bd->RTVFormat;
+    psoDesc.DSVFormat = bd->DSVFormat;
     psoDesc.SampleDesc.Count = 1;
     psoDesc.Flags = D3D12_PIPELINE_STATE_FLAG_NONE;
 
@@ -735,6 +737,7 @@ bool ImGui_ImplDX12_Init(ImGui_ImplDX12_InitInfo* init_info)
 
     bd->pd3dDevice = init_info->Device;
     bd->RTVFormat = init_info->RTVFormat;
+    bd->DSVFormat = init_info->DSVFormat;
     bd->numFramesInFlight = init_info->NumFramesInFlight;
     bd->pd3dSrvDescHeap = init_info->SrvDescriptorHeap;
 

--- a/backends/imgui_impl_dx12.h
+++ b/backends/imgui_impl_dx12.h
@@ -30,6 +30,7 @@ struct ImGui_ImplDX12_InitInfo
     ID3D12CommandQueue*         CommandQueue;
     int                         NumFramesInFlight;
     DXGI_FORMAT                 RTVFormat;
+    DXGI_FORMAT                 DSVFormat;
     void*                       UserData;
 
     // Allocating SRV descriptors for textures is up to the application, so we provide callbacks.


### PR DESCRIPTION
This is particullarly important for those who use RenderPasses

Let me explain the problem:

with this snippet:

`
m_CurrentBufferIndex = m_SwapChain->GetCurrentBackBufferIndex();
auto backBuffer = m_RenderTargets[m_CurrentBufferIndex];
auto rtvHandle = m_RTVHandles[m_CurrentBufferIndex];
auto dsvHandle = m_DSVHandle;

D3D12_RESOURCE_BARRIER rtSetupBarrier{};
rtSetupBarrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
rtSetupBarrier.Transition.pResource = backBuffer.Get();
rtSetupBarrier.Transition.StateBefore = D3D12_RESOURCE_STATE_PRESENT;
rtSetupBarrier.Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
rtSetupBarrier.Transition.Subresource = 0;
rtSetupBarrier.Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;

m_CommandLists[m_CurrentBufferIndex]->ResourceBarrier(1, &rtSetupBarrier);

D3D12_RENDER_PASS_RENDER_TARGET_DESC renderTargetDesc = {};
renderTargetDesc.cpuDescriptor = rtvHandle;
renderTargetDesc.BeginningAccess.Type = D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_CLEAR;
renderTargetDesc.BeginningAccess.Clear.ClearValue = m_ClearColor;
renderTargetDesc.EndingAccess.Type = D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE;

//D24_S8 dsv
D3D12_RENDER_PASS_DEPTH_STENCIL_DESC depthStencilDesc = {};
depthStencilDesc.cpuDescriptor = m_DSVHandle;
depthStencilDesc.DepthBeginningAccess.Type = D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_CLEAR;
depthStencilDesc.DepthBeginningAccess.Clear.ClearValue.DepthStencil.Depth = 1.0f;
depthStencilDesc.DepthBeginningAccess.Clear.ClearValue.DepthStencil.Stencil = 0;
depthStencilDesc.DepthEndingAccess.Type = D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE;

m_CommandLists[m_CurrentBufferIndex]->BeginRenderPass(1, &renderTargetDesc, &depthStencilDesc, D3D12_RENDER_PASS_FLAG_NONE);
`

and the previous version, the render was throwing:
`D3D12 ERROR: ID3D12CommandList::DrawIndexedInstanced: The PSO indicates a format of DXGI_FORMAT_UNKNOWN to be bound to the rasterizer, but the render pass depth stencil descriptor indicates an incompatible format (DXGI_FORMAT_D24_UNORM_S8_UINT). [ EXECUTION ERROR #1170: RENDER_PASS_ERROR]`

This snippet is to the use set also the DSV format to the Imgui PSO.

