### PR TITLE
fix: resolve the issue of font texture loss when resizing the window in opengl2 & sdl2 environment

### DIFF
--- a/examples/example_sdl2_opengl2/main.cpp
+++ b/examples/example_sdl2_opengl2/main.cpp
@@ -47,8 +47,6 @@ int main(int, char**)
         return -1;
     }
 
-    SDL_GLContext gl_context = SDL_GL_CreateContext(window);
-    SDL_GL_MakeCurrent(window, gl_context);
     SDL_GL_SetSwapInterval(1); // Enable vsync
 
     // Setup Dear ImGui context
@@ -63,7 +61,7 @@ int main(int, char**)
     //ImGui::StyleColorsLight();
 
     // Setup Platform/Renderer backends
-    ImGui_ImplSDL2_InitForOpenGL(window, gl_context);
+    ImGui_ImplSDL2_InitForOpenGL(window, nullptr);
     ImGui_ImplOpenGL2_Init();
 
     // Load Fonts
@@ -168,7 +166,6 @@ int main(int, char**)
     ImGui_ImplSDL2_Shutdown();
     ImGui::DestroyContext();
 
-    SDL_GL_DeleteContext(gl_context);
     SDL_DestroyWindow(window);
     SDL_Quit();
 


### PR DESCRIPTION
Hi, the OpenGL2 backend does not require a context, and when creating and specifying a context for its window, changing the window size will cause the font texture to be lost on Windows platform:
![image](https://github.com/user-attachments/assets/2464233b-765a-4c94-b5eb-18418c8a1695)


