### PR TITLE
sdlrenderer2: Use endian-dependent RGBA32 texture format, to match `SDL_Color`.

### DIFF
--- a/backends/imgui_impl_sdlrenderer2.cpp
+++ b/backends/imgui_impl_sdlrenderer2.cpp
@@ -21,6 +21,7 @@
 // - Introduction, links and more at the top of imgui.cpp
 
 // CHANGELOG
+//  2025-01-17: Use endian-dependent RGBA32 texture format, to match SDL_Color.
 //  2024-10-09: Expose selected render state in ImGui_ImplSDLRenderer2_RenderState, which you can access in 'void* platform_io.Renderer_RenderState' during draw callbacks.
 //  2024-05-14: *BREAKING CHANGE* ImGui_ImplSDLRenderer3_RenderDrawData() requires SDL_Renderer* passed as parameter.
 //  2023-05-30: Renamed imgui_impl_sdlrenderer.h/.cpp to imgui_impl_sdlrenderer2.h/.cpp to accommodate for upcoming SDL3.
@@ -228,7 +229,7 @@ bool ImGui_ImplSDLRenderer2_CreateFontsTexture()
 
     // Upload texture to graphics system
     // (Bilinear sampling is required by default. Set 'io.Fonts->Flags |= ImFontAtlasFlags_NoBakedLines' or 'style.AntiAliasedLinesUseTex = false' to allow point/nearest sampling)
-    bd->FontTexture = SDL_CreateTexture(bd->Renderer, SDL_PIXELFORMAT_ABGR8888, SDL_TEXTUREACCESS_STATIC, width, height);
+    bd->FontTexture = SDL_CreateTexture(bd->Renderer, SDL_PIXELFORMAT_RGBA32, SDL_TEXTUREACCESS_STATIC, width, height);
     if (bd->FontTexture == nullptr)
     {
         SDL_Log("error creating texture");


### PR DESCRIPTION
SDL2's renderer takes in colors in `SDL_Color` format. Here's the relevant [documentation](https://wiki.libsdl.org/SDL2/SDL_Color):

> The bits of this structure can be directly reinterpreted as an integer-packed color which uses the [`SDL_PIXELFORMAT_RGBA32`](https://wiki.libsdl.org/SDL2/SDL_PIXELFORMAT_RGBA32) format ([`SDL_PIXELFORMAT_ABGR8888`](https://wiki.libsdl.org/SDL2/SDL_PIXELFORMAT_ABGR8888) on little-endian systems and [`SDL_PIXELFORMAT_RGBA8888`](https://wiki.libsdl.org/SDL2/SDL_PIXELFORMAT_RGBA8888) on big-endian systems).

This change is needed to render the alpha channel correctly on the Wii U, which is big endian.