### PR TITLE
Backends: WebGPU: include imgui.h before backend check

### DIFF
--- a/backends/imgui_impl_wgpu.cpp
+++ b/backends/imgui_impl_wgpu.cpp
@@ -41,6 +41,8 @@
 //  2021-02-18: Change blending equation to preserve alpha in output buffer.
 //  2021-01-28: Initial version.
 
+#include "imgui.h"
+
 // When targeting native platforms (i.e. NOT emscripten), one of IMGUI_IMPL_WEBGPU_BACKEND_DAWN
 // or IMGUI_IMPL_WEBGPU_BACKEND_WGPU must be provided. See imgui_impl_wgpu.h for more details.
 #ifndef __EMSCRIPTEN__
@@ -53,7 +55,6 @@
     #endif
 #endif
 
-#include "imgui.h"
 #ifndef IMGUI_DISABLE
 #include "imgui_impl_wgpu.h"
 #include <limits.h>


### PR DESCRIPTION
The backend check would always fail in non-Emscripten settings because `imgui`, and transitively `imconfig.h`, would not be included at this point in the code. The result is the following compile error, which modifying `imconfig.h` would not solve. (This issue can be worked around by supplying the definition via the build system.)

```
imgui/backends/imgui_impl_wgpu.cpp:48:6: error: #error exactly one of IMGUI_IMPL_WEBGPU_BACKEND_DAWN or IMGUI_IMPL_WEBGPU_BACKEND_WGPU must be defined!
   48 |     #error exactly one of IMGUI_IMPL_WEBGPU_BACKEND_DAWN or IMGUI_IMPL_WEBGPU_BACKEND_WGPU must be defined!
      |      ^~~~~
```

I'm trying to get IMGUI working with WebGPU under Dawn. I encountered this issue; afterwards there are some other compile issues that I need to solve.