### PR TITLE
Wrapping last punctuation if there are continuous punctuation symbols 

### DIFF
--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -4004,7 +4004,14 @@ const char* ImFont::CalcWordWrapPositionA(float scale, const char* text, const c
             }
 
             // Allow wrapping after punctuation.
-            inside_word = (c != '.' && c != ',' && c != ';' && c != '!' && c != '?' && c != '\"');
+            unsigned int next_c = (unsigned int)*next_s;
+            bool current_is_punctuation = (c == '.' || c == ',' || c == ';' || c == '!' || c == '?' || c == '\"');
+            bool next_is_punctuation = (next_c == '.' || next_c == ',' || next_c == ';' || next_c == '!' || next_c == '?' || next_c == '\"');
+            if (current_is_punctuation && !next_is_punctuation) {
+                inside_word = false;
+            } else {
+                inside_word = true;
+            }
         }
 
         // We ignore blank width at the end of the line (they can be skipped)


### PR DESCRIPTION
Wrapping last punctuation if there are continuous punctuation symbols https://github.com/ocornut/imgui/issues/8139
Looks like the CalcWordWrapPositionA method wrap one first punctuation, perhaps wrap at last punctuation would be a good solution ? 

