### PR TITLE
Fix dllimport conflict for PushTextureID and PopTextureID

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -3329,8 +3329,8 @@ struct ImDrawList
 
     // Obsolete names
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
-    IMGUI_API void  PushTextureID(ImTextureRef tex_ref) { PushTexture(tex_ref); }   // RENAMED in 1.92.x
-    IMGUI_API void  PopTextureID()                      { PopTexture(); }           // RENAMED in 1.92.x
+    inline    void  PushTextureID(ImTextureRef tex_ref) { PushTexture(tex_ref); }   // RENAMED in 1.92.x
+    inline    void  PopTextureID()                      { PopTexture(); }           // RENAMED in 1.92.x
 #endif
     //inline  void  AddEllipse(const ImVec2& center, float radius_x, float radius_y, ImU32 col, float rot = 0.0f, int num_segments = 0, float thickness = 1.0f) { AddEllipse(center, ImVec2(radius_x, radius_y), col, rot, num_segments, thickness); } // OBSOLETED in 1.90.5 (Mar 2024)
     //inline  void  AddEllipseFilled(const ImVec2& center, float radius_x, float radius_y, ImU32 col, float rot = 0.0f, int num_segments = 0) { AddEllipseFilled(center, ImVec2(radius_x, radius_y), col, rot, num_segments); }                        // OBSOLETED in 1.90.5 (Mar 2024)


### PR DESCRIPTION
The obsolete functions `PushTextureID()` and `PopTextureID()` have inline definitions but are also marked as `IMGUI_API`. When `IMGUI_API` is defined as `__declspec(dllimport)`, this causes a compilation error on certain compilers since `dllimport` cannot be used on a function with a body (though MSVC is more lenient and accepts it).

This is the error log from compiling with MinGW GCC (`x86_64-w64-mingw32-g++`) on a Windows CI:

```
C:\...\include/imgui.h:3332:21: error: function 'void ImDrawList::PushTextureID(ImTextureRef)' definition is marked dllimport
 3332 |     IMGUI_API void  PushTextureID(ImTextureRef tex_ref) { PushTexture(tex_ref); }   // RENAMED in 1.92.x
      |                     ^~~~~~~~~~~~~
C:\...\include/imgui.h:3333:21: error: function 'void ImDrawList::PopTextureID()' definition is marked dllimport
 3333 |     IMGUI_API void  PopTextureID()                      { PopTexture(); }           // RENAMED in 1.92.x
      |                     ^~~~~~~~~~~~
```

It appears that other obsolete functions have `IMGUI_API` replaced with `inline`, though these two were missed.