### PR TITLE
Fonts: show `ImFontConfig::FontNo` in `DebugNodeFont`

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -16973,8 +16973,8 @@ void ImGui::DebugNodeFont(ImFont* font)
     for (int src_n = 0; src_n < font->Sources.Size; src_n++)
     {
         ImFontConfig* src = font->Sources[src_n];
-        if (TreeNode(src, "Input %d: \'%s\', Oversample: %d,%d, PixelSnapH: %d, Offset: (%.1f,%.1f)",
-            src_n, src->Name, src->OversampleH, src->OversampleV, src->PixelSnapH, src->GlyphOffset.x, src->GlyphOffset.y))
+        if (TreeNode(src, "Input %d: \'%s\' [%d], Oversample: %d,%d, PixelSnapH: %d, Offset: (%.1f,%.1f)",
+            src_n, src->Name, src->FontNo, src->OversampleH, src->OversampleV, src->PixelSnapH, src->GlyphOffset.x, src->GlyphOffset.y))
         {
             const ImFontLoader* loader = src->FontLoader ? src->FontLoader : atlas->FontLoader;
             Text("Loader: '%s'", loader->Name ? loader->Name : "N/A");


### PR DESCRIPTION
Slight troubleshooting QoL improvement for when the font face/variation index is dynamic.

<img width="387" height="139" alt="Screenshot" src="https://github.com/user-attachments/assets/73386086-9c73-462d-87a9-7792f3aa6aac" />
