### PR TITLE
Backends: DX12: Let user specifies an optional custom error handling function by setting ImGui_ImplDX12_InitInfo::CheckHrResultFn

### DIFF
--- a/backends/imgui_impl_dx12.h
+++ b/backends/imgui_impl_dx12.h
@@ -45,6 +45,9 @@ struct ImGui_ImplDX12_InitInfo
     D3D12_GPU_DESCRIPTOR_HANDLE LegacySingleSrvGpuDescriptor;
 #endif
 
+    // (Optional) Debugging
+    void                        (*CheckHrResultFn)(HRESULT hr);
+
     ImGui_ImplDX12_InitInfo()   { memset((void*)this, 0, sizeof(*this)); }
 };
 


### PR DESCRIPTION
Add optional CheckHrResultFn member to ImGui_ImplDX12_InitInfo for custom error handling, matching Vulkan backend. Also fix a couple of missing error checks.

In the example file, I changed CreateDeviceD3D to return HRESULT instead of bool, preserving existing error and cleanup logic. However, I think direct error checks and early aborts would be better here. It would simplify the code and cleanup is not handled properly anyway and is very difficult to manage without RAII.

To be clear, I suggest replacing this:
```cpp
    HRESULT hr = CreateDeviceD3D(hwnd);
    if (FAILED(hr))
    {
        CleanupDeviceD3D();
        ::UnregisterClassW(wc.lpszClassName, wc.hInstance);
        check_hr_result(hr);
    }
    [...]
    HRESULT CreateDeviceD3D(HWND hWnd)
    {
        [...]
        HRESULT hr = D3D12CreateDevice(nullptr, featureLevel, IID_PPV_ARGS(&g_pd3dDevice));
        if (FAILED(hr))
            return hr;
        [...]
    }
```

By this:
```cpp
    CreateDeviceD3D(hwnd);
    [...]
    void CreateDeviceD3D(HWND hWnd)
    {
        [...]
        HRESULT hr = D3D12CreateDevice(nullptr, featureLevel, IID_PPV_ARGS(&g_pd3dDevice));
        check_hr_result(hr);
        [...]
    }
```

If you agree, I will make these changes.