### PR TITLE
SDLGPU: Add swapchain parameters to InitInfo

### DIFF
--- a/backends/imgui_impl_sdlgpu3.cpp
+++ b/backends/imgui_impl_sdlgpu3.cpp
@@ -677,6 +677,7 @@ static void ImGui_ImplSDLGPU3_CreateWindow(ImGuiViewport* viewport)
     ImGui_ImplSDLGPU3_Data* data = ImGui_ImplSDLGPU3_GetBackendData();
     SDL_Window* window = SDL_GetWindowFromID((SDL_WindowID)(intptr_t)viewport->PlatformHandle);
     SDL_ClaimWindowForGPUDevice(data->InitInfo.Device, window);
+    SDL_SetGPUSwapchainParameters(data->InitInfo.Device, window, data->InitInfo.SwapchainComposition, data->InitInfo.PresentMode);
     viewport->RendererUserData = (void*)1;
 }
 

--- a/backends/imgui_impl_sdlgpu3.h
+++ b/backends/imgui_impl_sdlgpu3.h
@@ -31,9 +31,11 @@
 // - Remember to set ColorTargetFormat to the correct format. If you're rendering to the swapchain, call SDL_GetGPUSwapchainTextureFormat to query the right value
 struct ImGui_ImplSDLGPU3_InitInfo
 {
-    SDL_GPUDevice*       Device             = nullptr;
-    SDL_GPUTextureFormat ColorTargetFormat  = SDL_GPU_TEXTUREFORMAT_INVALID;
-    SDL_GPUSampleCount   MSAASamples        = SDL_GPU_SAMPLECOUNT_1;
+    SDL_GPUDevice*              Device                  = nullptr;
+    SDL_GPUTextureFormat        ColorTargetFormat       = SDL_GPU_TEXTUREFORMAT_INVALID;
+    SDL_GPUSampleCount          MSAASamples             = SDL_GPU_SAMPLECOUNT_1;
+    SDL_GPUSwapchainComposition SwapchainComposition    = SDL_GPU_SWAPCHAINCOMPOSITION_SDR;
+    SDL_GPUPresentMode          PresentMode             = SDL_GPU_PRESENTMODE_VSYNC;
 };
 
 // Follow "Getting Started" link and check examples/ folder to learn about using backends!

--- a/examples/example_sdl3_sdlgpu3/main.cpp
+++ b/examples/example_sdl3_sdlgpu3/main.cpp
@@ -95,6 +95,8 @@ int main(int, char**)
     init_info.Device = gpu_device;
     init_info.ColorTargetFormat = SDL_GetGPUSwapchainTextureFormat(gpu_device, window);
     init_info.MSAASamples = SDL_GPU_SAMPLECOUNT_1;
+    init_info.SwapchainComposition = SDL_GPU_SWAPCHAINCOMPOSITION_SDR;
+    init_info.PresentMode = SDL_GPU_PRESENTMODE_VSYNC;
     ImGui_ImplSDLGPU3_Init(&init_info);
 
     // Load Fonts


### PR DESCRIPTION
This is a fix for viewports in sdl3gpu so that SwapchainParameters in the viewports created can be configured in the same way as the original window. Before my fixes, the windows were initialized without parameters.

* Added `SwapchainComposition` and `PresentMode` fields to the `ImGui_ImplSDLGPU3_InitInfo` struct.
```cpp
struct ImGui_ImplSDLGPU3_InitInfo
{
    SDL_GPUDevice*              Device                  = nullptr;
    SDL_GPUTextureFormat        ColorTargetFormat       = SDL_GPU_TEXTUREFORMAT_INVALID;
    SDL_GPUSampleCount          MSAASamples             = SDL_GPU_SAMPLECOUNT_1;
    SDL_GPUSwapchainComposition SwapchainComposition    = SDL_GPU_SWAPCHAINCOMPOSITION_SDR;
    SDL_GPUPresentMode          PresentMode             = SDL_GPU_PRESENTMODE_VSYNC;
};
```
* Updated `ImGui_ImplSDLGPU3_CreateWindow` to call `SDL_SetGPUSwapchainParameters` with the new swapchain configuration values from the initialization struct.
```cpp
static void ImGui_ImplSDLGPU3_CreateWindow(ImGuiViewport* viewport)
{
    ImGui_ImplSDLGPU3_Data* data = ImGui_ImplSDLGPU3_GetBackendData();
    SDL_Window* window = SDL_GetWindowFromID((SDL_WindowID)(intptr_t)viewport->PlatformHandle);
    SDL_ClaimWindowForGPUDevice(data->InitInfo.Device, window);
    SDL_SetGPUSwapchainParameters(data->InitInfo.Device, window, data->InitInfo.SwapchainComposition, data->InitInfo.PresentMode);
    viewport->RendererUserData = (void*)1;
}
```

**Demonstration**

To demonstrate the error, the following was used in `examples/example_sdl3_sdlgpu3/main.cpp`
```cpp
SDL_SetGPUSwapchainParameters(gpu_device, window, SDL_GPU_SWAPCHAINCOMPOSITION_SDR_LINEAR, SDL_GPU_PRESENTMODE_IMMEDIATE);
```

With different swapchain_composition parameters, sdl3gpu may throw an error without crashing
```
Validation Error: [ VUID-vkCmdDrawIndexed-renderPass-02684 ] | MessageID = 0x8cb637c2
(Warning - This VUID has now been reported 10 times, which is the duplicated_message_limit value, this will be the last time reporting it).
vkCmdDrawIndexed(): pSubpasses[0].pColorAttachments[0].attachment is incompatible between VkRenderPass 0x6e300000006e3 (from VkCommandBuffer 0x2748b47dd70) and VkRenderPass 0x7b000000007b (from VkPipeline 0x810000000081), pAttachments[0].format (VK_FORMAT_B8G8R8A8_UNORM) != pAttachments[0].format (VK_FORMAT_B8G8R8A8_SRGB).
The Vulkan spec states: The current render pass must be compatible with the renderPass member of the VkGraphicsPipelineCreateInfo structure specified when creating the VkPipeline bound to VK_PIPELINE_BIND_POINT_GRAPHICS (https://vulkan.lunarg.com/doc/view/1.4.321.1/windows/antora/spec/latest/chapters/drawing. html#VUID-vkCmdDrawIndexed-renderPass-02684)
Objects: 4
    [0] VkCommandBuffer 0x2748b47dd70
    [1] VkRenderPass 0x6e300000006e3
    [2] VkPipeline 0x810000000081
    [3] VkRenderPass 0x7b000000007b
```


https://github.com/user-attachments/assets/a98dd162-6911-4030-97a9-01bf1316e3f0

After I made changes to `imgui_impl_sdlgpu3.cpp` and `imgui_impl_sdlgpu3.h`, two lines were added before `ImGui_ImplSDLGPU3_Init` in the file `examples/example_sdl3_sdlgpu3/main.cpp` to configure SwapchainParameters in the viewports being created

```cpp
init_info.SwapchainComposition = SDL_GPU_SWAPCHAINCOMPOSITION_SDR_LINEAR;
init_info.PresentMode = SDL_GPU_PRESENTMODE_IMMEDIATE;
```


https://github.com/user-attachments/assets/12a18ff4-347c-49fd-8bbd-3e9f3561ab02

