### PR TITLE
Demo: Added "Widgets/Text/Different Size Text" section to show font system changes in v1.92

### DIFF
--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -3548,6 +3548,35 @@ static void DemoWindowWidgetsText()
             ImGui::TreePop();
         }
 
+        IMGUI_DEMO_MARKER("Widgets/Text/Different Size Text");
+        if (ImGui::TreeNode("Different Size Text"))
+        {
+            const ImGuiStyle& style = ImGui::GetStyle();
+
+            for (float scaling = 0.5f; scaling < 4.01f; scaling += 0.5f)
+            {
+                ImGui::PushFont(nullptr, style.FontSizeBase * scaling);
+                ImGui::Text("Text size is %.1f (style.FontSizeBase * %.1f)", style.FontSizeBase * scaling, scaling);
+                ImGui::PopFont();
+            }
+
+            static float custom_scaling{ 1.0f };
+            ImGui::SliderFloat("Custom Scaling##Different Size Text", &custom_scaling, 0.5f, 4.0f, "%.1f");
+            ImGui::SameLine(); HelpMarker("ImGui::PushFont(nullptr, style.FontSizeBase * custom_scaling);");
+            ImGui::PushFont(nullptr, style.FontSizeBase * custom_scaling);
+            ImGui::Text("Text size is %.1f (style.FontSizeBase * %.1f)", style.FontSizeBase * custom_scaling, custom_scaling);
+            ImGui::PopFont();
+
+            static float custom_font_size{ 16.0f };
+            ImGui::SliderFloat("Custom Font Size##Different Size Text", &custom_font_size, 10.0f, 100.0f, "%.1f");
+            ImGui::SameLine(); HelpMarker("ImGui::PushFont(nullptr, custom_font_size);");
+            ImGui::PushFont(nullptr, custom_font_size);
+            ImGui::Text("Text size is %.1f", custom_font_size);
+            ImGui::PopFont();
+
+            ImGui::TreePop();
+        }
+
         IMGUI_DEMO_MARKER("Widgets/Text/Word Wrapping");
         if (ImGui::TreeNode("Word Wrapping"))
         {


### PR DESCRIPTION
I found the Demo did not provide usage demonstrations for `PushFont` and `PopFont` :(

![image](https://github.com/user-attachments/assets/9725a5b7-6999-4f42-a5ba-f646d444d50a)

So I created this PR. This will be helpful.

![image](https://github.com/user-attachments/assets/8e1e577e-e8c9-4057-a0db-e81f89f268d4)
