### PR TITLE
Backends: OSX: Remove notification observer when shutting down

### DIFF
--- a/backends/imgui_impl_osx.mm
+++ b/backends/imgui_impl_osx.mm
@@ -497,6 +497,7 @@ void ImGui_ImplOSX_Shutdown()
     ImGui_ImplOSX_Data* bd = ImGui_ImplOSX_GetBackendData();
     IM_ASSERT(bd != nullptr && "No platform backend to shutdown, or already shutdown?");
 
+    [[NSNotificationCenter defaultCenter] removeObserver:bd->Observer];
     bd->Observer = nullptr;
     if (bd->Monitor != nullptr)
     {


### PR DESCRIPTION
This change removes the ImGui observer from NSNotificationCenter when shutting down. 

### Explanation:
This prevents an issue that may occur when shutting down, where ImGui receives a `NSApplicationDidResignActiveNotification` from the notification center. When this happens, ImGui will call `ImGui::GetIO()` but this call will trigger an assert as the context has already been destroyed, causing the application to crash.
