### PR TITLE
Fix incorrect assertion for multiviewport support on Vulkan

### DIFF
--- a/backends/imgui_impl_vulkan.cpp
+++ b/backends/imgui_impl_vulkan.cpp
@@ -2147,7 +2147,7 @@ static void ImGui_ImplVulkan_SwapBuffers(ImGuiViewport* viewport, void*)
 void ImGui_ImplVulkan_InitMultiViewportSupport()
 {
     ImGuiPlatformIO& platform_io = ImGui::GetPlatformIO();
-    if (ImGui::GetIO().ConfigFlags & ImGuiConfigFlags_ViewportsEnable)
+    if (ImGui::GetIO().BackendFlags & ImGuiBackendFlags_PlatformHasViewports)
         IM_ASSERT(platform_io.Platform_CreateVkSurface != nullptr && "Platform needs to setup the CreateVkSurface handler.");
     platform_io.Renderer_CreateWindow = ImGui_ImplVulkan_CreateWindow;
     platform_io.Renderer_DestroyWindow = ImGui_ImplVulkan_DestroyWindow;


### PR DESCRIPTION
When running the GLFW Vulkan backend under Wayland, viewports are disabled by default. In the `ImGui_ImplVulkan_InitMultiViewportSupport` function there is a check if viewports are enabled. If the result is true an assertion is run.

However, the check is done incorrectly, because it's done against `ImGuiConfigFlags_ViewportsEnable`, which dear imgui does not modify in any way. Instead the ultimate value, which dictates whether dear imgui supports viewports for the given platform is `ImGuiBackendFlags_PlatformHasViewports`.

This means that on Wayland `ImGuiConfigFlags_ViewportsEnable` may be enabled, but since viewports were previously disabled for the platform it fails because `platform_io.Platform_CreateVkSurface` is null.

Rewrote the check to use `ImGuiBackendFlags_PlatformHasViewports` now, which fixes the bug.