### PR TITLE
Backends: DX12: Reuse upload buffer and grow it only when necessary

### DIFF
--- a/backends/imgui_impl_dx12.cpp
+++ b/backends/imgui_impl_dx12.cpp
@@ -23,6 +23,7 @@
 // CHANGELOG
 // (minor and older changes stripped away, please see git history for details)
 //  2025-XX-XX: Platform: Added support for multiple windows via the ImGuiPlatformIO interface.
+//  2025-10-10: DirectX12: Reuse upload buffer and grow it only when necessary. (#9002)
 //  2025-09-29: DirectX12: Rework synchronization logic. (#8961)
 //  2025-09-29: DirectX12: Enable swapchain tearing to eliminate viewports framerate throttling. (#8965)
 //  2025-09-29: DirectX12: Reuse a command list and allocator for texture uploads instead of recreating them each time. (#8963)


### PR DESCRIPTION
This PR follows up on https://github.com/ocornut/imgui/pull/8963#issuecomment-3357259522. It reuses the upload buffer whenever possible, recreating it only when necessary. It also leaves it mapped until destruction to avoid the overhead of repeated Map()/Unmap() calls. This is both safe and a recommended best practice:

> [Resources on CPU-accessible heaps can be persistently mapped, meaning Map can be called once, immediately after resource creation. Unmap never needs to be called, but the address returned from Map must no longer be used after the last reference to the resource is released. When using persistent map, the application must ensure the CPU finishes writing data into memory before the GPU executes a command list that reads or writes the memory.](https://learn.microsoft.com/en-us/windows/win32/api/d3d12/nf-d3d12-id3d12resource-map?utm_source=chatgpt.com#advanced-usage-models)

> [It is safe and recommended to keep buffers persistently mapped if they need mapping, to avoid the overhead of calling Map()/Unmap() many times.](https://gpuopen.com/learn/using-d3d12-heap-type-gpu-upload/)

I benchmarked it with the following code, and verified that the texture was reuploaded every frame:

```cpp
    io.Fonts->TexMinWidth = 64;
    io.Fonts->TexMinHeight = 64;
    io.Fonts->TexMaxWidth = 256;
    io.Fonts->TexMaxHeight = 256;
    
    int i = 0;
    
    [main_loop]
    
    ImGui::PushFont(ImGui::GetFont(), (float)(10 + (i++ % 10))); // Lord have mercy on this atrocity
   
    [...]
    
    ImGui::PopFont();
```

Before:
<img width="399" height="350" alt="before_release" src="https://github.com/user-attachments/assets/eec145e2-074d-4f6b-8245-434b8b13f967" />

After:
<img width="399" height="352" alt="after_release" src="https://github.com/user-attachments/assets/11682b6e-046f-412e-9afc-dfe16756d91a" />

I know this benchmark is unrealistic, and in real use the performance difference is likely negligible since the texture doesn’t change that often. But it's still more efficient, and since it doesn’t really make the code more complex, I think this is a worthwhile improvement.