### PR TITLE
Skip memcpy in ImVector::operator= if Data isn't initialized

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -2181,7 +2181,7 @@ struct ImVector
     // Constructors, destructor
     inline ImVector()                                       { Size = Capacity = 0; Data = NULL; }
     inline ImVector(const ImVector<T>& src)                 { Size = Capacity = 0; Data = NULL; operator=(src); }
-    inline ImVector<T>& operator=(const ImVector<T>& src)   { clear(); resize(src.Size); if (src.Data) memcpy(Data, src.Data, (size_t)Size * sizeof(T)); return *this; }
+    inline ImVector<T>& operator=(const ImVector<T>& src)   { clear(); resize(src.Size); if (Data && src.Data) memcpy(Data, src.Data, (size_t)Size * sizeof(T)); return *this; }
     inline ~ImVector()                                      { if (Data) IM_FREE(Data); } // Important: does not destruct anything
 
     inline void         clear()                             { if (Data) { Size = Capacity = 0; IM_FREE(Data); Data = NULL; } }  // Important: does not destruct anything


### PR DESCRIPTION
`ImVector::operator=` doesn't properly copy a vector with Size = 0 and non-nil Data. It always sets the destination vector's Data pointer to NULL before resizing it to hold the same amount of items in the source vector. But when src.Size = 0 the destination vector won't have its Data pointer initialized, and src.Data is not null which results in a call to `memcpy(NULL, src.Data, 0)`. This causes a crash when the program is compiled with `-fsanitize=undefined -fno-sanitize-recover`. The fix is to check if `src.Data` _and_ `this->Data` are both non-nil.

I encountered this by accidentally using `auto` instead of `auto&` and causing a copy assignment of `ImGuiIO::InputQueueCharacters`. `EndFrame()` calls `InputQueueCharacters.resize(0)` which sets its Size to 0 but leaves its Data untouched (which is non-NULL once keys have been pressed). Afterwards, trying to make a new copy of the object returned from `GetIO()` invokes ImVector's copy constructor which calls `ImVector::operator=` and causes the error above.

Here's is a stripped down example tested with `c++ -fsanitize=undefined $(pkg-config --cflags --libs sdl2) -I imgui imgui/backends/imgui_impl_opengl3.cpp imgui/backends/imgui_impl_sdl2.cpp imgui/*.cpp test.cc`:

``` C++
#include <SDL.h>
#include "imgui.h"
#include "backends/imgui_impl_sdl2.h"
#include "backends/imgui_impl_opengl3.h"

int
main(void)
{
    SDL_Window *window = SDL_CreateWindow("",
                                          SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
                                          128, 128, SDL_WINDOW_OPENGL);
    SDL_GLContext context = SDL_GL_CreateContext(window);

    ImGui::CreateContext();
    ImGui_ImplSDL2_InitForOpenGL(window, context);
    ImGui_ImplOpenGL3_Init("#version 330");

    for (int quit = 0; quit == 0; ) {
        ImGui_ImplOpenGL3_NewFrame();
        ImGui_ImplSDL2_NewFrame();
        ImGui::NewFrame();

        for (SDL_Event e; SDL_PollEvent(&e); ) {
            ImGui_ImplSDL2_ProcessEvent(&e);
            switch (e.type) {
            case SDL_QUIT:
                quit = 1;
                break;
            }

            ImGuiIO io = ImGui::GetIO(); // causes undefined behavior once keys are pressed
            ImVector<ImWchar> iqc = ImGui::GetIO().InputQueueCharacters; // same issue
        }

        ImGui::Render();
        ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
        SDL_GL_SwapWindow(window);
    }

    // Minimal example
    ImVector<int> a, b;
    b.push_back(1); // b.Size = 1, b.Data != NULL
    b.resize(0);    // b.Size = 0, b.Data != NULL
    a = b;          // a::resize(0) doesn't initialize a.Data
                    // memcpy(NULL, b.Data, 0) is called
}
```
