### PR TITLE
Added missing IM_UNUSED

### DIFF
--- a/backends/imgui_impl_metal.mm
+++ b/backends/imgui_impl_metal.mm
@@ -143,6 +143,7 @@ bool ImGui_ImplMetal_Init(id<MTLDevice> device)
 void ImGui_ImplMetal_Shutdown()
 {
     ImGui_ImplMetal_Data* bd = ImGui_ImplMetal_GetBackendData();
+    IM_UNUSED(bd);
     IM_ASSERT(bd != nullptr && "No renderer backend to shutdown, or already shutdown?");
     ImGui_ImplMetal_DestroyDeviceObjects();
     ImGui_ImplMetal_DestroyBackendData();


### PR DESCRIPTION
In release the bd triggers an unused-variable warning.
This trivial addition fixes this.

Alternatively you could put the DestroyBackendData into an `if(bd != nullptr)`.

Thanks for considering!
