### PR TITLE
Update imgui_stdlib.h to respect IMGUI_DISABLE

### DIFF
--- a/misc/cpp/imgui_stdlib.h
+++ b/misc/cpp/imgui_stdlib.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#ifndef IMGUI_DISABLE
+
 #include <string>
 
 namespace ImGui
@@ -19,3 +21,5 @@ namespace ImGui
     IMGUI_API bool  InputTextMultiline(const char* label, std::string* str, const ImVec2& size = ImVec2(0, 0), ImGuiInputTextFlags flags = 0, ImGuiInputTextCallback callback = nullptr, void* user_data = nullptr);
     IMGUI_API bool  InputTextWithHint(const char* label, const char* hint, std::string* str, ImGuiInputTextFlags flags = 0, ImGuiInputTextCallback callback = nullptr, void* user_data = nullptr);
 }
+
+#endif // #ifndef IMGUI_DISABLE


### PR DESCRIPTION
**Issue**: currently if you include `imgui_stdlib.h` with `IMGUI_DISABLE` set, it generates lots of errors. 
**Proposed solution**: Instead of having additional conditional code in the user's code, replicate the use of `IMGUI_DISABLE` into this header, per `imgui.h` etc.

(For the record I agree to the copyright & contributor license for this and any future contributions to ocornut/imgui)