### PR TITLE
Add ID overload to BeginPopup

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -12270,6 +12270,18 @@ bool ImGui::BeginPopup(const char* str_id, ImGuiWindowFlags flags)
     return BeginPopupEx(id, flags);
 }
 
+bool ImGui::BeginPopup(ImGuiID id, ImGuiWindowFlags flags)
+{
+    ImGuiContext& g = *GImGui;
+    if (g.OpenPopupStack.Size <= g.BeginPopupStack.Size) // Early out for performance
+    {
+        g.NextWindowData.ClearFlags(); // We behave like Begin() and need to consume those values
+        return false;
+    }
+    flags |= ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoSavedSettings;
+    return BeginPopupEx(id, flags);
+}
+
 // If 'p_open' is specified for a modal popup window, the popup will have a regular close button which will close the popup.
 // Note that popup visibility status is owned by Dear ImGui (and manipulated with e.g. OpenPopup).
 // - *p_open set back to false in BeginPopupModal() when popup is not open.

--- a/imgui.h
+++ b/imgui.h
@@ -839,6 +839,7 @@ namespace ImGui
     //  - BeginPopup(): query popup state, if open start appending into the window. Call EndPopup() afterwards if returned true. ImGuiWindowFlags are forwarded to the window.
     //  - BeginPopupModal(): block every interaction behind the window, cannot be closed by user, add a dimming background, has a title bar.
     IMGUI_API bool          BeginPopup(const char* str_id, ImGuiWindowFlags flags = 0);                         // return true if the popup is open, and you can start outputting to it.
+    IMGUI_API bool          BeginPopup(ImGuiID id, ImGuiWindowFlags flags = 0);                                 // id overload.
     IMGUI_API bool          BeginPopupModal(const char* name, bool* p_open = NULL, ImGuiWindowFlags flags = 0); // return true if the modal is open, and you can start outputting to it.
     IMGUI_API void          EndPopup();                                                                         // only call EndPopup() if BeginPopupXXX() returns true!
 


### PR DESCRIPTION
As the title says, this PR adds an overload to  ``BeginPopup`` and takes in an ``ImGuiID``.

``OpenPopup`` already has an ``ImGuiID`` overload, so I was a bit confused why ``BeginPopup`` didn't have this. 
Related to:  #3993 

This is not a huge issue since there are some workarounds, but they either make you add a new variable or include ``imgui_internal.h``

### Workaround 1:

Add name variable to use in ``GetID`` and ``BeginPopup``

```cpp
const char* name = "MyPopUp";
ImGuiID id = ImGui::GetID(name);

if (ImGui::Button("Open PopUp")) {
	ImGui::OpenPopup(id);
}

if (ImGui::BeginPopup(name)) {
	ImGui::Text("Hello from popup!");
	if (ImGui::Button("Close"))
		ImGui::CloseCurrentPopup();
	ImGui::EndPopup();
}
```

### Workaround 2:

Include ``imgui_internal.h`` and use ``BeginPopupEx``

Edit: This also removed all of the default flags, so you need to manually add those again.

```cpp
#include "imgui_internal.h"

ImGuiID id = ImGui::GetID("MyPopUp");

if (ImGui::Button("Open PopUp")) {
	ImGui::OpenPopup(id);
}

if (ImGui::BeginPopupEx(id, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoSavedSettings)) {
	ImGui::Text("Hello from popup!");
	if (ImGui::Button("Close"))
		ImGui::CloseCurrentPopup();
	ImGui::EndPopup();
}
```

**PR fix:**

Added an overload for ``BeginPopup`` to take in an ``ImGuiID``

```cpp
ImGuiID id = ImGui::GetID("MyPopUp");

if (ImGui::Button("Open PopUp")) {
	ImGui::OpenPopup(id);
}

if (ImGui::BeginPopup(id)) {
	ImGui::Text("Hello from popup!");
	if (ImGui::Button("Close"))
		ImGui::CloseCurrentPopup();
	ImGui::EndPopup();
}
```

Most of the time, I call ``OpenPopup`` in nested IDs so I almost always use ``ImGuiID`` for pop-ups.

_This is my first PR, so I'm sorry if I missed a rule/guideline._