### PR TITLE
Fix multiline word wrap InputText assert crash (reproduced only on docking)

### DIFF
--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -5485,7 +5485,8 @@ bool ImGui::InputTextEx(const char* label, const char* hint, char* buf, int buf_
 
             const char* text_selected_begin = buf_display + ImMin(state->Stb->select_start, state->Stb->select_end);
             const char* text_selected_end = buf_display + ImMax(state->Stb->select_start, state->Stb->select_end);
-            for (int line_n = line_visible_n0; line_n < line_visible_n1; line_n++)
+            int line_n_max = ImMin(line_visible_n1, line_index->Offsets.Size); // We may not have offsets for all the lines if the text was scrolled this frame
+            for (int line_n = line_visible_n0; line_n < line_n_max; line_n++)
             {
                 const char* p = line_index->get_line_begin(buf_display, line_n);
                 const char* p_eol = line_index->get_line_end(buf_display, line_n);


### PR DESCRIPTION
# What happens

ImVector out of bounds assert gets triggered: `IM_ASSERT(i >= 0 && i < Size); return Data[i];`

When rendering selection, [we iterate](https://github.com/ocornut/imgui/blob/9a5d5c45f54b1301ea471622eddede70384243af/imgui_widgets.cpp#L5488) from `line_visible_n0` to `line_visible_n1`, looking in `line_index->Offsets` for line offsets. However, if the TextInput was scrolled in this frame to e.g. focus on cursor, [line_visible_n0/n1 are updated](https://github.com/ocornut/imgui/blob/9a5d5c45f54b1301ea471622eddede70384243af/imgui_widgets.cpp#L5474), while `line_index->Offsets` aren't. This leads to [out-of-bounds access in selection rendering](https://github.com/ocornut/imgui/blob/9a5d5c45f54b1301ea471622eddede70384243af/imgui_widgets.cpp#L5490). A possible solution would be to recalculate offsets if scrolling happened, or to restructure code in some other way, however a straightforward solution for now is to just avoid iterating beyond `line_index->Offsets`, as this will happen only for 1 frame (next frame offsets [will be recalculated](https://github.com/ocornut/imgui/blob/9a5d5c45f54b1301ea471622eddede70384243af/imgui_widgets.cpp#L5404)).

## Why it doesn't happen when we render lines without selection

With regular text rendering, instead of iterating over each line [we do the following](https://github.com/ocornut/imgui/blob/9a5d5c45f54b1301ea471622eddede70384243af/imgui_widgets.cpp#L5528):
```c++
line_index->get_line_begin(buf_display, line_visible_n0),
line_index->get_line_end(buf_display, line_visible_n1 - 1),
```
`get_line_end` safely returns `EndOffset` if we pass line number beyond offsets. This may not be ideal (performance-wise), but doesn't lead to a crash.
> [!WARNING]  
> I'm not entirely sure if `line_visible_n0` can ever be >= `line_index->Offsets.Size` in this case, but I'm out of time to analyze this and can't make it crash. Text input doesn't immediately scroll to selected text but rather does so in steps, and it seems `line_visible_n0` always stays within `line_index->Offsets`

In case of selection rendering, we run `get_line_begin` on each line separately, which only checks for 0 offsets: `Offsets.Size != 0 ? Offsets[n] : 0`, and Offsets[n] (`IM_ASSERT(i >= 0 && i < Size); return Data[i];`) triggers an assertion.

# Reproduction steps

I could only reproduce this on **docking** branch with f**ull-screen dockspace**.

1. Switch to docking branch, add `ImGui::DockSpaceOverViewport();`, launch an example, dock imgui example window to the app window (because this allows to resize TextInput without it losing `ActiveId`)
2. In MultiLine TextInput switch ON word wrap (because this enables `CursorCenterY`)
3. Paste a bunch of lines (so that there are more than can be visible at once), select any word
4. Keeping the text selected, use the scroll wheel to scroll so that selection is no longer visible
5. Resize the width of the app window manually

https://github.com/user-attachments/assets/ec5bc5e1-5abf-47c8-81c4-4f2f6bb0cf0d

