### PR TITLE
Do not lose focus on the dock window when a Popup opens

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -18462,7 +18462,7 @@ static bool IsDockNodeTitleBarHighlighted(ImGuiDockNode* node, ImGuiDockNode* ro
     {
         // FIXME: This could all be backed in RootWindowForTitleBarHighlight? Probably need to reorganize for both dock nodes + other RootWindowForTitleBarHighlight users (not-node)
         ImGuiWindow* parent_window = g.NavWindow->RootWindow;
-        while (parent_window->Flags & ImGuiWindowFlags_ChildMenu)
+        while (parent_window->Flags & (ImGuiWindowFlags_ChildMenu|ImGuiWindowFlags_Popup) && !(parent_window->Flags & ImGuiWindowFlags_Modal))
             parent_window = parent_window->ParentWindow->RootWindow;
         ImGuiDockNode* start_parent_node = parent_window->DockNodeAsHost ? parent_window->DockNodeAsHost : parent_window->DockNode;
         for (ImGuiDockNode* parent_node = start_parent_node; parent_node != NULL; parent_node = parent_node->HostWindow ? parent_node->HostWindow->RootWindow->DockNode : NULL)


### PR DESCRIPTION
I've noticed that in the Docking branch, when you open a Combo/Popup the titlebar on the current dockable window loses focus:

https://github.com/user-attachments/assets/daaf30d6-d11e-4033-aaec-cbc7d0fa5063

I'm not sure if this is intended, at least it doesn't seem right for combo-boxes (which are Popups under the hood).

This change seems to work, IsDockNodeTitleBarHighlighted was already checking the case in which the window was a child menu, I've added the check for Popups except when it is a modal.

https://github.com/user-attachments/assets/4fb5faec-0dd8-4877-a65f-aab7256bc754

