### PR TITLE
ABI: Define exact-bit-width integers through stdint

### DIFF
--- a/imconfig.h
+++ b/imconfig.h
@@ -36,6 +36,9 @@
 //#define IMGUI_DISABLE_DEMO_WINDOWS                        // Disable demo windows: ShowDemoWindow()/ShowStyleEditor() will be empty.
 //#define IMGUI_DISABLE_DEBUG_TOOLS                         // Disable metrics/debugger and other debug tools: ShowMetricsWindow(), ShowDebugLogWindow() and ShowIDStackToolWindow() will be empty.
 
+//---- Platform and compiler specific options
+//#define IMGUI_DISABLE_STDINT_EXACT_BIT_WIDTH_INTEGER      // Disable use of stdint.h / cstdint if your environment does not support exact-bit-width integers. (This is unlikely to happen in modern desktop OS)
+
 //---- Don't implement some functions to reduce linkage requirements.
 //#define IMGUI_DISABLE_WIN32_DEFAULT_CLIPBOARD_FUNCTIONS   // [Win32] Don't implement default clipboard handler. Won't use and link with OpenClipboard/GetClipboardData/CloseClipboard etc. (user32.lib/.a, kernel32.lib/.a)
 //#define IMGUI_ENABLE_WIN32_DEFAULT_IME_FUNCTIONS          // [Win32] [Default with Visual Studio] Implement default IME handler (require imm32.lib/.a, auto-link for Visual Studio, -limm32 on command-line for MinGW)

--- a/imgui.h
+++ b/imgui.h
@@ -151,7 +151,18 @@ Index of this file:
 //-----------------------------------------------------------------------------
 
 // Scalar data types
-typedef unsigned int        ImGuiID;// A unique ID used by widgets (typically the result of hashing a stack of string)
+#ifndef IMGUI_DISABLE_STDINT_EXACT_BIT_WIDTH_INTEGER
+#include <stdint.h>
+typedef int8_t              ImS8;   // 8-bit signed integer
+typedef uint8_t             ImU8;   // 8-bit unsigned integer
+typedef int16_t             ImS16;  // 16-bit signed integer
+typedef uint16_t            ImU16;  // 16-bit unsigned integer
+typedef int32_t             ImS32;  // 32-bit signed integer == int
+typedef uint32_t            ImU32;  // 32-bit unsigned integer (often used to store packed colors)
+typedef int64_t             ImS64;  // 64-bit signed integer
+typedef uint64_t            ImU64;  // 64-bit unsigned integer
+#else
+// FIXME: Unfortunately, there are multiple data models, such as ILP32/LLP64, ILP64, LP64. Please adjust the following code according to the actual situation of your target platform.
 typedef signed char         ImS8;   // 8-bit signed integer
 typedef unsigned char       ImU8;   // 8-bit unsigned integer
 typedef signed short        ImS16;  // 16-bit signed integer
@@ -160,6 +171,8 @@ typedef signed int          ImS32;  // 32-bit signed integer == int
 typedef unsigned int        ImU32;  // 32-bit unsigned integer (often used to store packed colors)
 typedef signed   long long  ImS64;  // 64-bit signed integer
 typedef unsigned long long  ImU64;  // 64-bit unsigned integer
+#endif
+typedef ImU32               ImGuiID;// A unique ID used by widgets (typically the result of hashing a stack of string)
 
 // Forward declarations: ImDrawList, ImFontAtlas layer
 struct ImDrawChannel;               // Temporary storage to output draw commands out of order, used by ImDrawListSplitter and ImDrawList::ChannelsSplit()


### PR DESCRIPTION
This is a possible implementation for issue [#8546](https://github.com/ocornut/imgui/issues/8546).

Modern programming languages and their desktop OS target have standardized data models. For example: Java, C #, Rust, Zig, Go, and others have standardized (in language specification) 8/16/32/64 bit width integers/unsigned integers.

The main application scenarios for dear imgui are desktop GUI and possibly embedded system GUI. In either scenario, it is unlikely to involve integer data models other than 8/16/32/64.
