### PR TITLE
Update lunasvg API to support v3.0+ (FreeType compat)

### DIFF
--- a/misc/freetype/imgui_freetype.cpp
+++ b/misc/freetype/imgui_freetype.cpp
@@ -880,7 +880,12 @@ static FT_Error ImGuiLunasvgPortRender(FT_GlyphSlot slot, FT_Pointer* _state)
 
     // rows is height, pitch (or stride) equals to width * sizeof(int32)
     lunasvg::Bitmap bitmap((uint8_t*)slot->bitmap.buffer, slot->bitmap.width, slot->bitmap.rows, slot->bitmap.pitch);
+#if LUNASVG_VERSION_MAJOR >= 3
     state->svg->render(bitmap, state->matrix); // state->matrix is already scaled and translated
+#else
+    state->svg->setMatrix(state->svg->matrix().identity()); // Reset the svg matrix to the default value
+    state->svg->render(bitmap, state->matrix);              // state->matrix is already scaled and translated
+#endif 
     state->err = FT_Err_Ok;
     return state->err;
 }
@@ -903,7 +908,11 @@ static FT_Error ImGuiLunasvgPortPresetSlot(FT_GlyphSlot slot, FT_Bool cache, FT_
         return state->err;
     }
 
+#if LUNASVG_VERSION_MAJOR >= 3
     lunasvg::Box box = state->svg->boundingBox();
+#else
+    lunasvg::Box box = state->svg->box();
+#endif
     double scale = std::min(metrics.x_ppem / box.w, metrics.y_ppem / box.h);
     double xx = (double)document->transform.xx / (1 << 16);
     double xy = -(double)document->transform.xy / (1 << 16);
@@ -912,6 +921,7 @@ static FT_Error ImGuiLunasvgPortPresetSlot(FT_GlyphSlot slot, FT_Bool cache, FT_
     double x0 = (double)document->delta.x / 64 * box.w / metrics.x_ppem;
     double y0 = -(double)document->delta.y / 64 * box.h / metrics.y_ppem;
 
+#if LUNASVG_VERSION_MAJOR >= 3
     // Scale, transform and pre-translate the matrix for the rendering step
     state->matrix = lunasvg::Matrix::translated(-box.x, -box.y);
     state->matrix.multiply(lunasvg::Matrix(xx, xy, yx, yy, x0, y0));
@@ -919,6 +929,19 @@ static FT_Error ImGuiLunasvgPortPresetSlot(FT_GlyphSlot slot, FT_Bool cache, FT_
 
     // Apply updated transformation to the bounding box
     box.transform(state->matrix);
+#else
+    // Scale and transform, we don't translate the svg yet
+    state->matrix.identity();
+    state->matrix.scale(scale, scale);
+    state->matrix.transform(xx, xy, yx, yy, x0, y0);
+    state->svg->setMatrix(state->matrix);
+
+    // Pre-translate the matrix for the rendering step
+    state->matrix.translate(-box.x, -box.y);
+
+    // Get the box again after the transformation
+    box = state->svg->box();
+#endif
 
     // Calculate the bitmap size
     slot->bitmap_left = FT_Int(box.x);


### PR DESCRIPTION
LunaSVG went to 3.0 a few months back (Oct 2024), which introduced a breaking change in the Matrix/Transform API for SVG rendering (https://github.com/sammycage/lunasvg/releases/tag/v3.0.0).
Here is an updated version of imgui_freetype with support for LunaSVG v3.0+
We could also maintain compatibility for both pre/post 3.0 by adding a ifdef on LUNASVG_VERSION_MAJOR, I didn't do it yet to keep the code as straigtforward as possible

Main changes in LunaSVG:
 * lunasvg::Matrix::transform() has been removed, in favor of Matrix::multiply(Matrix)
 * lunasvg::Document no longer carries its own transform matrix, it's up to the caller to maintain it and pass it to Document::render()
