### PR TITLE
Update GLFW backend X11 and WL detection

### DIFF
--- a/backends/imgui_impl_glfw.cpp
+++ b/backends/imgui_impl_glfw.cpp
@@ -117,7 +117,8 @@
 #define GLFW_EXPOSE_NATIVE_COCOA
 #endif
 #include <GLFW/glfw3native.h>
-#elif !defined(__EMSCRIPTEN__)
+#elif !defined(__EMSCRIPTEN__) &&\
+  (defined(unix) || defined(__unix) || defined(__unix__) || defined(__linux__) || defined(__linux) || defined(linux))
 #ifndef GLFW_EXPOSE_NATIVE_X11      // for glfwGetX11Window() on Freedesktop (Linux, BSD, etc.)
 #define GLFW_EXPOSE_NATIVE_X11
 #endif


### PR DESCRIPTION
Quick fix for recently added GLFW *..._EXPOSE_NATIVE_...* defines to access internals of X11 and Wayland platforms (bad design decision in the first place but whatever).

Just check for *if not windows or apple and `!defined(__EMSCRIPTEN__)`* is not enough to assume that platform has X11 or Wayland. 
PR adds checks for unix or linux OS defines to ensure back-end may access GLFW internals for these platforms.
