### PR TITLE
Default to first monitor if viewport is outside bounds

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -16538,7 +16538,7 @@ static int ImGui::FindPlatformMonitorForRect(const ImRect& rect)
     // Use a minimum threshold of 1.0f so a zero-sized rect won't false positive, and will still find the correct monitor given its position.
     // This is necessary for tooltips which always resize down to zero at first.
     const float surface_threshold = ImMax(rect.GetWidth() * rect.GetHeight() * 0.5f, 1.0f);
-    int best_monitor_n = -1;
+    int best_monitor_n = 0; // Default to the first monitor as fallback
     float best_monitor_surface = 0.001f;
 
     for (int monitor_n = 0; monitor_n < g.PlatformIO.Monitors.Size && best_monitor_surface < surface_threshold; monitor_n++)


### PR DESCRIPTION
Fixes https://github.com/ocornut/imgui/issues/8385 by returning a valid monitor from FindPlatformMonitorForRect. This function only checks the rect if more than one monitor is present, so seems reasonable to assume that it should return a valid monitor even if the rect doesn't clip with the monitor.

Issue was causing an assert when a viewport was loaded out of the bounds of any of the monitors. Before the assert was introduced (in d66f4e5890f8df2a52434aac2d14ff381663b1c1) the viewport would be eventually clamped with ClampWindowPos using g.FallbackMonitor.

