### PR TITLE
CI windows vulkan update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,20 +35,9 @@ jobs:
           Expand-Archive -Path SDL3-devel-3.2.18-VC.zip
           echo "SDL3_DIR=$(pwd)\SDL3-devel-3.2.18-VC\SDL3-3.2.18\" >>${env:GITHUB_ENV}
 
-          # VulkanSDK (retrieve minimal bits of the SDK from git)
-          $vulkanVersion = "1.4.326"
-          # 1. Get the vulkan headers, we will treat that folder as the sdk folder to avoid having to copy headers around
-          Invoke-WebRequest -Uri "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v$($vulkanVersion).zip" -OutFile Vulkan-Headers-$($vulkanVersion).zip
-          Expand-Archive -Path Vulkan-Headers-$($vulkanVersion).zip
-          echo "VULKAN_SDK=$(pwd)\Vulkan-Headers-$($vulkanVersion)\Vulkan-Headers-$($vulkanVersion)" >>${env:GITHUB_ENV}
-          # 2. Get and build the vulkan loader source code (UPDATE_DEPS=On will make it automatically fetch its dependencies)
-          Invoke-WebRequest -Uri "https://github.com/KhronosGroup/Vulkan-Loader/archive/refs/tags/v$($vulkanVersion).zip" -OutFile Vulkan-Loader-$($vulkanVersion).zip
-          Expand-Archive -Path Vulkan-Loader-$($vulkanVersion).zip
-          cmake -S Vulkan-Loader-$($vulkanVersion)\Vulkan-Loader-$($vulkanVersion) -B VulkanLoader-build -D UPDATE_DEPS=On
-          cmake --build VulkanLoader-build
-          # 3. Copy the built lib/dll to the expected place
-          mkdir Vulkan-Headers-$($vulkanVersion)\Vulkan-Headers-$($vulkanVersion)\Lib
-          copy VulkanLoader-build\loader\Debug\vulkan-1.* Vulkan-Headers-$($vulkanVersion)\Vulkan-Headers-$($vulkanVersion)\Lib\
+          Invoke-WebRequest -Uri "https://github.com/ocornut/imgui/files/3789205/vulkan-sdk-1.1.121.2.zip" -OutFile vulkan-sdk-1.1.121.2.zip
+          Expand-Archive -Path vulkan-sdk-1.1.121.2.zip
+          echo "VULKAN_SDK=$(pwd)\vulkan-sdk-1.1.121.2\" >>${env:GITHUB_ENV}
 
       - name: Fix Projects
         shell: powershell

--- a/.github/workflows/build_windows_vulkan_libs.ps1
+++ b/.github/workflows/build_windows_vulkan_libs.ps1
@@ -1,0 +1,33 @@
+# Set default vulkan version if none provided
+if (-not $env:VULKAN_TAG) { $env:VULKAN_TAG = "1.4.326" }
+
+# Create output folder
+mkdir vulkanArtifact
+
+# Download Vulkan Headers
+
+Invoke-WebRequest -Uri "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v$($env:VULKAN_TAG).zip" -OutFile Vulkan-Headers-$($env:VULKAN_TAG).zip
+Expand-Archive -Path Vulkan-Headers-$($env:VULKAN_TAG).zip
+
+# Copy Vulkan Headers to artifact folder
+
+cp -R Vulkan-Headers-$($env:VULKAN_TAG)\Vulkan-Headers-$($env:VULKAN_TAG)\include vulkanArtifact\Include
+
+# Download Vulkan Loader
+
+Invoke-WebRequest -Uri "https://github.com/KhronosGroup/Vulkan-Loader/archive/refs/tags/v$($env:VULKAN_TAG).zip" -OutFile Vulkan-Loader-$($env:VULKAN_TAG).zip
+Expand-Archive -Path Vulkan-Loader-$($env:VULKAN_TAG).zip
+
+# Build Vulkan Loader x64
+
+cmake -S Vulkan-Loader-$($env:VULKAN_TAG)\Vulkan-Loader-$($env:VULKAN_TAG) -B VulkanLoader-build64 -D UPDATE_DEPS=On -A x64
+cmake --build VulkanLoader-build64
+mkdir vulkanArtifact\Lib
+copy VulkanLoader-build64\loader\Debug\vulkan-1.lib vulkanArtifact\Lib
+
+# Build Vulkan Loader win32
+
+cmake -S Vulkan-Loader-$($env:VULKAN_TAG)\Vulkan-Loader-$($env:VULKAN_TAG) -B VulkanLoader-build32 -D UPDATE_DEPS=On -A Win32
+cmake --build VulkanLoader-build32
+mkdir vulkanArtifact\Lib32
+copy VulkanLoader-build32\loader\Debug\vulkan-1.lib vulkanArtifact\Lib32

--- a/.github/workflows/build_windows_vulkan_libs.yml
+++ b/.github/workflows/build_windows_vulkan_libs.yml
@@ -1,0 +1,22 @@
+name: build-windows-vulkan-libs
+
+on: workflow_dispatch
+
+jobs:
+  Windows:
+    runs-on: windows-2025
+    env:
+      VULKAN_TAG: 1.4.326
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Vulkan libs
+        shell: powershell
+        run: .github/workflows/build_windows_vulkan_libs.ps1
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: vulkan_windows_libs_${{ env.VULKAN_TAG }}
+          path: vulkanArtifact
+          overwrite: 'true'
+          


### PR DESCRIPTION
This reworks the way vulkan sdk is pulled, to hopefully simplify the burden of updating vulkan sdk
Also provide help for https://github.com/ocornut/imgui/issues/8778

The general idea is to grab the minimal bits we need from the khronos repo with a specific tag. We only pull 2 things:
* vulkan-header (just what we need to build all the code)
* vulkan-loader (so we can link the loader in).

This treats the vulkan-header as the "vulkan sdk" folder, as it allow us to not have to copy out all the headers after unzip.
The loader require a minimal build to generate the .lib/dll required. This is done by just invoking cmake in the vulkan-load folder, and copying those out to the "vulkan sdk" folder.

For convenience, a $vulkanVersion is provided to target whatever release of the sdk we want to build against, and simplify the burden of updating.

Note: an initial attempt was done by pulling the sdk zip from lunarg, but that turned into a much longer download process, and there was issue unzipping the archive. This is way faster to just download the header/loader and use that for builds.
