### PR TITLE
Add SDL3 High DPI flag in FAQ.md

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -562,7 +562,8 @@ Please note that if you are not using multi-viewports with multi-monitors using 
 
 On Windows, in addition to scaling the font size (make sure to round to an integer) and using `style.ScaleAllSizes()`, you will need to inform Windows that your application is DPI aware. If this is not done, Windows will scale the application window and the UI text will be blurry. Potential solutions to indicate DPI awareness on Windows are:
 
-- For SDL: the flag `SDL_WINDOW_ALLOW_HIGHDPI` needs to be passed to `SDL_CreateWindow()``.
+- For SDL2: the flag `SDL_WINDOW_ALLOW_HIGHDPI` needs to be passed to `SDL_CreateWindow()`.
+- For SDL3: the flag `SDL_WINDOW_HIGH_PIXEL_DENSITY` needs to be passed to `SDL_CreateWindow()`.
 - For GLFW: this is done automatically.
 - For other Windows projects with other backends, or wrapper projects:
   - We provide a `ImGui_ImplWin32_EnableDpiAwareness()` helper method in the Win32 backend.


### PR DESCRIPTION
1. Add high DPI flag for SDL3
    - Check the SDL3 migration guide for this name change: https://github.com/libsdl-org/SDL/blob/f2866418d4c0c64006d750c518853a430f4d7be8/docs/README-migration.md?plain=1#L2261
3. Fix minor typo for inline code
