### PR TITLE
Demo: Fix '= =' typo in text

### DIFF
--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -2170,7 +2170,7 @@ static void DemoWindowWidgetsQueryingStatuses()
         );
         ImGui::BulletText(
             "with Hovering Delay or Stationary test:\n"
-            "IsItemHovered() = = %d\n"
+            "IsItemHovered() = %d\n"
             "IsItemHovered(_Stationary) = %d\n"
             "IsItemHovered(_DelayShort) = %d\n"
             "IsItemHovered(_DelayNormal) = %d\n"


### PR DESCRIPTION
The "Widgets > Querying Item Status" section of the demo has one status line with `= =` instead of `=`.