### PR TITLE
WebGPU GLFW and SDL2 examples

### DIFF
--- a/backends/imgui_impl_wgpu.cpp
+++ b/backends/imgui_impl_wgpu.cpp
@@ -672,9 +672,15 @@ bool ImGui_ImplWGPU_CreateDeviceObjects()
     // Vertex input configuration
     WGPUVertexAttribute attribute_desc[] =
     {
+#ifndef __EMSCRIPTEN__
+        { {}, WGPUVertexFormat_Float32x2, (uint64_t)offsetof(ImDrawVert, pos), 0 },
+        { {}, WGPUVertexFormat_Float32x2, (uint64_t)offsetof(ImDrawVert, uv),  1 },
+        { {}, WGPUVertexFormat_Unorm8x4,  (uint64_t)offsetof(ImDrawVert, col), 2 },
+#else
         { WGPUVertexFormat_Float32x2, (uint64_t)offsetof(ImDrawVert, pos), 0 },
         { WGPUVertexFormat_Float32x2, (uint64_t)offsetof(ImDrawVert, uv),  1 },
         { WGPUVertexFormat_Unorm8x4,  (uint64_t)offsetof(ImDrawVert, col), 2 },
+#endif
     };
 
     WGPUVertexBufferLayout buffer_layouts[1];

--- a/examples/example_sdl2_wgpu/CMakeLists.txt
+++ b/examples/example_sdl2_wgpu/CMakeLists.txt
@@ -1,0 +1,110 @@
+# Building for desktop (WebGPU-native) with Dawn:
+#  1. git clone https://github.com/google/dawn dawn
+#  2. cmake -B build -DIMGUI_DAWN_DIR=dawn
+#  3. cmake --build build
+# The resulting binary will be found at one of the following locations:
+#   * build/Debug/example_sdl2_wgpu[.exe]
+#   * build/example_sdl2_wgpu[.exe]
+
+# Building for Emscripten:
+#  1. Install Emscripten SDK following the instructions: https://emscripten.org/docs/getting_started/downloads.html
+#  2. Install Ninja build system
+#  3. emcmake cmake -G Ninja -B build
+#  3. cmake --build build
+#  4. emrun build/index.html
+
+cmake_minimum_required(VERSION 3.10.2)
+project(imgui_example_sdl2_wgpu C CXX)
+
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Debug CACHE STRING "" FORCE)
+endif()
+
+set(CMAKE_CXX_STANDARD 17) # Dawn requires C++17
+
+# Dear ImGui
+set(IMGUI_DIR ../../)
+
+# Libraries
+if(EMSCRIPTEN)
+  add_compile_options(-sDISABLE_EXCEPTION_CATCHING=1 -DIMGUI_DISABLE_FILE_FUNCTIONS=1)
+else()
+  # Dawn wgpu desktop
+  set(DAWN_FETCH_DEPENDENCIES ON)
+  set(IMGUI_DAWN_DIR CACHE PATH "path to dawn")
+  if (NOT IMGUI_DAWN_DIR)
+    message(FATAL_ERROR "Please specify the Dawn repository by setting IMGUI_DAWN_DIR")
+  endif()
+
+  option(DAWN_FETCH_DEPENDENCIES "Use fetch_dawn_dependencies.py as an alternative to using depot_tools" ON)
+
+  # Dawn builds many things by default - disable things we don't need
+  option(DAWN_BUILD_SAMPLES "Enables building Dawn's samples" OFF)
+  option(TINT_BUILD_CMD_TOOLS "Build the Tint command line tools" OFF)
+  option(TINT_BUILD_DOCS "Build documentation" OFF)
+  option(TINT_BUILD_TESTS "Build tests" OFF)
+  if (NOT APPLE)
+    option(TINT_BUILD_MSL_WRITER "Build the MSL output writer" OFF)
+  endif()
+  if(WIN32)
+    option(TINT_BUILD_SPV_READER "Build the SPIR-V input reader" OFF)
+    option(TINT_BUILD_WGSL_READER "Build the WGSL input reader" ON)
+    option(TINT_BUILD_GLSL_WRITER "Build the GLSL output writer" OFF)
+    option(TINT_BUILD_GLSL_VALIDATOR "Build the GLSL output validator" OFF)
+    option(TINT_BUILD_SPV_WRITER "Build the SPIR-V output writer" OFF)
+    option(TINT_BUILD_WGSL_WRITER "Build the WGSL output writer" ON)
+  endif()
+
+  add_subdirectory("${IMGUI_DAWN_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/dawn" EXCLUDE_FROM_ALL)
+
+  find_package(SDL2 REQUIRED)
+
+  set(LIBRARIES webgpu_dawn webgpu_cpp)
+endif()
+
+
+add_executable(example_sdl2_wgpu
+  main.cpp
+  sdl2wgpu.cpp
+  # backend files
+  ${IMGUI_DIR}/backends/imgui_impl_sdl2.cpp
+  ${IMGUI_DIR}/backends/imgui_impl_wgpu.cpp
+  # Dear ImGui files
+  ${IMGUI_DIR}/imgui.cpp
+  ${IMGUI_DIR}/imgui_draw.cpp
+  ${IMGUI_DIR}/imgui_demo.cpp
+  ${IMGUI_DIR}/imgui_tables.cpp
+  ${IMGUI_DIR}/imgui_widgets.cpp
+)
+IF(NOT EMSCRIPTEN)
+  target_compile_definitions(example_sdl2_wgpu PUBLIC
+    "IMGUI_IMPL_WEBGPU_BACKEND_DAWN"
+  )
+endif()
+target_include_directories(example_sdl2_wgpu PUBLIC
+  ${IMGUI_DIR}
+  ${IMGUI_DIR}/backends
+  ${SDL2_INCLUDE_DIRS}
+)
+
+target_link_libraries(example_sdl2_wgpu PUBLIC ${LIBRARIES} ${SDL2_LIBRARIES})
+
+# Emscripten settings
+if(EMSCRIPTEN)
+  target_compile_options(example_sdl2_wgpu PUBLIC "-sUSE_SDL=2" )
+  target_link_options(example_sdl2_wgpu PRIVATE
+    "-sUSE_WEBGPU=1"
+    "-sWASM=1"
+    "-sALLOW_MEMORY_GROWTH=1"
+    "-sNO_EXIT_RUNTIME=0"
+    "-sASSERTIONS=1"
+    "-sDISABLE_EXCEPTION_CATCHING=1"
+    "-sNO_FILESYSTEM=1"
+    "-sUSE_SDL=2"
+  )
+  set_target_properties(example_sdl2_wgpu PROPERTIES OUTPUT_NAME "index")
+  # copy our custom index.html to build directory
+  add_custom_command(TARGET example_sdl2_wgpu POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_LIST_DIR}/web/index.html" $<TARGET_FILE_DIR:example_sdl2_wgpu>
+  )
+endif()

--- a/examples/example_sdl2_wgpu/Makefile.emscripten
+++ b/examples/example_sdl2_wgpu/Makefile.emscripten
@@ -1,0 +1,91 @@
+#
+# Makefile to use with emscripten
+# See https://emscripten.org/docs/getting_started/downloads.html
+# for installation instructions.
+#
+# This Makefile assumes you have loaded emscripten's environment.
+# (On Windows, you may need to execute emsdk_env.bat or encmdprompt.bat ahead)
+#
+# Running `make` will produce three files:
+#  - web/index.html (current stored in the repository)
+#  - web/index.js
+#  - web/index.wasm
+#
+# All three are needed to run the demo.
+
+CC = emcc
+CXX = em++
+WEB_DIR = web
+EXE = $(WEB_DIR)/index.js
+IMGUI_DIR = ../..
+SOURCES = main.cpp
+SOURCES += $(IMGUI_DIR)/imgui.cpp $(IMGUI_DIR)/imgui_demo.cpp $(IMGUI_DIR)/imgui_draw.cpp $(IMGUI_DIR)/imgui_tables.cpp $(IMGUI_DIR)/imgui_widgets.cpp
+SOURCES += $(IMGUI_DIR)/backends/imgui_impl_glfw.cpp $(IMGUI_DIR)/backends/imgui_impl_wgpu.cpp
+OBJS = $(addsuffix .o, $(basename $(notdir $(SOURCES))))
+UNAME_S := $(shell uname -s)
+CPPFLAGS =
+LDFLAGS =
+EMS =
+
+##---------------------------------------------------------------------
+## EMSCRIPTEN OPTIONS
+##---------------------------------------------------------------------
+
+# ("EMS" options gets added to both CPPFLAGS and LDFLAGS, whereas some options are for linker only)
+EMS += -s DISABLE_EXCEPTION_CATCHING=1
+LDFLAGS += -s USE_GLFW=3 -s USE_WEBGPU=1
+LDFLAGS += -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s NO_EXIT_RUNTIME=0 -s ASSERTIONS=1
+
+# Build as single file (binary text encoded in .html file)
+#LDFLAGS += -sSINGLE_FILE
+
+# Emscripten allows preloading a file or folder to be accessible at runtime.
+# The Makefile for this example project suggests embedding the misc/fonts/ folder into our application, it will then be accessible as "/fonts"
+# See documentation for more details: https://emscripten.org/docs/porting/files/packaging_files.html
+# (Default value is 0. Set to 1 to enable file-system and include the misc/fonts/ folder as part of the build.)
+USE_FILE_SYSTEM ?= 0
+ifeq ($(USE_FILE_SYSTEM), 0)
+LDFLAGS += -s NO_FILESYSTEM=1
+CPPFLAGS += -DIMGUI_DISABLE_FILE_FUNCTIONS
+endif
+ifeq ($(USE_FILE_SYSTEM), 1)
+LDFLAGS += --no-heap-copy --preload-file ../../misc/fonts@/fonts
+endif
+
+##---------------------------------------------------------------------
+## FINAL BUILD FLAGS
+##---------------------------------------------------------------------
+
+CPPFLAGS += -I$(IMGUI_DIR) -I$(IMGUI_DIR)/backends
+#CPPFLAGS += -g
+CPPFLAGS += -Wall -Wformat -Os $(EMS)
+#LDFLAGS += --shell-file shell_minimal.html
+LDFLAGS += $(EMS)
+
+##---------------------------------------------------------------------
+## BUILD RULES
+##---------------------------------------------------------------------
+
+%.o:%.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c -o $@ $<
+
+%.o:$(IMGUI_DIR)/%.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c -o $@ $<
+
+%.o:$(IMGUI_DIR)/backends/%.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c -o $@ $<
+
+all: $(EXE)
+	@echo Build complete for $(EXE)
+
+$(WEB_DIR):
+	mkdir $@
+
+serve: all
+	python3 -m http.server -d $(WEB_DIR)
+
+$(EXE): $(OBJS) $(WEB_DIR)
+	$(CXX) -o $@ $(OBJS) $(LDFLAGS)
+
+clean:
+	rm -f $(EXE) $(OBJS) $(WEB_DIR)/*.js $(WEB_DIR)/*.wasm $(WEB_DIR)/*.wasm.pre

--- a/examples/example_sdl2_wgpu/README.md
+++ b/examples/example_sdl2_wgpu/README.md
@@ -1,0 +1,24 @@
+## How to Build
+
+- You need to install Emscripten from https://emscripten.org/docs/getting_started/downloads.html, and have the environment variables set, as described in https://emscripten.org/docs/getting_started/downloads.html#installation-instructions
+
+- Depending on your configuration, in Windows you may need to run `emsdk/emsdk_env.bat` in your console to access the Emscripten command-line tools.
+
+- You may also refer to our [Continuous Integration setup](https://github.com/ocornut/imgui/tree/master/.github/workflows) for Emscripten setup.
+
+- Then build using `make -f Makefile.emscripten` while in the `example_glfw_wgpu/` directory.
+
+- Requires recent Emscripten as WGPU is still a work-in-progress API.
+
+## How to Run
+
+To run on a local machine:
+- Make sure your browse supports WGPU and it is enabled. WGPU is still WIP not enabled by default in most browser.
+- `make serve` will use Python3 to spawn a local webserver, you can then browse http://localhost:8000 to access your build.
+- Otherwise, generally you will need a local webserver:
+  - Quoting [https://emscripten.org/docs/getting_started](https://emscripten.org/docs/getting_started/Tutorial.html#generating-html):<br>
+_"Unfortunately several browsers (including Chrome, Safari, and Internet Explorer) do not support file:// [XHR](https://emscripten.org/docs/site/glossary.html#term-xhr) requests, and can’t load extra files needed by the HTML (like a .wasm file, or packaged file data as mentioned lower down). For these browsers you’ll need to serve the files using a [local webserver](https://emscripten.org/docs/getting_started/FAQ.html#faq-local-webserver) and then open http://localhost:8000/hello.html."_
+  - Emscripten SDK has a handy `emrun` command: `emrun web/example_glfw_wgpu.html --browser firefox` which will spawn a temporary local webserver (in Firefox). See https://emscripten.org/docs/compiling/Running-html-files-with-emrun.html for details.
+  - You may use Python 3 builtin webserver: `python -m http.server -d web` (this is what `make serve` uses).
+  - You may use Python 2 builtin webserver: `cd web && python -m SimpleHTTPServer`.
+  - If you are accessing the files over a network, certain browsers, such as Firefox, will restrict Gamepad API access to secure contexts only (e.g. https only).

--- a/examples/example_sdl2_wgpu/main.cpp
+++ b/examples/example_sdl2_wgpu/main.cpp
@@ -1,0 +1,387 @@
+// Dear ImGui: standalone example application for using GLFW + WebGPU
+// - Emscripten is supported for publishing on web. See https://emscripten.org.
+// - Dawn is used as a WebGPU implementation on desktop.
+
+// Learn about Dear ImGui:
+// - FAQ                  https://dearimgui.com/faq
+// - Getting Started      https://dearimgui.com/getting-started
+// - Documentation        https://dearimgui.com/docs (same as your local docs/ folder).
+// - Introduction, links and more at the top of imgui.cpp
+
+
+#include "imgui.h"
+#include "imgui_impl_sdl2.h"
+#include "imgui_impl_wgpu.h"
+#include <stdio.h>
+
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#include <emscripten/html5.h>
+#include <emscripten/html5_webgpu.h>
+#else
+#endif
+#define SDL_MAIN_HANDLED
+#include "sdl2wgpu.h"
+#include <SDL.h>
+
+#include <webgpu/webgpu.h>
+#include <webgpu/webgpu_cpp.h>
+
+// This example can also compile and run with Emscripten! See 'Makefile.emscripten' for details.
+#ifdef __EMSCRIPTEN__
+#include "../libs/emscripten/emscripten_mainloop_stub.h"
+#endif
+
+// Global WebGPU required states
+static WGPUInstance      wgpu_instance = nullptr;
+static WGPUDevice        wgpu_device = nullptr;
+static WGPUSurface       wgpu_surface = nullptr;
+static WGPUTextureFormat wgpu_preferred_fmt = WGPUTextureFormat_Undefined;  // acquired from SurfaceCapabilities
+static int               wgpu_surface_width = 1280;
+static int               wgpu_surface_height = 720;
+
+static WGPUSurfaceConfiguration surfaceConfiguration {};
+
+// Forward declarations
+static bool InitWGPU(SDL_Window* window);
+static void surfaceResize(int width, int height);
+
+// Main code
+int main(int, char**)
+{
+    // Init SDL
+    SDL_Init(SDL_INIT_VIDEO);
+    SDL_Window *window = SDL_CreateWindow("Dear ImGui SDL+WebGPU example", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, wgpu_surface_width, wgpu_surface_height, SDL_WINDOW_RESIZABLE);
+
+    // Initialize WGPU
+    InitWGPU(window);
+
+    // Setup Dear ImGui context
+    IMGUI_CHECKVERSION();
+    ImGui::CreateContext();
+    ImGuiIO& io = ImGui::GetIO(); (void)io;
+    io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;     // Enable Keyboard Controls
+    io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;      // Enable Gamepad Controls
+
+    // Setup Dear ImGui style
+    ImGui::StyleColorsDark();
+    //ImGui::StyleColorsLight();
+
+    // Setup Platform/Renderer backends
+    ImGui_ImplSDL2_InitForOther(window);
+#ifdef __EMSCRIPTEN__
+    //ImGui_ImplSDL2_InstallEmscriptenCallbacks(window, "#canvas");
+#endif
+    ImGui_ImplWGPU_InitInfo init_info;
+    init_info.Device = wgpu_device;
+    init_info.NumFramesInFlight = 3;
+    init_info.RenderTargetFormat = wgpu_preferred_fmt;
+    init_info.DepthStencilFormat = WGPUTextureFormat_Undefined;
+    ImGui_ImplWGPU_Init(&init_info);
+
+    // Load Fonts
+    // - If no fonts are loaded, dear imgui will use the default font. You can also load multiple fonts and use ImGui::PushFont()/PopFont() to select them.
+    // - AddFontFromFileTTF() will return the ImFont* so you can store it if you need to select the font among multiple.
+    // - If the file cannot be loaded, the function will return a nullptr. Please handle those errors in your application (e.g. use an assertion, or display an error and quit).
+    // - The fonts will be rasterized at a given size (w/ oversampling) and stored into a texture when calling ImFontAtlas::Build()/GetTexDataAsXXXX(), which ImGui_ImplXXXX_NewFrame below will call.
+    // - Use '#define IMGUI_ENABLE_FREETYPE' in your imconfig file to use Freetype for higher quality font rendering.
+    // - Read 'docs/FONTS.md' for more instructions and details.
+    // - Remember that in C/C++ if you want to include a backslash \ in a string literal you need to write a double backslash \\ !
+    // - Emscripten allows preloading a file or folder to be accessible at runtime. See Makefile for details.
+    //io.Fonts->AddFontDefault();
+#ifndef IMGUI_DISABLE_FILE_FUNCTIONS
+    //io.Fonts->AddFontFromFileTTF("fonts/segoeui.ttf", 18.0f);
+    //io.Fonts->AddFontFromFileTTF("fonts/DroidSans.ttf", 16.0f);
+    //io.Fonts->AddFontFromFileTTF("fonts/Roboto-Medium.ttf", 16.0f);
+    //io.Fonts->AddFontFromFileTTF("fonts/Cousine-Regular.ttf", 15.0f);
+    //io.Fonts->AddFontFromFileTTF("fonts/ProggyTiny.ttf", 10.0f);
+    //ImFont* font = io.Fonts->AddFontFromFileTTF("fonts/ArialUni.ttf", 18.0f, nullptr, io.Fonts->GetGlyphRangesJapanese());
+    //IM_ASSERT(font != nullptr);
+#endif
+
+    // Our state
+    bool show_demo_window = true;
+    bool show_another_window = false;
+    ImVec4 clear_color = ImVec4(0.45f, 0.55f, 0.60f, 1.00f);
+
+    SDL_Event event;
+    bool canCloseWindow = false;
+    // Main loop
+#ifdef __EMSCRIPTEN__
+    // For an Emscripten build we are disabling file-system access, so let's not attempt to do a fopen() of the imgui.ini file.
+    // You may manually call LoadIniSettingsFromMemory() to load settings from your own storage.
+    io.IniFilename = nullptr;
+    EMSCRIPTEN_MAINLOOP_BEGIN
+#else
+    while (!canCloseWindow) 
+#endif
+    {
+        while (SDL_PollEvent(&event)) {
+            ImGui_ImplSDL2_ProcessEvent(&event);
+            if (event.type == SDL_QUIT ||
+               (event.type == SDL_WINDOWEVENT && event.window.event == SDL_WINDOWEVENT_CLOSE &&
+                event.window.windowID == SDL_GetWindowID(window)))
+                    canCloseWindow = true;
+        }
+        // Poll and handle events (inputs, window resize, etc.)
+        // You can read the io.WantCaptureMouse, io.WantCaptureKeyboard flags to tell if dear imgui wants to use your inputs.
+        // - When io.WantCaptureMouse is true, do not dispatch mouse input data to your main application, or clear/overwrite your copy of the mouse data.
+        // - When io.WantCaptureKeyboard is true, do not dispatch keyboard input data to your main application, or clear/overwrite your copy of the keyboard data.
+        // Generally you may always pass all inputs to dear imgui, and hide them from your application based on those two flags.
+
+        // React to changes in screen size
+        int width, height;
+        SDL_GetWindowSize(window, &width, &height);
+        if (width != wgpu_surface_width || height != wgpu_surface_height)  {
+            surfaceResize(width, height);
+            continue;
+        }
+
+        // Start the Dear ImGui frame
+        ImGui_ImplWGPU_NewFrame();
+        ImGui_ImplSDL2_NewFrame();
+        ImGui::NewFrame();
+
+
+        // 1. Show the big demo window (Most of the sample code is in ImGui::ShowDemoWindow()! You can browse its code to learn more about Dear ImGui!).
+        if (show_demo_window)
+            ImGui::ShowDemoWindow(&show_demo_window);
+
+        // 2. Show a simple window that we create ourselves. We use a Begin/End pair to create a named window.
+        {
+            static float f = 0.0f;
+            static int counter = 0;
+
+            ImGui::Begin("Hello, world!");                                // Create a window called "Hello, world!" and append into it.
+
+            ImGui::Text("This is some useful text.");                     // Display some text (you can use a format strings too)
+            ImGui::Checkbox("Demo Window", &show_demo_window);            // Edit bools storing our window open/close state
+            ImGui::Checkbox("Another Window", &show_another_window);
+
+            ImGui::SliderFloat("float", &f, 0.0f, 1.0f);                  // Edit 1 float using a slider from 0.0f to 1.0f
+            ImGui::ColorEdit3("clear color", (float*)&clear_color);       // Edit 3 floats representing a color
+
+            if (ImGui::Button("Button"))                                  // Buttons return true when clicked (most widgets return true when edited/activated)
+                counter++;
+            ImGui::SameLine();
+            ImGui::Text("counter = %d", counter);
+
+            ImGui::Text("Application average %.3f ms/frame (%.1f FPS)", 1000.0f / io.Framerate, io.Framerate);
+            ImGui::End();
+        }
+
+        // 3. Show another simple window.
+        if (show_another_window)
+        {
+            ImGui::Begin("Another Window", &show_another_window);         // Pass a pointer to our bool variable (the window will have a closing button that will clear the bool when clicked)
+            ImGui::Text("Hello from another window!");
+            if (ImGui::Button("Close Me"))
+                show_another_window = false;
+            ImGui::End();
+        }
+
+        // Rendering
+        ImGui::Render();
+
+#ifndef __EMSCRIPTEN__
+        // Tick needs to be called in Dawn to display validation errors
+        wgpuDeviceTick(wgpu_device);
+#endif
+        WGPUSurfaceTexture surfaceTexture;
+        wgpuSurfaceGetCurrentTexture(wgpu_surface, &surfaceTexture);
+
+        WGPUTextureViewDescriptor viewDescriptor {};
+        viewDescriptor.format          = wgpu_preferred_fmt;
+        viewDescriptor.dimension       = WGPUTextureViewDimension_2D;
+        viewDescriptor.mipLevelCount   = WGPU_MIP_LEVEL_COUNT_UNDEFINED;
+        viewDescriptor.arrayLayerCount = WGPU_ARRAY_LAYER_COUNT_UNDEFINED;
+        viewDescriptor.aspect          = WGPUTextureAspect_All;
+
+        WGPUTextureView textureView = wgpuTextureCreateView((WGPUTexture &) surfaceTexture, &viewDescriptor);
+
+        WGPURenderPassColorAttachment color_attachments {};
+        color_attachments.depthSlice = WGPU_DEPTH_SLICE_UNDEFINED;
+        color_attachments.loadOp     = WGPULoadOp_Clear;
+        color_attachments.storeOp    = WGPUStoreOp_Store;
+        color_attachments.clearValue = { clear_color.x * clear_color.w, clear_color.y * clear_color.w, clear_color.z * clear_color.w, clear_color.w };
+        color_attachments.view       = textureView;
+
+        WGPURenderPassDescriptor render_pass_desc {};
+        render_pass_desc.colorAttachmentCount   = 1;
+        render_pass_desc.colorAttachments       = &color_attachments;
+        render_pass_desc.depthStencilAttachment = nullptr;
+
+        WGPUCommandEncoderDescriptor enc_desc = {};
+        WGPUCommandEncoder encoder = wgpuDeviceCreateCommandEncoder(wgpu_device, &enc_desc);
+
+        WGPURenderPassEncoder pass = wgpuCommandEncoderBeginRenderPass(encoder, &render_pass_desc);
+        ImGui_ImplWGPU_RenderDrawData(ImGui::GetDrawData(), pass);
+        wgpuRenderPassEncoderEnd(pass);
+
+        WGPUCommandBufferDescriptor cmd_buffer_desc {};
+        WGPUCommandBuffer cmd_buffer = wgpuCommandEncoderFinish(encoder, &cmd_buffer_desc);
+        WGPUQueue queue = wgpuDeviceGetQueue(wgpu_device);
+        wgpuQueueSubmit(queue, 1, &cmd_buffer);
+
+#ifndef __EMSCRIPTEN__
+        wgpuSurfacePresent(wgpu_surface);
+#endif
+        wgpuTextureViewRelease(color_attachments.view);
+        wgpuRenderPassEncoderRelease(pass);
+        wgpuCommandEncoderRelease(encoder);
+        wgpuCommandBufferRelease(cmd_buffer);
+    }
+#ifdef __EMSCRIPTEN__
+    EMSCRIPTEN_MAINLOOP_END;
+#endif
+
+    // Cleanup
+    ImGui_ImplWGPU_Shutdown();
+    ImGui_ImplSDL2_Shutdown();
+    ImGui::DestroyContext();
+
+    // Terminate SDL
+    SDL_DestroyWindow(window);
+    SDL_Quit();
+
+    return 0;
+}
+
+static bool InitWGPU(SDL_Window* window)
+{
+#ifdef __EMSCRIPTEN__
+    wgpu::Instance instance = wgpuCreateInstance(nullptr);
+    wgpu_device = emscripten_webgpu_get_device();
+    if (!wgpu_device)
+        return false;
+#else
+    WGPUInstanceDescriptor instanceDescriptor {};
+    instanceDescriptor.capabilities.timedWaitAnyEnable = true;
+    wgpu::Instance instance = wgpuCreateInstance(&instanceDescriptor);
+
+    wgpu::RequestAdapterOptions adapterOptions {};
+    static wgpu::Adapter localAdapter;
+
+    // Synchronously (wait until) acquire Adapter
+    instance.WaitAny(
+        instance.RequestAdapter(
+            &adapterOptions, wgpu::CallbackMode::WaitAnyOnly,
+            [](wgpu::RequestAdapterStatus status, wgpu::Adapter adapter, wgpu::StringView message) {
+                if (status != wgpu::RequestAdapterStatus::Success) {
+                    printf("Failed to get an adapter: %s\n", message.data);
+                    return;
+                }
+                localAdapter = std::move(adapter);
+            }),
+        UINT64_MAX);
+    assert(localAdapter != nullptr);
+
+#ifndef NDEBUG
+    wgpu::AdapterInfo info;
+    localAdapter.GetInfo(&info);
+    printf("Using adapter: \" %s \"\n", info.device.data);
+#endif
+
+    wgpu::DeviceDescriptor deviceDesc {};
+    deviceDesc.SetDeviceLostCallback(
+        wgpu::CallbackMode::AllowSpontaneous,
+        [](const wgpu::Device&, wgpu::DeviceLostReason reason, wgpu::StringView message) {
+            const char* reasonName = "";
+            switch (reason) {
+                case wgpu::DeviceLostReason::Unknown:           reasonName = "Unknown";         break;
+                case wgpu::DeviceLostReason::Destroyed:         reasonName = "Destroyed";       break;
+                case wgpu::DeviceLostReason::InstanceDropped:   reasonName = "InstanceDropped"; break;
+                case wgpu::DeviceLostReason::FailedCreation:    reasonName = "FailedCreation";  break;
+                default:                                        reasonName = "UNREACHABLE";     break;
+            }
+            printf("%s error: %s\n", reasonName, message.data);
+        });
+
+    deviceDesc.SetUncapturedErrorCallback(
+        [](const wgpu::Device&, wgpu::ErrorType type, wgpu::StringView message) {
+            const char* errorTypeName = "";
+            switch (type) {
+                case wgpu::ErrorType::Validation:  errorTypeName = "Validation";      break;
+                case wgpu::ErrorType::OutOfMemory: errorTypeName = "Out of memory";   break;
+                case wgpu::ErrorType::Unknown:     errorTypeName = "Unknown";         break;
+                case wgpu::ErrorType::Internal:    errorTypeName = "Internal";        break;
+                default:                           errorTypeName = "UNREACHABLE";     break;
+            }
+            printf("%s error: %s\n", errorTypeName, message.data);
+        });
+
+    // Synchronously (wait until) create the device
+    static wgpu::Device localDevice;
+    instance.WaitAny(
+        localAdapter.RequestDevice(
+            &deviceDesc, wgpu::CallbackMode::WaitAnyOnly,
+            [](wgpu::RequestDeviceStatus status, wgpu::Device device, wgpu::StringView message) {
+                if (status != wgpu::RequestDeviceStatus::Success) {
+                    printf("Failed to get an device: %s\n", message.data);
+                    return;
+                }
+                localDevice = std::move(device);
+                //queue = sample->device.GetQueue();
+            }),
+        UINT64_MAX);
+
+    assert(localDevice != nullptr);
+
+#endif
+
+#ifdef __EMSCRIPTEN__
+    wgpu::SurfaceDescriptorFromCanvasHTMLSelector html_surface_desc = {};
+    html_surface_desc.selector = "#canvas";
+    wgpu::SurfaceDescriptor surface_desc = {};
+    surface_desc.nextInChain = &html_surface_desc;
+    wgpu::Surface surface = instance.CreateSurface(&surface_desc);
+
+    wgpu::Adapter adapter = {};
+    wgpu_preferred_fmt = (WGPUTextureFormat)surface.GetPreferredFormat(adapter);
+#else
+
+    wgpu::Surface surface = SDL_getWGPUSurface(instance.Get(), window);
+    if (!surface)
+        return false;
+
+    // Configure the surface.
+    wgpu::SurfaceCapabilities capabilities;
+    surface.GetCapabilities(localAdapter, &capabilities);
+    wgpu_preferred_fmt = (WGPUTextureFormat) capabilities.formats[0];
+
+    surfaceConfiguration.presentMode = WGPUPresentMode_Fifo; // (WGPUPresentModes) capabilities.presentModes[0]
+    surfaceConfiguration.alphaMode   = WGPUCompositeAlphaMode_Auto;
+    surfaceConfiguration.usage       = WGPUTextureUsage_RenderAttachment;
+    surfaceConfiguration.device      = localDevice.Get();
+    surfaceConfiguration.format      = wgpu_preferred_fmt;
+    surfaceConfiguration.width       = wgpu_surface_width;
+    surfaceConfiguration.height      = wgpu_surface_height;
+    surface.Configure((const wgpu::SurfaceConfiguration *) &surfaceConfiguration);
+
+    wgpu_device   = localDevice.MoveToCHandle();
+#endif
+    wgpu_instance = instance.MoveToCHandle();
+    wgpu_surface  = surface.MoveToCHandle();
+
+    return true;
+}
+
+void surfaceResize(int width, int height)
+{
+    ImGui_ImplWGPU_InvalidateDeviceObjects();
+
+    surfaceConfiguration.width       = width;
+    surfaceConfiguration.height      = height;
+
+    surfaceConfiguration.presentMode = WGPUPresentMode_Fifo;
+    surfaceConfiguration.alphaMode   = WGPUCompositeAlphaMode_Auto;
+    surfaceConfiguration.usage       = WGPUTextureUsage_RenderAttachment;
+    surfaceConfiguration.device      = wgpu_device;
+    surfaceConfiguration.format      = wgpu_preferred_fmt;
+
+    wgpu_surface_width  = width;
+    wgpu_surface_height = height;
+
+    wgpuSurfaceConfigure( wgpu_surface, (WGPUSurfaceConfiguration *) &surfaceConfiguration );
+    ImGui_ImplWGPU_CreateDeviceObjects();
+}

--- a/examples/example_sdl2_wgpu/sdl2wgpu.cpp
+++ b/examples/example_sdl2_wgpu/sdl2wgpu.cpp
@@ -1,0 +1,56 @@
+//------------------------------------------------------------------------------
+//  Copyright (c) 2018-2025 Michele Morrone
+//  All rights reserved.
+//
+//  https://michelemorrone.eu - https://brutpitt.com
+//
+//  X: https://x.com/BrutPitt - GitHub: https://github.com/BrutPitt
+//
+//  direct mail: brutpitt(at)gmail.com - me(at)michelemorrone.eu
+//
+//  This software is distributed under the terms of the BSD 2-Clause license
+//------------------------------------------------------------------------------
+#include "sdl2wgpu.h"
+#include <SDL_syswm.h>
+
+WGPUSurface SDL_getWGPUSurface(WGPUInstance instance, SDL_Window* window)
+{
+    SDL_SysWMinfo sysWMInfo;
+    SDL_VERSION(&sysWMInfo.version);
+    SDL_GetWindowWMInfo(window, &sysWMInfo);
+
+#if defined(SDL_VIDEO_DRIVER_X11)
+    const WGPUChainedStruct chainedStruct { {}, WGPUSType_SurfaceSourceXlibWindow };
+    const WGPUSurfaceSourceXlibWindow surfaceSourceDesc { chainedStruct , sysWMInfo.info.x11.display, sysWMInfo.info.x11.window };
+    const WGPUSurfaceDescriptor surfaceDescriptor { (WGPUChainedStruct*) &surfaceSourceDesc, nullptr };
+    return wgpuInstanceCreateSurface(instance, &surfaceDescriptor);
+
+#elif defined(SDL_VIDEO_DRIVER_WAYLAND)
+    const WGPUChainedStruct chainedStruct { {}, WGPUSType_SurfaceSourceWaylandSurface };
+    const WGPUSurfaceSourceWaylandSurface surfaceSourceDesc { chainedStruct , sysWMInfo.info.wl.display, sysWMInfo.info.wl.surface };
+    const WGPUSurfaceDescriptor surfaceDescriptor { (WGPUChainedStruct*) &surfaceSourceDesc, nullptr };
+    return wgpuInstanceCreateSurface(instance, &surfaceDescriptor);
+
+#elif defined(SDL_VIDEO_DRIVER_WINDOWS)
+    const WGPUChainedStruct chainedStruct { {}, WGPUSType_SurfaceSourceWindowsHWND };
+    const WGPUSurfaceSourceWindowsHWND surfaceSourceDesc { chainedStruct , sysWMInfo.info.win.hinstance, sysWMInfo.info.win.window };
+    const WGPUSurfaceDescriptor surfaceDescriptor { (WGPUChainedStruct*) &surfaceSourceDesc, nullptr };
+    return wgpuInstanceCreateSurface(instance, &surfaceDescriptor);
+
+#elif defined(SDL_VIDEO_DRIVER_EMSCRIPTEN) //deprecated for DAWN, but yet used from EMSCRIPTEN
+    const WGPUChainedStruct chainedStruct { {}, WGPUSType_SurfaceDescriptorFromCanvasHTMLSelector };
+    const WGPUSurfaceDescriptorFromCanvasHTMLSelector surfaceSourceDesc = { chainedStruct, "canvas" };
+    const WGPUSurfaceDescriptor surfaceDescriptor { (WGPUChainedStruct*) &surfaceSourceDesc, nullptr };
+    return wgpuInstanceCreateSurface(instance, &surfaceDescriptor);
+/*
+#elif defined(SDL_VIDEO_DRIVER_EMSCRIPTEN)  // NEW for DAWN but not used from EMSCRIPTEN (yet)
+    const WGPUChainedStruct chainedStruct { {}, WGPUSType_EmscriptenSurfaceSourceCanvasHTMLSelector };
+    const WGPUEmscriptenSurfaceSourceCanvasHTMLSelector surfaceSourceDesc = { chainedStruct, "canvas" };
+    const WGPUSurfaceDescriptor surfaceDescriptor { (WGPUChainedStruct*) &surfaceSourceDesc, nullptr };
+    return wgpuInstanceCreateSurface(instance, &surfaceDescriptor);
+ */
+#else
+#error "Unsupported WGPU Backend"
+#endif
+}
+

--- a/examples/example_sdl2_wgpu/sdl2wgpu.h
+++ b/examples/example_sdl2_wgpu/sdl2wgpu.h
@@ -1,0 +1,24 @@
+//------------------------------------------------------------------------------
+//  Copyright (c) 2018-2025 Michele Morrone
+//  All rights reserved.
+//
+//  https://michelemorrone.eu - https://brutpitt.com
+//
+//  X: https://x.com/BrutPitt - GitHub: https://github.com/BrutPitt
+//
+//  direct mail: brutpitt(at)gmail.com - me(at)michelemorrone.eu
+//
+//  This software is distributed under the terms of the BSD 2-Clause license
+//------------------------------------------------------------------------------
+#pragma once
+#include <webgpu/webgpu.h>
+#include <SDL.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+WGPUSurface SDL_getWGPUSurface(WGPUInstance instance, SDL_Window* window);
+#ifdef __cplusplus
+}
+#endif
+

--- a/examples/example_sdl2_wgpu/web/index.html
+++ b/examples/example_sdl2_wgpu/web/index.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<html lang="en-us">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no"/>
+    <title>Dear ImGui Emscripten+GLFW+WebGPU example</title>
+    <style>
+        body { margin: 0; background-color: black }
+        .emscripten {
+            position: absolute;
+            top: 0px;
+            left: 0px;
+            margin: 0px;
+            border: 0;
+            width: 100%;
+            height: 100%;
+            overflow: hidden;
+            display: block;
+            image-rendering: optimizeSpeed;
+            image-rendering: -moz-crisp-edges;
+            image-rendering: -o-crisp-edges;
+            image-rendering: -webkit-optimize-contrast;
+            image-rendering: optimize-contrast;
+            image-rendering: crisp-edges;
+            image-rendering: pixelated;
+            -ms-interpolation-mode: nearest-neighbor;
+        }
+    </style>
+  </head>
+  <body>
+    <canvas class="emscripten" id="canvas" oncontextmenu="event.preventDefault()"></canvas>
+    <script type='text/javascript'>
+      var Module;
+      (async () => {
+        Module = {
+          preRun: [],
+          postRun: [],
+          print: (function() {
+              return function(text) {
+                  text = Array.prototype.slice.call(arguments).join(' ');
+                  console.log(text);
+              };
+          })(),
+          printErr: function(text) {
+              text = Array.prototype.slice.call(arguments).join(' ');
+              console.error(text);
+          },
+          canvas: (function() {
+              var canvas = document.getElementById('canvas');
+              //canvas.addEventListener("webglcontextlost", function(e) { alert('FIXME: WebGL context lost, please reload the page'); e.preventDefault(); }, false);
+              return canvas;
+          })(),
+          setStatus: function(text) {
+              console.log("status: " + text);
+          },
+          monitorRunDependencies: function(left) {
+              // no run dependencies to log
+          }
+        };
+        window.onerror = function() {
+          console.log("onerror: " + event);
+        };
+
+      // Initialize the graphics adapter
+      {
+          if (!navigator.gpu) {
+            throw Error("WebGPU not supported.");
+          }
+
+          const adapter = await navigator.gpu.requestAdapter();
+          const device = await adapter.requestDevice();
+          Module.preinitializedWebGPUDevice = device;
+      }
+
+      {
+          const js = document.createElement('script');
+          js.async = true;
+          js.src = "index.js";
+          document.body.appendChild(js);
+      }
+      })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
As already anticipated [here](https://github.com/ocornut/imgui/issues/8191), I send you the PR with the example GLFW in which the Swap-Chain was removed in favor of *SurfaceConfigure*.

But given the little troubles with GLFW (Validation Layer messages), I wanted to check with SDL2 if everything worked well.
So I created a function to acquire the surface in a native way on SDL.
It works and has been tested (with ImGui SDL2 WebGPU example) in Windows, Linux (X11) and Emscripten 
There is also the possibility with Linux (Wayland) , but I haven't tried it yet.

The ImGui SDL2 WebGPU example works well: [the web version is live here](https://brutpitt.github.io/myRepos/imgui/example_sdl2_wgpu/) (obviously a browser with webGPU capabilities is required)


