### PR TITLE
Fix scrollbar rect not respecting border size in all cases

### DIFF
--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -915,9 +915,9 @@ ImRect ImGui::GetWindowScrollbarRect(ImGuiWindow* window, ImGuiAxis axis)
     const float scrollbar_size = window->ScrollbarSizes[axis ^ 1]; // (ScrollbarSizes.x = width of Y scrollbar; ScrollbarSizes.y = height of X scrollbar)
     IM_ASSERT(scrollbar_size > 0.0f);
     if (axis == ImGuiAxis_X)
-        return ImRect(inner_rect.Min.x, ImMax(outer_rect.Min.y, outer_rect.Max.y - border_size - scrollbar_size), inner_rect.Max.x - border_size, outer_rect.Max.y - border_size);
+        return ImRect(inner_rect.Min.x + border_size, ImMax(outer_rect.Min.y + border_size, outer_rect.Max.y - border_size - scrollbar_size), inner_rect.Max.x - border_size, outer_rect.Max.y - border_size);
     else
-        return ImRect(ImMax(outer_rect.Min.x, outer_rect.Max.x - border_size - scrollbar_size), inner_rect.Min.y, outer_rect.Max.x - border_size, inner_rect.Max.y - border_size);
+        return ImRect(ImMax(outer_rect.Min.x + border_size, outer_rect.Max.x - border_size - scrollbar_size), inner_rect.Min.y + border_size, outer_rect.Max.x - border_size, inner_rect.Max.y - border_size);
 }
 
 void ImGui::Scrollbar(ImGuiAxis axis)


### PR DESCRIPTION
Steps to repro:
1. open the imgui_examples project and run it
2. open style editor, set the child border size to 6 or higher to see bug clearly using arrow keys and enter key to set custom size
3. navigate to scrolling section, observe the scrollbar placements for vertical and horizontal

Result:
Before this bug fix, the window border overlaps the top of the scrollbar for vertical and left of the scrollbar for horizontal.

(size 12 to be very obvious)
![image](https://github.com/user-attachments/assets/6355377e-a926-4b30-9478-f8ca9779c0b6)


Image Fixed (size 6):
![image](https://github.com/user-attachments/assets/c6af1e4c-e136-4c7e-891a-19c3d3850464)
 