### PR TITLE
Added void* cast to suppress trivially-copyable warning

### DIFF
--- a/backends/imgui_impl_glfw.cpp
+++ b/backends/imgui_impl_glfw.cpp
@@ -223,9 +223,6 @@ static void ImGui_ImplGlfw_ShutdownMultiViewportSupport();
 
 // Functions
 
-//Prototype to avoid -Werror=missing-declarations warning
-ImGuiKey ImGui_ImplGlfw_KeyToImGuiKey(int keycode, int scancode);
-
 // Not static to allow third-party code to use that if they want to (but undocumented)
 ImGuiKey ImGui_ImplGlfw_KeyToImGuiKey(int keycode, int scancode);
 ImGuiKey ImGui_ImplGlfw_KeyToImGuiKey(int keycode, int scancode)


### PR DESCRIPTION
Constructor for ImGui_ImplVulkan_ViewportData calls memset on RenderBuffers without a void* cast causing compile warnings