### PR TITLE
Docs: Fix some typos

### DIFF
--- a/backends/imgui_impl_opengl3.cpp
+++ b/backends/imgui_impl_opengl3.cpp
@@ -54,7 +54,7 @@
 //  2021-01-03: OpenGL: Backup, setup and restore GL_STENCIL_TEST state.
 //  2020-10-23: OpenGL: Backup, setup and restore GL_PRIMITIVE_RESTART state.
 //  2020-10-15: OpenGL: Use glGetString(GL_VERSION) instead of glGetIntegerv(GL_MAJOR_VERSION, ...) when the later returns zero (e.g. Desktop GL 2.x)
-//  2020-09-17: OpenGL: Fix to avoid compiling/calling glBindSampler() on ES or pre 3.3 context which have the defines set by a loader.
+//  2020-09-17: OpenGL: Fix to avoid compiling/calling glBindSampler() on ES or pre-3.3 context which have the defines set by a loader.
 //  2020-07-10: OpenGL: Added support for glad2 OpenGL loader.
 //  2020-05-08: OpenGL: Made default GLSL version 150 (instead of 130) on OSX.
 //  2020-04-21: OpenGL: Fixed handling of glClipControl(GL_UPPER_LEFT) by inverting projection matrix.

--- a/backends/imgui_impl_osx.mm
+++ b/backends/imgui_impl_osx.mm
@@ -39,7 +39,7 @@
 //  2024-07-02: Update for io.SetPlatformImeDataFn() -> io.PlatformSetImeDataFn() renaming in main library.
 //  2023-10-05: Inputs: Added support for extra ImGuiKey values: F13 to F20 function keys. Stopped mapping F13 into PrintScreen.
 //  2023-04-09: Inputs: Added support for io.AddMouseSourceEvent() to discriminate ImGuiMouseSource_Mouse/ImGuiMouseSource_Pen.
-//  2023-02-01: Fixed scroll wheel scaling for devices emitting events with hasPreciseScrollingDeltas==false (e.g. non-Apple mices).
+//  2023-02-01: Fixed scroll wheel scaling for devices emitting events with hasPreciseScrollingDeltas==false (e.g. non-Apple mice).
 //  2022-11-02: Fixed mouse coordinates before clicking the host window.
 //  2022-10-06: Fixed mouse inputs on flipped views.
 //  2022-09-26: Inputs: Renamed ImGuiKey_ModXXX introduced in 1.87 to ImGuiMod_XXX (old names still supported).

--- a/backends/imgui_impl_vulkan.cpp
+++ b/backends/imgui_impl_vulkan.cpp
@@ -53,7 +53,7 @@
 //  2022-10-11: Using 'nullptr' instead of 'NULL' as per our switch to C++11.
 //  2022-10-04: Vulkan: Added experimental ImGui_ImplVulkan_RemoveTexture() for api symmetry. (#914, #5738).
 //  2022-01-20: Vulkan: Added support for ImTextureID as VkDescriptorSet. User need to call ImGui_ImplVulkan_AddTexture(). Building for 32-bit targets requires '#define ImTextureID ImU64'. (#914).
-//  2021-10-15: Vulkan: Call vkCmdSetScissor() at the end of render a full-viewport to reduce likehood of issues with people using VK_DYNAMIC_STATE_SCISSOR in their app without calling vkCmdSetScissor() explicitly every frame.
+//  2021-10-15: Vulkan: Call vkCmdSetScissor() at the end of render a full-viewport to reduce likelihood of issues with people using VK_DYNAMIC_STATE_SCISSOR in their app without calling vkCmdSetScissor() explicitly every frame.
 //  2021-06-29: Reorganized backend to pull data from a single structure to facilitate usage with multiple-contexts (all g_XXXX access changed to bd->XXXX).
 //  2021-03-22: Vulkan: Fix mapped memory validation error when buffer sizes are not multiple of VkPhysicalDeviceLimits::nonCoherentAtomSize.
 //  2021-02-18: Vulkan: Change blending equation to preserve alpha in output buffer.

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -101,7 +101,7 @@ Other changes:
   - Default for selected tabs: TabCloseButtonMinWidthSelected = -1.0f (always visible)
   - Default for unselected tabs: TabCloseButtonMinWidthUnselected = 0.0f (visible when hovered)
 - Tabs: fixed middle-mouse-button to close tab not checking that close button
-  is hovered, merely it's visibility. (#8399, #8387) [@nicovanbentum]
+  is hovered, merely its visibility. (#8399, #8387) [@nicovanbentum]
 - TextLink(), TextLinkOpenURL(): fixed honoring text baseline alignment.
   (#8451, #7660) [@achabense]
 - TextLinkOpenURL(): fixed default Win32 io.PlatformOpenInShellFn handler to
@@ -678,7 +678,7 @@ Other changes:
   by an extra pixel + rework the change so that contents doesn't overlap the bottom and
   right border in a scrolling table. (#6765, #3752, #7428)
 - Tables: fixed an issue resizing columns or querying hovered column/row when using multiple
-  synched instances that are layed out at different X positions. (#7933)
+  synced instances that are laid out at different X positions. (#7933)
 - Tabs: avoid queuing a refocus when tab is already focused, which would have the
   side-effect of e.g. closing popup on a mouse release. (#7914)
 - InputText: allow callback to update buffer while in read-only mode. (imgui_club/#46)
@@ -911,7 +911,7 @@ Other changes:
 - Windows: BeginChild(): fixed a glitch when during a resize of a child window which is
   tightly close to the boundaries of its parent (e.g. with zero WindowPadding), the child
   position could have temporarily be moved around by erroneous padding application. (#7706)
-- TabBar, Style: added ImGuiTabBarFlags_DrawSelectedOverline option to draw an horizontal
+- TabBar, Style: added ImGuiTabBarFlags_DrawSelectedOverline option to draw a horizontal
   line over selected tabs to increase visibility. This is used by docking.
   Added corresponding ImGuiCol_TabSelectedOverline and ImGuiCol_TabDimmedSelectedOverline colors.
 - Tables: added TableGetHoveredColumn() to public API, as an alternative to testing for
@@ -974,7 +974,7 @@ Other changes:
 - Scrollbar: made scrolling logic more standard: clicking above or below the
   grab scrolls by one page, holding mouse button repeats scrolling. (#7328, #150)
 - Scrollbar: fixed miscalculation of vertical scrollbar visibility when required
-  solely by the presence of an horizontal scrollbar. (#1574)
+  solely by the presence of a horizontal scrollbar. (#1574)
 - InputScalar, InputInt, InputFloat: added ImGuiInputTextFlags_ParseEmptyRefVal
   to parse an empty field as zero-value. (#7305) [@supermerill, @ocornut]
 - InputScalar, InputInt, InputFloat: added ImGuiInputTextFlags_DisplayEmptyRefVal
@@ -1108,7 +1108,7 @@ Decorated log and release notes: https://github.com/ocornut/imgui/releases/tag/v
 
 Breaking changes:
 
-- TreeNode: Fixed a layout inconsistency when using a empty/hidden label followed
+- TreeNode: Fixed a layout inconsistency when using an empty/hidden label followed
   by a SameLine() call. (#7505, #282)
      Before: TreeNode("##Hidden"); SameLine(); Text("Hello");
              // This was actually incorrect! BUT appeared to look ok with the default style
@@ -1207,7 +1207,7 @@ Other changes:
   Note that only simple polygons (no self-intersections, no holes) are supported.
 - DrawList: Allow AddText() to accept null ranges. (#3615, 7391)
 - Docs: added more wiki links to headers of imgui.h/imgui.cpp to facilitate discovery
-  of interesting resources, because github doesn't allow Wiki to be crawled by search engines.
+  of interesting resources, because GitHub doesn't allow Wiki to be crawled by search engines.
   - This is the main wiki: https://github.com/ocornut/imgui/wiki
   - This is the crawlable version: https://github-wiki-see.page/m/ocornut/imgui/wiki
     Adding a link to the crawlable version, even though it is not intended for humans,
@@ -1359,7 +1359,7 @@ Other changes:
   - BeginChild(): Resize borders rendered even when ImGuiWindowFlags_NoBackground
     is specified. (#1710, #7194)
   - Fixed some auto-resizing path using style.WindowMinSize.x (instead of x/y)
-    for both axises since 1.90. (#7106) [@n0bodysec]
+    for both axes since 1.90. (#7106) [@n0bodysec]
   - Scrolling: internal scrolling value is rounded instead of truncated, as a way to reduce
     speed asymmetry when (incorrectly) attempting to scroll by non-integer amount. (#6677)
 - Navigation (Keyboard/gamepad):
@@ -1517,7 +1517,7 @@ Other changes:
     - Combining this with also specifying ImGuiChildFlags_AlwaysAutoResize disables
       this optimization, meaning child contents will never be clipped (not recommended).
     - Please be considerate that child are full windows and carry significant overhead:
-      combining auto-resizing for both axises to create a non-scrolling child to merely draw
+      combining auto-resizing for both axes to create a non-scrolling child to merely draw
       a border would be better more optimally using BeginGroup(). (see #1496)
       (until we come up with new helpers for framed groups and work-rect adjustments).
   - BeginChild(): made it possible to use SetNextWindowSizeConstraints() rectangle, often
@@ -1579,7 +1579,7 @@ Other changes:
     parent-menu would erroneously close the child-menu. (Regression from 1.88). (#6869)
   - MenuBar: Fixed an issue where layouting an item in the menu-bar would erroneously
     register contents size in a way that would affect the scrolling layer.
-    Was most often noticeable when using an horizontal scrollbar. (#6789)
+    Was most often noticeable when using a horizontal scrollbar. (#6789)
 - InputText:
   - InputTextMultiline: Fixed a crash pressing Down on last empty line of a multi-line buffer.
     (regression from 1.89.2, only happened in some states). (#6783, #6000)
@@ -1785,7 +1785,7 @@ Breaking changes:
 
 - Moved io.HoverDelayShort/io.HoverDelayNormal to style.HoverDelayShort/style.HoverDelayNormal.
   As the fields were added in 1.89 and expected to be left unchanged by most users, or only
-  tweaked once during app initialisation, we are exceptionally accepting the breakage.
+  tweaked once during app initialization, we are exceptionally accepting the breakage.
   Majority of users should not even notice.
 - Overlapping items: (#6512, #3909, #517)
   - Added 'SetNextItemAllowOverlap()' (called before an item) as a replacement for using
@@ -1885,7 +1885,7 @@ Breaking changes:
 - Commented out obsolete/redirecting functions that were marked obsolete more than two years ago:
    - ListBoxHeader()  -> use BeginListBox()
    - ListBoxFooter()  -> use EndListBox()
-   - Note how two variants of ListBoxHeader() existed. Check commented versions in imgui.h for refeence.
+   - Note how two variants of ListBoxHeader() existed. Check commented versions in imgui.h for reference.
 - Backends: SDL_Renderer: Renamed 'imgui_impl_sdlrenderer.h/cpp' to 'imgui_impl_sdlrenderer2.h/cpp',
   in order to accommodate for upcoming SDL3 and change in its SDL_Renderer API. (#6286)
 - Backends: GLUT: Removed call to ImGui::NewFrame() from ImGui_ImplGLUT_NewFrame().
@@ -2112,20 +2112,20 @@ Other changes:
   due to how unique table instance id was generated. (#6140) [@ocornut, @rodrigorc]
 - Inputs, Scrolling: Made horizontal scroll wheel and horizontal scroll direction consistent
   across backends/os. (#4019, #6096, #1463) [@PathogenDavid, @ocornut, @rokups]
-  - Clarified that 'wheel_y > 0.0f' scrolls Up, 'wheel_y > 0.0f' scrolls Down.
-    Clarified that 'wheel_x > 0.0f' scrolls Left, 'wheel_x > 0.0f' scrolls Right.
+  - Clarified that 'wheel_y > 0.0f' scrolls Up, 'wheel_y < 0.0f' scrolls Down.
+    Clarified that 'wheel_x > 0.0f' scrolls Left, 'wheel_x < 0.0f' scrolls Right.
   - Backends: Fixed horizontal scroll direction for Win32 and SDL backends. (#4019)
   - Shift+WheelY support on non-OSX machines was already correct. (#2424, #1463)
     (whereas on OSX machines Shift+WheelY turns into WheelX at the OS level).
   - If you use a custom backend, you should verify horizontal wheel direction.
-    - Axises are flipped by OSX for mouse & touch-pad when 'Natural Scrolling' is on.
-    - Axises are flipped by Windows for touch-pad when 'Settings->Touchpad->Down motion scrolls up' is on.
+    - Axes are flipped by OSX for mouse & touch-pad when 'Natural Scrolling' is on.
+    - Axes are flipped by Windows for touch-pad when 'Settings->Touchpad->Down motion scrolls up' is on.
     - You can use 'Demo->Tools->Debug Log->IO" to visualize values submitted to Dear ImGui.
   - Known issues remaining with Emscripten:
     - The magnitude of wheeling values on Emscripten was improved but isn't perfect. (#6096)
     - When running the Emscripten app on a Mac with a mouse, SHIFT+WheelY doesn't turn into WheelX.
       This is because we don't know that we are running on Mac and apply our own Shift+swapping
-      on top of OSX' own swapping, so wheel axises are swapped twice. Emscripten apps may need
+      on top of OSX's own swapping, so wheel axes are swapped twice. Emscripten apps may need
       to find a way to detect this and set io.ConfigMacOSXBehaviors manually (if you know a way
       let us know!), or offer the "OSX-style behavior" option to their user.
 - Window: Avoid rendering shapes for hidden resize grips.
@@ -2151,7 +2151,7 @@ Other changes:
   values for io.DeltaTime, and browser features such as "privacy.resistFingerprinting=true"
   can exacerbate that. (#6114, #3644)
 - Backends: OSX: Fixed scroll/wheel scaling for devices emitting events with
-  hasPreciseScrollingDeltas==false (e.g. non-Apple mices).
+  hasPreciseScrollingDeltas==false (e.g. non-Apple mice).
 - Backends: Win32: flipping WM_MOUSEHWHEEL horizontal value to match other backends and
   offer consistent horizontal scrolling direction. (#4019)
 - Backends: SDL2: flipping SDL_MOUSEWHEEL horizontal value to match other backends and
@@ -2355,7 +2355,7 @@ Other Changes:
 - Scrolling: Mitigated issue where multi-axis mouse-wheel inputs (usually from touch pad
   events) are incorrectly locking scrolling in a parent window. (#4559, #3795, #2604)
 - Scrolling: Exposed SetNextWindowScroll() in public API. Useful to remove a scrolling
-  delay in some situations where e.g. windows need to be synched. (#1526)
+  delay in some situations where e.g. windows need to be synced. (#1526)
 - InputText: added experimental io.ConfigInputTextEnterKeepActive feature to make pressing
   Enter keep the input active and select all text.
 - InputText: numerical fields automatically accept full-width characters (U+FF01..U+FF5E)
@@ -2399,7 +2399,7 @@ Other Changes:
 - Menus: Fixed using IsItemHovered()/IsItemClicked() on BeginMenu(). (#5775)
 - Menus, Popups: Experimental fix for issue where clicking on an open BeginMenu() item called from
   a window which is neither a popup neither a menu used to incorrectly close and reopen the menu
-  (the fix may have side-effect and is labelld as experimental as we may need to revert). (#5775)
+  (the fix may have side-effect and is labelled as experimental as we may need to revert). (#5775)
 - Menus, Nav: Fixed keyboard/gamepad navigation occasionally erroneously landing on menu-item
   in parent window when the parent is not a popup. (#5730)
 - Menus, Nav: Fixed not being able to close a menu with Left arrow when parent is not a popup. (#5730)
@@ -2537,7 +2537,7 @@ Other Changes:
   always lead to menu closure. Fixes using items that are not MenuItem() or BeginItem() at the root
   level of a popup with a child menu opened.
 - Menus: Menus emitted from the main/scrolling layer are not part of the same menu-set as menus emitted
-  from the menu-bar, avoiding  accidental hovering from one to the other. (#3496, #4797) [@rokups]
+  from the menu-bar, avoiding accidental hovering from one to the other. (#3496, #4797) [@rokups]
 - Style: Adjust default value of GrabMinSize from 10.0f to 12.0f.
 - Stack Tool: Added option to copy item path to clipboard. (#4631)
 - Settings: Fixed out-of-bounds read when .ini file on disk is empty. (#5351) [@quantum5]
@@ -2639,7 +2639,7 @@ Breaking Changes:
     io.AddKeyEvent(), io.AddKeyAnalogEvent().
   - Added io.AddKeyAnalogEvent() function, obsoleting writing directly to io.NavInputs[] arrays.
 - Renamed ImGuiKey_KeyPadEnter to ImGuiKey_KeypadEnter to align with new symbols. Kept redirection enum. (#2625)
-- Removed support for legacy arithmetic operators (+,+-,*,/) when inputing text into a slider/drag. (#4917, #3184)
+- Removed support for legacy arithmetic operators (+,+-,*,/) when inputting text into a slider/drag. (#4917, #3184)
   This doesn't break any api/code but a feature that was accessible by end-users (which seemingly no one used).
   (Instead you may implement custom expression evaluators to provide a better version of this).
 - Backends: GLFW: backend now uses glfwSetCursorPosCallback().
@@ -2695,7 +2695,7 @@ Other Changes:
 - Backends: GLFW: Retrieve mouse position using glfwSetCursorPosCallback() + fallback when focused but not hovered/captured.
 - Backends: GLFW: Submit gamepad data using io.AddKeyEvent/AddKeyAnalogEvent() functions, stopped writing to io.NavInputs[]. (#4921)
 - Backends: GLFW: Added ImGui_ImplGlfw_InstallCallbacks()/ImGui_ImplGlfw_RestoreCallbacks() helpers to facilitate user installing
-  callbacks after iniitializing backend. (#4981)
+  callbacks after initializing backend. (#4981)
 - Backends: Win32: Submit keys and key mods using io.AddKeyEvent(). (#2625, #4921)
 - Backends: Win32: Retrieve mouse position using WM_MOUSEMOVE/WM_MOUSELEAVE + fallback when focused but not hovered/captured.
 - Backends: Win32: Submit mouse data using io.AddMousePosEvent(), AddMouseButtonEvent(), AddMouseWheelEvent() functions. (#4921)
@@ -2777,7 +2777,7 @@ Other Changes:
 - Menus: fixed sub-menu items inside a popups from closing the popup.
 - Menus: fixed top-level menu from not consistently using style.PopupRounding. (#4788)
 - InputText, Nav: fixed repeated calls to SetKeyboardFocusHere() preventing to use InputText(). (#4682)
-- Inputtext, Nav: fixed using SetKeyboardFocusHere() on InputTextMultiline(). (#4761)
+- InputText, Nav: fixed using SetKeyboardFocusHere() on InputTextMultiline(). (#4761)
 - InputText: made double-click select word, triple-line select line. Word delimitation logic differs
   slightly from the one used by CTRL+arrows. (#2244)
 - InputText: fixed ReadOnly flag preventing callbacks from receiving the text buffer. (#4762) [@actondev]
@@ -2808,7 +2808,7 @@ Other Changes:
 - Misc: Fix MinGW DLL build issue (when IMGUI_API is defined). [@rokups]
 - CI: Add MinGW DLL build to test suite. [@rokups]
 - Backends: Vulkan: Call vkCmdSetScissor() at the end of render with a full-viewport to reduce
-  likehood of issues with people using VK_DYNAMIC_STATE_SCISSOR in their app without calling
+  likelihood of issues with people using VK_DYNAMIC_STATE_SCISSOR in their app without calling
   vkCmdSetScissor() explicitly every frame. (#4644)
 - Backends: OpenGL3: Using buffer orphaning + glBufferSubData(), seems to fix leaks with multi-viewports
   with some Intel HD drivers, and perhaps improve performances. (#4468, #4504, #2981, #3381) [@parbo]
@@ -2884,7 +2884,7 @@ Other Changes:
 - Nav: Fixed vertical scoring offset when wrapping on Y in a decorated window.
 - Nav: Improve scrolling behavior when navigating to an item larger than view.
 - TreePush(): removed unnecessary/inconsistent legacy behavior where passing a NULL value to
-  the TreePush(const char*) and TreePush(const void*) functions would use an hard-coded replacement.
+  the TreePush(const char*) and TreePush(const void*) functions would use a hard-coded replacement.
   The only situation where that change would make a meaningful difference is TreePush((const char*)NULL)
   (_explicitly_ casting a null pointer to const char*), which is unlikely and will now crash.
   You may replace it with anything else.
@@ -3007,9 +3007,9 @@ Other Changes:
 - Fonts: Functions with a 'float size_pixels' parameter can accept zero if it is set in ImFontSize::SizePixels.
 - Fonts: Prefer using U+FFFD character for fallback instead of '?', if available. (#4269)
 - Fonts: Use U+FF0E dot character to construct an ellipsis if U+002E '.' is not available. (#4269)
-- Fonts: Added U+FFFD ("replacement character") to default asian glyphs ranges. (#4269)
+- Fonts: Added U+FFFD ("replacement character") to default Asian glyphs ranges. (#4269)
 - Fonts: Fixed calling ClearTexData() (clearing CPU side font data) triggering an assert in NewFrame(). (#3487)
-- DrawList: Fixed AddCircle/AddCircleFilled() with auto-tesselation not using accelerated paths for small circles.
+- DrawList: Fixed AddCircle/AddCircleFilled() with auto-tessellation not using accelerated paths for small circles.
   Fixed AddCircle/AddCircleFilled() with 12 segments which had a broken edge. (#4419, #4421) [@thedmd]
 - Demo: Fixed requirement in 1.83 to link with imgui_demo.cpp if IMGUI_DISABLE_METRICS_WINDOW is not set. (#4171)
   Normally the right way to disable compiling the demo is to set IMGUI_DISABLE_DEMO_WINDOWS, but we want to avoid
@@ -3053,7 +3053,7 @@ Other Changes:
 - Examples: OSX+OpenGL2: Fix event forwarding (fix key remaining stuck when using shortcuts with Cmd/Super key).
   Other OSX examples were not affected. (#4253, #1873) [@rokups]
 - Examples: Updated all .vcxproj to VS2015 (toolset v140) to facilitate usage with vcpkg.
-- Examples: SDL2: Accommodate  for vcpkg install having headers in SDL2/SDL.h vs SDL.h.
+- Examples: SDL2: Accommodate for vcpkg install having headers in SDL2/SDL.h vs SDL.h.
 
 
 -----------------------------------------------------------------------
@@ -3175,7 +3175,7 @@ Breaking Changes:
 - ImDrawList: clarified that PathArcTo()/PathArcToFast() won't render with radius < 0.0f. Previously it sorts
   of accidentally worked but would lead to counter-clockwise paths which and have an effect on anti-aliasing.
 - InputText: renamed ImGuiInputTextFlags_AlwaysInsertMode to ImGuiInputTextFlags_AlwaysOverwrite, old name was an
-  incorrect description of behavior. Was ostly used by memory editor. Kept inline redirection function. (#2863)
+  incorrect description of behavior. Was mostly used by memory editor. Kept inline redirection function. (#2863)
 - Moved 'misc/natvis/imgui.natvis' to 'misc/debuggers/imgui.natvis' as we will provide scripts for other debuggers.
 - Style: renamed rarely used style.CircleSegmentMaxError (old default = 1.60f)
   to style.CircleTessellationMaxError (new default = 0.30f) as its meaning changed. (#3808) [@thedmd]
@@ -3273,7 +3273,7 @@ Other Changes:
      - For a Platform Monitor, the work area is generally the full area minus space used by task-bars.
   - All of this has been the case in 'docking' branch for a long time. What we've done is merely merging
     a small chunk of the multi-viewport logic into 'master' to standardize some concepts ahead of time.
-- Tables: Fixed PopItemWidth() or multi-components items not restoring per-colum ItemWidth correctly. (#3760)
+- Tables: Fixed PopItemWidth() or multi-components items not restoring per-column ItemWidth correctly. (#3760)
 - Window: Fixed minor title bar text clipping issue when FramePadding is small/zero and there are no
   close button in the window. (#3731)
 - SliderInt: Fixed click/drag when v_min==v_max from setting the value to zero. (#3774) [@erwincoumans]
@@ -3310,7 +3310,7 @@ Other Changes:
   User needs to call ImGui_ImplVulkan_LoadFunctions() with their custom loader prior to other functions.
 - Backends: Metal: Fixed texture storage mode when building on Mac Catalyst. (#3748) [@Belinsky-L-V]
 - Backends: OSX: Fixed mouse position not being reported when mouse buttons other than left one are down. (#3762) [@rokups]
-- Backends: WebGPU: Added enderer backend for WebGPU support (imgui_impl_wgpu.cpp) (#3632) [@bfierz]
+- Backends: WebGPU: Added renderer backend for WebGPU support (imgui_impl_wgpu.cpp) (#3632) [@bfierz]
   Please note that WebGPU is currently experimental, will not run on non-beta browsers, and may break.
 - Examples: WebGPU: Added Emscripten+WebGPU example. (#3632) [@bfierz]
 - Backends: GLFW: Added ImGui_ImplGlfw_InitForOther() initialization call to use with non OpenGL API. (#3632)
@@ -3509,12 +3509,12 @@ Other Changes:
 - Columns: Fix inverted ClipRect being passed to renderer when using certain primitives inside of
   a fully clipped column. (#3475) [@szreder]
 - Popups, Tooltips: Fix edge cases issues with positioning popups and tooltips when they are larger than
-  viewport on either or both axises. [@Rokups]
+  viewport on either or both axes. [@Rokups]
 - Fonts: AddFontDefault() adjust its vertical offset based on floor(size/13) instead of always +1.
   Was previously done by altering DisplayOffset.y but wouldn't work for DPI scaled font.
 - Metrics: Various tweaks, listing windows front-to-back, greying inactive items when possible.
 - Demo: Add simple InputText() callbacks demo (aside from the more elaborate ones in 'Examples->Console').
-- Backends: OpenGL3: Fix to avoid compiling/calling glBindSampler() on ES or pre 3.3 contexts which have
+- Backends: OpenGL3: Fix to avoid compiling/calling glBindSampler() on ES or pre-3.3 contexts which have
   the defines set by a loader. (#3467, #1985) [@jjwebb]
 - Backends: Vulkan: Some internal refactor aimed at allowing multi-viewport feature to create their
   own render pass. (#3455, #3459) [@FunMiles]
@@ -3603,7 +3603,7 @@ Other Changes:
   and allowed to pass them to InvisibleButton(): ImGuiButtonFlags_MouseButtonLeft/Right/Middle.
   This is a small but rather important change because lots of multi-button behaviors could previously
   only be achieved using lower-level/internal API. Now also available via high-level InvisibleButton()
-  with is a de-facto versatile building block to creating custom widgets with the public API.
+  with is a de facto versatile building block to creating custom widgets with the public API.
 - Fonts: Fixed ImFontConfig::GlyphExtraSpacing and ImFontConfig::PixelSnapH settings being pulled
   from the merged/target font settings when merging fonts, instead of being pulled from the source
   font settings.
@@ -3750,7 +3750,7 @@ Other Changes:
   ImGuiListClipper as the first thing after Begin() could largely break size calculations. (#3073)
 - Added optional support for Unicode plane 1-16 (#2538, #2541, #2815) [@cloudwu, @samhocevar]
   - Compile-time enable with '#define IMGUI_USE_WCHAR32' in imconfig.h.
-  - More onsistent handling of unsupported code points (0xFFFD).
+  - More consistent handling of unsupported code points (0xFFFD).
   - Surrogate pairs are supported when submitting UTF-16 data via io.AddInputCharacterUTF16(),
     allowing for more complete CJK input.
   - sizeof(ImWchar) goes from 2 to 4. IM_UNICODE_CODEPOINT_MAX goes from 0xFFFF to 0x10FFFF.
@@ -3834,7 +3834,7 @@ Other Changes:
 
 - Inputs: Added ImGuiMouseButton enum for convenience (e.g. ImGuiMouseButton_Right=1).
   We forever guarantee that the existing value will not changes so existing code is free to use 0/1/2.
-- Nav: Fixed a bug where the initial CTRL-Tab press while in a child window sometimes selected
+- Nav: Fixed a bug where the initial CTRL+Tab press while in a child window sometimes selected
   the current root window instead of always selecting the previous root window. (#787)
 - ColorEdit: Fix label alignment when using ImGuiColorEditFlags_NoInputs. (#2955) [@rokups]
 - ColorEdit: In HSV display of a RGB stored value, attempt to locally preserve Saturation
@@ -4007,7 +4007,7 @@ Other Changes:
   mostly for consistency. (#2159, #2160) [@goran-w]
 - Selectable: Added ImGuiSelectableFlags_AllowItemOverlap flag in public api (was previously internal only).
 - Style: Allow style.WindowMenuButtonPosition to be set to ImGuiDir_None to hide the collapse button. (#2634, #2639)
-- Font: Better ellipsis ("...") drawing implementation. Instead of drawing three pixel-ey dots (which was glaringly
+- Font: Better ellipsis ("...") drawing implementation. Instead of drawing three pixely dots (which was glaringly
   unfitting with many types of fonts) we first attempt to find a standard ellipsis glyphs within the loaded set.
   Otherwise we render ellipsis using '.' from the font from where we trim excessive spacing to make it as narrow
   as possible. (#2775) [@rokups]
@@ -4343,7 +4343,7 @@ Other Changes:
 - InputText: Fixed an edge case crash that would happen if another widget sharing the same ID
   is being swapped with an InputText that has yet to be activated.
 - InputText: Fixed various display corruption related to swapping the underlying buffer while
-  a input widget is active (both for writable and read-only paths). Often they would manifest
+  an input widget is active (both for writable and read-only paths). Often they would manifest
   when manipulating the scrollbar of a multi-line input text.
 - ColorEdit, ColorPicker, ColorButton: Added ImGuiColorEditFlags_InputHSV to manipulate color
   values encoded as HSV (in order to avoid HSV<>RGB round trips and associated singularities).
@@ -4354,7 +4354,7 @@ Other Changes:
   reading the 4th float in the array (value was read and discarded). (#2384) [@haldean]
 - MenuItem, Selectable: Fixed disabled widget interfering with navigation (fix c2db7f63 in 1.67).
 - Tabs: Fixed a crash when using many BeginTabBar() recursively (didn't affect docking). (#2371)
-- Tabs: Added extra mis-usage error recovery. Past the assert, common mis-usage don't lead to
+- Tabs: Added extra misusage error recovery. Past the assert, common misusage don't lead to
   hard crashes any more, facilitating integration with scripting languages. (#1651)
 - Tabs: Fixed ImGuiTabItemFlags_SetSelected being ignored if the tab is not visible (with
   scrolling policy enabled) or if is currently appearing.
@@ -4397,7 +4397,7 @@ Breaking Changes:
 
 - Removed io.DisplayVisibleMin/DisplayVisibleMax (which were marked obsolete and removed from viewport/docking branch already).
 - Made it illegal/assert when io.DisplayTime == 0.0f (with an exception for the first frame).
-  If for some reason your time step calculation gives you a zero value, replace it with a arbitrarily small value!
+  If for some reason your time step calculation gives you a zero value, replace it with an arbitrarily small value!
 
 Other Changes:
 
@@ -4495,7 +4495,7 @@ Other Changes:
   in the parent window, so there is no mismatch between the layout in parent and the position of the child window.
 - InputFloat: When using ImGuiInputTextFlags_ReadOnly the step buttons are disabled. (#2257)
 - DragFloat: Fixed broken mouse direction change with power!=1.0. (#2174, #2206) [@Joshhua5]
-- Nav: Fixed an keyboard issue where holding Activate/Space for longer than two frames on a button would unnecessary
+- Nav: Fixed a keyboard issue where holding Activate/Space for longer than two frames on a button would unnecessary
   keep the focus on the parent window, which could steal it from newly appearing windows. (#787)
 - Nav: Fixed animated window titles from being updated when displayed in the CTRL+Tab list. (#787)
 - Error recovery: Extraneous/undesired calls to End() are now being caught by an assert in the End() function closer
@@ -4647,7 +4647,7 @@ Changes:
   then separate your changes into several patches that can more easily be applied to 1.64 on a per-file basis.
   What I found worked nicely for me, was to open the diff of the old patches in an interactive merge/diff tool,
   search for the corresponding function in the new code and apply the chunks manually.
-- As a reminder, if you have any change to imgui.cpp it is a good habit to discuss them on the github,
+- As a reminder, if you have any change to imgui.cpp it is a good habit to discuss them on the GitHub,
   so a solution applicable on the Master branch can be found. If your company has changes that you cannot
   disclose you may also contact me privately.
 
@@ -4682,7 +4682,7 @@ Other Changes:
 - Nav: Added a CTRL+TAB window list and changed the highlight system accordingly. The change is motivated by upcoming
   Docking features. (#787)
 - Nav: Made CTRL+TAB skip menus + skip the current navigation window if is has the ImGuiWindow_NoNavFocus set. (#787)
-  While it was previously possible, you won't be able to CTRL-TAB out and immediately back in a window with the
+  While it was previously possible, you won't be able to CTRL+TAB out and immediately back in a window with the
   ImGuiWindow_NoNavFocus flag.
 - Window: Allow menu and popups windows from ignoring the style.WindowMinSize values so short menus/popups are not padded. (#1909)
 - Window: Added global io.ConfigResizeWindowsFromEdges option to enable resizing windows from their edges and from
@@ -4717,7 +4717,7 @@ Other Changes:
 - Fixed assertion when transitioning from an active ID to another within a group, affecting ColorPicker (broken in 1.62). (#2023, #820, #956, #1875).
 - Fixed PushID() from keeping alive the new ID Stack top value (if a previously active widget shared the ID it would be erroneously kept alive).
 - Fixed horizontal mouse wheel not forwarding the request to the parent window if ImGuiWindowFlags_NoScrollWithMouse is set. (#1463, #1380, #1502)
-- Fixed a include build issue for Cygwin in non-POSIX (Win32) mode. (#1917, #1319, #276)
+- Fixed an include build issue for Cygwin in non-POSIX (Win32) mode. (#1917, #1319, #276)
 - ImDrawList: Improved handling for worst-case vertices reservation policy when large amount of text (e.g. 1+ million character strings)
   are being submitted in a single call. It would typically have crashed InputTextMultiline(). (#200)
 - OS/Windows: Fixed missing ImmReleaseContext() call in the default Win32 IME handler. (#1932) [@vby]
@@ -4952,7 +4952,7 @@ Other Changes:
   - Set io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard to enable. NewFrame() will automatically
     fill io.NavInputs[] based on your io.KeysDown[] + io.KeyMap[] arrays.
   - Basic controls: arrows to navigate, Alt to enter menus, Space to activate item, Enter to edit text,
-    Escape to cancel/close, Ctrl-Tab to focus windows, etc.
+    Escape to cancel/close, Ctrl+Tab to focus windows, etc.
   - When keyboard navigation is active (io.NavActive + ImGuiConfigFlags_NavEnableKeyboard),
     the io.WantCaptureKeyboard flag will be set.
   - For more advanced uses, you may want to read from io.NavActive or io.NavVisible. Read imgui.cpp for more details.
@@ -5002,7 +5002,7 @@ Other Changes:
 - Style: Exposed ImGuiStyleVar_WindowTitleAlign, ImGuiStyleVar_ScrollbarSize, ImGuiStyleVar_ScrollbarRounding,
   ImGuiStyleVar_GrabRounding + added an assert to reduce accidental breakage. (#1181)
 - Style: Added style.MouseCursorScale help when using the software mouse cursor facility. (#939).
-- Style: Close button nows display a cross before hovering. Fixed cross positioning being a little off. Uses button colors for highlight when hovering. (#707)
+- Style: Close buttons now display a cross before hovering. Fixed cross positioning being a little off. Uses button colors for highlight when hovering. (#707)
 - Popup: OpenPopup() Always reopen existing pop-ups. (Removed imgui_internal.h's OpenPopupEx() which was used for this.) (#1497, #1533).
 - Popup: BeginPopupContextItem(), BeginPopupContextWindow(), BeginPopupContextVoid(), OpenPopupOnItemClick() all react on mouse release instead of mouse press. (~#439)
 - Popup: Better handling of user mistakenly calling OpenPopup() every frame (with the 'reopen_existing' option).
@@ -5025,7 +5025,7 @@ Other Changes:
 - Drag and Drop: Increased payload type string to 32 characters instead of 8. (#143)
 - Drag and Drop: TreeNode as drop target displays rectangle over full frame. (#1597, #143)
 - DragFloat: Fix/workaround for backends which do not preserve a valid mouse position when dragged out of bounds. (#1559)
-- InputFloat: Allow inputing value using scientific notation e.g. "1e+10".
+- InputFloat: Allow inputting value using scientific notation e.g. "1e+10".
 - InputDouble: Added InputDouble() function. We use a format string instead of a 'decimal_precision'
   parameter to also for "%e" and variants. (#1011)
 - Slider, Combo: Use ImGuiCol_FrameBgHovered color when hovered. (#1456) [@stfx]
@@ -5070,7 +5070,7 @@ Other Changes:
 - Demo: Improved Selectable() examples. (#1528)
 - Demo: Tweaked the Child demos, added a menu bar to the second child to test some navigation functions.
 - Demo: Console: Using ImGuiCol_Text to be more friendly to color changes.
-- Demo: Using IM_COL32() instead of ImColor() in ImDrawList centric contexts. Trying to phase out use of the ImColor helper whenever possible.
+- Demo: Using IM_COL32() instead of ImColor() in ImDrawList-centric contexts. Trying to phase out use of the ImColor helper whenever possible.
 - Examples: Files in examples/ now include their own changelog so it is easier to occasionally update your backends if needed.
 - Examples: Using Dark theme by default. (#707). Tweaked demo code.
 - Examples: Added support for horizontal mouse wheel for API that allows it. (#1463) [@tseeker]
@@ -5188,7 +5188,7 @@ Other Changes:
 - Window: Added ImGuiWindowFlags_ResizeFromAnySide flag to resize from any borders or from the
   lower-left corner of a window. This requires your backend to honor GetMouseCursor() requests
   for full usability. (#822)
-- Window: Sizing fixes when using SetNextWindowSize() on individual axises.
+- Window: Sizing fixes when using SetNextWindowSize() on individual axes.
 - Window: Hide new window for one frame until they calculate their size.
   Also fixes SetNextWindowPos() given a non-zero pivot. (#1694)
 - Window: Made mouse wheel scrolling accommodate better to windows that are smaller than the scroll step.
@@ -5490,7 +5490,7 @@ Other Changes:
   check the Demo window and comment for `ImGuiColorEditFlags_`.
   Some of the options it supports are: two color picker types (hue bar + sat/val rectangle,
   hue wheel + rotating sat/val triangle), display as u8 or float, lifting 0.0..1.0 constraints
-  (currently rgba only),  context menus, alpha bar, background checkerboard options, preview tooltip,
+  (currently rgba only), context menus, alpha bar, background checkerboard options, preview tooltip,
   basic revert. For simple use, calling the existing `ColorEdit4()` function as you did before
   will be enough, as you can now open the color picker from there.
 - Added `SetColorEditOptions()` to set default color options (e.g. if you want HSV over RGBA,
@@ -5592,7 +5592,7 @@ Other Changes:
   certain style settings and zero WindowMinSize).
 - EndGroup(): Made IsItemHovered() work when an item was activated within the group. (#849)
 - BulletText(): Fixed stopping to display formatted string after the '##' mark.
-- Closing the focused window restore focus to the first active root window in descending z-order .(part of #727)
+- Closing the focused window restore focus to the first active root window in descending z-order. (part of #727)
 - Word-wrapping: Fixed a bug where we never wrapped after a 1 character word. [@sronsse]
 - Word-wrapping: Fixed TextWrapped() overriding wrap position if one is already set. (#690)
 - Word-wrapping: Fixed incorrect testing for negative wrap coordinates, they are perfectly legal. (#706)
@@ -5629,7 +5629,7 @@ Other Changes:
 - Demo: ShowStyleEditor: show font character map / grid in more details.
 - Demo: Console: Fixed a completion bug when multiple candidates are equals and match until the end.
 - Demo: Fixed 1-byte off overflow in the ShowStyleEditor() combo usage. (#783) [@bear24rw]
-- Examples: Accessing ImVector fields directly, feel less stl-ey. (#810)
+- Examples: Accessing ImVector fields directly, feel less stl-y. (#810)
 - Examples: OpenGL*: Saving/restoring existing scissor rectangle for completeness. (#807)
 - Examples: OpenGL*: Saving/restoring active texture number (the value modified by glActiveTexture). (#1087, #1088, #1116)
 - Examples: OpenGL*: Saving/restoring separate color/alpha blend functions correctly. (#1120) [@greggman]
@@ -5793,7 +5793,7 @@ Other Changes:
   after a text input modification (e.g. "0.0" --> "0.000" would keep returning true). (#564)
 - DragFloat(): Always apply value when mouse is held/widget active, so that an always-resetting
   variable (e.g. non saved local) can be passed.
-- InputText(): OS X friendly behaviors:  (@zhiayang), (#473)
+- InputText(): OS X friendly behaviors: (@zhiayang), (#473)
   - Word movement uses ALT key;
   - Shortcuts uses CMD key;
   - Double-clicking text select a single word;
@@ -5918,7 +5918,7 @@ Changes:
 - PlotHistogram(): improved rendering of histogram with a lot of values.
 - Dummy(): creates an item so functions such as IsItemHovered() can be used.
 - BeginChildFrame() helper: added the extra_flags parameter.
-- Scrollbar: fixed rounding of background + child window consistenly have ChildWindowBg color under ScrollbarBg fill. (#355).
+- Scrollbar: fixed rounding of background + child window consistently have ChildWindowBg color under ScrollbarBg fill. (#355).
 - Scrollbar: background color less translucent in default style so it works better when changing background color.
 - Scrollbar: fixed minor rendering offset when borders are enabled. (#365)
 - ImDrawList: fixed 1 leak per ImDrawList using the ChannelsSplit() API (via Columns). (#318)
@@ -5934,7 +5934,7 @@ Changes:
 - Internal: Extracted a EndFrame() function out of Render() but kept it internal/private + clarified some asserts. (#335)
 - Internal: Added missing IMGUI_API definitions in imgui_internal.h (#326)
 - Internal: ImLoadFileToMemory() return void\* instead of taking void*\* + allow optional int\* file_size.
-- Demo: Horizontal scrollbar demo allows to enable simultanaeous scrollbars on both axises.
+- Demo: Horizontal scrollbar demo allows to enable simultaneous scrollbars on both axes.
 - Tools: binary_to_compressed_c.cpp: added -nocompress option.
 - Examples: Added example for the Marmalade platform.
 - Examples: Added batch files to build Windows examples with VS.
@@ -5979,7 +5979,7 @@ Other Changes:
 - ImDrawList: Added an assert on overflowing index value (#292).
 - ImDrawList: Fixed issues with channels split/merge. Now functional without manually adding a draw cmd. Added comments.
 - ImDrawData: Added ScaleClipRects() helper useful when rendering scaled. (#287).
-- Fixed Bullet() inconsistent layout behaviour when clipped.
+- Fixed Bullet() inconsistent layout behavior when clipped.
 - Fixed IsWindowHovered() not taking account of window hoverability (may be disabled because of a popup).
 - Fixed InvisibleButton() not honoring negative size consistently with other widgets that do so.
 - Fixed OpenPopup() accessing current window, effectively opening "Debug" when called from an empty window stack.
@@ -5991,7 +5991,7 @@ Other Changes:
   the first place so it's not really a useful default.
 - Begin(): Minor fixes with windows main clipping rectangle (e.g. child window with border).
 - Begin(): Window flags are only read on the first call of the frame. Subsequent calls ignore flags, which allows
-  appending to a window without worryin about flags.
+  appending to a window without worrying about flags.
 - InputText(): ignore character input when ctrl/alt are held. (Normally those text input are ignored by most wrappers.) (#279).
 - Demo: Fixed incorrectly formed string passed to Combo (#298).
 - Demo: Added simple Log demo.
@@ -6025,7 +6025,7 @@ Other Changes:
   and more natural to extend ImGui. However please note that none of the content in imgui_internal.h is guaranteed
   for forward-compatibility and code using those types/functions may occasionally break. (#219)
 - All sample code is in imgui_demo.cpp. Please keep this file in your project and consider allowing your code to call
-  the ShowTestWindow() function as de-facto guide to ImGui features. It will be stripped out by the linker when unused.
+  the ShowTestWindow() function as de facto guide to ImGui features. It will be stripped out by the linker when unused.
 - Added GetContentRegionAvail() helper (basically GetContentRegionMax() - GetCursorPos()).
 - Added ImGuiWindowFlags_NoInputs for totally input-passthru window.
 - Button(): honor negative size consistently with other widgets that do so (width -100 to align the button 100 pixels
@@ -6390,7 +6390,7 @@ Other Changes:
 - IsItemHovered() return false if another widget is active, aka we can't use what we are hovering now.
 - Added IsItemHoveredRect() if old behavior of IsItemHovered() is needed (e.g. for implementing
   the drop side of a drag'n drop operation).
-- IsItemhovered() include space taken by label and behave consistently for all widgets (#145)
+- IsItemHovered() include space taken by label and behave consistently for all widgets (#145)
 - Auto-filling child window feed their content size to parent (#170)
 - InputText() removed the odd ~ characters when clipping.
 - InputText() update its width in case of resize initiated programmatically while the widget is active.
@@ -6454,7 +6454,7 @@ Other Changes:
 - Sliders: Fixed parsing of decimal precision back from format string when using %%.
 - Sliders: Fixed hovering bounding test excluding padding between outer frame and grab (there was a few pixels dead-zone).
 - Separator() logs itself as text when passing through text log.
-- Optimisation: TreeNodeV() early out if SkipItems is set without formatting.
+- Optimization: TreeNodeV() early out if SkipItems is set without formatting.
 - Moved various static buffers into state. Increase the formatted string buffer from 1K to 3K.
 - Examples: Example console keeps focus on input box at all times.
 - Examples: Updated to GLFW 3.1. Moved to examples/libs/ folder.
@@ -6583,8 +6583,8 @@ Other Changes:
   Callback now passed an "EventFlag" parameter.
 - InputText: Added ImGuiInputTextFlags_CharsUppercase and ImGuiInputTextFlags_CharsNoBlank stock filters.
 - PushItemWidth() can take negative value to right-align items.
-- Optimisation: Columns offsets cached to avoid unnecessary binary search.
-- Optimisation: Optimized CalcTextSize() function by about 25% (they are often the bottleneck when
+- Optimization: Columns offsets cached to avoid unnecessary binary search.
+- Optimization: Optimized CalcTextSize() function by about 25% (they are often the bottleneck when
   submitting thousands of clipped items).
 - Added ImGuiCol_ChildWindowBg, ImGuiStyleVar_ChildWindowRounding for completeness and flexibility.
 - Added BeginChild() variant that takes an ImGuiID.
@@ -6627,7 +6627,7 @@ Decorated log and release notes: https://github.com/ocornut/imgui/releases/tag/v
 
 Breaking Changes:
 
-- Big update! Initialisation had to be changed. You don't need to load PNG data anymore. Th
+- Big update! Initialization had to be changed. You don't need to load PNG data anymore. The
   new system gives you uncompressed texture data.
   - This sequence:
       const void* png_data;
@@ -6637,7 +6637,7 @@ Breaking Changes:
   - Became:
       unsigned char* pixels;
       int width, height;
-      // io.Fonts->AddFontFromFileTTF("myfontfile.ttf", 24.0f);  // Optionally load another font
+      // io.Fonts->AddFontFromFileTTF("myfontfile.ttf", 24.0f); // Optionally load another font
       io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);
       // <Copy to GPU>
       io.Fonts->TexID = (your_texture_identifier);
@@ -6659,7 +6659,7 @@ Other Changes:
 - Added IsItemActive() to tell if last widget is being held / modified (as opposed to just
   being hovered). Useful for custom dragging behaviors.
 - Style: Added FrameRounding setting for a more rounded look (default to 0 for now).
-- Window: Fixed using multiple Begin/End pair on the same wnidow.
+- Window: Fixed using multiple Begin/End pair on the same window.
 - Window: Fixed style.WindowMinSize not being honored properly.
 - Window: Added SetCursorScreenPos() helper (WindowPos+CursorPos = ScreenPos).
 - ColorEdit3: clicking on color square change the edition. The toggle button is hidden by default.
@@ -6690,10 +6690,10 @@ Decorated log and release notes: https://github.com/ocornut/imgui/releases/tag/v
 - Dragging outside area of a widget while it is active doesn't trigger hover on other widgets.
 - Activating widget bring parent window to front if not already.
 - Checkbox and Radio buttons activate on click-release to be consistent with other widgets and most UI.
-- InputText() nows consume input characters immediately so they cannot be reused if
+- InputText() now consumes input characters immediately so they cannot be reused if
   ImGui::Update is called again with a call to ImGui::Render(). (fixes #105)
 - Examples: Console: added support for History callbacks + some cleanup.
-- Various small optimisations.
+- Various small optimizations.
 - Cleanup and other fixes.
 
 
@@ -6896,7 +6896,7 @@ Decorated log and release notes: https://github.com/ocornut/imgui/releases/tag/v
 
 Breaking Changes:
 
-- The behaviour of PixelCenterOffset changed! You may need to change your value if you had set
+- The behavior of PixelCenterOffset changed! You may need to change your value if you had set
   it to non-default in your code and/or offset your projection matrix by 0.5 pixels. It is
   likely that the default PixelCenterOffset value of 0.0 is now suitable unless your rendering
   uses some form of multisampling.
@@ -6990,7 +6990,7 @@ Decorated log and release notes: https://github.com/ocornut/imgui/releases/tag/v
 
 - OpenGL example now use the fixed function-pipeline + cleanups, down by 150 lines.
 - Added quick & dirty Makefiles for MacOSX and Linux.
-- Simplified the DrawList system, ImDrawCmd include the clipping rectangle + some optimisations.
+- Simplified the DrawList system, ImDrawCmd include the clipping rectangle + some optimizations.
 - Fixed warnings for more stringent compilation settings.
 
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -543,7 +543,7 @@ The short answer is: obtain the desired DPI scale, load your fonts resized with 
 
 Your application may want to detect DPI change and reload the fonts and reset style between frames.
 
-Your ui code  should avoid using hardcoded constants for size and positioning. Prefer to express values as multiple of reference values such as `ImGui::GetFontSize()` or `ImGui::GetFrameHeight()`. So e.g. instead of seeing a hardcoded height of 500 for a given item/window, you may want to use `30*ImGui::GetFontSize()` instead.
+Your UI code should avoid using hardcoded constants for size and positioning. Prefer to express values as multiple of reference values such as `ImGui::GetFontSize()` or `ImGui::GetFrameHeight()`. So e.g. instead of seeing a hardcoded height of 500 for a given item/window, you may want to use `30*ImGui::GetFontSize()` instead.
 
 Down the line Dear ImGui will provide a variety of standardized reference values to facilitate using this.
 
@@ -666,7 +666,7 @@ You may take a look at:
 
 Yes. People have written game editors, data browsers, debuggers, profilers, and all sorts of non-trivial tools with the library. In my experience, the simplicity of the API is very empowering. Your UI runs close to your live data. Make the tools always-on and everybody in the team will be inclined to create new tools (as opposed to more "offline" UI toolkits where only a fraction of your team effectively creates tools). The list of sponsors below is also an indicator that serious game teams have been using the library.
 
-Dear ImGui is very programmer centric and the immediate-mode GUI paradigm might require you to readjust some habits before you can realize its full potential. Dear ImGui is about making things that are simple, efficient, and powerful.
+Dear ImGui is very programmer-centric and the immediate-mode GUI paradigm might require you to readjust some habits before you can realize its full potential. Dear ImGui is about making things that are simple, efficient, and powerful.
 
 Dear ImGui is built to be efficient and scalable toward the needs for AAA-quality applications running all day. The IMGUI paradigm offers different opportunities for optimization than the more typical RMGUI paradigm.
 

--- a/docs/TODO.txt
+++ b/docs/TODO.txt
@@ -279,7 +279,7 @@ It's mostly a bunch of personal notes, probably incomplete. Feel free to query i
  - nav: expose wrap around flags/logic to allow e.g. grid based layout (pressing NavRight on the right-most element would go to the next row, etc.). see internal's NavMoveRequestTryWrapping().
  - nav: patterns to make it possible for arrows key to update selection (see JustMovedTo in range_select branch)
  - nav: restore/find nearest NavId when current one disappear (e.g. pressed a button that disappear, or perhaps auto restoring when current button change name)
- - nav: SetItemDefaultFocus() level of priority, so widget like Selectable when inside a popup could claim a low-priority default focus on the first selected iem
+ - nav: SetItemDefaultFocus() level of priority, so widgets like Selectable when inside a popup could claim a low-priority default focus on the first selected item
  - nav: holding space to repeat a button doesn't show button activated during hold.
  - nav: NavFlattened: init requests don't work properly on flattened siblings.
  - nav: NavFlattened: pageup/pagedown/home/end don't work properly on flattened siblings.
@@ -329,7 +329,7 @@ It's mostly a bunch of personal notes, probably incomplete. Feel free to query i
  - backends: opengl: explicitly disable GL_STENCIL_TEST in bindings.
  - backends: vulkan: viewport: support for synchronized swapping of multiple swap chains.
  - backends: bgfx: https://gist.github.com/RichardGale/6e2b74bc42b3005e08397236e4be0fd0
- - backends: emscriptem: with refactored examples, we could provide a direct imgui_impl_emscripten platform layer (see eg. https://github.com/floooh/sokol-samples/blob/master/html5/imgui-emsc.cc#L42)
+ - backends: emscripten: with refactored examples, we could provide a direct imgui_impl_emscripten platform layer (see eg. https://github.com/floooh/sokol-samples/blob/master/html5/imgui-emsc.cc#L42)
 
  - bindings: ways to use clang ast dump to generate bindings or helpers for bindings? (e.g. clang++ -Xclang -ast-dump=json imgui.h) (--> use https://github.com/dearimgui/dear_bindings)
 

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -655,7 +655,7 @@ CODE
  - 2022/04/05 (1.88) - inputs: renamed ImGuiKeyModFlags to ImGuiModFlags. Kept inline redirection enums (will obsolete). This was never used in public API functions but technically present in imgui.h and ImGuiIO.
  - 2022/01/20 (1.87) - inputs: reworded gamepad IO.
                         - Backend writing to io.NavInputs[]            -> backend should call io.AddKeyEvent()/io.AddKeyAnalogEvent() with ImGuiKey_GamepadXXX values.
- - 2022/01/19 (1.87) - sliders, drags: removed support for legacy arithmetic operators (+,+-,*,/) when inputing text. This doesn't break any api/code but a feature that used to be accessible by end-users (which seemingly no one used).
+ - 2022/01/19 (1.87) - sliders, drags: removed support for legacy arithmetic operators (+,+-,*,/) when inputting text. This doesn't break any api/code but a feature that used to be accessible by end-users (which seemingly no one used).
  - 2022/01/17 (1.87) - inputs: reworked mouse IO.
                         - Backend writing to io.MousePos               -> backend should call io.AddMousePosEvent()
                         - Backend writing to io.MouseDown[]            -> backend should call io.AddMouseButtonEvent()
@@ -4954,7 +4954,7 @@ void ImGui::StartMouseMovingWindow(ImGuiWindow* window)
 
 // Handle mouse moving window
 // Note: moving window with the navigation keys (Square + d-pad / CTRL+TAB + Arrows) are processed in NavUpdateWindowing()
-// FIXME: We don't have strong guarantee that g.MovingWindow stay synched with g.ActiveId == g.MovingWindow->MoveId.
+// FIXME: We don't have strong guarantee that g.MovingWindow stay synced with g.ActiveId == g.MovingWindow->MoveId.
 // This is currently enforced by the fact that BeginDragDropSource() is setting all g.ActiveIdUsingXXXX flags to inhibit navigation inputs,
 // but if we should more thoroughly test cases where g.ActiveId or g.MovingWindow gets changed and not the other.
 void ImGui::UpdateMouseMovingWindowNewFrame()
@@ -6563,7 +6563,7 @@ static int ImGui::UpdateWindowManualResize(ImGuiWindow* window, const ImVec2& si
         {
             // Auto-fit when double-clicking
             size_target = CalcWindowSizeAfterConstraint(window, size_auto_fit);
-            ret_auto_fit_mask = 0x03; // Both axises
+            ret_auto_fit_mask = 0x03; // Both axes
             ClearActiveID();
         }
         else if (held)
@@ -9701,7 +9701,7 @@ void ImGui::UpdateMouseWheel()
     if (g.IO.MouseWheelRequestAxisSwap)
         wheel = ImVec2(wheel.y, 0.0f);
 
-    // Maintain a rough average of moving magnitude on both axises
+    // Maintain a rough average of moving magnitude on both axes
     // FIXME: should by based on wall clock time rather than frame-counter
     g.WheelingAxisAvg.x = ImExponentialMovingAverage(g.WheelingAxisAvg.x, ImAbs(wheel.x), 30);
     g.WheelingAxisAvg.y = ImExponentialMovingAverage(g.WheelingAxisAvg.y, ImAbs(wheel.y), 30);
@@ -9714,7 +9714,7 @@ void ImGui::UpdateMouseWheel()
 
     // Mouse wheel scrolling: find target and apply
     // - don't renew lock if axis doesn't apply on the window.
-    // - select a main axis when both axises are being moved.
+    // - select a main axis when both axes are being moved.
     if (ImGuiWindow* window = (g.WheelingWindow ? g.WheelingWindow : FindBestWheelingWindow(wheel)))
         if (!(window->Flags & ImGuiWindowFlags_NoScrollWithMouse) && !(window->Flags & ImGuiWindowFlags_NoMouseInputs))
         {

--- a/imgui.h
+++ b/imgui.h
@@ -544,7 +544,7 @@ namespace ImGui
     IMGUI_API void          LabelTextV(const char* label, const char* fmt, va_list args)    IM_FMTLIST(2);
     IMGUI_API void          BulletText(const char* fmt, ...)                                IM_FMTARGS(1); // shortcut for Bullet()+Text()
     IMGUI_API void          BulletTextV(const char* fmt, va_list args)                      IM_FMTLIST(1);
-    IMGUI_API void          SeparatorText(const char* label);                               // currently: formatted text with an horizontal line
+    IMGUI_API void          SeparatorText(const char* label);                               // currently: formatted text with a horizontal line
 
     // Widgets: Main
     // - Most widgets return true when the value has been changed or when pressed/selected

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -8415,7 +8415,7 @@ void ImGui::ShowStyleEditor(ImGuiStyle* ref)
                 ImGui::EndTooltip();
             }
             ImGui::SameLine();
-            HelpMarker("When drawing circle primitives with \"num_segments == 0\" tesselation will be calculated automatically.");
+            HelpMarker("When drawing circle primitives with \"num_segments == 0\" tessellation will be calculated automatically.");
 
             ImGui::DragFloat("Global Alpha", &style.Alpha, 0.005f, 0.20f, 1.0f, "%.2f"); // Not exposing zero here so user doesn't "lose" the UI (zero alpha clips all widgets). But application code could have a toggle to switch between zero and non-zero.
             ImGui::DragFloat("Disabled Alpha", &style.DisabledAlpha, 0.005f, 0.0f, 1.0f, "%.2f"); ImGui::SameLine(); HelpMarker("Additional alpha multiplier for disabled items (multiply over current value of Alpha).");
@@ -8446,7 +8446,7 @@ void ImGui::ShowUserGuide()
     ImGui::BulletText("CTRL+Tab to select a window.");
     if (io.FontAllowUserScaling)
         ImGui::BulletText("CTRL+Mouse Wheel to zoom window contents.");
-    ImGui::BulletText("While inputing text:\n");
+    ImGui::BulletText("While inputting text:\n");
     ImGui::Indent();
     ImGui::BulletText("CTRL+Left/Right to word jump.");
     ImGui::BulletText("CTRL+A or double-click to select all.");
@@ -8877,7 +8877,7 @@ struct ExampleAppConsole
                 else
                 {
                     // Multiple matches. Complete as much as we can..
-                    // So inputing "C"+Tab will complete to "CL" then display "CLEAR" and "CLASSIFY" as matches.
+                    // So inputting "C"+Tab will complete to "CL" then display "CLEAR" and "CLASSIFY" as matches.
                     int match_len = (int)(word_end - word_start);
                     for (;;)
                     {

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -2801,7 +2801,7 @@ struct IMGUI_API ImGuiTable
 {
     ImGuiID                     ID;
     ImGuiTableFlags             Flags;
-    void*                       RawData;                    // Single allocation to hold Columns[], DisplayOrderToIndex[] and RowCellData[]
+    void*                       RawData;                    // Single allocation to hold Columns[], DisplayOrderToIndex[], and RowCellData[]
     ImGuiTableTempData*         TempData;                   // Transient data while table is active. Point within g.CurrentTableStack[]
     ImSpan<ImGuiTableColumn>    Columns;                    // Point within RawData[]
     ImSpan<ImGuiTableColumnIdx> DisplayOrderToIndex;        // Point within RawData[]. Store display order of columns (when not reordered, the values are 0...Count-1)
@@ -2815,7 +2815,7 @@ struct IMGUI_API ImGuiTable
     int                         ColumnsCount;               // Number of columns declared in BeginTable()
     int                         CurrentRow;
     int                         CurrentColumn;
-    ImS16                       InstanceCurrent;            // Count of BeginTable() calls with same ID in the same frame (generally 0). This is a little bit similar to BeginCount for a window, but multiple table with same ID look are multiple tables, they are just synched.
+    ImS16                       InstanceCurrent;            // Count of BeginTable() calls with same ID in the same frame (generally 0). This is a little bit similar to BeginCount for a window, but multiple tables with the same ID are multiple tables, they are just synced.
     ImS16                       InstanceInteracted;         // Mark which instance (generally 0) of the same ID is being interacted with
     float                       RowPosY1;
     float                       RowPosY2;
@@ -2847,7 +2847,7 @@ struct IMGUI_API ImGuiTable
     float                       AngledHeadersHeight;        // Set by TableAngledHeadersRow(), used in TableUpdateLayout()
     float                       AngledHeadersSlope;         // Set by TableAngledHeadersRow(), used in TableUpdateLayout()
     ImRect                      OuterRect;                  // Note: for non-scrolling table, OuterRect.Max.y is often FLT_MAX until EndTable(), unless a height has been specified in BeginTable().
-    ImRect                      InnerRect;                  // InnerRect but without decoration. As with OuterRect, for non-scrolling tables, InnerRect.Max.y is
+    ImRect                      InnerRect;                  // InnerRect but without decoration. As with OuterRect, for non-scrolling tables, InnerRect.Max.y is "
     ImRect                      WorkRect;
     ImRect                      InnerClipRect;
     ImRect                      BgClipRect;                 // We use this to cpu-clip cell background color fill, evolve during the frame as we cross frozen rows boundaries

--- a/imgui_tables.cpp
+++ b/imgui_tables.cpp
@@ -977,7 +977,7 @@ void ImGui::TableUpdateLayout(ImGuiTable* table)
     // [Part 4] Apply final widths based on requested widths
     const ImRect work_rect = table->WorkRect;
     const float width_spacings = (table->OuterPaddingX * 2.0f) + (table->CellSpacingX1 + table->CellSpacingX2) * (table->ColumnsEnabledCount - 1);
-    const float width_removed = (table->HasScrollbarYPrev && !table->InnerWindow->ScrollbarY) ? g.Style.ScrollbarSize : 0.0f; // To synchronize decoration width of synched tables with mismatching scrollbar state (#5920)
+    const float width_removed = (table->HasScrollbarYPrev && !table->InnerWindow->ScrollbarY) ? g.Style.ScrollbarSize : 0.0f; // To synchronize decoration width of synced tables with mismatching scrollbar state (#5920)
     const float width_avail = ImMax(1.0f, (((table->Flags & ImGuiTableFlags_ScrollX) && table->InnerWidth == 0.0f) ? table->InnerClipRect.GetWidth() : work_rect.GetWidth()) - width_removed);
     const float width_avail_for_stretched_columns = width_avail - width_spacings - sum_width_requests;
     float width_remaining_for_stretched_columns = width_avail_for_stretched_columns;
@@ -1390,7 +1390,7 @@ void    ImGui::EndTable()
 
     // Setup inner scrolling range
     // FIXME: This ideally should be done earlier, in BeginTable() SetNextWindowContentSize call, just like writing to inner_window->DC.CursorMaxPos.y,
-    // but since the later is likely to be impossible to do we'd rather update both axises together.
+    // but since the later is likely to be impossible to do we'd rather update both axes together.
     if (table->Flags & ImGuiTableFlags_ScrollX)
     {
         const float outer_padding_for_border = (table->Flags & ImGuiTableFlags_BordersOuterV) ? TABLE_BORDER_SIZE : 0.0f;

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -8898,7 +8898,7 @@ bool ImGui::BeginMenuEx(const char* label, const char* icon, bool enabled)
     const ImGuiSelectableFlags selectable_flags = ImGuiSelectableFlags_NoHoldingActiveID | ImGuiSelectableFlags_NoSetKeyOwner | ImGuiSelectableFlags_SelectOnClick | ImGuiSelectableFlags_NoAutoClosePopups;
     if (window->DC.LayoutType == ImGuiLayoutType_Horizontal)
     {
-        // Menu inside an horizontal menu bar
+        // Menu inside a horizontal menu bar
         // Selectable extend their highlight by half ItemSpacing in each direction.
         // For ChildMenu, the popup position will be overwritten by the call to FindBestWindowPosForPopup() in Begin()
         popup_pos = ImVec2(pos.x - 1.0f - IM_TRUNC(style.ItemSpacing.x * 0.5f), pos.y - style.FramePadding.y + window->MenuBarHeight);


### PR DESCRIPTION
* Changed a few British English spellings to American English, as that is the primary English dialect used by this project
* Adjusted the comments on `imgui_internal.h:2818` and `imgui_internal.h:2850`
* Didn't change every instance of `ui` to `UI`, or `Ctrl` to `CTRL`, or similar stuff