### PR TITLE
Fix for compile errors with wgpu backend on OSX/dawn

### DIFF
--- a/backends/imgui_impl_wgpu.cpp
+++ b/backends/imgui_impl_wgpu.cpp
@@ -397,10 +397,12 @@ void ImGui_ImplWGPU_RenderDrawData(ImDrawData* draw_data, WGPURenderPassEncoder 
         WGPUBufferDescriptor vb_desc =
         {
             nullptr,
-            "Dear ImGui Vertex buffer",
+            {
+                "Dear ImGui Vertex buffer",
 #if defined(IMGUI_IMPL_WEBGPU_BACKEND_DAWN) || defined(IMGUI_IMPL_WEBGPU_BACKEND_WGPU)
-            WGPU_STRLEN,
+                WGPU_STRLEN,
 #endif
+            },
             WGPUBufferUsage_CopyDst | WGPUBufferUsage_Vertex,
             MEMALIGN(fr->VertexBufferSize * sizeof(ImDrawVert), 4),
             false
@@ -424,9 +426,11 @@ void ImGui_ImplWGPU_RenderDrawData(ImDrawData* draw_data, WGPURenderPassEncoder 
         WGPUBufferDescriptor ib_desc =
         {
             nullptr,
-            "Dear ImGui Index buffer",
+            {
+                "Dear ImGui Index buffer",
 #if defined(IMGUI_IMPL_WEBGPU_BACKEND_DAWN) || defined(IMGUI_IMPL_WEBGPU_BACKEND_WGPU)
-            WGPU_STRLEN,
+                WGPU_STRLEN,
+            },
 #endif
             WGPUBufferUsage_CopyDst | WGPUBufferUsage_Index,
             MEMALIGN(fr->IndexBufferSize * sizeof(ImDrawIdx), 4),
@@ -636,10 +640,12 @@ static void ImGui_ImplWGPU_CreateUniformBuffer()
     WGPUBufferDescriptor ub_desc =
     {
         nullptr,
-        "Dear ImGui Uniform buffer",
+        {
+            "Dear ImGui Uniform buffer",
 #if defined(IMGUI_IMPL_WEBGPU_BACKEND_DAWN) || defined(IMGUI_IMPL_WEBGPU_BACKEND_WGPU)
-        WGPU_STRLEN,
+            WGPU_STRLEN,
 #endif
+        },
         WGPUBufferUsage_CopyDst | WGPUBufferUsage_Uniform,
         MEMALIGN(sizeof(Uniforms), 16),
         false


### PR DESCRIPTION
On OSX clang when building for wgpu with `-DIMGUI_IMPL_WEBGPU_BACKEND_DAWN=1`, the following errors occur:

```cpp
theta/thirdparty/imgui/imgui_impl_wgpu.cpp:400:13: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
  400 |             "Dear ImGui Vertex buffer",
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~
      |             {
  401 | #if defined(IMGUI_IMPL_WEBGPU_BACKEND_DAWN) || defined(IMGUI_IMPL_WEBGPU_BACKEND_WGPU)
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  402 |             WGPU_STRLEN,
      |             ~~~~~~~~~~~
      |                        }
theta/thirdparty/imgui/imgui_impl_wgpu.cpp:427:13: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
  427 |             "Dear ImGui Index buffer",
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~
      |             {
  428 | #if defined(IMGUI_IMPL_WEBGPU_BACKEND_DAWN) || defined(IMGUI_IMPL_WEBGPU_BACKEND_WGPU)
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  429 |             WGPU_STRLEN,
      |             ~~~~~~~~~~~
      |                        }
theta/thirdparty/imgui/imgui_impl_wgpu.cpp:639:9: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
  639 |         "Dear ImGui Uniform buffer",
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |         {
  640 | #if defined(IMGUI_IMPL_WEBGPU_BACKEND_DAWN) || defined(IMGUI_IMPL_WEBGPU_BACKEND_WGPU)
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  641 |         WGPU_STRLEN,
      |         ~~~~~~~~~~~
      |                    }
```

The definition for a wgpu BufferDescriptor is:
```cpp
typedef struct WGPUBufferDescriptor {
    WGPUChainedStruct * nextInChain;
    WGPUStringView label;
    WGPUBufferUsage usage;
    uint64_t size;
    WGPUBool mappedAtCreation;
} WGPUBufferDescriptor WGPU_STRUCTURE_ATTRIBUTE;
```

and for `WGPUStringView`:

```cpp
typedef struct WGPUStringView {
    WGPU_NULLABLE char const * data;
    size_t length;
} WGPUStringView WGPU_STRUCTURE_ATTRIBUTE;
```

In order for the `length` parameter to be included in the string view, braces are needed around that parameter.