### PR TITLE
Fix metal backend memory leaks

### DIFF
--- a/backends/imgui_impl_metal.mm
+++ b/backends/imgui_impl_metal.mm
@@ -3,7 +3,7 @@
 
 // Implemented features:
 //  [X] Renderer: User texture binding. Use 'MTLTexture' as ImTextureID. Read the FAQ about ImTextureID!
-//  [X] Renderer: Large meshes support (64k+ vertices) with 16-bit indices.
+//  [X] Renderer: Large meshes support (64k+ vertices) even with 16-bit indices (ImGuiBackendFlags_RendererHasVtxOffset).
 
 // You can use unmodified imgui_impl_* files in your project. See examples/ folder for examples of using this.
 // Prefer including the entire imgui/ repository into your project (either as a copy or as a submodule), and only build the backends you need.

--- a/backends/imgui_impl_metal.mm
+++ b/backends/imgui_impl_metal.mm
@@ -363,12 +363,14 @@ void ImGui_ImplMetal_DestroyFontsTexture()
 bool ImGui_ImplMetal_CreateDeviceObjects(id<MTLDevice> device)
 {
     ImGui_ImplMetal_Data* bd = ImGui_ImplMetal_GetBackendData();
-    MTLDepthStencilDescriptor* depthStencilDescriptor = [[[MTLDepthStencilDescriptor alloc] init] autorelease];
+    MTLDepthStencilDescriptor* depthStencilDescriptor = [[MTLDepthStencilDescriptor alloc] init];
     depthStencilDescriptor.depthWriteEnabled = NO;
     depthStencilDescriptor.depthCompareFunction = MTLCompareFunctionAlways;
-    bd->SharedMetalContext.depthStencilState = [device newDepthStencilStateWithDescriptor:depthStencilDescriptor];
-    ImGui_ImplMetal_CreateFontsTexture(device);
 
+    bd->SharedMetalContext.depthStencilState = [device newDepthStencilStateWithDescriptor:depthStencilDescriptor];
+    [depthStencilDescriptor release];
+
+    ImGui_ImplMetal_CreateFontsTexture(device);
     return true;
 }
 
@@ -376,6 +378,8 @@ void ImGui_ImplMetal_DestroyDeviceObjects()
 {
     ImGui_ImplMetal_Data* bd = ImGui_ImplMetal_GetBackendData();
     ImGui_ImplMetal_DestroyFontsTexture();
+    [bd->SharedMetalContext.depthStencilState release];
+    bd->SharedMetalContext.depthStencilState = nil;
     [bd->SharedMetalContext.renderPipelineStateCache removeAllObjects];
 }
 

--- a/backends/imgui_impl_metal.mm
+++ b/backends/imgui_impl_metal.mm
@@ -154,17 +154,15 @@ void ImGui_ImplMetal_Shutdown()
 
 void ImGui_ImplMetal_NewFrame(MTLRenderPassDescriptor* renderPassDescriptor)
 {
-   ImGui_ImplMetal_Data* bd = ImGui_ImplMetal_GetBackendData();
-   IM_ASSERT(bd != nil && "Context or backend not initialized! Did you call ImGui_ImplMetal_Init()?");
-
+    ImGui_ImplMetal_Data* bd = ImGui_ImplMetal_GetBackendData();
+    IM_ASSERT(bd != nil && "Context or backend not initialized! Did you call ImGui_ImplMetal_Init()?");
 #ifdef IMGUI_IMPL_METAL_CPP
-   bd->SharedMetalContext.framebufferDescriptor = (__bridge FramebufferDescriptor*)CFBridgingRelease([[FramebufferDescriptor alloc] initWithRenderPassDescriptor:(__bridge MTLRenderPassDescriptor*)renderPassDescriptor]);
+    bd->SharedMetalContext.framebufferDescriptor = [[[FramebufferDescriptor alloc] initWithRenderPassDescriptor:renderPassDescriptor]autorelease];
 #else
-   bd->SharedMetalContext.framebufferDescriptor = [[FramebufferDescriptor alloc] initWithRenderPassDescriptor:renderPassDescriptor];
+    bd->SharedMetalContext.framebufferDescriptor = [[FramebufferDescriptor alloc] initWithRenderPassDescriptor:renderPassDescriptor];
 #endif
-
-   if (bd->SharedMetalContext.depthStencilState == nil)
-       ImGui_ImplMetal_CreateDeviceObjects(bd->SharedMetalContext.device);
+    if (bd->SharedMetalContext.depthStencilState == nil)
+        ImGui_ImplMetal_CreateDeviceObjects(bd->SharedMetalContext.device);
 }
 
 static void ImGui_ImplMetal_SetupRenderState(ImDrawData* drawData, id<MTLCommandBuffer> commandBuffer,
@@ -364,28 +362,16 @@ void ImGui_ImplMetal_DestroyFontsTexture()
 
 bool ImGui_ImplMetal_CreateDeviceObjects(id<MTLDevice> device)
 {
-   ImGui_ImplMetal_Data* bd = ImGui_ImplMetal_GetBackendData();
-
+    ImGui_ImplMetal_Data* bd = ImGui_ImplMetal_GetBackendData();
+    MTLDepthStencilDescriptor* depthStencilDescriptor = [[MTLDepthStencilDescriptor alloc] init];
+    depthStencilDescriptor.depthWriteEnabled = NO;
+    depthStencilDescriptor.depthCompareFunction = MTLCompareFunctionAlways;
+    bd->SharedMetalContext.depthStencilState = [device newDepthStencilStateWithDescriptor:depthStencilDescriptor];
 #ifdef IMGUI_IMPL_METAL_CPP
-   @autoreleasepool {
-       MTLDepthStencilDescriptor* depthStencilDescriptor = [MTLDepthStencilDescriptor new];
-       depthStencilDescriptor.depthWriteEnabled = NO;
-       depthStencilDescriptor.depthCompareFunction = MTLCompareFunctionAlways;
-       depthStencilDescriptor.backFaceStencil = nil;
-       depthStencilDescriptor.frontFaceStencil = nil;
-       id<MTLDepthStencilState> state = [(__bridge id<MTLDevice>)device newDepthStencilStateWithDescriptor:depthStencilDescriptor];
-       bd->SharedMetalContext.depthStencilState = (__bridge id<MTLDepthStencilState>)state;
-       [depthStencilDescriptor release];
-   }
-#else
-   MTLDepthStencilDescriptor* depthStencilDescriptor = [[MTLDepthStencilDescriptor alloc] init];
-   depthStencilDescriptor.depthWriteEnabled = NO;
-   depthStencilDescriptor.depthCompareFunction = MTLCompareFunctionAlways;
-   bd->SharedMetalContext.depthStencilState = [device newDepthStencilStateWithDescriptor:depthStencilDescriptor];
+    [depthStencilDescriptor release];
 #endif
-
-   ImGui_ImplMetal_CreateFontsTexture(device);
-   return true;
+    ImGui_ImplMetal_CreateFontsTexture(device);
+    return true;
 }
 
 void ImGui_ImplMetal_DestroyDeviceObjects()


### PR DESCRIPTION
This fixes all runtime memory leaks when using the backend with metal-cpp. There are still some leaks left that needs to be fixed that occur at startup.