### PR TITLE
Change SDL2 backend to use controller events.

### DIFF
--- a/backends/imgui_impl_sdl2.h
+++ b/backends/imgui_impl_sdl2.h
@@ -38,9 +38,4 @@ IMGUI_IMPL_API void     ImGui_ImplSDL2_Shutdown();
 IMGUI_IMPL_API void     ImGui_ImplSDL2_NewFrame();
 IMGUI_IMPL_API bool     ImGui_ImplSDL2_ProcessEvent(const SDL_Event* event);
 
-// Gamepad selection automatically starts in AutoFirst mode, picking first available SDL_Gamepad. You may override this.
-// When using manual mode, caller is responsible for opening/closing gamepad.
-enum ImGui_ImplSDL2_GamepadMode { ImGui_ImplSDL2_GamepadMode_AutoFirst, ImGui_ImplSDL2_GamepadMode_AutoAll, ImGui_ImplSDL2_GamepadMode_Manual };
-IMGUI_IMPL_API void     ImGui_ImplSDL2_SetGamepadMode(ImGui_ImplSDL2_GamepadMode mode, struct _SDL_GameController** manual_gamepads_array = nullptr, int manual_gamepads_count = -1);
-
 #endif // #ifndef IMGUI_DISABLE

--- a/examples/example_sdl2_directx11/main.cpp
+++ b/examples/example_sdl2_directx11/main.cpp
@@ -114,16 +114,37 @@ int main(int, char**)
         while (SDL_PollEvent(&event))
         {
             ImGui_ImplSDL2_ProcessEvent(&event);
-            if (event.type == SDL_QUIT)
-                done = true;
-            if (event.type == SDL_WINDOWEVENT && event.window.event == SDL_WINDOWEVENT_CLOSE && event.window.windowID == SDL_GetWindowID(window))
-                done = true;
-            if (event.type == SDL_WINDOWEVENT && event.window.event == SDL_WINDOWEVENT_RESIZED && event.window.windowID == SDL_GetWindowID(window))
+            switch (event.type)
             {
-                // Release all outstanding references to the swap chain's buffers before resizing.
-                CleanupRenderTarget();
-                g_pSwapChain->ResizeBuffers(0, 0, 0, DXGI_FORMAT_UNKNOWN, 0);
-                CreateRenderTarget();
+                case SDL_QUIT:
+                {
+                    done = true;
+                    break;
+                }
+                case SDL_CONTROLLERDEVICEADDED:
+                {
+                    // Start receiving SDL_CONTROLLER* events.
+                    SDL_GameControllerOpen(event.cdevice.which);
+                    break;
+                }
+                case SDL_CONTROLLERDEVICEREMOVED:
+                {
+                    SDL_GameController* ctr = SDL_GameControllerFromInstanceID(event.cdevice.which);
+                    if (ctr)
+                        SDL_GameControllerClose(ctr);
+                    break;
+                }
+                case SDL_WINDOWEVENT:
+                {
+                    if (event.window.event == SDL_WINDOWEVENT_RESIZED)
+                    {
+                        // Release all outstanding references to the swap chain's buffers before resizing.
+                        CleanupRenderTarget();
+                        g_pSwapChain->ResizeBuffers(0, 0, 0, DXGI_FORMAT_UNKNOWN, 0);
+                        CreateRenderTarget();
+                    }
+                    break;
+                }
             }
         }
         if (SDL_GetWindowFlags(window) & SDL_WINDOW_MINIMIZED)

--- a/examples/example_sdl2_opengl2/main.cpp
+++ b/examples/example_sdl2_opengl2/main.cpp
@@ -100,10 +100,27 @@ int main(int, char**)
         while (SDL_PollEvent(&event))
         {
             ImGui_ImplSDL2_ProcessEvent(&event);
-            if (event.type == SDL_QUIT)
-                done = true;
-            if (event.type == SDL_WINDOWEVENT && event.window.event == SDL_WINDOWEVENT_CLOSE && event.window.windowID == SDL_GetWindowID(window))
-                done = true;
+            switch (event.type)
+            {
+                case SDL_QUIT:
+                {
+                    done = true;
+                    break;
+                }
+                case SDL_CONTROLLERDEVICEADDED:
+                {
+                    // Start receiving SDL_CONTROLLER* events.
+                    SDL_GameControllerOpen(event.cdevice.which);
+                    break;
+                }
+                case SDL_CONTROLLERDEVICEREMOVED:
+                {
+                    SDL_GameController* ctr = SDL_GameControllerFromInstanceID(event.cdevice.which);
+                    if (ctr)
+                        SDL_GameControllerClose(ctr);
+                    break;
+                }
+            }
         }
         if (SDL_GetWindowFlags(window) & SDL_WINDOW_MINIMIZED)
         {

--- a/examples/example_sdl2_opengl3/main.cpp
+++ b/examples/example_sdl2_opengl3/main.cpp
@@ -148,10 +148,27 @@ int main(int, char**)
         while (SDL_PollEvent(&event))
         {
             ImGui_ImplSDL2_ProcessEvent(&event);
-            if (event.type == SDL_QUIT)
-                done = true;
-            if (event.type == SDL_WINDOWEVENT && event.window.event == SDL_WINDOWEVENT_CLOSE && event.window.windowID == SDL_GetWindowID(window))
-                done = true;
+            switch (event.type)
+            {
+                case SDL_QUIT:
+                {
+                    done = true;
+                    break;
+                }
+                case SDL_CONTROLLERDEVICEADDED:
+                {
+                    // Start receiving SDL_CONTROLLER* events.
+                    SDL_GameControllerOpen(event.cdevice.which);
+                    break;
+                }
+                case SDL_CONTROLLERDEVICEREMOVED:
+                {
+                    SDL_GameController* ctr = SDL_GameControllerFromInstanceID(event.cdevice.which);
+                    if (ctr)
+                        SDL_GameControllerClose(ctr);
+                    break;
+                }
+            }
         }
         if (SDL_GetWindowFlags(window) & SDL_WINDOW_MINIMIZED)
         {

--- a/examples/example_sdl2_sdlrenderer2/main.cpp
+++ b/examples/example_sdl2_sdlrenderer2/main.cpp
@@ -102,10 +102,27 @@ int main(int, char**)
         while (SDL_PollEvent(&event))
         {
             ImGui_ImplSDL2_ProcessEvent(&event);
-            if (event.type == SDL_QUIT)
-                done = true;
-            if (event.type == SDL_WINDOWEVENT && event.window.event == SDL_WINDOWEVENT_CLOSE && event.window.windowID == SDL_GetWindowID(window))
-                done = true;
+            switch (event.type)
+            {
+                case SDL_QUIT:
+                {
+                    done = true;
+                    break;
+                }
+                case SDL_CONTROLLERDEVICEADDED:
+                {
+                    // Start receiving SDL_CONTROLLER* events.
+                    SDL_GameControllerOpen(event.cdevice.which);
+                    break;
+                }
+                case SDL_CONTROLLERDEVICEREMOVED:
+                {
+                    SDL_GameController* ctr = SDL_GameControllerFromInstanceID(event.cdevice.which);
+                    if (ctr)
+                        SDL_GameControllerClose(ctr);
+                    break;
+                }
+            }
         }
         if (SDL_GetWindowFlags(window) & SDL_WINDOW_MINIMIZED)
         {

--- a/examples/example_sdl2_vulkan/main.cpp
+++ b/examples/example_sdl2_vulkan/main.cpp
@@ -446,10 +446,27 @@ int main(int, char**)
         while (SDL_PollEvent(&event))
         {
             ImGui_ImplSDL2_ProcessEvent(&event);
-            if (event.type == SDL_QUIT)
-                done = true;
-            if (event.type == SDL_WINDOWEVENT && event.window.event == SDL_WINDOWEVENT_CLOSE && event.window.windowID == SDL_GetWindowID(window))
-                done = true;
+            switch (event.type)
+            {
+                case SDL_QUIT:
+                {
+                    done = true;
+                    break;
+                }
+                case SDL_CONTROLLERDEVICEADDED:
+                {
+                    // Start receiving SDL_CONTROLLER* events.
+                    SDL_GameControllerOpen(event.cdevice.which);
+                    break;
+                }
+                case SDL_CONTROLLERDEVICEREMOVED:
+                {
+                    SDL_GameController* ctr = SDL_GameControllerFromInstanceID(event.cdevice.which);
+                    if (ctr)
+                        SDL_GameControllerClose(ctr);
+                    break;
+                }
+            }
         }
         if (SDL_GetWindowFlags(window) & SDL_WINDOW_MINIMIZED)
         {


### PR DESCRIPTION
This changes the SDL2 backend to use `SDL_CONTROLLER*` events instead of peeking into an array of controllers.
`ImGui_ImplSDL2_SetGamepadMode()` was removed.

### Explanation
Having the backend peek into the controller state from inside `ImGui_ImplSDL2_NewFrame()` (as opposed to `ImGui_ImplSDL2_ProcessEvent()`) was causing me trouble when using the on-screen keyboard on the Wii U. Currently, the SDL2 port does not handle the keyboard, so I have to manually feed it input events; and to avoid conflicts with ImGui, any event sent to the on-screen keyboard has to NOT be sent to ImGui, or it starts interpreting dpad up/down (as the user navigates through the keyboard keys) and touch events as an attempt to focus away from an `Input*` widget. The logic I have to implement is:

- If the on-screen keyboard is visible, input events are sent to the keyboard routines.
- If the on-screen keyboard is not visible, input events are sent to the SDL2 backend.

I can bypass `_ProcessEvent()` when the on-screen keyboard is visible, but that's pointless when the controllers are being read from within `_NewFrame()`.

Because controller events are now being handled in `_ProcessEvent()`, there's no use for a controller array to be kept around in the backend. Games/apps will open/close controllers as they're attached/detached, and manage it themselves, possibly wrapping them in C++ classes; so it's obnoxious having to keep an array of controllers just to feed to the SDL2 backend through `ImGui_ImplSDL2_SetGamepadMode()`.

I've updated most of the SDL2 examples, to open/close the controllers as they're attached/detached. I'll wait for your feedback before doing the same for the SDL3 backend and examples.