### PR TITLE
Fix assertion from `DebugNodeTexture` when `ImTextureID_Invalid` is non-zero

### DIFF
--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -2631,6 +2631,7 @@ ImFontAtlas::ImFontAtlas()
     TexMinHeight = 128;
     TexMaxWidth = 8192;
     TexMaxHeight = 8192;
+    TexRef._TexID = ImTextureID_Invalid;
     RendererHasTextures = false; // Assumed false by default, as apps can call e.g Atlas::Build() after backend init and before ImGui can update.
     TexNextUniqueID = 1;
     FontNextUniqueID = 1;


### PR DESCRIPTION
The `memset` in `ImFontAtlas`'s constructor resets `ImTextureRef::_TexID` to 0 instead of `ImTextureID_Invalid`.

This trips up the assertion in `ImTextureRef::GetTexID` which is called only by `FormatTextureIDForDebugDisplay(ImDrawCmd)`.

1. `#define ImTextureID_Invalid ((ImTextureID)-1)`
2. `ShowMetricsWindow()` > DrawLists > [Expand any draw list]
3. ../../imgui.h:3841: ImTextureID ImTextureRef::GetTexID() const: Assertion `!(_TexData != __null && _TexID != ((ImTextureID)-1))' failed.
