### PR TITLE
Fix event capture in multi-window applications

### DIFF
--- a/backends/imgui_impl_osx.mm
+++ b/backends/imgui_impl_osx.mm
@@ -663,6 +663,10 @@ static ImGuiMouseSource GetMouseSource(NSEvent* event)
 
 static bool ImGui_ImplOSX_HandleEvent(NSEvent* event, NSView* view)
 {
+    if (event.window != view.window) {
+        return false;
+    }
+    
     ImGuiIO& io = ImGui::GetIO();
 
     if (event.type == NSEventTypeLeftMouseDown || event.type == NSEventTypeRightMouseDown || event.type == NSEventTypeOtherMouseDown)


### PR DESCRIPTION
Description:
When using Dear ImGui in a macOS application with multiple windows, input events from windows without ImGui views are incorrectly captured by the global event monitor in the OSX backend. 

Reproduction steps:
1. Create a macOS application with two windows
2. Add ImGui view to Window A only
3. Try to interact with Window B
4. Observe that mouse events in Window B are being captured by ImGui

Fix:
Added window check in ImGui_ImplOSX_HandleEvent to ensure events are only processed when they originate from the window containing the ImGui view:

```objc
static bool ImGui_ImplOSX_HandleEvent(NSEvent* event, NSView* view)
{
    // Only process events from the window containing ImGui view
    if (event.window != view.window) {
        return false;
    }
    // ... rest of the event handling logic
}
```


Testing:
1. Build test application with:
   - Window A containing ImGui view
   - Window B without ImGui
2. Verify Window B receives events normally
3. Verify ImGui functionality in Window A works correctly


