### PR TITLE
Backend: DX12: Remove unused members pFrameResources and frameIndex

### DIFF
--- a/backends/imgui_impl_dx12.cpp
+++ b/backends/imgui_impl_dx12.cpp
@@ -112,9 +112,6 @@ struct ImGui_ImplDX12_Data
     ID3D12CommandAllocator*     pTexCmdAllocator;
     ID3D12GraphicsCommandList*  pTexCmdList;
 
-    ImGui_ImplDX12_RenderBuffers* pFrameResources;
-    UINT                        frameIndex;
-
     ImGui_ImplDX12_Data()       { memset((void*)this, 0, sizeof(*this)); }
 };
 


### PR DESCRIPTION
Nothing fancy, this PR removes two unused member variables in ImGui_ImplDX12_Data.