### PR TITLE
GLFW3.4+ on X11: copy the WM_CLASS property from the parent window for viewports

### DIFF
--- a/examples/example_glfw_opengl2/Makefile
+++ b/examples/example_glfw_opengl2/Makefile
@@ -32,7 +32,7 @@ LIBS =
 
 ifeq ($(UNAME_S), Linux) #LINUX
 	ECHO_MESSAGE = "Linux"
-	LIBS += -lGL `pkg-config --static --libs glfw3`
+	LIBS += -lGL -lX11 `pkg-config --static --libs glfw3`
 
 	CXXFLAGS += `pkg-config --cflags glfw3`
 	CFLAGS = $(CXXFLAGS)

--- a/examples/example_glfw_opengl3/Makefile
+++ b/examples/example_glfw_opengl3/Makefile
@@ -41,7 +41,7 @@ LIBS =
 
 ifeq ($(UNAME_S), Linux) #LINUX
 	ECHO_MESSAGE = "Linux"
-	LIBS += $(LINUX_GL_LIBS) `pkg-config --static --libs glfw3`
+	LIBS += $(LINUX_GL_LIBS) -lX11 `pkg-config --static --libs glfw3`
 
 	CXXFLAGS += `pkg-config --cflags glfw3`
 	CFLAGS = $(CXXFLAGS)

--- a/examples/example_glfw_vulkan/CMakeLists.txt
+++ b/examples/example_glfw_vulkan/CMakeLists.txt
@@ -35,7 +35,7 @@ find_package(Vulkan REQUIRED)
 #find_library(VULKAN_LIBRARY
   #NAMES vulkan vulkan-1)
 #set(LIBRARIES "glfw;${VULKAN_LIBRARY}")
-set(LIBRARIES "glfw;Vulkan::Vulkan")
+set(LIBRARIES "glfw;Vulkan::Vulkan;X11")
 
 # Use vulkan headers from glfw:
 include_directories(${GLFW_DIR}/deps)


### PR DESCRIPTION
This PR resolves one of the issues listed in #8289. The issue should not be closed, because this PR does not fix all the issues that are still needed to be resolved to mark the PR as complete. I hope to resolve #8289 in followup pull requests in the near future.

This patch makes it possible for dear imgui to copy the `WM_CLASS` property of a window under X11 when compiled with GLFW version 3.4 and later.

This PR does not fix the following:

1. The Wayland app ID not being copied or set(GLFW does not set a default app ID)
1. Making it possible to differentiate between viewports when configuring tiling window managers in both X11 and Wayland

However, it does fix a number of issues, such as:

1. Viewport windows being treated as separate applications by various desktop environment features
1. Even though differentiating between viewports and the root window/s of the same application is not implemented here, it does allow for differentiating between viewports of other dear imgui applications

Unfortunately, to make this PR possible, the implementation uses the native X11 API, due to GLFW not implementing any method of getting the value of window hints or of its internal structures :/

## Testing
Tested this under latest Arch Linux, Ubuntu Linux 24.10 and Ubuntu Linux 24.4. Due to the unavailability of GLFW version 3.4 in Ubuntu 24.04 this patch will not be covered by our Linux CI correctly unfortunately :/