### PR TITLE
Fixed missing symbols when using IMGUI_DISABLE_DEMO_WINDOWS

### DIFF
--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -10397,6 +10397,8 @@ void ImGui::ShowAboutWindow(bool*) {}
 void ImGui::ShowDemoWindow(bool*) {}
 void ImGui::ShowUserGuide() {}
 void ImGui::ShowStyleEditor(ImGuiStyle*) {}
+bool ImGui::ShowStyleSelector(const char* label) { return false; }
+void ImGui::ShowFontSelector(const char* label) {}
 
 #endif
 


### PR DESCRIPTION
When using IMGUI_DISABLE_DEMO_WINDOWS  with [ImPlot](https://github.com/epezent/implot) it will complain about missing symbols. It appears that some of the functions in ImGui.h don't end up with stub implementations.

This just adds the missing stubs for ImGui Demo so ImPlot can still compile when the Demo window is disabled.

Spotted in a CMake project whilst exposing some options from ImGui/ImPlot. 

