### PR TITLE
Fix ExampleDescriptorHeapAllocator free index overflow for example_win32_directx12

### DIFF
--- a/examples/example_win32_directx12/main.cpp
+++ b/examples/example_win32_directx12/main.cpp
@@ -54,7 +54,7 @@ struct ExampleDescriptorHeapAllocator
         HeapHandleIncrement = device->GetDescriptorHandleIncrementSize(HeapType);
         FreeIndices.reserve((int)desc.NumDescriptors);
         for (int n = desc.NumDescriptors; n > 0; n--)
-            FreeIndices.push_back(n);
+            FreeIndices.push_back(n - 1);
     }
     void Destroy()
     {


### PR DESCRIPTION
Previously, the loop added indices from `NumDescriptors` down to `1`, causing an overflow error. Since the allocated index is used directly in Alloc to compute descriptor addresses:
```cpp
void Alloc(D3D12_CPU_DESCRIPTOR_HANDLE* out_cpu_desc_handle, D3D12_GPU_DESCRIPTOR_HANDLE* out_gpu_desc_handle)
{
    IM_ASSERT(FreeIndices.Size > 0);
    int idx = FreeIndices.back();
    FreeIndices.pop_back();
    out_cpu_desc_handle->ptr = HeapStartCpu.ptr + (idx * HeapHandleIncrement);
    out_gpu_desc_handle->ptr = HeapStartGpu.ptr + (idx * HeapHandleIncrement);
}
```
The change adjusts the push_back call to use `n - 1` so that the indices correctly range from `NumDescriptors - 1` down to `0`.
