### PR TITLE
Make sure texture sampling in the dx12 backend is not limited to the highest mip

### DIFF
--- a/backends/imgui_impl_dx12.cpp
+++ b/backends/imgui_impl_dx12.cpp
@@ -499,7 +499,7 @@ bool    ImGui_ImplDX12_CreateDeviceObjects()
         staticSampler.ComparisonFunc = D3D12_COMPARISON_FUNC_ALWAYS;
         staticSampler.BorderColor = D3D12_STATIC_BORDER_COLOR_TRANSPARENT_BLACK;
         staticSampler.MinLOD = 0.f;
-        staticSampler.MaxLOD = 0.f;
+        staticSampler.MaxLOD = D3D12_FLOAT32_MAX;
         staticSampler.ShaderRegister = 0;
         staticSampler.RegisterSpace = 0;
         staticSampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;


### PR DESCRIPTION
In the current DX12 backend even though the sampler is a MIN_MAG_MIP_LINEAR filter, MaxLOD was set to 0. As a result there was **no mipmapping happening** as the sampling was limited only to the top mip.

According to the [D3D12_STATIC_SAMPLER_DESC documentation](https://learn.microsoft.com/en-us/windows/win32/api/d3d12/ns-d3d12-d3d12_static_sampler_desc) "To have no upper limit on LOD set this to a large value such as D3D12_FLOAT32_MAX".

This changes sets it to D3D12_FLOAT32_MAX to make sure that mipmap usage is not limited.