### PR TITLE
Combo: fix assertion failure when ConfigDebugBeginReturnValueOnce=true

### DIFF
--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -2032,7 +2032,8 @@ bool ImGui::BeginComboPopup(ImGuiID popup_id, const ImRect& bb, ImGuiComboFlags 
     if (!ret)
     {
         EndPopup();
-        IM_ASSERT(0);   // This should never happen as we tested for IsPopupOpen() above
+        // Begin will only return false when ConfigDebugBeginReturnValueOnce is true and opening for the first time
+        IM_ASSERT(g.IO.ConfigDebugBeginReturnValueOnce);
         return false;
     }
     g.BeginComboDepth++;


### PR DESCRIPTION
This fixes an assertion failure when calling `BeginCombo` with IO config `ConfigDebugBeginReturnValueOnce=true`, which causes all calls to `Begin` to return false on first use.