### PR TITLE
Make ClearPlatformHandlers and ClearRendererHandlers API public

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -3978,8 +3978,8 @@ struct ImGuiPlatformIO
     // Functions
     //------------------------------------------------------------------
 
-    void    ClearPlatformHandlers();    // Clear all Platform_XXX fields. Typically called on Platform Backend shutdown.
-    void    ClearRendererHandlers();    // Clear all Renderer_XXX fields. Typically called on Renderer Backend shutdown.
+    IMGUI_API void ClearPlatformHandlers();    // Clear all Platform_XXX fields. Typically called on Platform Backend shutdown.
+    IMGUI_API void ClearRendererHandlers();    // Clear all Renderer_XXX fields. Typically called on Renderer Backend shutdown.
 };
 
 // (Optional) Support for IME (Input Method Editor) via the platform_io.Platform_SetImeDataFn() function. Handler is called during EndFrame().


### PR DESCRIPTION
Hey,

I recently added the 1.92.4 version of imgui to conan-center-index and then now tried to update my app to use it. This now failed with a linkage error. The problem was relatively quick to find, but first lets describe the way the conan package is build:

To build imgui, the conan recipe provides a simplified cmake file to build just the .cpp files in the main folder. Backends are provided inside the package as source files to be compiled in the consuming application. Thus the huge matrix of possible backends doesn't need to be provided individually/a reasonable package can be offered leaving it open to the consumer to select the best fitting backends.

Now when building as a shared library, the recipe defaults to hidden visibility. With the backend not build as part of the package, the linker then fails to link the two backends. Here is what I got when I used https://github.com/conan-io/examples2/tree/main/examples/libraries/imgui/introduction for reproduction, changing the conanfile there to use 1.92.4(optionally -docking) and then building with `conan install . --build=missing -o:a '*/*:shared=True' && cmake . --preset conan-release && cd build/Release && cmake --build . -j`. That is the resulting linker problem:

```
ingmar@u2 [git@main [d]] % cmake --build . -j                                                                                    [imgui/introduction/build/Release]
[ 50%] Building CXX object CMakeFiles/dear-imgui-conan.dir/bindings/imgui_impl_opengl3.cpp.o
[ 66%] Building CXX object CMakeFiles/dear-imgui-conan.dir/opengl_shader.cpp.o
[ 83%] Building CXX object CMakeFiles/dear-imgui-conan.dir/file_manager.cpp.o
[ 83%] Building CXX object CMakeFiles/dear-imgui-conan.dir/bindings/imgui_impl_glfw.cpp.o
[ 83%] Building CXX object CMakeFiles/dear-imgui-conan.dir/main.cpp.o
[100%] Linking CXX executable dear-imgui-conan
Undefined symbols for architecture arm64:
  "ImGuiPlatformIO::ClearPlatformHandlers()", referenced from:
      ImGui_ImplGlfw_Shutdown() in imgui_impl_glfw.cpp.o
  "ImGuiPlatformIO::ClearRendererHandlers()", referenced from:
      ImGui_ImplOpenGL3_Shutdown() in imgui_impl_opengl3.cpp.o
ld: symbol(s) not found for architecture arm64
c++: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [dear-imgui-conan] Error 1
make[1]: *** [CMakeFiles/dear-imgui-conan.dir/all] Error 2
make: *** [all] Error 2
```

With the fix, it builds without the problem and also runs without a problem.
