### PR TITLE
Fix 3DS compilation

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -15145,6 +15145,12 @@ static void Platform_SetClipboardTextFn_DefaultImpl(ImGuiContext* ctx, const cha
 #endif
 
 #ifndef IMGUI_DISABLE_DEFAULT_SHELL_FUNCTIONS
+#ifdef __3DS__
+#define IMGUI_DISABLE_DEFAULT_SHELL_FUNCTIONS
+#endif
+#endif
+
+#ifndef IMGUI_DISABLE_DEFAULT_SHELL_FUNCTIONS
 #ifdef _WIN32
 #include <shellapi.h>   // ShellExecuteA()
 #ifdef _MSC_VER


### PR DESCRIPTION
Fix 3DS compilation using the devkitPro toolchain (and SDL3 as wrapper)

Solve #8476

Tested on hardware
![20250308_094527951](https://github.com/user-attachments/assets/22084090-4ffd-406c-9dfa-156b4f4dbbc2)

(the platform still has a fair amount of performance issues, like `Render` seemingly taking 16ms, but unsure if this is even fixable)