### PR TITLE
DX9 Backend: Recreate destroyed textures on CreateDeviceObjects()

### DIFF
--- a/backends/imgui_impl_dx9.cpp
+++ b/backends/imgui_impl_dx9.cpp
@@ -463,6 +463,14 @@ bool ImGui_ImplDX9_CreateDeviceObjects()
     ImGui_ImplDX9_Data* bd = ImGui_ImplDX9_GetBackendData();
     if (!bd || !bd->pd3dDevice)
         return false;
+
+    // Recreate all textures previously destroyed
+    for (ImTextureData* tex : ImGui::GetPlatformIO().Textures)
+        if (tex->Status == ImTextureStatus_Destroyed)
+        {
+            tex->SetStatus(ImTextureStatus_WantCreate);
+            ImGui_ImplDX9_UpdateTexture(tex);
+        }
     ImGui_ImplDX9_CreateDeviceObjectsForPlatformWindows();
     return true;
 }


### PR DESCRIPTION
Fix an issue where the textures where never re-created after invalidating the device objects, usually happen during:

```cpp
ImGui_ImplDX9_InvalidateDeviceObjects();
device->Reset(&d3dpp);
ImGui_ImplDX9_CreateDeviceObjects();
```

This was previously crashing for the next `ImGui::Begin()`, during the `PushTexture` for the `ContainerAtlas` ( in my case ):

```cpp
// Setup draw list and outer clipping rectangle
IM_ASSERT(window->DrawList->CmdBuffer.Size == 1 && window->DrawList->CmdBuffer[0].ElemCount == 0);
window->DrawList->PushTexture(g.Font->ContainerAtlas->TexRef);
PushClipRect(host_rect.Min, host_rect.Max, false);
```