### PR TITLE
Removed opengl to remove confusion.

### DIFF
--- a/examples/example_sdl3_sdlrenderer3/Makefile
+++ b/examples/example_sdl3_sdlrenderer3/Makefile
@@ -44,7 +44,7 @@ endif
 
 ifeq ($(OS), Windows_NT)
 	ECHO_MESSAGE = "MinGW"
-	LIBS += -lgdi32 -lopengl32 -limm32 `pkg-config --static --libs sdl3`
+	LIBS += -lgdi32 -limm32 `pkg-config --static --libs sdl3`
 
 	CXXFLAGS += `pkg-config --cflags sdl3`
 	CFLAGS = $(CXXFLAGS)

--- a/examples/example_sdl3_sdlrenderer3/main.cpp
+++ b/examples/example_sdl3_sdlrenderer3/main.cpp
@@ -15,11 +15,6 @@
 #include "imgui_impl_sdlrenderer3.h"
 #include <stdio.h>
 #include <SDL3/SDL.h>
-#if defined(IMGUI_IMPL_OPENGL_ES2)
-#include <SDL3/SDL_opengles2.h>
-#else
-#include <SDL3/SDL_opengl.h>
-#endif
 
 #ifdef __EMSCRIPTEN__
 #include "../libs/emscripten/emscripten_mainloop_stub.h"
@@ -36,7 +31,7 @@ int main(int, char**)
     }
 
     // Create window with SDL_Renderer graphics context
-    Uint32 window_flags = SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_HIDDEN;
+    Uint32 window_flags = SDL_WINDOW_RESIZABLE | SDL_WINDOW_HIDDEN;
     SDL_Window* window = SDL_CreateWindow("Dear ImGui SDL3+SDL_Renderer example", 1280, 720, window_flags);
     if (window == nullptr)
     {


### PR DESCRIPTION
This modifies the Makefile and main.cpp for examples/example_sdl3_sdlrenderer to remove the OpenGL includes and linking.  I only testing on MinGW-w64, so the MacOS version might still need to be fixed.

I made this change because it wasn't clear to me if SDL3 renderer _needed_ OpenGL for rendering or not.  This (slightly) updated code makes it clear that it doesn't.