### PR TITLE
WebGPU: Fix compile errors with newer Dawn versions after WGPUProgrammableStageDescriptor rename

### DIFF
--- a/backends/imgui_impl_wgpu.cpp
+++ b/backends/imgui_impl_wgpu.cpp
@@ -58,6 +58,12 @@
 #include <limits.h>
 #include <webgpu/webgpu.h>
 
+#ifdef IMGUI_IMPL_WEBGPU_BACKEND_DAWN
+// Dawn renamed WGPUProgrammableStageDescriptor to WGPUComputeState (see: https://github.com/webgpu-native/webgpu-headers/pull/413)
+// Using type alias until WGPU adopts the same naming convention
+using WGPUProgrammableStageDescriptor = WGPUComputeState;
+#endif
+
 // Dear ImGui prototypes from imgui_internal.h
 extern ImGuiID ImHashData(const void* data_p, size_t data_size, ImU32 seed = 0);
 #define MEMALIGN(_SIZE,_ALIGN)        (((_SIZE) + ((_ALIGN) - 1)) & ~((_ALIGN) - 1))    // Memory align (copied from IM_ALIGN() macro).


### PR DESCRIPTION
Dawn renamed `WGPUProgrammableStageDescriptor` type to `WGPUComputeState` (https://github.com/webgpu-native/webgpu-headers/pull/413) which breaks the current Dawn backend when building against newer versions. WGPU hasn't renamed it yet, so adding type alias as temporary fix until both backends adopt the same naming.

Compile errors encountered with newer versions of Dawn.
```
/home/phantom/Developer/Rain2/Rain-EngineUpgrade/vendor/imgui/backends/imgui_impl_wgpu.cpp:266:8: error: unknown type name 'WGPUProgrammableStageDescriptor'
static WGPUProgrammableStageDescriptor ImGui_ImplWGPU_CreateShaderModule(const char* wgsl_source)
       ^
/home/phantom/Developer/Rain2/Rain-EngineUpgrade/vendor/imgui/backends/imgui_impl_wgpu.cpp:283:5: error: unknown type name 'WGPUProgrammableStageDescriptor'
    WGPUProgrammableStageDescriptor stage_desc = {};
    ^
/home/phantom/Developer/Rain2/Rain-EngineUpgrade/vendor/imgui/backends/imgui_impl_wgpu.cpp:668:5: error: unknown type name 'WGPUProgrammableStageDescriptor'
    WGPUProgrammableStageDescriptor vertex_shader_desc = ImGui_ImplWGPU_CreateShaderModule(__shader_vert_wgsl);
    ^
/home/phantom/Developer/Rain2/Rain-EngineUpgrade/vendor/imgui/backends/imgui_impl_wgpu.cpp:690:5: error: unknown type name 'WGPUProgrammableStageDescriptor'
    WGPUProgrammableStageDescriptor pixel_shader_desc = ImGui_ImplWGPU_CreateShaderModule(__shader_frag_wgsl);
    ^
4 errors generated.
```