### PR TITLE
Set font size to be the em square's size and decouple from the line height

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -4027,7 +4027,7 @@ ImGuiContext::ImGuiContext(ImFontAtlas* shared_font_atlas)
     Initialized = false;
     Font = NULL;
     FontBaked = NULL;
-    FontSize = FontSizeBase = FontBakedScale = CurrentDpiScale = 0.0f;
+    FontSize = FontSizeBase = FontBakedScale = FontLineHeight = CurrentDpiScale = 0.0f;
     FontRasterizerDensity = 1.0f;
     IO.Fonts = shared_font_atlas ? shared_font_atlas : IM_NEW(ImFontAtlas)();
     if (shared_font_atlas == NULL)
@@ -5990,10 +5990,9 @@ ImVec2 ImGui::CalcTextSize(const char* text, const char* text_end, bool hide_tex
         text_display_end = text_end;
 
     ImFont* font = g.Font;
-    const float font_size = g.FontSize;
     if (text == text_display_end)
-        return ImVec2(0.0f, font_size);
-    ImVec2 text_size = font->CalcTextSizeA(font_size, FLT_MAX, wrap_width, text, text_display_end, NULL);
+        return ImVec2(0.0f, g.FontLineHeight);
+    ImVec2 text_size = font->CalcTextSizeA(g.FontSize, FLT_MAX, wrap_width, text, text_display_end, NULL);
 
     // Round
     // FIXME: This has been here since Dec 2015 (7b0bf230) but down the line we want this out.
@@ -7470,8 +7469,8 @@ bool ImGui::Begin(const char* name, bool* p_open, ImGuiWindowFlags flags)
         // Lock menu offset so size calculation can use it as menu-bar windows need a minimum size.
         window->DC.MenuBarOffset.x = ImMax(ImMax(window->WindowPadding.x, style.ItemSpacing.x), g.NextWindowData.MenuBarOffsetMinVal.x);
         window->DC.MenuBarOffset.y = g.NextWindowData.MenuBarOffsetMinVal.y;
-        window->TitleBarHeight = (flags & ImGuiWindowFlags_NoTitleBar) ? 0.0f : g.FontSize + g.Style.FramePadding.y * 2.0f;
-        window->MenuBarHeight = (flags & ImGuiWindowFlags_MenuBar) ? window->DC.MenuBarOffset.y + g.FontSize + g.Style.FramePadding.y * 2.0f : 0.0f;
+        window->TitleBarHeight = (flags & ImGuiWindowFlags_NoTitleBar) ? 0.0f : g.FontLineHeight + g.Style.FramePadding.y * 2.0f;
+        window->MenuBarHeight = (flags & ImGuiWindowFlags_MenuBar) ? window->DC.MenuBarOffset.y + g.FontLineHeight + g.Style.FramePadding.y * 2.0f : 0.0f;
         window->FontRefSize = g.FontSize; // Lock this to discourage calling window->CalcFontSize() outside of current window.
 
         // Depending on condition we use previous or current window size to compare against contents size to decide if a scrollbar should be visible.
@@ -7604,9 +7603,9 @@ bool ImGui::Begin(const char* name, bool* p_open, ImGuiWindowFlags flags)
         // Large values tend to lead to variety of artifacts and are not recommended.
         window->WindowRounding = (flags & ImGuiWindowFlags_ChildWindow) ? style.ChildRounding : ((flags & ImGuiWindowFlags_Popup) && !(flags & ImGuiWindowFlags_Modal)) ? style.PopupRounding : style.WindowRounding;
 
-        // For windows with title bar or menu bar, we clamp to FrameHeight(FontSize + FramePadding.y * 2.0f) to completely hide artifacts.
+        // For windows with title bar or menu bar, we clamp to FrameHeight(LineHeight + FramePadding.y * 2.0f) to completely hide artifacts.
         //if ((window->Flags & ImGuiWindowFlags_MenuBar) || !(window->Flags & ImGuiWindowFlags_NoTitleBar))
-        //    window->WindowRounding = ImMin(window->WindowRounding, g.FontSize + style.FramePadding.y * 2.0f);
+        //    window->WindowRounding = ImMin(window->WindowRounding, g.FontLineHeight + style.FramePadding.y * 2.0f);
 
         // Apply window focus (new and reactivated windows are moved to front)
         bool want_focus = false;
@@ -8775,8 +8774,8 @@ void ImGui::UpdateFontsNewFrame()
     g.Font = font;
     g.FontSizeBase = g.Style.FontSizeBase;
     g.FontSize = 0.0f;
-    ImFontStackData font_stack_data = { font, g.Style.FontSizeBase, g.Style.FontSizeBase };           // <--- Will restore FontSize
-    SetCurrentFont(font_stack_data.Font, font_stack_data.FontSizeBeforeScaling, 0.0f); // <--- but use 0.0f to enable scale
+    ImFontStackData font_stack_data = { font, g.Style.FontSizeBase, g.Style.FontSizeBase }; // <--- Will restore FontSize
+    SetCurrentFont(font_stack_data.Font, font_stack_data.FontSizeBeforeScaling, 0.0f);      // <--- but use 0.0f to enable scale
     g.FontStack.push_back(font_stack_data);
     IM_ASSERT(g.Font->IsLoaded());
 }
@@ -8908,6 +8907,7 @@ void ImGui::UpdateCurrentFontSize(float restore_font_size_after_scaling)
         g.Font->CurrentRasterizerDensity = g.FontRasterizerDensity;
     g.FontSize = final_size;
     g.FontBaked = (g.Font != NULL && window != NULL) ? g.Font->GetFontBaked(final_size) : NULL;
+    g.FontLineHeight = g.FontBaked ? g.FontBaked->LineHeight : g.FontSize;
     g.FontBakedScale = (g.Font != NULL && window != NULL) ? (g.FontSize / g.FontBaked->Size) : 0.0f;
     g.DrawListSharedData.FontSize = g.FontSize;
     g.DrawListSharedData.FontScale = g.FontBakedScale;
@@ -11402,25 +11402,25 @@ ImVec2 ImGui::CalcItemSize(ImVec2 size, float default_w, float default_h)
 float ImGui::GetTextLineHeight()
 {
     ImGuiContext& g = *GImGui;
-    return g.FontSize;
+    return g.FontLineHeight;
 }
 
 float ImGui::GetTextLineHeightWithSpacing()
 {
     ImGuiContext& g = *GImGui;
-    return g.FontSize + g.Style.ItemSpacing.y;
+    return g.FontLineHeight + g.Style.ItemSpacing.y;
 }
 
 float ImGui::GetFrameHeight()
 {
     ImGuiContext& g = *GImGui;
-    return g.FontSize + g.Style.FramePadding.y * 2.0f;
+    return g.FontLineHeight + g.Style.FramePadding.y * 2.0f;
 }
 
 float ImGui::GetFrameHeightWithSpacing()
 {
     ImGuiContext& g = *GImGui;
-    return g.FontSize + g.Style.FramePadding.y * 2.0f + g.Style.ItemSpacing.y;
+    return g.FontLineHeight + g.Style.FramePadding.y * 2.0f + g.Style.ItemSpacing.y;
 }
 
 ImVec2 ImGui::GetContentRegionAvail()
@@ -16695,8 +16695,7 @@ void ImGui::ShowMetricsWindow(bool* p_open)
             {
                 char buf[32];
                 ImFormatString(buf, IM_ARRAYSIZE(buf), "%d", window->BeginOrderWithinContext);
-                float font_size = GetFontSize();
-                draw_list->AddRectFilled(window->Pos, window->Pos + ImVec2(font_size, font_size), IM_COL32(200, 100, 100, 255));
+                draw_list->AddRectFilled(window->Pos, window->Pos + ImVec2(g.FontSize, g.FontLineHeight), IM_COL32(200, 100, 100, 255));
                 draw_list->AddText(window->Pos, IM_COL32(255, 255, 255, 255), buf);
             }
         }
@@ -17079,7 +17078,7 @@ void ImGui::DebugNodeFont(ImFont* font)
                     baked->FindGlyph((ImWchar)base);
 
             const int surface_sqrt = (int)ImSqrt((float)baked->MetricsTotalSurface);
-            Text("Ascent: %f, Descent: %f, Ascent-Descent: %f", baked->Ascent, baked->Descent, baked->Ascent - baked->Descent);
+            Text("Ascent: %f, Descent: %f, Ascent-Descent: %f, LineHeight: %f", baked->Ascent, baked->Descent, baked->Ascent - baked->Descent, baked->LineHeight);
             Text("Texture Area: about %d px ~%dx%d px", baked->MetricsTotalSurface, surface_sqrt, surface_sqrt);
             for (int src_n = 0; src_n < font->Sources.Size; src_n++)
             {
@@ -17424,7 +17423,7 @@ void ImGui::ShowDebugLogWindow(bool* p_open)
 {
     ImGuiContext& g = *GImGui;
     if ((g.NextWindowData.HasFlags & ImGuiNextWindowDataFlags_HasSize) == 0)
-        SetNextWindowSize(ImVec2(0.0f, GetFontSize() * 12.0f), ImGuiCond_FirstUseEver);
+        SetNextWindowSize(ImVec2(0.0f, GetTextLineHeight() * 12.0f), ImGuiCond_FirstUseEver);
     if (!Begin("Dear ImGui Debug Log", p_open) || GetCurrentWindow()->BeginCount > 1)
     {
         End();
@@ -17751,7 +17750,7 @@ void ImGui::ShowIDStackToolWindow(bool* p_open)
 {
     ImGuiContext& g = *GImGui;
     if ((g.NextWindowData.HasFlags & ImGuiNextWindowDataFlags_HasSize) == 0)
-        SetNextWindowSize(ImVec2(0.0f, GetFontSize() * 8.0f), ImGuiCond_FirstUseEver);
+        SetNextWindowSize(ImVec2(0.0f, GetTextLineHeight() * 8.0f), ImGuiCond_FirstUseEver);
     if (!Begin("Dear ImGui ID Stack Tool", p_open) || GetCurrentWindow()->BeginCount > 1)
     {
         End();

--- a/imgui.h
+++ b/imgui.h
@@ -3757,6 +3757,7 @@ struct ImFontBaked
 
     // [Internal] Members: Cold
     float                       Ascent, Descent;    // 4+4   // out // Ascent: distance from top to bottom of e.g. 'A' [0..FontSize] (unscaled)
+    float                       LineHeight;         // 4     // out // Vertical distance between two baselines
     unsigned int                MetricsTotalSurface:26;// 3  // out // Total surface in pixels to get an idea of the font rasterization/texture cost (not exact, we approximate the cost of padding between glyphs)
     unsigned int                WantDestroy:1;         // 0  //     // Queued for destroy
     unsigned int                LoadNoFallback:1;      // 0  //     // Disable loading fallback in lower-level calls.

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -4617,6 +4617,7 @@ static bool ImGui_ImplStbTrueType_FontBakedInit(ImFontAtlas* atlas, ImFontConfig
         stbtt_GetFontVMetrics(&bd_font_data->FontInfo, &unscaled_ascent, &unscaled_descent, &unscaled_line_gap);
         baked->Ascent = ImCeil(unscaled_ascent * scale_for_layout);
         baked->Descent = ImFloor(unscaled_descent * scale_for_layout);
+        baked->LineHeight = baked->Size;
     }
     return true;
 }
@@ -5061,7 +5062,7 @@ void ImFontBaked::ClearOutputData()
     IndexAdvanceX.clear();
     IndexLookup.clear();
     FallbackGlyphIndex = -1;
-    Ascent = Descent = 0.0f;
+    Ascent = Descent = LineHeight = 0.0f;
     MetricsTotalSurface = 0;
 }
 
@@ -5461,8 +5462,8 @@ ImVec2 ImFont::CalcTextSizeA(float size, float max_width, float wrap_width, cons
     if (!text_end)
         text_end = text_begin + ImStrlen(text_begin); // FIXME-OPT: Need to avoid this.
 
-    const float line_height = size;
     ImFontBaked* baked = GetFontBaked(size);
+    const float line_height = baked->LineHeight;
     const float scale = size / baked->Size;
 
     ImVec2 text_size = ImVec2(0, 0);
@@ -5592,9 +5593,9 @@ begin:
     if (!text_end)
         text_end = text_begin + ImStrlen(text_begin); // ImGui:: functions generally already provides a valid text_end, so this is merely to handle direct calls.
 
-    const float line_height = size;
     ImFontBaked* baked = GetFontBaked(size);
 
+    const float line_height = baked->LineHeight;
     const float scale = size / baked->Size;
     const float origin_x = x;
     const bool word_wrap_enabled = (wrap_width > 0.0f);

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -4574,7 +4574,7 @@ static bool ImGui_ImplStbTrueType_FontSrcInit(ImFontAtlas* atlas, ImFontConfig* 
     if (src->MergeMode && src->SizePixels == 0.0f)
         src->SizePixels = ref_size;
 
-    if (src->SizePixels >= 0.0f)
+    if (src->SizePixels > 0.0f)
         bd_font_data->ScaleFactor = stbtt_ScaleForPixelHeight(&bd_font_data->FontInfo, 1.0f);
     else
         bd_font_data->ScaleFactor = stbtt_ScaleForMappingEmToPixels(&bd_font_data->FontInfo, 1.0f);
@@ -4617,7 +4617,7 @@ static bool ImGui_ImplStbTrueType_FontBakedInit(ImFontAtlas* atlas, ImFontConfig
         stbtt_GetFontVMetrics(&bd_font_data->FontInfo, &unscaled_ascent, &unscaled_descent, &unscaled_line_gap);
         baked->Ascent = ImCeil(unscaled_ascent * scale_for_layout);
         baked->Descent = ImFloor(unscaled_descent * scale_for_layout);
-        baked->LineHeight = baked->Size;
+        baked->LineHeight = src->SizePixels > 0.0f ? baked->Size : baked->Ascent - baked->Descent;
     }
     return true;
 }

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -2149,8 +2149,9 @@ struct ImGuiContext
     ImVector<ImFontAtlas*>  FontAtlases;                        // List of font atlases used by the context (generally only contains g.IO.Fonts aka the main font atlas)
     ImFont*                 Font;                               // Currently bound font. (== FontStack.back().Font)
     ImFontBaked*            FontBaked;                          // Currently bound font at currently bound size. (== Font->GetFontBaked(FontSize))
-    float                   FontSize;                           // Currently bound font size == line height (== FontSizeBase + externals scales applied in the UpdateCurrentFontSize() function).
+    float                   FontSize;                           // Currently bound font size (== FontSizeBase + externals scales applied in the UpdateCurrentFontSize() function).
     float                   FontSizeBase;                       // Font size before scaling == style.FontSizeBase == value passed to PushFont() when specified.
+    float                   FontLineHeight;                     // Currently bound font's line height (+ externals scales applied in the UpdateCurrentFontSize() function).
     float                   FontBakedScale;                     // == FontBaked->Size / FontSize. Scale factor over baked size. Rarely used nowadays, very often == 1.0f.
     float                   FontRasterizerDensity;              // Current font density. Used by all calls to GetFontBaked().
     float                   CurrentDpiScale;                    // Current window/viewport DpiScale == CurrentViewport->DpiScale

--- a/imgui_tables.cpp
+++ b/imgui_tables.cpp
@@ -3075,7 +3075,7 @@ float ImGui::TableGetHeaderRowHeight()
     // In your custom header row you may omit this all together and just call TableNextRow() without a height...
     ImGuiContext& g = *GImGui;
     ImGuiTable* table = g.CurrentTable;
-    float row_height = g.FontSize;
+    float row_height = g.FontLineHeight;
     for (int column_n = 0; column_n < table->ColumnsCount; column_n++)
         if (IM_BITARRAY_TESTBIT(table->EnabledMaskByIndex, column_n))
             if ((table->Columns[column_n].Flags & ImGuiTableColumnFlags_NoHeaderLabel) == 0)

--- a/misc/freetype/imgui_freetype.cpp
+++ b/misc/freetype/imgui_freetype.cpp
@@ -442,7 +442,7 @@ static bool ImGui_ImplFreeType_FontBakedInit(ImFontAtlas* atlas, ImFontConfig* s
     // (FT_Set_Pixel_Sizes() essentially calls FT_Request_Size() with FT_SIZE_REQUEST_TYPE_NOMINAL)
     const float rasterizer_density = src->RasterizerDensity * baked->RasterizerDensity;
     FT_Size_RequestRec req;
-    req.type = (bd_font_data->UserFlags & ImGuiFreeTypeLoaderFlags_Bitmap) ? FT_SIZE_REQUEST_TYPE_NOMINAL : FT_SIZE_REQUEST_TYPE_REAL_DIM;
+    req.type = src->SizePixels <= 0.0f ? FT_SIZE_REQUEST_TYPE_NOMINAL : FT_SIZE_REQUEST_TYPE_REAL_DIM;
     req.width = 0;
     req.height = (uint32_t)(size * 64 * rasterizer_density);
     req.horiResolution = 0;
@@ -455,10 +455,9 @@ static bool ImGui_ImplFreeType_FontBakedInit(ImFontAtlas* atlas, ImFontConfig* s
         // Read metrics
         FT_Size_Metrics metrics = bd_baked_data->FtSize->metrics;
         const float scale = 1.0f / rasterizer_density;
-        baked->Ascent     = (float)FT_CEIL(metrics.ascender)  * scale;      // The pixel extents above the baseline in pixels (typically positive).
-        baked->Descent    = (float)FT_CEIL(metrics.descender) * scale;      // The extents below the baseline in pixels (typically negative).
-        baked->LineHeight = baked->Size; // (float)FT_CEIL(metrics.height) * scale;      // The baseline-to-baseline distance. Note that it usually is larger than the sum of the ascender and descender taken as absolute values. There is also no guarantee that no glyphs extend above or below subsequent baselines when using this distance. Think of it as a value the designer of the font finds appropriate.
-        //LineGap         = (float)FT_CEIL(metrics.height - metrics.ascender + metrics.descender) * scale; // The spacing in pixels between one row's descent and the next row's ascent.
+        baked->Ascent     = (float)FT_CEIL(metrics.ascender) * scale;       // The pixel extents above the baseline in pixels (typically positive).
+        baked->Descent    = (float)(metrics.descender >> 6)  * scale;       // The extents below the baseline in pixels (typically negative).
+        baked->LineHeight = src->SizePixels > 0.0f ? baked->Size : baked->Ascent - baked->Descent; // metrics.height also includes the font's suggested line gap
         //MaxAdvanceWidth = (float)FT_CEIL(metrics.max_advance) * scale;    // This field gives the maximum horizontal cursor advance for all glyphs in the font.
     }
     return true;

--- a/misc/freetype/imgui_freetype.cpp
+++ b/misc/freetype/imgui_freetype.cpp
@@ -455,9 +455,9 @@ static bool ImGui_ImplFreeType_FontBakedInit(ImFontAtlas* atlas, ImFontConfig* s
         // Read metrics
         FT_Size_Metrics metrics = bd_baked_data->FtSize->metrics;
         const float scale = 1.0f / rasterizer_density;
-        baked->Ascent     = (float)FT_CEIL(metrics.ascender) * scale;       // The pixel extents above the baseline in pixels (typically positive).
+        baked->Ascent     = (float)FT_CEIL(metrics.ascender)  * scale;      // The pixel extents above the baseline in pixels (typically positive).
         baked->Descent    = (float)FT_CEIL(metrics.descender) * scale;      // The extents below the baseline in pixels (typically negative).
-        //LineSpacing     = (float)FT_CEIL(metrics.height) * scale;         // The baseline-to-baseline distance. Note that it usually is larger than the sum of the ascender and descender taken as absolute values. There is also no guarantee that no glyphs extend above or below subsequent baselines when using this distance. Think of it as a value the designer of the font finds appropriate.
+        baked->LineHeight = baked->Size; // (float)FT_CEIL(metrics.height) * scale;      // The baseline-to-baseline distance. Note that it usually is larger than the sum of the ascender and descender taken as absolute values. There is also no guarantee that no glyphs extend above or below subsequent baselines when using this distance. Think of it as a value the designer of the font finds appropriate.
         //LineGap         = (float)FT_CEIL(metrics.height - metrics.ascender + metrics.descender) * scale; // The spacing in pixels between one row's descent and the next row's ascent.
         //MaxAdvanceWidth = (float)FT_CEIL(metrics.max_advance) * scale;    // This field gives the maximum horizontal cursor advance for all glyphs in the font.
     }


### PR DESCRIPTION
This pull request fixes the inconsistent font sizes (between fonts and between ImGui and other software) caused by ImGui treating the font size as the total pixel height instead of the size of the font's em square. (#4780, #8822)

Noto Sans vs Helvetica vs Segoe UI at 12px (FreeType):

Before:

<img width="215" height="68" alt="before_noto_12px" src="https://github.com/user-attachments/assets/ed68933f-aa80-44e0-94dd-048f8ba86fe0" />
<img width="215" height="68" alt="before_helvetica_12px" src="https://github.com/user-attachments/assets/e3863a2e-162d-4420-b706-216c0150ec08" />
<img width="215" height="68" alt="before_segoe_12px" src="https://github.com/user-attachments/assets/55e92c9f-5b40-46bd-b9e8-4966fcae7528" />

After:

<img width="215" height="68" alt="after_noto_12px" src="https://github.com/user-attachments/assets/7a4d1892-a322-430b-9e08-83e0ee9878a1" />
<img width="215" height="68" alt="after_helvetica_12px" src="https://github.com/user-attachments/assets/575ce50b-4663-4b72-889b-da613ffc4af1" />
<img width="215" height="68" alt="after_segoe_12px" src="https://github.com/user-attachments/assets/ea3faced-f363-414c-bba8-854456554eed" />

[Firefox](https://jsfiddle.net/Lzqemcwy/):

<img width="173" height="53" alt="20250803_04h08m23s_grim" src="https://github.com/user-attachments/assets/e4245040-9e3d-4a34-ae17-16094bc146b5" />

Baseline alignment when mixing multiple line heights in the same line is not handled (can't adjust already-drawn items after pushing a taller font later in the line...).

---

The first commit only adds the concept of line height. It's set to the font size so there are no visual changes with it alone.

I sifted through and individually checked all usages of the font size. ~~Tab close buttons look better at the font size (while the titlebar's look best using the line height) so I tweaked `CloseButton` to allow any size.~~

I was uncertain about these non-rendering-related uses that also affect the X axis (left them unchanged):
- `ImGuiWindow::FontRefSize`
- `ref_unit` in `BeginMenuEx`
- `scroll_r.Expand` in `EndBoxSelect`

The second commit sets the font size to be the em square size and the line `ascender - descender`. ([FreeType's `metrics.height`](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/freetype/freetype%24+%28face%7Croot%29-%3Eheight.%2B%3D&patternType=regexp&sm=0) includes `line_gap` which is undesirable.)

The old size behavior remains when `ImFontCfg::SizePixels` is greater than zero (for legacy backends, bitmap fonts like the default one...).