### PR TITLE
Fix swapchain acquisition in example_sdl3_sdlgpu3

### DIFF
--- a/examples/example_sdl3_sdlgpu3/main.cpp
+++ b/examples/example_sdl3_sdlgpu3/main.cpp
@@ -184,7 +184,7 @@ int main(int, char**)
         SDL_GPUCommandBuffer* command_buffer = SDL_AcquireGPUCommandBuffer(gpu_device); // Acquire a GPU command buffer
 
         SDL_GPUTexture* swapchain_texture;
-        SDL_AcquireGPUSwapchainTexture(command_buffer, window, &swapchain_texture, nullptr, nullptr); // Acquire a swapchain texture
+        SDL_WaitAndAcquireGPUSwapchainTexture(command_buffer, window, &swapchain_texture, nullptr, nullptr); // Acquire a swapchain texture
 
         if (swapchain_texture != nullptr && !is_minimized)
         {


### PR DESCRIPTION
I spotted a minor issue in the SDL_GPU backend example.

The example runs fine though the swapchain acquisition can be improved:
In the sample `SDL_AcquireGPUSwapchainTexture` is used instead of `SDL_WaitAndAcquireGPUSwapchainTexture`. 
This seems to be fine as long as `SDL_CreateGPUDevice` is used with `debug_mode` set to true.

If `debug_mode` is false though using `SDL_AcquireGPUSwapchainTexture` instead of `SDL_WaitAndAcquireGPUSwapchainTexture` will cause wrong timing resulting in frame drops and stuttering.

So it is best practice to prefer using `SDL_WaitAndAcquireGPUSwapchainTexture` over `SDL_AcquireGPUSwapchainTexture`.

From the [SDL wiki](https://wiki.libsdl.org/SDL3/SDL_AcquireGPUSwapchainTexture#remarks):

> If you use this function, it is possible to create a situation where many command buffers are allocated while the rendering context waits for the GPU to catch up, which will cause memory usage to grow. You should use [SDL_WaitAndAcquireGPUSwapchainTexture](https://wiki.libsdl.org/SDL3/SDL_WaitAndAcquireGPUSwapchainTexture)() unless you know what you are doing with timing.


