### PR TITLE
Backends: WebGPU: Add nextInChain field for VertexAttributes under Dawn

### DIFF
--- a/backends/imgui_impl_wgpu.cpp
+++ b/backends/imgui_impl_wgpu.cpp
@@ -687,9 +687,15 @@ bool ImGui_ImplWGPU_CreateDeviceObjects()
     // Vertex input configuration
     WGPUVertexAttribute attribute_desc[] =
     {
+#ifdef IMGUI_IMPL_WEBGPU_BACKEND_DAWN
+        { nullptr, WGPUVertexFormat_Float32x2, (uint64_t)offsetof(ImDrawVert, pos), 0 },
+        { nullptr, WGPUVertexFormat_Float32x2, (uint64_t)offsetof(ImDrawVert, uv),  1 },
+        { nullptr, WGPUVertexFormat_Unorm8x4,  (uint64_t)offsetof(ImDrawVert, col), 2 },
+#else
         { WGPUVertexFormat_Float32x2, (uint64_t)offsetof(ImDrawVert, pos), 0 },
         { WGPUVertexFormat_Float32x2, (uint64_t)offsetof(ImDrawVert, uv),  1 },
         { WGPUVertexFormat_Unorm8x4,  (uint64_t)offsetof(ImDrawVert, col), 2 },
+#endif
     };
 
     WGPUVertexBufferLayout buffer_layouts[1];


### PR DESCRIPTION
Compilation using Dawn fails with the following error:

```
imgui/backends/imgui_impl_wgpu.cpp: In function ‘bool ImGui_ImplWGPU_CreateDeviceObjects()’:
imgui/backends/imgui_impl_wgpu.cpp:690:11: error: cannot convert ‘WGPUVertexFormat’ to ‘WGPUChainedStruct*’ in initialization
  690 |         { WGPUVertexFormat_Float32x2, (uint64_t)offsetof(ImDrawVert, pos), 0 },
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~
      |           |
      |           WGPUVertexFormat
/home/alan/cpp-projects/hikari/third_party/imgui/backends/imgui_impl_wgpu.cpp:691:11: error: cannot convert ‘WGPUVertexFormat’ to ‘WGPUChainedStruct*’ in initialization
  691 |         { WGPUVertexFormat_Float32x2, (uint64_t)offsetof(ImDrawVert, uv),  1 },
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~
      |           |
      |           WGPUVertexFormat
/home/alan/cpp-projects/hikari/third_party/imgui/backends/imgui_impl_wgpu.cpp:692:11: error: cannot convert ‘WGPUVertexFormat’ to ‘WGPUChainedStruct*’ in initialization
  692 |         { WGPUVertexFormat_Unorm8x4,  (uint64_t)offsetof(ImDrawVert, col), 2 },
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~
      |           |
      |           WGPUVertexFormat
```

This commit fixes this issue. As far as I know, the Rust wgpu implementation does not have this field: https://docs.rs/wgpu/latest/wgpu/struct.VertexAttribute.html