### PR TITLE
Added ImGui::FreeDemoWindow to allow manual releasing of demo heap allocations

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -409,6 +409,7 @@ namespace ImGui
     IMGUI_API void          ShowFontSelector(const char* label);        // add font selector block (not a window), essentially a combo listing the loaded fonts.
     IMGUI_API void          ShowUserGuide();                            // add basic help/info block (not a window): how to manipulate ImGui as an end-user (mouse/keyboard controls).
     IMGUI_API const char*   GetVersion();                               // get the compiled version string e.g. "1.80 WIP" (essentially the value for IMGUI_VERSION from the compiled version of imgui.cpp)
+    IMGUI_API void          FreeDemoWindow();                           // manual deallocation of demo window heap allocations if ignored the destructor will free the heap allocations on application exit, useful for cleaning up allocs when using ImGui::SetAllocatorFunctions.
 
     // Styles
     IMGUI_API void          StyleColorsDark(ImGuiStyle* dst = NULL);    // new, recommended style (default)

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -295,7 +295,7 @@ void*                               GImGuiDemoMarkerCallbackUserData = NULL;
 //-----------------------------------------------------------------------------
 
 // Data to be shared across different functions of the demo.
-struct ImGuiDemoWindowData
+static struct ImGuiDemoWindowData
 {
     // Examples Apps (accessible from the "Examples" menu)
     bool ShowMainMenuBar = false;
@@ -324,8 +324,10 @@ struct ImGuiDemoWindowData
     bool DisableSections = false;
     ExampleTreeNode* DemoTree = NULL;
 
-    ~ImGuiDemoWindowData() { if (DemoTree) ExampleTree_DestroyNode(DemoTree); }
-};
+    ~ImGuiDemoWindowData() { ImGui::FreeDemoWindow(); };
+}s_demo_data = {};
+
+void ImGui::FreeDemoWindow() { if (s_demo_data.DemoTree) ExampleTree_DestroyNode(s_demo_data.DemoTree); };
 
 // Demonstrate most Dear ImGui features (this is big function!)
 // You may execute this function to experiment with the UI and understand what it does.
@@ -340,7 +342,7 @@ void ImGui::ShowDemoWindow(bool* p_open)
     IMGUI_CHECKVERSION();
 
     // Stored data
-    static ImGuiDemoWindowData demo_data;
+    ImGuiDemoWindowData& demo_data = s_demo_data;
 
     // Examples Apps (accessible from the "Examples" menu)
     if (demo_data.ShowMainMenuBar)          { ShowExampleAppMainMenuBar(); }
@@ -10834,6 +10836,7 @@ void ImGui::ShowDemoWindow(bool*) {}
 void ImGui::ShowUserGuide() {}
 void ImGui::ShowStyleEditor(ImGuiStyle*) {}
 bool ImGui::ShowStyleSelector(const char*) { return false; }
+void ImGui::FreeDemoWindow() {}
 
 #endif // #ifndef IMGUI_DISABLE_DEMO_WINDOWS
 


### PR DESCRIPTION
I noticed that if I used the demo window when also using `ImGui::SetAllocatorFunctions` for allocation tracking there would still be around 250 live allocations (0.3MiB) when my allocator runs it's leak detection just before the end of my application.

After looking inside of ImGui::ShowDemoWindow I can see that we build a static `ImGuiDemoWindowData` on the first call to the show the demo window, but this does mean there is no way to free these heap allocations manually, we must wait for application exit for the destructor to be called which then frees the demo tree data.

This change moves the local `ImGuiDemoWindowData demo_data` static out of `ImGui::ShowDemoWindow` and into the global scope of `imgui_demo.cpp` as `s_demo_data` this allows for adding a manual demo free function called `ImGui::FreeDemoWindow`, if this function is not manually called the behavior is the same as before and the debug data is freed on app exit.