### PR TITLE
Vulkan : add helpers to ease screenshot generation with multi viewports

### DIFF
--- a/backends/imgui_impl_vulkan.h
+++ b/backends/imgui_impl_vulkan.h
@@ -87,6 +87,7 @@ struct ImGui_ImplVulkan_InitInfo
     uint32_t                        MinImageCount;              // >= 2
     uint32_t                        ImageCount;                 // >= MinImageCount
     VkPipelineCache                 PipelineCache;              // Optional
+    VkImageUsageFlags               SwapchainImageUsage;        // Optional
 
     // Pipeline
     VkRenderPass                    RenderPass;                 // Ignored if using dynamic rendering
@@ -176,13 +177,16 @@ struct ImGui_ImplVulkanH_Frame;
 struct ImGui_ImplVulkanH_Window;
 
 // Helpers
-IMGUI_IMPL_API void                 ImGui_ImplVulkanH_CreateOrResizeWindow(VkInstance instance, VkPhysicalDevice physical_device, VkDevice device, ImGui_ImplVulkanH_Window* wd, uint32_t queue_family, const VkAllocationCallbacks* allocator, int w, int h, uint32_t min_image_count);
+IMGUI_IMPL_API void                 ImGui_ImplVulkanH_CreateOrResizeWindow(VkInstance instance, VkPhysicalDevice physical_device, VkDevice device, ImGui_ImplVulkanH_Window* wd, uint32_t queue_family, const VkAllocationCallbacks* allocator, int w, int h, uint32_t min_image_count, VkImageUsageFlags imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
 IMGUI_IMPL_API void                 ImGui_ImplVulkanH_DestroyWindow(VkInstance instance, VkDevice device, ImGui_ImplVulkanH_Window* wd, const VkAllocationCallbacks* allocator);
 IMGUI_IMPL_API VkSurfaceFormatKHR   ImGui_ImplVulkanH_SelectSurfaceFormat(VkPhysicalDevice physical_device, VkSurfaceKHR surface, const VkFormat* request_formats, int request_formats_count, VkColorSpaceKHR request_color_space);
 IMGUI_IMPL_API VkPresentModeKHR     ImGui_ImplVulkanH_SelectPresentMode(VkPhysicalDevice physical_device, VkSurfaceKHR surface, const VkPresentModeKHR* request_modes, int request_modes_count);
 IMGUI_IMPL_API VkPhysicalDevice     ImGui_ImplVulkanH_SelectPhysicalDevice(VkInstance instance);
 IMGUI_IMPL_API uint32_t             ImGui_ImplVulkanH_SelectQueueFamilyIndex(VkPhysicalDevice physical_device);
 IMGUI_IMPL_API int                  ImGui_ImplVulkanH_GetMinImageCountFromPresentMode(VkPresentModeKHR present_mode);
+
+//Optional, access to Vulkan objects associated with a viewport (eg to export a screenshot)
+IMGUI_IMPL_API ImGui_ImplVulkanH_Window* ImGui_ImplVulkan_GetWindowDataFromViewport(ImGuiViewport* viewport);
 
 // Helper structure to hold the data needed by one rendering frame
 // (Used by example's main.cpp. Used by multi-viewport features. Probably NOT used by your own engine/app.)


### PR DESCRIPTION
Followup to issue #8940.

- Adding helper function `ImGui_ImplVulkanH_Window* ImGui_ImplVulkan_GetWindowDataFromViewport(ImGuiViewport* viewport)` to retrieve the window related to a viewport. I tested it for screenshot generation, but usage could be wider.
- Adding optional field `SwapchainImageUsage` to struct `ImGui_ImplVulkan_InitInfo` to be able to specify additional usage for swapchain images (eg VK_IMAGE_USAGE_TRANSFER_SRC_BIT for a screenshot). This adds an argument to `ImGui_ImplVulkanH_CreateOrResizeWindow`, but default value has been set to keep the examples simple.
