### PR TITLE
Scroll : Dont scroll Y when scrollbar disabled

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -11591,7 +11591,7 @@ ImVec2 ImGui::ScrollToRectEx(ImGuiWindow* window, const ImRect& item_rect, ImGui
     ImGuiScrollFlags in_flags = flags;
     if ((flags & ImGuiScrollFlags_MaskX_) == 0 && window->ScrollbarX)
         flags |= ImGuiScrollFlags_KeepVisibleEdgeX;
-    if ((flags & ImGuiScrollFlags_MaskY_) == 0)
+    if ((flags & ImGuiScrollFlags_MaskY_) == 0 && window->ScrollbarY)
         flags |= window->Appearing ? ImGuiScrollFlags_AlwaysCenterY : ImGuiScrollFlags_KeepVisibleEdgeY;
 
     const bool fully_visible_x = item_rect.Min.x >= scroll_rect.Min.x && item_rect.Max.x <= scroll_rect.Max.x;


### PR DESCRIPTION
May be intentional behavior, but this changes brings the Y scrolling behavior inline with X scrolling.

Creating a window with `ImGuiWindowFlags_NoScrollbar` disables X scrolling but not Y scrolling.

This changes that behaviour.