### PR TITLE
Backends: DX12: Correct frame render buffer indexing to start at 0 and remove extra frame index incrementation

### DIFF
--- a/backends/imgui_impl_dx12.cpp
+++ b/backends/imgui_impl_dx12.cpp
@@ -1280,7 +1280,6 @@ static void ImGui_ImplDX12_SwapBuffers(ImGuiViewport* viewport, void*)
     ImGui_ImplDX12_ViewportData* vd = (ImGui_ImplDX12_ViewportData*)viewport->RendererUserData;
 
     vd->SwapChain->Present(0, bd->tearingSupport ? DXGI_PRESENT_ALLOW_TEARING : 0);
-    vd->FrameIndex++;
 }
 
 void ImGui_ImplDX12_InitMultiViewportSupport()


### PR DESCRIPTION
A minor change to move frame index incrementation after retrieving the frame render buffer to start from frame 0 instead of 1.