### PR TITLE
Make FreeType select a size for fixed sized fonts

### DIFF
--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -2885,6 +2885,71 @@ void ImFontAtlasTextureBlockConvert(const unsigned char* src_pixels, ImTextureFo
     }
 }
 
+void ImFontAtlasTextureBlockResize(const ImU32* src_pixels, const int src_w, const int src_h, ImU32* dst_pixels, const int dst_w, const int dst_h)
+{
+#if 0
+    // Point Sampling / Nearest Neighbor
+    for (int y = 0; y < dst_h; y++)
+    {
+        const int src_y = ImFloor(((y + 0.5f) * src_h) / dst_h);
+        for (int x = 0; x < dst_w; x++)
+        {
+            const int src_x = ImFloor(((x + 0.5f) * src_w) / dst_w);
+            dst_pixels[y * dst_w + x] = src_pixels[src_y * src_w + src_x];
+        }
+    }
+#else
+    // Box sampling - Imagine projecting the new, smaller pixels onto the larger source, covering multiple pixel.
+    for (int y = 0; y < dst_h; y++)
+    {
+        for (int x = 0; x < dst_w; x++)
+        {
+            // We perform a weighted mean.
+            ImVec4 color;
+            float weight_sum = 0.0f;
+
+            // Walk from upper edge to bottom edge (vertical)
+            const float edge_up = ((float)y * src_h) / dst_h;
+            const float edge_down = ((y + 1.0f) * src_h) / dst_h;
+            for (float frac_pos_y = edge_up; frac_pos_y < edge_down;)
+            {
+                const int src_y = (int)ImFloor(frac_pos_y); IM_ASSERT(src_y < src_h);
+                const float frac_y = 1.0f - (frac_pos_y - src_y);
+
+                // Walk from left edge to right edge (horizontal)
+                const float edge_left = ((float)x * src_w) / dst_w;
+                const float edge_right = ((x + 1.0f) * src_w) / dst_w;
+                for (float frac_pos_x = edge_left; frac_pos_x < edge_right;)
+                {
+                    const int src_x = (int)ImFloor(frac_pos_x); IM_ASSERT(src_x < src_w);
+                    const float frac_x = 1.0f - (frac_pos_x - src_x);
+
+                    const float src_pixel_weight = frac_x * frac_y;
+
+                    const ImVec4 pixel_color = ImGui::ColorConvertU32ToFloat4(src_pixels[src_y * src_w + src_x]);
+                    color.x += pixel_color.x * src_pixel_weight;
+                    color.y += pixel_color.y * src_pixel_weight;
+                    color.z += pixel_color.z * src_pixel_weight;
+                    color.w += pixel_color.w * src_pixel_weight;
+                    weight_sum += src_pixel_weight;
+
+                    frac_pos_x += frac_x;
+                }
+
+                frac_pos_y += frac_y;
+            }
+
+            color.x /= weight_sum;
+            color.y /= weight_sum;
+            color.z /= weight_sum;
+            color.w /= weight_sum;
+
+            dst_pixels[y * dst_w + x] = ImGui::ColorConvertFloat4ToU32(color);
+        }
+    }
+#endif
+}
+
 // Source buffer may be written to (used for in-place mods).
 // Post-process hooks may eventually be added here.
 void ImFontAtlasTextureBlockPostProcess(ImFontAtlasPostProcessData* data)

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -3958,6 +3958,7 @@ IMGUI_API void              ImFontAtlasUpdateDrawListsTextures(ImFontAtlas* atla
 IMGUI_API void              ImFontAtlasUpdateDrawListsSharedData(ImFontAtlas* atlas);
 
 IMGUI_API void              ImFontAtlasTextureBlockConvert(const unsigned char* src_pixels, ImTextureFormat src_fmt, int src_pitch, unsigned char* dst_pixels, ImTextureFormat dst_fmt, int dst_pitch, int w, int h);
+IMGUI_API void              ImFontAtlasTextureBlockResize(const ImU32* src_pixels, const int src_w, const int src_h, ImU32* dst_pixels, const int dst_w, const int dst_h);
 IMGUI_API void              ImFontAtlasTextureBlockPostProcess(ImFontAtlasPostProcessData* data);
 IMGUI_API void              ImFontAtlasTextureBlockPostProcessMultiply(ImFontAtlasPostProcessData* data, float multiply_factor);
 IMGUI_API void              ImFontAtlasTextureBlockFill(ImTextureData* dst_tex, int dst_x, int dst_y, int w, int h, ImU32 col);


### PR DESCRIPTION
### This PR implements:
- select size for fixed sized unscalable bitmap fonts (sbix and CBDT/CBLC)
- rescale bitmap before adding it to atlas

This enables imgui+freetype to just use the system provided emojie fonts. (NotoColorEmoji and AppleColorEmoji)

### TODO:
- [x] Better rescaling using [box sampling](https://en.wikipedia.org/wiki/Image_scaling#Box_sampling)
- [ ] More testing
  - [ ] niche api usages
  - [x] more fonts
  - [x] multi bitmap fonts without fallbacks (apple emoji)
  - [x] em square pr (hm looks the same, but that pr has uncommited changes)
- [ ] figure out why emojies are generally offset upwards

---

This should make CBDT fonts like NotoColorEmoji and AppleColorEmoji play nice. Bitmap fonts are often preferred by distributors over COLRv1, because they are more universally supported, while also being smaller than SVGinOT fonts.

see https://github.com/ocornut/imgui/issues/6302

---

### built-in font + system provided NotoColorEmoji (109px) at font size 13:
<img width="844" height="783" alt="image" src="https://github.com/user-attachments/assets/a03285f9-a358-4ec2-8d4e-c85b3e0c7be7" />

### built-in font + system provided NotoColorEmoji (109px) at font size 26:
<img width="1165" height="836" alt="image" src="https://github.com/user-attachments/assets/2308b2d4-ce8b-4dc6-a95c-dad16c28b9ab" />


<details><summary>Old images</summary>

### built-in font + system provided NotoColorEmoji (109px) at font size 13:
<img width="953" height="775" alt="image" src="https://github.com/user-attachments/assets/3f56aa49-e464-4100-8df5-8bcf6d5c63f1" />

### built-in font + system provided NotoColorEmoji (109px) at font size 26:
<img width="1158" height="857" alt="image" src="https://github.com/user-attachments/assets/49cd1821-a0db-471a-ac8b-b61bbbe5cd7f" />

</details>

<details><summary>Old Old images</summary>

### built-in font + system provided NotoColorEmoji (109px) at font size 13:
<img width="878" height="878" alt="image" src="https://github.com/user-attachments/assets/da8ab2c7-4738-47ac-b21b-e2fa4a171ff8" />

### built-in font + system provided NotoColorEmoji (109px) at font size 26:
<img width="1014" height="886" alt="image" src="https://github.com/user-attachments/assets/59b89021-e007-4ef4-a2b2-17fe96cf0e16" />

</details> 