### PR TITLE
Makefiles for example_apple_opengl2 and example_apple_metal

### DIFF
--- a/examples/example_apple_metal/Makefile
+++ b/examples/example_apple_metal/Makefile
@@ -1,0 +1,25 @@
+# Makefile for example_apple_metal, for macOS only (**not iOS**)
+TARGET      := example_apple_metal
+CXX         := clang++
+CXXFLAGS    := -std=c++17 -ObjC++ -fobjc-arc -Wall -Wextra \
+               -I../../                             \
+               -I../../backends
+FRAMEWORKS  := -framework AppKit -framework Metal -framework MetalKit -framework QuartzCore -framework GameController
+IMGUI_SRC   := ../../imgui.cpp ../../imgui_draw.cpp ../../imgui_demo.cpp \
+               ../../imgui_tables.cpp ../../imgui_widgets.cpp
+BACKENDS    := ../../backends/imgui_impl_metal.mm ../../backends/imgui_impl_osx.mm
+SRC         := main.mm $(IMGUI_SRC) $(BACKENDS)
+
+.PHONY: all run clean
+
+
+all: $(TARGET)
+
+$(TARGET): $(SRC)
+	$(CXX) $(CXXFLAGS) $^ $(FRAMEWORKS) -o $@
+
+run: all
+	./$(TARGET)
+
+clean:
+	rm -f $(TARGET) *.o

--- a/examples/example_apple_metal/main.mm
+++ b/examples/example_apple_metal/main.mm
@@ -338,7 +338,18 @@
 
 int main(int argc, const char * argv[])
 {
-    return NSApplicationMain(argc, argv);
+    @autoreleasepool
+    {
+        [NSApplication sharedApplication];
+        [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+
+        AppDelegate *appDelegate = [[AppDelegate alloc] init];   // creates window
+        [NSApp setDelegate:appDelegate];
+
+        [NSApp activateIgnoringOtherApps:YES];
+        [NSApp run];
+    }
+    return 0;
 }
 
 #else

--- a/examples/example_apple_opengl2/Makefile
+++ b/examples/example_apple_opengl2/Makefile
@@ -1,0 +1,25 @@
+IMGUI_DIR = ../../
+CXX = clang++
+CXXFLAGS = -std=c++17 -ObjC++ -Wall -Wextra -g -I$(IMGUI_DIR) -I$(IMGUI_DIR)/backends
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework GameController
+
+SOURCES = \
+    main.mm \
+    $(IMGUI_DIR)/backends/imgui_impl_osx.mm \
+    $(IMGUI_DIR)/backends/imgui_impl_opengl2.cpp \
+    $(IMGUI_DIR)/imgui.cpp \
+    $(IMGUI_DIR)/imgui_draw.cpp \
+    $(IMGUI_DIR)/imgui_demo.cpp \
+    $(IMGUI_DIR)/imgui_tables.cpp \
+    $(IMGUI_DIR)/imgui_widgets.cpp
+
+TARGET = imgui_example_apple_opengl2
+
+all: $(TARGET)
+
+$(TARGET): $(SOURCES)
+	$(CXX) $(CXXFLAGS) $(SOURCES) -o imgui_example_apple_opengl2 $(FRAMEWORKS)
+
+clean:
+	rm -f $(TARGET)
+	rm -rf $(TARGET).dSYM


### PR DESCRIPTION
- These makefile work only for macOS: use XCode for iOS
- They will produce a raw exe. They will not a produce an macOS application bundle (i.e a folder that includes exe and resources). To get app bundles, use the XCode project.

- For example_apple_metal.mm,  an adjustment was required in main.mm (for macOS only), to ensure that the exe can run without any plist or storyboard under macOS


Note: `example_sdl2_opengl3` and `example_glfw_opengl3` already provide a Makefile, which will work on macOS (if glfw and sdl2 are installed via homebrew)
