### PR TITLE
Allow Splitting same node multiple times

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -19911,8 +19911,6 @@ ImGuiID ImGui::DockBuilderSplitNode(ImGuiID id, ImGuiDir split_dir, float size_r
         return 0;
     }
 
-    IM_ASSERT(!node->IsSplitNode()); // Assert if already Split
-
     ImGuiDockRequest req;
     req.Type = ImGuiDockRequestType_Split;
     req.DockTargetWindow = NULL;


### PR DESCRIPTION
This allows splitting a dock node so that you can create a left/right/up/down docking location programmatically.

Without this, the programmer can only split one direction off of the main dockId which prevents docking multiple windows to the other sides of the main program window.

According to other issues regarding docking, this appears to be intended functionality.

Example:

```cpp
    const ImGuiID dockId = ImGui::GetID("main_dock");
    if (!ImGui::DockBuilderGetNode(dockId)) {
        ImGui::DockBuilderRemoveNode(dockId);
        ImGui::DockBuilderAddNode(dockId, ImGuiDockNodeFlags_NoTabBar);

        ImGui::DockBuilderDockWindow("Main Game", dockId);

        ImGuiID rightId = ImGui::DockBuilderSplitNode(dockId, ImGuiDir_Right, 0.25f, nullptr, nullptr);
        ImGuiID topId = ImGui::DockBuilderSplitNode(dockId, ImGuiDir_Up, 0.25f, nullptr, nullptr);
        ImGuiID bottomId = ImGui::DockBuilderSplitNode(dockId, ImGuiDir_Down, 0.25f, nullptr, nullptr);
        ImGui::DockBuilderSetNodeSize(rightId, ImVec2(viewport->Size.x * 0.2f, viewport->Size.y));
        ImGui::DockBuilderSetNodeSize(topId, ImVec2(viewport->Size.x, viewport->Size.y * 0.1f));
        ImGui::DockBuilderSetNodeSize(bottomId, ImVec2(viewport->Size.x, viewport->Size.y * 0.1f));
        
        ImGui::DockBuilderDockWindow("Scene Explorer", rightId);
        ImGui::DockBuilderDockWindow("Tools", topId);
        ImGui::DockBuilderDockWindow("Content Browser", bottomId);

        ImGui::DockBuilderFinish(dockId);
    }

    ImGui::DockSpace(dockId, ImVec2(0.0f, 0.0f), ImGuiDockNodeFlags_None | ImGuiDockNodeFlags_NoDockingInCentralNode);
```