### PR TITLE
Fix assertion failure when `ImFontAtlasRectEntry::Generation` overflows

### DIFF
--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -4292,7 +4292,7 @@ void ImFontAtlasPackDiscardRect(ImFontAtlas* atlas, ImFontAtlasRectId id)
     IM_ASSERT(index_entry->IsUsed && index_entry->TargetIndex >= 0);
     index_entry->IsUsed = false;
     index_entry->TargetIndex = builder->RectsIndexFreeListStart;
-    index_entry->Generation++;
+    while (++index_entry->Generation == 0); // keep non-zero on overflow
 
     const int pack_padding = atlas->TexGlyphPadding;
     builder->RectsIndexFreeListStart = index_idx;

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -3736,12 +3736,12 @@ inline bool operator==(const ImTextureRef& lhs, const ImTextureRef& rhs)    { re
 inline bool operator!=(const ImTextureRef& lhs, const ImTextureRef& rhs)    { return lhs._TexID != rhs._TexID || lhs._TexData != rhs._TexData; }
 
 // Refer to ImFontAtlasPackGetRect() to better understand how this works.
-#define ImFontAtlasRectId_IndexMask_        (0x000FFFFF)    // 20-bits: index to access builder->RectsIndex[].
+#define ImFontAtlasRectId_IndexMask_        (0x0007FFFF)    // 20-bits signed: index to access builder->RectsIndex[].
 #define ImFontAtlasRectId_GenerationMask_   (0x3FF00000)    // 10-bits: entry generation, so each ID is unique and get can safely detected old identifiers.
 #define ImFontAtlasRectId_GenerationShift_  (20)
 inline int               ImFontAtlasRectId_GetIndex(ImFontAtlasRectId id)       { return id & ImFontAtlasRectId_IndexMask_; }
 inline int               ImFontAtlasRectId_GetGeneration(ImFontAtlasRectId id)  { return (id & ImFontAtlasRectId_GenerationMask_) >> ImFontAtlasRectId_GenerationShift_; }
-inline ImFontAtlasRectId ImFontAtlasRectId_Make(int index_idx, int gen_idx)     { IM_ASSERT(index_idx < ImFontAtlasRectId_IndexMask_ && gen_idx < (ImFontAtlasRectId_GenerationMask_ >> ImFontAtlasRectId_GenerationShift_)); return (ImFontAtlasRectId)(index_idx | (gen_idx << ImFontAtlasRectId_GenerationShift_)); }
+inline ImFontAtlasRectId ImFontAtlasRectId_Make(int index_idx, int gen_idx)     { IM_ASSERT(index_idx >= 0 && index_idx <= ImFontAtlasRectId_IndexMask_ && gen_idx <= (ImFontAtlasRectId_GenerationMask_ >> ImFontAtlasRectId_GenerationShift_)); return (ImFontAtlasRectId)(index_idx | (gen_idx << ImFontAtlasRectId_GenerationShift_)); }
 
 // Packed rectangle lookup entry (we need an indirection to allow removing/reordering rectangles)
 // User are returned ImFontAtlasRectId values which are meant to be persistent.
@@ -3751,7 +3751,7 @@ inline ImFontAtlasRectId ImFontAtlasRectId_Make(int index_idx, int gen_idx)     
 struct ImFontAtlasRectEntry
 {
     int                 TargetIndex : 20;   // When Used: ImFontAtlasRectId -> into Rects[]. When unused: index to next unused RectsIndex[] slot to consume free-list.
-    int                 Generation : 10;    // Increased each time the entry is reused for a new rectangle.
+    unsigned int        Generation : 10;    // Increased each time the entry is reused for a new rectangle.
     unsigned int        IsUsed : 1;
 };
 


### PR DESCRIPTION
Letting the following snippet run for a while (~40s @ 240FPS) triggers an assertion failure due to `ImFontAtlasRectEntry::Generation` overflowing:

```cpp
ImGui::PushFont(nullptr, rand() % 512);
ImGui::Text("Lorem ipsum dolor sit amet");
ImGui::PopFont();
```

```
../../imgui_draw.cpp:4263: ImFontAtlasRectId ImFontAtlasPackAllocRectEntry(ImFontAtlas*, int): Assertion `index_entry->IsUsed == false && index_entry->Generation > 0' failed.
```

The assertion in `ImFontAtlasRectId_Make` was also off by one (takes ~1.5m @ 240FPS to trigger):

```
../../imgui_internal.h:3744: ImFontAtlasRectId ImFontAtlasRectId_Make(int, int): Assertion `index_idx < (0x000FFFFF) && gen_idx < ((0x3FF00000) >> (20))' failed.
```

EDIT: Tightened the assert in `ImFontAtlasRectId_Make` to catch would-be negative `TargetIndex` values (<0 and 0x80000-0xFFFFF).