### PR TITLE
AutoFitSize no longer ignores title length if it's wider than the content of the window

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -6565,6 +6565,19 @@ static ImVec2 CalcWindowAutoFitSize(ImGuiWindow* window, const ImVec2& size_cont
     ImVec2 size_pad = window->WindowPadding * 2.0f;
     ImVec2 size_desired = size_contents + size_pad + ImVec2(decoration_w_without_scrollbars, decoration_h_without_scrollbars);
 
+    if ((window->Flags & ImGuiWindowFlags_NoTitleBar) == 0)
+    {
+        // Content may be shorter than title. In that case, make sure we auto resize based on title to not clip it off.
+        ImVec2 title_size = ImGui::CalcTextSize(window->Name, NULL, true);
+        title_size.x += style.FramePadding.x * 2.0f;
+
+        float collapse_button_width = (window->Flags & ImGuiWindowFlags_NoCollapse) == 0 ? (g.FontSize + style.FramePadding.x * 2.0f) : 0.0f;
+        float close_button_width = window->HasCloseButton ? (g.FontSize + style.FramePadding.x * 2.0f) : 0.0f;
+
+        float min_title_width = title_size.x + collapse_button_width + close_button_width;
+        size_desired.x = ImMax(size_desired.x, min_title_width + style.WindowPadding.x * 2.0f);
+    }
+    
     // Determine maximum window size
     // Child windows are layed within their parent (unless they are also popups/menus) and thus have no restriction
     ImVec2 size_max = ((window->Flags & ImGuiWindowFlags_ChildWindow) && !(window->Flags & ImGuiWindowFlags_Popup)) ? ImVec2(FLT_MAX, FLT_MAX) : ImGui::GetMainViewport()->WorkSize - style.DisplaySafeAreaPadding * 2.0f;


### PR DESCRIPTION
Previously, if you had a window created with a text saying "Hey" and title bar saying, "My really long title", the title would be cut off. With this change, as long as title is longer than the content, it will make the window auto size to fit the title in as well.

It's very noticeable with ImGuiWindowFlags_AlwaysAutoResize flag.

This PR also takes into account the width of collapse button and close button (if present)