### PR TITLE
ImGui_ImplAllegro5_UpdateMouseCursor should not create a new cursor each frame

### DIFF
--- a/backends/imgui_impl_allegro5.cpp
+++ b/backends/imgui_impl_allegro5.cpp
@@ -98,6 +98,7 @@ struct ImGui_ImplAllegro5_Data
 
     ImVector<ImDrawVertAllegro> BufVertices;
     ImVector<int>               BufIndices;
+    ImGuiMouseCursor            CursorCache;
 
     ImGui_ImplAllegro5_Data()   { memset((void*)this, 0, sizeof(*this)); }
 };
@@ -568,7 +569,19 @@ static void ImGui_ImplAllegro5_UpdateMouseCursor()
 
     ImGui_ImplAllegro5_Data* bd = ImGui_ImplAllegro5_GetBackendData();
     ImGuiMouseCursor imgui_cursor = ImGui::GetMouseCursor();
-    if (io.MouseDrawCursor || imgui_cursor == ImGuiMouseCursor_None)
+
+    if (io.MouseDrawCursor) {
+        // Hide OS mouse cursor if imgui is drawing it
+        imgui_cursor = ImGuiMouseCursor_None;
+    }
+
+    if (bd->CursorCache == imgui_cursor) {
+        return;
+    }
+
+    bd->CursorCache = imgui_cursor;
+
+    if (imgui_cursor == ImGuiMouseCursor_None)
     {
         // Hide OS mouse cursor if imgui is drawing it or if it wants no cursor
         al_set_mouse_cursor(bd->Display, bd->MouseCursorInvisible);


### PR DESCRIPTION
Currently, ImGui sends a call to Allegro each time a frame is drawn, either reusing a stored invisible cursor or creating a new system cursor.

Allegro currently has a memory leak in its X11 interface (see [this Allegro PR](https://github.com/liballeg/allegro5/pull/1604)) where system cursors are not cleared when a new one is generated. This paired with creating a new cursor each frame results in a leak that results in an XWayland abort within 10 minutes (see [this xorg bug report](https://gitlab.freedesktop.org/xorg/xserver/-/issues/1773))

This fix reduces the amount of unnecessary cursor creations by caching which cursor is currently being rendered, and only creating a new one when it changes. This does not fix the memory leak, but heavily mitigates its effect.