### PR TITLE
Fix clang compiler diagnostic for glfw backend: nontrivial-memaccess

### DIFF
--- a/backends/imgui_impl_glfw.cpp
+++ b/backends/imgui_impl_glfw.cpp
@@ -1064,7 +1064,7 @@ struct ImGui_ImplGlfw_ViewportData
     WNDPROC     PrevWndProc;
 #endif
 
-    ImGui_ImplGlfw_ViewportData()  { memset(this, 0, sizeof(*this)); IgnoreWindowSizeEventFrame = IgnoreWindowPosEventFrame = -1; }
+    ImGui_ImplGlfw_ViewportData()  { memset((void*)this, 0, sizeof(*this)); IgnoreWindowSizeEventFrame = IgnoreWindowPosEventFrame = -1; }
     ~ImGui_ImplGlfw_ViewportData() { IM_ASSERT(Window == nullptr); }
 };
 


### PR DESCRIPTION
This is a glfw backend fix that is similar to https://github.com/ocornut/imgui/commit/419a9ada16eb9b6d84ead4911b9c2a32820cfffb

Diagnostic:

```
[build] ../imgui/backends/imgui_impl_glfw.cpp:1067:45: error: first argument in call to 'memset' is a pointer to non-trivially copyable type 'ImGui_ImplGlfw_ViewportData' [-Werror,-Wnontrivial-memaccess]
[build]  1067 |     ImGui_ImplGlfw_ViewportData()  { memset(this, 0, sizeof(*this)); IgnoreWindowSizeEventFrame = IgnoreWindowPosEventFrame = -1; }
[build]       |                                             ^
[build] ../imgui/backends/imgui_impl_glfw.cpp:1067:45: note: explicitly cast the pointer to silence this warning
[build]  1067 |     ImGui_ImplGlfw_ViewportData()  { memset(this, 0, sizeof(*this)); IgnoreWindowSizeEventFrame = IgnoreWindowPosEventFrame = -1; }
[build]       |                                             ^
[build]       |                                             (void*)
```

Compilers that generate this diagnostic:

- `clang version 17.0.0 (https://github.com/llvm/llvm-project.git cdcefd2f9a2d08e774fc7dcf631361a03bf6b810)`
- `clang version 18.0.0 (https://github.com/llvm/llvm-project.git 985a72b6b3e74f0d29780b2a97b5817473338ffe)`
- `clang version 19.0.0git (https://github.com/llvm/llvm-project.git decbd29f9e9be50756a083cd677f7fea22cd3c91)`
- `clang version 20.0.0git (https://github.com/llvm/llvm-project.git 9685681aa47561c9941bb70aa84a09c55c7db824)`

