### PR TITLE
OpenGL3: Always validate texture before uploading data

### DIFF
--- a/backends/imgui_impl_opengl3.cpp
+++ b/backends/imgui_impl_opengl3.cpp
@@ -723,6 +723,11 @@ static void ImGui_ImplOpenGL3_DestroyTexture(ImTextureData* tex)
 
 void ImGui_ImplOpenGL3_UpdateTexture(ImTextureData* tex)
 {
+    if (tex->Status == ImTextureStatus_WantDestroy && tex->UnusedFrames > 0) {
+        ImGui_ImplOpenGL3_DestroyTexture(tex);
+        return;
+    }
+
     // FIXME: Consider backing up and restoring
     if (tex->Status == ImTextureStatus_WantCreate || tex->Status == ImTextureStatus_WantUpdates)
     {
@@ -770,6 +775,15 @@ void ImGui_ImplOpenGL3_UpdateTexture(ImTextureData* tex)
         GL_CALL(glGetIntegerv(GL_TEXTURE_BINDING_2D, &last_texture));
 
         GLuint gl_tex_id = (GLuint)(intptr_t)tex->TexID;
+
+        GLint is_texture = 0;
+        glGetIntegerv(GL_TEXTURE_BINDING_2D, &is_texture);
+        if (!glIsTexture(gl_tex_id)) {
+            // Texture was destroyed, mark for recreation
+            tex->SetStatus(ImTextureStatus_WantCreate);
+            return;
+        }
+
         GL_CALL(glBindTexture(GL_TEXTURE_2D, gl_tex_id));
 #if GL_UNPACK_ROW_LENGTH // Not on WebGL/ES
         GL_CALL(glPixelStorei(GL_UNPACK_ROW_LENGTH, tex->Width));
@@ -793,8 +807,6 @@ void ImGui_ImplOpenGL3_UpdateTexture(ImTextureData* tex)
         tex->SetStatus(ImTextureStatus_OK);
         GL_CALL(glBindTexture(GL_TEXTURE_2D, last_texture)); // Restore state
     }
-    else if (tex->Status == ImTextureStatus_WantDestroy && tex->UnusedFrames > 0)
-        ImGui_ImplOpenGL3_DestroyTexture(tex);
 }
 
 // If you get an error please report on github. You may try different GL context version or GLSL version. See GL<>GLSL version table at the top of this file.


### PR DESCRIPTION
**CHIPSET:** QUALCOMM
**PLATFORM:** ANDROID 15 (Qualcomm Adreno)
**COMPILER:** NDK Version 28.2.13676358
**ISSUE:** SIGSEGV crash in Adreno GPU driver during glTexSubImage2D operations

**PROBLEM:**
```
11-01 11:02:33.017 16155 17680 F libc    : Fatal signal 11 (SIGSEGV), code -6 (SI_TKILL) in tid 17680 (RenderThread 2), pid 16155 (MainThread-UE4)
11-01 11:02:33.855 18185 18185 F DEBUG   : *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
11-01 11:02:33.855 18185 18185 F DEBUG   : Build fingerprint: 'motorola/fogos_gp/fogos:15/V1UGS35H.75-14-9-2/eac32d-ecdb65:user/release-keys'
11-01 11:02:33.855 18185 18185 F DEBUG   : Revision: 'pvt'
11-01 11:02:33.855 18185 18185 F DEBUG   : ABI: 'arm64'
11-01 11:02:33.855 18185 18185 F DEBUG   : Timestamp: 2025-11-01 11:02:33.402938530+0530
11-01 11:02:33.855 18185 18185 F DEBUG   : Process uptime: 117s
11-01 11:02:33.855 18185 18185 F DEBUG   : Cmdline: com.pubg.imobile
11-01 11:02:33.855 18185 18185 F DEBUG   : pid: 16155, tid: 17680, name: RenderThread 2  >>> com.pubg.imobile <<<
11-01 11:02:33.855 18185 18185 F DEBUG   : uid: 10367
11-01 11:02:33.855 18185 18185 F DEBUG   : signal 11 (SIGSEGV), code -6 (SI_TKILL), fault addr --------
11-01 11:02:33.855 18185 18185 F DEBUG   :     x0  0000000000000270  x1  00000000ffff8000  x2  00000000000000f0  x3  000000ee874aabb0
11-01 11:02:33.855 18185 18185 F DEBUG   :     x4  0000000000000004  x5  0000000000002000  x6  0000000000000008  x7  00000077f3749cb0
11-01 11:02:33.855 18185 18185 F DEBUG   :     x8  00000000000000f0  x9  000000000000003d  x10 00000000000000f0  x11 0000000000000000
11-01 11:02:33.855 18185 18185 F DEBUG   :     x12 0000000000004000  x13 000000000000003d  x14 000000000000000d  x15 00000000000002f0
11-01 11:02:33.855 18185 18185 F DEBUG   :     x16 000000000001e800  x17 00000000000003c0  x18 0000000000000042  x19 0000000000000004
11-01 11:02:33.855 18185 18185 F DEBUG   :     x20 000000000000c004  x21 000000000000001c  x22 00000076ed8a0000  x23 0000000000000042
11-01 11:02:33.855 18185 18185 F DEBUG   :     x24 0000000000000034  x25 000000000000c01c  x26 0000000000000050  x27 0000000000000034
11-01 11:02:33.855 18185 18185 F DEBUG   :     x28 000000ee8749ebac  x29 00000077f3749cc0
11-01 11:02:33.855 18185 18185 F DEBUG   :     lr  00000078637e1738  sp  00000077f3749bf0  pc  00000078637e1754  pst 0000000020001000
11-01 11:02:33.855 18185 18185 F DEBUG   : 25 total frames
11-01 11:02:33.855 18185 18185 F DEBUG   : backtrace:
11-01 11:02:33.855 18185 18185 F DEBUG   :       #00 pc 00000000002e1754  /vendor/lib64/egl/libGLESv2_adreno.so (!!!0000!4d0cdaba868e987aa070f5a6b168e2!923a446bf8!+1508) (BuildId: 721d54f40d3386f8e2b78472894bf3c4)
11-01 11:02:33.855 18185 18185 F DEBUG   :       #01 pc 00000000002dd9ac  /vendor/lib64/egl/libGLESv2_adreno.so (!!!0000!6fd1d11959478379873bee344e3720!923a446bf8!+2772) (BuildId: 721d54f40d3386f8e2b78472894bf3c4)
11-01 11:02:33.855 18185 18185 F DEBUG   :       #02 pc 00000000002ad86c  /vendor/lib64/egl/libGLESv2_adreno.so (!!!0000!e9a0267a4c3f12c4fb16e257d3a26e!923a446bf8!+5260) (BuildId: 721d54f40d3386f8e2b78472894bf3c4)
11-01 11:02:33.855 18185 18185 F DEBUG   :       #03 pc 00000000002b2a3c  /vendor/lib64/egl/libGLESv2_adreno.so (!!!0000!9c0715a0352375a9ec27cf88ce6933!923a446bf8!+468) (BuildId: 721d54f40d3386f8e2b78472894bf3c4)
11-01 11:02:33.855 18185 18185 F DEBUG   :       #04 pc 0000000000121ab8  /vendor/lib64/egl/libGLESv2_adreno.so (!!!0000!27efe93e728a48e12b9279ac49fad7!923a446bf8!+1600) (BuildId: 721d54f40d3386f8e2b78472894bf3c4)
11-01 11:02:33.855 18185 18185 F DEBUG   :       #05 pc 000000000027395c  /vendor/lib64/egl/libGLESv2_adreno.so (!!!0000!e94336f9c3a8e90238c7c8557996da!923a446bf8!+1356) (BuildId: 721d54f40d3386f8e2b78472894bf3c4)
11-01 11:02:33.855 18185 18185 F DEBUG   :       #06 pc 00000000001c6fa0  /vendor/lib64/egl/libGLESv2_adreno.so (!!!0000!0e6b00ab8c4b112f9f6effa6a8b2b5!923a446bf8!+3080) (BuildId: 721d54f40d3386f8e2b78472894bf3c4)
11-01 11:02:33.855 18185 18185 F DEBUG   :       #07 pc 00000000001c3898  /vendor/lib64/egl/libGLESv2_adreno.so (!!!0000!4ecf3032464df959aad423cba1a73c!923a446bf8!+848) (BuildId: 721d54f40d3386f8e2b78472894bf3c4)
11-01 11:02:33.855 18185 18185 F DEBUG   :       #08 pc 00000000001e2474  /vendor/lib64/egl/libGLESv2_adreno.so (!!!0000!141e50cb152287019aff218176d094!923a446bf8!+220) (BuildId: 721d54f40d3386f8e2b78472894bf3c4)
11-01 11:02:33.855 18185 18185 F DEBUG   :       #09 pc 00000000000f8c98  /vendor/lib64/egl/libGLESv2_adreno.so (glTexSubImage2D+144) (BuildId: 721d54f40d3386f8e2b78472894bf3c4)
11-01 11:02:33.855 18185 18185 F DEBUG   :       #10 pc 00000000000cef24  /data/adb/modules/imguiHook/zygisk/imguiHook.so
11-01 11:02:33.855 18185 18185 F DEBUG   :       #23 pc 00000000000a6f0c  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start(void*)+196) (BuildId: a8f27e9c92eaa8155ecc6e9c01b1b1d3)
11-01 11:02:33.855 18185 18185 F DEBUG   :       #24 pc 00000000000993b4  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+68) (BuildId: a8f27e9c92eaa8155ecc6e9c01b1b1d3)
```

The current ImGui_ImplOpenGL3_UpdateTexture function attempts texture operations without validating if the OpenGL texture handle is still valid, causing crashes in the Adreno driver when processing destroyed or invalid textures.
```
GLuint gl_tex_id = (GLuint)(intptr_t)tex->TexID;
GL_CALL(glBindTexture(GL_TEXTURE_2D, gl_tex_id));
```

**ROOT CAUSE:**
* Texture IDs become invalid after destruction but are still used
* No validation before glBindTexture() and glTexSubImage2D() calls
* Driver-level crash in /vendor/lib64/egl/libGLESv2_adreno.so

**SOLUTIONS:**
* Add texture validation using glIsTexture() before any texture operations.
* Automatic recovery by marking invalid textures for recreation.
* Also early exit optimization for textures scheduled for destruction.

