### PR TITLE
SDL3 GPU - Reuse transfer buffers

### DIFF
--- a/backends/imgui_impl_sdlgpu3.cpp
+++ b/backends/imgui_impl_sdlgpu3.cpp
@@ -35,10 +35,10 @@
 // Reusable buffers used for rendering 1 current in-flight frame, for ImGui_ImplSDLGPU3_RenderDrawData()
 struct ImGui_ImplSDLGPU3_FrameData
 {
-    SDL_GPUBuffer*         VertexBuffer     = nullptr;
-    SDL_GPUBuffer*         IndexBuffer      = nullptr;
-    uint32_t               VertexBufferSize = 0;
-    uint32_t               IndexBufferSize  = 0;
+    SDL_GPUBuffer*      VertexBuffer     = nullptr;
+    SDL_GPUBuffer*      IndexBuffer      = nullptr;
+    uint32_t            VertexBufferSize = 0;
+    uint32_t            IndexBufferSize  = 0;
 
     SDL_GPUTransferBuffer* VertexTransferBuffer = nullptr;
     SDL_GPUTransferBuffer* IndexTransferBuffer = nullptr;


### PR DESCRIPTION
Quickly tested on the docking branch, hopefully not breaking anything.

There is another transfer buffer de/allocation in `ImGui_ImplSDLGPU3_UpdateTexture` but it doesn't seem relevant for my existing app. Should perhaps be replaced as well.

Close #8534