### PR TITLE
Add better support for CJK wrapping.

### DIFF
--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -5429,9 +5429,9 @@ const char* ImFont::CalcWordWrapPosition(float size, const char* text, const cha
             last_char_is_cjk = false;
             last_char_is_init = false;
         }
-        else if (ImCharIsTermW(c))
+        else if (ImCharIsHeadProhibitedW(c))
         {
-            // Terminators can overflow, at most once.
+            // Can overflow, at most once.
             line_width += word_width + blank_width;
             word_width = 0.0f;
             blank_width = char_width;
@@ -5443,7 +5443,7 @@ const char* ImFont::CalcWordWrapPosition(float size, const char* text, const cha
         }
         else
         {
-            if (ImCharIsInitW(c))
+            if (ImCharIsTailProhibitedW(c))
             {
                 line_width += word_width + blank_width;
                 word_width = blank_width = 0.0f;
@@ -5462,7 +5462,7 @@ const char* ImFont::CalcWordWrapPosition(float size, const char* text, const cha
             // CJK characters are not separated by spaces, so we treat them as a single word.
             // This is a very simple heuristic, but it works for most cases.
             last_char_is_cjk = 0x3003 <= c && c <= 0xFFFF;
-            last_char_is_init = ImCharIsInitW(c);
+            last_char_is_init = ImCharIsTailProhibitedW(c);
             word_width += char_width;
             if (inside_word)
             {

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -5368,7 +5368,7 @@ const char* ImFont::CalcWordWrapPosition(float size, const char* text, const cha
     // Chinese punctuations are merged into nearby characters.
     // [《短][歌][行》][曹][操：][对][酒][当][歌，][人][生][几][何！][譬][如][朝][露，][去][日][苦][多……]
     // English words are separated even if no spaces are inserted.
-    // [ImGui][是][即][使][模][式][的][界][面][框][架。]
+    // [ImGui][是][即][时][模][式][的][界][面][框][架。]
 
     ImFontBaked* baked = GetFontBaked(size);
     const float scale = size / baked->Size;
@@ -5451,14 +5451,14 @@ const char* ImFont::CalcWordWrapPosition(float size, const char* text, const cha
                 prev_word_end = word_end;
                 word_end = next_s;
             }
-            else if (0x3003 <= c && c <= 0xFFFF) 
+            else if (0x3003 <= c && c <= 0xFFFF)
             {
                 line_width += word_width + blank_width;
                 word_width = blank_width = 0.0f;
                 inside_word = true;
                 if ((!last_char_is_init && 0x3003 <= c && c <= 0xFFFF) || !last_char_is_cjk)
                     prev_word_end = s;
-            } 
+            }
             // CJK characters are not separated by spaces, so we treat them as a single word.
             // This is a very simple heuristic, but it works for most cases.
             last_char_is_cjk = 0x3003 <= c && c <= 0xFFFF;

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -401,14 +401,14 @@ IM_MSVC_RUNTIME_CHECKS_OFF
 inline char             ImToUpper(char c)               { return (c >= 'a' && c <= 'z') ? c &= ~32 : c; }
 inline bool             ImCharIsBlankA(char c)          { return c == ' ' || c == '\t'; }
 inline bool             ImCharIsBlankW(unsigned int c)  { return c == ' ' || c == '\t' || c == 0x3000; }
-// Terminators: Chinese punctuations that should not appear at the start of line.
-// Only include characters can be typed within 1 or 2 hits on a standard Chinese keyboard.
-// List: ～！）】、：；’”，。》」？
-inline bool             ImCharIsTermW(unsigned int c)   { return c == 0xff5e || c == 0xff01 || c == 0xff09 || c == 0x3011 || c == 0x3001 || c == 0xff1a || c == 0xff1b || c == 0x2019 || c == 0x201d || c == 0xff0c || c == 0x3002 || c == 0x300b || c == 0x300d || c == 0xff1f; }
-// Initializers: Chinese punctuations that should not appear at the end of line.
-// Only include characters can be typed within 1 or 2 hits on a standard Chinese keyboard.
-// List: （【《「
-inline bool             ImCharIsInitW(unsigned int c)   { return c == 0xff08 || c == 0x3010 || c == 0x300a || c == 0x300c; }
+// Head Prohibited: Punctuations that should not appear at the start of line.
+// Only include characters can be typed within 1 or 2 hits on a standard keyboard.
+// List: ～！）】、：；’”，。》」』？
+inline bool             ImCharIsHeadProhibitedW(unsigned int c)   { return c == 0xff5e || c == 0xff01 || c == 0xff09 || c == 0x3011 || c == 0x3001 || c == 0xff1a || c == 0xff1b || c == 0x2019 || c == 0x201d || c == 0xff0c || c == 0x3002 || c == 0x300b || c == 0x300d || c == 0x300f || c == 0xff1f; }
+// Tail Prohibited: Punctuations that should not appear at the end of line.
+// Only include characters can be typed within 1 or 2 hits on a standard keyboard.
+// List: （【《「『
+inline bool             ImCharIsTailProhibitedW(unsigned int c)   { return c == 0xff08 || c == 0x3010 || c == 0x300a || c == 0x300c || c == 0x300e; }
 inline bool             ImCharIsXdigitA(char c)         { return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f'); }
 IM_MSVC_RUNTIME_CHECKS_RESTORE
 

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -401,6 +401,14 @@ IM_MSVC_RUNTIME_CHECKS_OFF
 inline char             ImToUpper(char c)               { return (c >= 'a' && c <= 'z') ? c &= ~32 : c; }
 inline bool             ImCharIsBlankA(char c)          { return c == ' ' || c == '\t'; }
 inline bool             ImCharIsBlankW(unsigned int c)  { return c == ' ' || c == '\t' || c == 0x3000; }
+// Terminators: Chinese punctuations that should not appear at the start of line.
+// Only include characters can be typed within 1 or 2 hits on a standard Chinese keyboard.
+// List: ～！）】\：；’”，。》」？
+inline bool             ImCharIsTermW(unsigned int c)    { return c == 0xff5e || c == 0xff01 || c == 0xff09 || c == 0x3011 || c == 0x3001 || c == 0xff1a || c == 0xff1b || c == 0x2019 || c == 0x201d || c == 0xff0c || c == 0x3002 || c == 0x300b || c == 0x300d || c == 0xff1f; }
+// Initializers: Chinese punctuations that should not appear at the end of line.
+// Only include characters can be typed within 1 or 2 hits on a standard Chinese keyboard.
+// List: （【《「
+inline bool             ImCharIsInitalW(unsigned int c)  { return c == 0xff08 || c == 0x3010 || c == 0x300a || c == 0x300c; }
 inline bool             ImCharIsXdigitA(char c)         { return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f'); }
 IM_MSVC_RUNTIME_CHECKS_RESTORE
 

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -403,12 +403,12 @@ inline bool             ImCharIsBlankA(char c)          { return c == ' ' || c =
 inline bool             ImCharIsBlankW(unsigned int c)  { return c == ' ' || c == '\t' || c == 0x3000; }
 // Terminators: Chinese punctuations that should not appear at the start of line.
 // Only include characters can be typed within 1 or 2 hits on a standard Chinese keyboard.
-// List: ～！）】\：；’”，。》」？
+// List: ～！）】、：；’”，。》」？
 inline bool             ImCharIsTermW(unsigned int c)    { return c == 0xff5e || c == 0xff01 || c == 0xff09 || c == 0x3011 || c == 0x3001 || c == 0xff1a || c == 0xff1b || c == 0x2019 || c == 0x201d || c == 0xff0c || c == 0x3002 || c == 0x300b || c == 0x300d || c == 0xff1f; }
 // Initializers: Chinese punctuations that should not appear at the end of line.
 // Only include characters can be typed within 1 or 2 hits on a standard Chinese keyboard.
 // List: （【《「
-inline bool             ImCharIsInitalW(unsigned int c)  { return c == 0xff08 || c == 0x3010 || c == 0x300a || c == 0x300c; }
+inline bool             ImCharIsInitW(unsigned int c)  { return c == 0xff08 || c == 0x3010 || c == 0x300a || c == 0x300c; }
 inline bool             ImCharIsXdigitA(char c)         { return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f'); }
 IM_MSVC_RUNTIME_CHECKS_RESTORE
 

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -404,11 +404,11 @@ inline bool             ImCharIsBlankW(unsigned int c)  { return c == ' ' || c =
 // Terminators: Chinese punctuations that should not appear at the start of line.
 // Only include characters can be typed within 1 or 2 hits on a standard Chinese keyboard.
 // List: ～！）】、：；’”，。》」？
-inline bool             ImCharIsTermW(unsigned int c)    { return c == 0xff5e || c == 0xff01 || c == 0xff09 || c == 0x3011 || c == 0x3001 || c == 0xff1a || c == 0xff1b || c == 0x2019 || c == 0x201d || c == 0xff0c || c == 0x3002 || c == 0x300b || c == 0x300d || c == 0xff1f; }
+inline bool             ImCharIsTermW(unsigned int c)   { return c == 0xff5e || c == 0xff01 || c == 0xff09 || c == 0x3011 || c == 0x3001 || c == 0xff1a || c == 0xff1b || c == 0x2019 || c == 0x201d || c == 0xff0c || c == 0x3002 || c == 0x300b || c == 0x300d || c == 0xff1f; }
 // Initializers: Chinese punctuations that should not appear at the end of line.
 // Only include characters can be typed within 1 or 2 hits on a standard Chinese keyboard.
 // List: （【《「
-inline bool             ImCharIsInitW(unsigned int c)  { return c == 0xff08 || c == 0x3010 || c == 0x300a || c == 0x300c; }
+inline bool             ImCharIsInitW(unsigned int c)   { return c == 0xff08 || c == 0x3010 || c == 0x300a || c == 0x300c; }
 inline bool             ImCharIsXdigitA(char c)         { return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f'); }
 IM_MSVC_RUNTIME_CHECKS_RESTORE
 


### PR DESCRIPTION
Added better wrapping for mixed language text.

1. Chinese characters can break at anywhere.
2. Head prohibited punctuations will overflow and will not appear at the start of the line.
3. Tail prohibited punctuations will not appear at the end of the line.

Notice how "PR 的同时" in the second paragragh break in the two videos.

Demo text used: The Chinese translation of CONTRIBUTING.md in this repo and [离骚](https://zh.wikisource.org/zh-hans/%E9%9B%A2%E9%A8%B7)

https://github.com/user-attachments/assets/8fff4326-8ff6-49df-9aeb-3e38ebcd53bb


https://github.com/user-attachments/assets/e4d5e93b-a80f-444b-9044-d1f8b44e7e9a

TODO: 
1. Better way to detect CJK characters. Currently I use `0x3003 <= c && c <= 0xFFFF`.
2. I don't speak Japanese or Korean so I don't know other punctuations. Add more punctuation supports.

Needs feedback in real use cases, currently only tested with a few examples.
