### PR TITLE
Fix dllimport/dllexport definitions in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,15 +51,11 @@ jobs:
       - name: Build example_null (mingw 64-bit, as DLL)
         shell: bash
         run: |
-          echo '#ifdef _EXPORT'                                  >  example_single_file.cpp
-          echo '#  define IMGUI_API __declspec(dllexport)'       >> example_single_file.cpp
-          echo '#else'                                           >> example_single_file.cpp
-          echo '#  define IMGUI_API __declspec(dllimport)'       >> example_single_file.cpp
-          echo '#endif'                                          >> example_single_file.cpp
+          echo '#define IMGUI_API __declspec(dllexport)'         >  example_single_file.cpp
           echo '#define IMGUI_IMPLEMENTATION'                    >> example_single_file.cpp
           echo '#include "misc/single_file/imgui_single_file.h"' >> example_single_file.cpp
-          g++ -I. -Wall -Wformat -D_EXPORT -shared -o libimgui.dll -Wl,--out-implib,libimgui.a example_single_file.cpp -limm32
-          g++ -I. -Wall -Wformat -o example_null.exe examples/example_null/main.cpp -L. -limgui
+          g++ -I. -Wall -Wformat -shared -o libimgui.dll -Wl,--out-implib,libimgui.a example_single_file.cpp -limm32
+          g++ -I. -Wall -Wformat -DIMGUI_API='__declspec(dllimport)' -o example_null.exe examples/example_null/main.cpp -L. -limgui
           rm -f example_null.exe libimgui.* example_single_file.*
 
       - name: Build example_null (extra warnings, msvc 64-bit)
@@ -99,16 +95,12 @@ jobs:
         run: |
           call "%VS_PATH%\VC\Auxiliary\Build\vcvars64.bat"
 
-          echo #ifdef _EXPORT                                  >  example_single_file.cpp
-          echo #  define IMGUI_API __declspec(dllexport)       >> example_single_file.cpp
-          echo #else                                           >> example_single_file.cpp
-          echo #  define IMGUI_API __declspec(dllimport)       >> example_single_file.cpp
-          echo #endif                                          >> example_single_file.cpp
+          echo #define IMGUI_API __declspec(dllexport)         >  example_single_file.cpp
           echo #define IMGUI_IMPLEMENTATION                    >> example_single_file.cpp
           echo #include "misc/single_file/imgui_single_file.h" >> example_single_file.cpp
 
-          cl.exe /D_USRDLL /D_WINDLL /D_EXPORT /I. example_single_file.cpp /LD /FeImGui.dll /link
-          cl.exe /I. ImGui.lib /Feexample_null.exe examples/example_null/main.cpp
+          cl.exe /D_USRDLL /D_WINDLL /I. example_single_file.cpp /LD /FeImGui.dll /link
+          cl.exe /DIMGUI_API=__declspec(dllimport) /I. ImGui.lib /Feexample_null.exe examples/example_null/main.cpp
 
       - name: Build Win32 example_glfw_opengl2
         shell: cmd


### PR DESCRIPTION
This lets the CI detect the problem from #8729. The previous CI setup had these issues which prevented it from throwing an error when a function had `IMGUI_API` with a function body:

- Even though `example_single_file.cpp` had `#  define IMGUI_API __declspec(dllimport)` this preprocessor branch was never hit. We can remove the `#ifdef _EXPORT` and `-D_EXPORT` to simplify the CI.
- This means `dllimport` was never actually used in the test code. It is now defined from the command line when compiling `example_null` where the functions from the DLL are expected to be imported.

I tested this updated CI with a branch where the changes from #8729 were undone, and it failed with the following log, which is expected:

```
Run echo '#define IMGUI_API __declspec(dllexport)'         >  example_single_file.cpp
  echo '#define IMGUI_API __declspec(dllexport)'         >  example_single_file.cpp
  echo '#define IMGUI_IMPLEMENTATION'                    >> example_single_file.cpp
  echo '#include "misc/single_file/imgui_single_file.h"' >> example_single_file.cpp
  g++ -I. -Wall -Wformat -shared -o libimgui.dll -Wl,--out-implib,libimgui.a example_single_file.cpp -limm32
  g++ -I. -Wall -Wformat -DIMGUI_API='__declspec(dllimport)' -o example_null.exe examples/example_null/main.cpp -L. -limgui
  rm -f example_null.exe libimgui.* example_single_file.*
  shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
  env:
    VS_PATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\
    MSBUILD_PATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\
    SDL2_DIR: D:\a\imgui\imgui\SDL2-devel-2.26.3-VC\SDL2-2.26.3\
    VULKAN_SDK: D:\a\imgui\imgui\vulkan-sdk-1.1.121.2\
  
In file included from examples/example_null/main.cpp:4:
./imgui.h:3332:21: error: function 'void ImDrawList::PushTextureID(ImTextureRef)' definition is marked dllimport
     IMGUI_API void  PushTextureID(ImTextureRef tex_ref) { PushTexture(tex_ref); }   // RENAMED in 1.92.x
                     ^~~~~~~~~~~~~
./imgui.h:3333:21: error: function 'void ImDrawList::PopTextureID()' definition is marked dllimport
     IMGUI_API void  PopTextureID()                      { PopTexture(); }           // RENAMED in 1.92.x
                     ^~~~~~~~~~~~
Error: Process completed with exit code 1.
```

Even though the MSVC CI does not fail in this situation, I also updated it for consistency.