### PR TITLE
Add dedicated style color for selected tree nodes

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -3697,6 +3697,7 @@ const char* ImGui::GetStyleColorName(ImGuiCol idx)
     case ImGuiCol_Header: return "Header";
     case ImGuiCol_HeaderHovered: return "HeaderHovered";
     case ImGuiCol_HeaderActive: return "HeaderActive";
+    case ImGuiCol_HeaderSelected: return "HeaderSelected";
     case ImGuiCol_Separator: return "Separator";
     case ImGuiCol_SeparatorHovered: return "SeparatorHovered";
     case ImGuiCol_SeparatorActive: return "SeparatorActive";

--- a/imgui.h
+++ b/imgui.h
@@ -1798,6 +1798,7 @@ enum ImGuiCol_
     ImGuiCol_Header,                // Header* colors are used for CollapsingHeader, TreeNode, Selectable, MenuItem
     ImGuiCol_HeaderHovered,
     ImGuiCol_HeaderActive,
+    ImGuiCol_HeaderSelected,
     ImGuiCol_Separator,
     ImGuiCol_SeparatorHovered,
     ImGuiCol_SeparatorActive,

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -6880,9 +6880,14 @@ bool ImGui::TreeNodeBehavior(ImGuiID id, ImGuiTreeNodeFlags flags, const char* l
         else
         {
             // Unframed typed for tree nodes
-            if (hovered || selected)
+            if (selected)
             {
-                const ImU32 bg_col = GetColorU32((held && hovered) ? ImGuiCol_HeaderActive : hovered ? ImGuiCol_HeaderHovered : ImGuiCol_Header);
+                const ImU32 bg_col = GetColorU32(ImGuiCol_HeaderSelected);
+                RenderFrame(frame_bb.Min, frame_bb.Max, bg_col, false);
+            }
+            if (hovered)
+            {
+                const ImU32 bg_col = GetColorU32((held && hovered) ? ImGuiCol_HeaderActive : ImGuiCol_HeaderHovered);
                 RenderFrame(frame_bb.Min, frame_bb.Max, bg_col, false);
             }
             RenderNavCursor(frame_bb, id, nav_render_cursor_flags);


### PR DESCRIPTION
I have used this change to have dedicated color for selected tree nodes. I have no idea if there is some simple way to get it done without changing ImGui, and I don't know if my changes are to the right direction. But it works for me.


https://github.com/user-attachments/assets/8bc51e85-8bfb-4387-9654-9e9b0c877df7

