### PR TITLE
Storing 64-bit data in ImGuiStorage (closes #8829)

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -2825,6 +2825,30 @@ void* ImGuiStorage::GetVoidPtr(ImGuiID key) const
     return it->val_p;
 }
 
+ImS64 ImGuiStorage::GetInt64(ImGuiID key, ImS64 default_val) const
+{
+    ImGuiStoragePair* it = ImLowerBound(const_cast<ImGuiStoragePair*>(Data.Data), const_cast<ImGuiStoragePair*>(Data.Data + Data.Size), key);
+    if (it == Data.Data + Data.Size || it->key != key)
+        return default_val;
+    return it->val_s64;
+}
+
+ImU64 ImGuiStorage::GetUint64(ImGuiID key, ImU64 default_val) const
+{
+    ImGuiStoragePair* it = ImLowerBound(const_cast<ImGuiStoragePair*>(Data.Data), const_cast<ImGuiStoragePair*>(Data.Data + Data.Size), key);
+    if (it == Data.Data + Data.Size || it->key != key)
+        return default_val;
+    return it->val_u64;
+}
+
+double ImGuiStorage::GetDouble(ImGuiID key, double default_val) const
+{
+    ImGuiStoragePair* it = ImLowerBound(const_cast<ImGuiStoragePair*>(Data.Data), const_cast<ImGuiStoragePair*>(Data.Data + Data.Size), key);
+    if (it == Data.Data + Data.Size || it->key != key)
+        return default_val;
+    return it->val_d;
+}
+
 // References are only valid until a new value is added to the storage. Calling a Set***() function or a Get***Ref() function invalidates the pointer.
 int* ImGuiStorage::GetIntRef(ImGuiID key, int default_val)
 {
@@ -2853,6 +2877,30 @@ void** ImGuiStorage::GetVoidPtrRef(ImGuiID key, void* default_val)
     if (it == Data.Data + Data.Size || it->key != key)
         it = Data.insert(it, ImGuiStoragePair(key, default_val));
     return &it->val_p;
+}
+
+ImS64* ImGuiStorage::GetInt64Ref(ImGuiID key, ImS64 default_val)
+{
+    ImGuiStoragePair* it = ImLowerBound(Data.Data, Data.Data + Data.Size, key);
+    if (it == Data.Data + Data.Size || it->key != key)
+        it = Data.insert(it, ImGuiStoragePair(key, default_val));
+    return &it->val_s64;
+}
+
+ImU64* ImGuiStorage::GetUint64Ref(ImGuiID key, ImU64 default_val)
+{
+    ImGuiStoragePair* it = ImLowerBound(Data.Data, Data.Data + Data.Size, key);
+    if (it == Data.Data + Data.Size || it->key != key)
+        it = Data.insert(it, ImGuiStoragePair(key, default_val));
+    return &it->val_u64;
+}
+
+double* ImGuiStorage::GetDoubleRef(ImGuiID key, double default_val)
+{
+    ImGuiStoragePair* it = ImLowerBound(Data.Data, Data.Data + Data.Size, key);
+    if (it == Data.Data + Data.Size || it->key != key)
+        it = Data.insert(it, ImGuiStoragePair(key, default_val));
+    return &it->val_d;
 }
 
 // FIXME-OPT: Need a way to reuse the result of lower_bound when doing GetInt()/SetInt() - not too bad because it only happens on explicit interaction (maximum one a frame)
@@ -2886,6 +2934,33 @@ void ImGuiStorage::SetVoidPtr(ImGuiID key, void* val)
         Data.insert(it, ImGuiStoragePair(key, val));
     else
         it->val_p = val;
+}
+
+void ImGuiStorage::SetInt64(ImGuiID key, ImS64 val)
+{
+    ImGuiStoragePair* it = ImLowerBound(Data.Data, Data.Data + Data.Size, key);
+    if (it == Data.Data + Data.Size || it->key != key)
+        Data.insert(it, ImGuiStoragePair(key, val));
+    else
+        it->val_s64 = val;
+}
+
+void ImGuiStorage::SetUint64(ImGuiID key, ImU64 val)
+{
+    ImGuiStoragePair* it = ImLowerBound(Data.Data, Data.Data + Data.Size, key);
+    if (it == Data.Data + Data.Size || it->key != key)
+        Data.insert(it, ImGuiStoragePair(key, val));
+    else
+        it->val_u64 = val;
+}
+
+void ImGuiStorage::SetDouble(ImGuiID key, double val)
+{
+    ImGuiStoragePair* it = ImLowerBound(Data.Data, Data.Data + Data.Size, key);
+    if (it == Data.Data + Data.Size || it->key != key)
+        Data.insert(it, ImGuiStoragePair(key, val));
+    else
+        it->val_d = val;
 }
 
 void ImGuiStorage::SetAllInt(int v)

--- a/imgui.h
+++ b/imgui.h
@@ -2729,10 +2729,13 @@ struct ImGuiTextBuffer
 struct ImGuiStoragePair
 {
     ImGuiID     key;
-    union       { int val_i; float val_f; void* val_p; };
+    union       { int val_i; float val_f; void* val_p; ImS64 val_s64; ImU64 val_u64; double val_d; };
     ImGuiStoragePair(ImGuiID _key, int _val)    { key = _key; val_i = _val; }
     ImGuiStoragePair(ImGuiID _key, float _val)  { key = _key; val_f = _val; }
     ImGuiStoragePair(ImGuiID _key, void* _val)  { key = _key; val_p = _val; }
+    ImGuiStoragePair(ImGuiID _key, ImS64 _val)  { key = _key; val_s64 = _val; }
+    ImGuiStoragePair(ImGuiID _key, ImU64 _val)  { key = _key; val_u64 = _val; }
+    ImGuiStoragePair(ImGuiID _key, double _val) { key = _key; val_d = _val; }
 };
 
 // Helper: Key->Value storage
@@ -2760,6 +2763,12 @@ struct ImGuiStorage
     IMGUI_API void      SetFloat(ImGuiID key, float val);
     IMGUI_API void*     GetVoidPtr(ImGuiID key) const; // default_val is NULL
     IMGUI_API void      SetVoidPtr(ImGuiID key, void* val);
+    IMGUI_API ImS64     GetInt64(ImGuiID key, ImS64 default_val = 0) const;
+    IMGUI_API void      SetInt64(ImGuiID key, ImS64 val);
+    IMGUI_API ImU64     GetUint64(ImGuiID key, ImU64 default_val = 0) const;
+    IMGUI_API void      SetUint64(ImGuiID key, ImU64 val);
+    IMGUI_API double    GetDouble(ImGuiID key, double default_val = 0.0f) const;
+    IMGUI_API void      SetDouble(ImGuiID key, double val);
 
     // - Get***Ref() functions finds pair, insert on demand if missing, return pointer. Useful if you intend to do Get+Set.
     // - References are only valid until a new value is added to the storage. Calling a Set***() function or a Get***Ref() function invalidates the pointer.
@@ -2769,6 +2778,9 @@ struct ImGuiStorage
     IMGUI_API bool*     GetBoolRef(ImGuiID key, bool default_val = false);
     IMGUI_API float*    GetFloatRef(ImGuiID key, float default_val = 0.0f);
     IMGUI_API void**    GetVoidPtrRef(ImGuiID key, void* default_val = NULL);
+    IMGUI_API ImS64*    GetInt64Ref(ImGuiID key, ImS64 default_val = 0);
+    IMGUI_API ImU64*    GetUint64Ref(ImGuiID key, ImU64 default_val = 0);
+    IMGUI_API double*   GetDoubleRef(ImGuiID key, double default_val = 0);
 
     // Advanced: for quicker full rebuild of a storage (instead of an incremental one), you may add all your contents and then sort once.
     IMGUI_API void      BuildSortByKey();


### PR DESCRIPTION
Summary:
This PR adds support for storing 64-bit data types in ImGuiStorage, addressing [issue #8829](https://github.com/ocornut/imgui/issues/8829).

Details:

Introduced support for the following data types:
- ImS64 (signed 64-bit integer)
- ImU64 (unsigned 64-bit integer)
- double

Implemented new getter and setter methods:
- SetInt64, GetInt64, GetInt64Ref
- SetUint64, GetUint64, GetUint64Ref
- SetDouble, GetDouble, GetDoubleRef

These methods allow native storage and retrieval of 64-bit values in ImGuiStorage without relying on bit-casting or platform-dependent hacks.