### PR TITLE
Restore ability to specify FreeType font "named instance index"

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -3473,7 +3473,7 @@ struct ImFontConfig
     bool            MergeMode;              // false    // Merge into previous ImFont, so you can combine multiple inputs font into one ImFont (e.g. ASCII font + icons + Japanese glyphs). You may want to use GlyphOffset.y when merge font of different heights.
     bool            PixelSnapH;             // false    // Align every glyph AdvanceX to pixel boundaries. Useful e.g. if you are merging a non-pixel aligned font with the default font. If enabled, you can set OversampleH/V to 1.
     bool            PixelSnapV;             // true     // Align Scaled GlyphOffset.y to pixel boundaries.
-    ImS8            FontNo;                 // 0        // Index of font within TTF/OTF file
+    ImS32           FontNo;                 // 0        // Index of font within TTF/OTF file
     ImS8            OversampleH;            // 0 (2)    // Rasterize at higher quality for sub-pixel positioning. 0 == auto == 1 or 2 depending on size. Note the difference between 2 and 3 is minimal. You can reduce this to 1 for large glyphs save memory. Read https://github.com/nothings/stb/blob/master/tests/oversample/README.md for details.
     ImS8            OversampleV;            // 0 (1)    // Rasterize at higher quality for sub-pixel positioning. 0 == auto == 1. This is not really useful as we don't use sub-pixel positions on the Y axis.
     float           SizePixels;             //          // Size in pixels for rasterizer (more or less maps to the resulting font height).

--- a/misc/freetype/imgui_freetype.cpp
+++ b/misc/freetype/imgui_freetype.cpp
@@ -174,7 +174,7 @@ struct ImGui_ImplFreeType_FontSrcBakedData
 
 bool ImGui_ImplFreeType_FontSrcData::InitFont(FT_Library ft_library, ImFontConfig* src, ImGuiFreeTypeLoaderFlags extra_font_loader_flags)
 {
-    FT_Error error = FT_New_Memory_Face(ft_library, (uint8_t*)src->FontData, (uint32_t)src->FontDataSize, (uint32_t)src->FontNo, &FtFace);
+    FT_Error error = FT_New_Memory_Face(ft_library, (uint8_t*)src->FontData, (FT_Long)src->FontDataSize, (FT_Long)src->FontNo, &FtFace);
     if (error != 0)
         return false;
     error = FT_Select_Charmap(FtFace, FT_ENCODING_UNICODE);


### PR DESCRIPTION
The member `ImFontConfig::FontNo` is used as the argument `face_index` when FreeType is enabled which is a 32-bit value where the upper and lower 16 bits have different uses. One of the recent font rendering changes for 1.92 seems to have changed this member from `int` to `ImS8` which prevents specifying the full 32 bits. The upper 16 bits allow for specifying the "named instance index" / named font variation in certain fonts, like predefined font weights (Bold, SemiBold, Light, etc.).

For completeness I've also fixed the call to `FT_New_Memory_Face` to use the correct casts to `FT_Long` which is a typedef of `signed long` rather than `uint32_t` to avoid a signed -> unsigned -> signed roundtrip.

From the FreeType doc comments:
```
   *   face_index ::
   *     This field holds two different values.  Bits 0-15 are the index of
   *     the face in the font file (starting with value~0).  Set it to~0 if
   *     there is only one face in the font file.
   *
   *     [Since 2.6.1] Bits 16-30 are relevant to TrueType GX and OpenType
   *     Font Variations only, specifying the named instance index for the
   *     current face index (starting with value~1; value~0 makes FreeType
   *     ignore named instances).  For non-variation fonts, bits 16-30 are
   *     ignored.  Assuming that you want to access the third named instance
   *     in face~4, `face_index` should be set to 0x00030004.  If you want
   *     to access face~4 without variation handling, simply set
   *     `face_index` to value~4.
```