### PR TITLE
Vulkan: Fix texture synchronization

### DIFF
--- a/backends/imgui_impl_vulkan.cpp
+++ b/backends/imgui_impl_vulkan.cpp
@@ -807,6 +807,7 @@ void ImGui_ImplVulkan_UpdateTexture(ImTextureData* tex)
         {
             VkImageMemoryBarrier copy_barrier[1] = {};
             copy_barrier[0].sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+            copy_barrier[0].srcAccessMask = VK_ACCESS_HOST_WRITE_BIT;
             copy_barrier[0].dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
             copy_barrier[0].oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
             copy_barrier[0].newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
@@ -816,7 +817,7 @@ void ImGui_ImplVulkan_UpdateTexture(ImTextureData* tex)
             copy_barrier[0].subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
             copy_barrier[0].subresourceRange.levelCount = 1;
             copy_barrier[0].subresourceRange.layerCount = 1;
-            vkCmdPipelineBarrier(bd->TexCommandBuffer, VK_PIPELINE_STAGE_HOST_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, copy_barrier);
+            vkCmdPipelineBarrier(bd->TexCommandBuffer, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT | VK_PIPELINE_STAGE_HOST_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, copy_barrier);
 
             VkBufferImageCopy region = {};
             region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;

--- a/backends/imgui_impl_vulkan.cpp
+++ b/backends/imgui_impl_vulkan.cpp
@@ -805,9 +805,18 @@ void ImGui_ImplVulkan_UpdateTexture(ImTextureData* tex)
 
         // Copy to Image:
         {
+            VkBufferMemoryBarrier upload_barrier[1] = {};
+            upload_barrier[0].sType = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER;
+            upload_barrier[0].srcAccessMask = VK_ACCESS_HOST_WRITE_BIT;
+            upload_barrier[0].dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+            upload_barrier[0].srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            upload_barrier[0].dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            upload_barrier[0].buffer = upload_buffer;
+            upload_barrier[0].offset = 0;
+            upload_barrier[0].size = upload_size;
+
             VkImageMemoryBarrier copy_barrier[1] = {};
             copy_barrier[0].sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
-            copy_barrier[0].srcAccessMask = VK_ACCESS_HOST_WRITE_BIT;
             copy_barrier[0].dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
             copy_barrier[0].oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
             copy_barrier[0].newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
@@ -817,7 +826,7 @@ void ImGui_ImplVulkan_UpdateTexture(ImTextureData* tex)
             copy_barrier[0].subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
             copy_barrier[0].subresourceRange.levelCount = 1;
             copy_barrier[0].subresourceRange.layerCount = 1;
-            vkCmdPipelineBarrier(bd->TexCommandBuffer, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT | VK_PIPELINE_STAGE_HOST_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, copy_barrier);
+            vkCmdPipelineBarrier(bd->TexCommandBuffer, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT | VK_PIPELINE_STAGE_HOST_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 1, upload_barrier, 1, copy_barrier);
 
             VkBufferImageCopy region = {};
             region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;


### PR DESCRIPTION
This fixes two bugs around synchronization when uploading textures to the GPU:
- The pipeline barrier only waits on the copy with `VK_PIPELINE_STAGE_HOST_BIT`, but it must also wait for any ongoing reads to be complete with `VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT`.
- The [specification for `vkFlushMappedMemoryRanges`](https://registry.khronos.org/vulkan/specs/latest/man/html/vkFlushMappedMemoryRanges.html) states that it does not guarantee for writes to be available to the device unless a memory dependency is specified on `VK_ACCESS_HOST_WRITE_BIT`.

The first bug is currently caught by the synchronization profile of the validation layers with this message:
```
Validation Error: [ SYNC-HAZARD-WRITE-AFTER-READ ] | MessageID = 0x376bc9df
vkQueueSubmit(): WRITE_AFTER_READ hazard detected. vkCmdPipelineBarrier (from VkCommandBuffer 0x55da2be07fb0 submitted on the current VkQueue 0x55da2bcf0cb0) writes to VkImage 0x250000000025, which was previously read by vkCmdDrawIndexed (from VkCommandBuffer 0x55da2bd5a610 submitted on VkQueue 0x55da2bcf0cb0). 
No sufficient synchronization is present to ensure that a layout transition does not conflict with a prior read (VK_ACCESS_2_SHADER_SAMPLED_READ_BIT) at VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT.
Vulkan insight: an execution dependency is sufficient to prevent this hazard.
Objects: 2
    [0] VkQueue 0x55da2bcf0cb0
    [1] VkCommandBuffer 0x55da2be07fb0
```