### PR TITLE
fix ImGui_ImplWin32_KeyEventToImGuiKey to handle VK_PROCESSKEY for languages that use IME

### DIFF
--- a/backends/imgui_impl_win32.cpp
+++ b/backends/imgui_impl_win32.cpp
@@ -431,6 +431,21 @@ ImGuiKey ImGui_ImplWin32_KeyEventToImGuiKey(WPARAM wParam, LPARAM lParam)
         return ImGuiKey_KeypadEnter;
 
     const int scancode = (int)LOBYTE(HIWORD(lParam));
+
+    // Convert keycodes for languages that use IME
+    if (wParam == VK_PROCESSKEY)
+    {
+        wParam = ::MapVirtualKey(scancode, MAPVK_VSC_TO_VK_EX);
+
+        // In some Korean layout, unmatching key down and key up events are emitted when you switch language to Korean.
+        // (e.g. VK_LMENU on key down and VK_HANGUL on key up when you press right alt)
+        // So it must be ignored to avoid key stucks
+        if (wParam == VK_LMENU || wParam == VK_LCONTROL)
+        {
+            return ImGuiKey_None;
+        }
+    }    
+
     //IMGUI_DEBUG_LOG("scancode %3d, keycode = 0x%02X\n", scancode, wParam);
     switch (wParam)
     {


### PR DESCRIPTION
For some languages that use IME(Korean, Japanese with kana input mode and more), key down events are emitted as `VK_PROCESSKEY` for some keys when using their native languages.

In the current implementation of imgui_impl_win32.cpp, `ImGui_ImplWin32_KeyEventToImGuiKey` doesn't handle this so the program becomes unresponsive to key downs until the user switch the language back to English.

https://github.com/user-attachments/assets/1ba4d0ec-d5ea-47b5-9aae-c757143226da

(I only placed the virtual keyboard to show you how the input layout looks like. I was typing with a physical keyboard. You can guess what I was typing by the IME box on the top left corner.)

As shown, key down events are not received. I also tested this with Japanese IME with kana input mode and it also has the same issue.

https://github.com/user-attachments/assets/7b90a4b5-7c7f-48e0-bcf5-a3aed22cadf6

I fixed this by calling `MapVirtualKey` if `wParam` is `VK_PROCESSKEY` in `ImGui_ImplWin32_KeyEventToImGuiKey`.

https://github.com/user-attachments/assets/3a8ec41b-3dcf-43b9-bb81-bef46a561d2f

In some Korean keyboard layouts, an unmatching set of key down and key up events are emitted when you switch between English and Korean, causing a key stuck.(Japanese kana input mode doesn't seem to have this problem.)

1. For Korean keyboard (103/106 key), user switch between Korean and English with a dedicated Han/Eng key. No events are emitted so key stuck does not happen in this case.

2. For Korean keyboard (101 key) Type 1, users switch between Korean and English with right alt. When pressed, it emits `VK_LMENU` on key down and `VK_HANGUL` on key up, causing left alt key to get stuck.

3. For Korean keyboard (101 key) Type 2, users switch between Korean and English with right control. When pressed, it emits `VK_LCONTROL` on key down and `VK_HANGUL` on key up, causing left control key to get stuck.

4. For Korean keyboard (101 key) Type 3, users switch between Korean and English by pressing left shift and spacebar together. When pressed, it behaves differently by the order you press and release the keys and sometimes causes spacebar to get stuck. If spacebar is pressed first, I couldn't find a way to prevent this for the case that the keys are pressed and released in the order of space -> shift -> shift -> space.

I made the code check if `MapVirtualKey` returned `VK_LMENU` or `VK_LCONTROL` to resolve the case 2 and 3.