### PR TITLE
SDL2/3: don't retrieve global mouse state in relative mode

### DIFF
--- a/backends/imgui_impl_sdl2.cpp
+++ b/backends/imgui_impl_sdl2.cpp
@@ -624,10 +624,16 @@ static void ImGui_ImplSDL2_UpdateMouseData()
         // (Optional) Fallback to provide mouse position when focused (SDL_MOUSEMOTION already provides this when hovered or captured)
         if (bd->MouseCanUseGlobalState && bd->MouseButtonsDown == 0)
         {
-            int window_x, window_y, mouse_x_global, mouse_y_global;
-            SDL_GetGlobalMouseState(&mouse_x_global, &mouse_y_global);
-            SDL_GetWindowPosition(bd->Window, &window_x, &window_y);
-            io.AddMousePosEvent((float)(mouse_x_global - window_x), (float)(mouse_y_global - window_y));
+            // `SDL_GetGlobalMouseState` is invalid in relative mouse mode
+            if (!SDL_GetWindowRelativeMouseMode(bd->Window))
+            {
+                // Single-viewport mode: mouse position in client window coordinates (io.MousePos is (0,0) when the mouse is on the upper-left corner of the app window)
+                float mouse_x_global, mouse_y_global;
+                int window_x, window_y;
+                SDL_GetGlobalMouseState(&mouse_x_global, &mouse_y_global);
+                SDL_GetWindowPosition(focused_window, &window_x, &window_y);
+                io.AddMousePosEvent(mouse_x_global - window_x, mouse_y_global - window_y);
+            }
         }
     }
 }

--- a/backends/imgui_impl_sdl3.cpp
+++ b/backends/imgui_impl_sdl3.cpp
@@ -590,12 +590,16 @@ static void ImGui_ImplSDL3_UpdateMouseData()
         // (Optional) Fallback to provide mouse position when focused (SDL_EVENT_MOUSE_MOTION already provides this when hovered or captured)
         if (bd->MouseCanUseGlobalState && bd->MouseButtonsDown == 0)
         {
-            // Single-viewport mode: mouse position in client window coordinates (io.MousePos is (0,0) when the mouse is on the upper-left corner of the app window)
-            float mouse_x_global, mouse_y_global;
-            int window_x, window_y;
-            SDL_GetGlobalMouseState(&mouse_x_global, &mouse_y_global);
-            SDL_GetWindowPosition(focused_window, &window_x, &window_y);
-            io.AddMousePosEvent(mouse_x_global - window_x, mouse_y_global - window_y);
+            // `SDL_GetGlobalMouseState` is invalid in relative mouse mode
+            if (!SDL_GetWindowRelativeMouseMode(bd->Window))
+            {
+                // Single-viewport mode: mouse position in client window coordinates (io.MousePos is (0,0) when the mouse is on the upper-left corner of the app window)
+                float mouse_x_global, mouse_y_global;
+                int window_x, window_y;
+                SDL_GetGlobalMouseState(&mouse_x_global, &mouse_y_global);
+                SDL_GetWindowPosition(focused_window, &window_x, &window_y);
+                io.AddMousePosEvent(mouse_x_global - window_x, mouse_y_global - window_y);
+            }
         }
     }
 }


### PR DESCRIPTION
Fix mouse movement in relative mode.

Relative mode allows:
* Forcing mouse within window bound while hiding the cursor
* Multiple mice support

As a side effect, putting the window in relative mode would then makes the ImGui backend entirely reliant on mouse events. From what I understand this snippet is only useful in case the mouse goes outside window boundary, so I don't believe this is an issue?

Solve #8407 