### PR TITLE
Fix X11 viewport window management for tiling WMs

### DIFF
--- a/examples/example_glfw_opengl3/Makefile
+++ b/examples/example_glfw_opengl3/Makefile
@@ -41,7 +41,7 @@ LIBS =
 
 ifeq ($(UNAME_S), Linux) #LINUX
 	ECHO_MESSAGE = "Linux"
-	LIBS += $(LINUX_GL_LIBS) `pkg-config --static --libs glfw3`
+	LIBS += $(LINUX_GL_LIBS) -lX11 `pkg-config --static --libs glfw3`
 
 	CXXFLAGS += `pkg-config --cflags glfw3`
 	CFLAGS = $(CXXFLAGS)


### PR DESCRIPTION
Implement proper window type hints (replaces #8474)
This addresses the window management issues described in #8289:

Key Changes:
- Remove WM_CLASS property copying (from #8474 implementation)
- Implement _NET_WM_WINDOW_TYPE_DIALOG
- Set override_redirect=False for proper window management

Tested on:
  - Arch Linux (6.15.9-arch1-1) GLFW 3.4-2
  - Window Managers:
    • i3wm
    • Xfce4 (x11)

Recommendation:
- Close #8474 as superseded
- Additional testing encouraged