### PR TITLE
Demo: Rename DockingSplitterSize slider label to DockingSeparatorSize for consistency

### DIFF
--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -8401,7 +8401,7 @@ void ImGui::ShowStyleEditor(ImGuiStyle* ref)
             ImGui::SliderFloat("ImageBorderSize", &style.ImageBorderSize, 0.0f, 1.0f, "%.0f");
 
             ImGui::SeparatorText("Docking");
-            ImGui::SliderFloat("DockingSplitterSize", &style.DockingSeparatorSize, 0.0f, 12.0f, "%.0f");
+            ImGui::SliderFloat("DockingSeparatorSize", &style.DockingSeparatorSize, 0.0f, 12.0f, "%.0f");
 
             ImGui::SeparatorText("Tooltips");
             for (int n = 0; n < 2; n++)


### PR DESCRIPTION
I noticed it when I couldn't find `ImGui::GetStyle().DockingsplitterSize`