### PR TITLE
Check for allocated descriptor set (Vulkan backend)

### DIFF
--- a/backends/imgui_impl_vulkan.cpp
+++ b/backends/imgui_impl_vulkan.cpp
@@ -1267,6 +1267,7 @@ VkDescriptorSet ImGui_ImplVulkan_AddTexture(VkSampler sampler, VkImageView image
     }
 
     // Update the Descriptor Set:
+    if (descriptor_set != VK_NULL_HANDLE)
     {
         VkDescriptorImageInfo desc_image[1] = {};
         desc_image[0].sampler = sampler;


### PR DESCRIPTION
This PR fixes an issue with `vkUpdateDescriptorSets()` in `ImGui_ImplVulkan_AddTexture()` in the Vulkan backend.  `vkUpdateDescriptorSets()` gets called in cases for which the previous `vkAllocateDescriptorSets()` failed (returning `VK_NULL_HANDLE` in `descriptor_set`). This leads to the situation that `vkUpdateDescriptorSets()` gets called with an invalid handle and it reported by the validation layer:

```
[    18.02136] [192902] [default:D] vkDebug: Validation Error: [ UNASSIGNED-GeneralParameterError-RequiredHandle ] | MessageID = 0x8fdcb17b | vkUpdateDescriptorSets(): pDescriptorWrites[0].dstSet is VK_NULL_HANDLE.
```

I can reproduce this issue on macOS using Vulkan/MoltenVK by rendering multiple textures (viewports) that rapidly change in size (e.g. by resizing the main window). This triggers calls to `ImGui_ImplVulkan_AddTexture()` in my program very frequently.