### PR TITLE
Allow to specify next window border draw flags

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -478,6 +478,7 @@ namespace ImGui
     IMGUI_API void          SetNextWindowFocus();                                                       // set next window to be focused / top-most. call before Begin()
     IMGUI_API void          SetNextWindowScroll(const ImVec2& scroll);                                  // set next window scrolling value (use < 0.0f to not affect a given axis).
     IMGUI_API void          SetNextWindowBgAlpha(float alpha);                                          // set next window background color alpha. helper to easily override the Alpha component of ImGuiCol_WindowBg/ChildBg/PopupBg. you may also use ImGuiWindowFlags_NoBackground.
+    IMGUI_API void          SetNextWindowBorderDrawFlags(ImDrawFlags flags);                            // set next window border draw flags
     IMGUI_API void          SetWindowPos(const ImVec2& pos, ImGuiCond cond = 0);                        // (not recommended) set current window position - call within Begin()/End(). prefer using SetNextWindowPos(), as this may incur tearing and side-effects.
     IMGUI_API void          SetWindowSize(const ImVec2& size, ImGuiCond cond = 0);                      // (not recommended) set current window size - call within Begin()/End(). set to ImVec2(0, 0) to force an auto-fit. prefer using SetNextWindowSize(), as this may incur tearing and minor side-effects.
     IMGUI_API void          SetWindowCollapsed(bool collapsed, ImGuiCond cond = 0);                     // (not recommended) set current window collapsed state. prefer using SetNextWindowCollapsed().

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -1303,7 +1303,7 @@ enum ImGuiNextWindowDataFlags_
     ImGuiNextWindowDataFlags_HasWindowFlags           = 1 << 8,
     ImGuiNextWindowDataFlags_HasChildFlags            = 1 << 9,
     ImGuiNextWindowDataFlags_HasRefreshPolicy         = 1 << 10,
-    ImGuiNextWindowDataFlags_HasWindowBorderDrawFlags = 1 << 11,
+    ImGuiNextWindowDataFlags_HasBorderDrawFlags       = 1 << 11,
 };
 
 // Storage for SetNexWindow** functions
@@ -1329,6 +1329,7 @@ struct ImGuiNextWindowData
     float                       BgAlphaVal;             // Override background alpha
     ImVec2                      MenuBarOffsetMinVal;    // (Always on) This is not exposed publicly, so we don't clear it and it doesn't have a corresponding flag (could we? for consistency?)
     ImGuiWindowRefreshFlags     RefreshFlagsVal;
+    ImDrawFlags                 BorderDrawFlags;
 
     ImGuiNextWindowData()       { memset(this, 0, sizeof(*this)); }
     inline void ClearFlags()    { HasFlags = ImGuiNextWindowDataFlags_None; }
@@ -2616,6 +2617,7 @@ struct IMGUI_API ImGuiWindow
     ImGuiID                 ID;                                 // == ImHashStr(Name)
     ImGuiWindowFlags        Flags;                              // See enum ImGuiWindowFlags_
     ImGuiChildFlags         ChildFlags;                         // Set when window is a child window. See enum ImGuiChildFlags_
+    ImDrawFlags             BorderDrawFlags;                    // Set when ImGuiNextWindowDataFlags_HasBorderDrawFlags is set, ImDrawFlags_RoundCornersAll otherwise
     ImGuiViewportP*         Viewport;                           // Always set in Begin(). Inactive windows may have a NULL value here if their viewport was discarded.
     ImVec2                  Pos;                                // Position (always rounded-up to nearest pixel)
     ImVec2                  Size;                               // Current size (==SizeFull or collapsed title bar size)


### PR DESCRIPTION
Hello! This adds an ability to specify next window/child window border draw flags.

https://github.com/user-attachments/assets/c8e4ae4d-68ff-4814-9156-0a0df8861b87

Usage example:
```cpp
 ImGuiWindowFlags window_flags = 0;
 if (!has_title_bar)
     window_flags |= ImGuiWindowFlags_NoTitleBar;
 if (has_menu_bar)
     window_flags |= ImGuiWindowFlags_MenuBar;

 static bool has_top_left_border = false;
 static bool has_bottom_left_border = false;
 static bool has_top_right_border = false;
 static bool has_bottom_right_border = false;

 ImDrawFlags border_draw_flags = 0;
 if (has_top_left_border)
     border_draw_flags |= ImDrawFlags_RoundCornersTopLeft;
 if (has_bottom_left_border)
     border_draw_flags |= ImDrawFlags_RoundCornersBottomLeft;
 if (has_top_right_border)
     border_draw_flags |= ImDrawFlags_RoundCornersTopRight;
 if (has_bottom_right_border)
     border_draw_flags |= ImDrawFlags_RoundCornersBottomRight;

 ImGui::SetNextWindowBorderDrawFlags(border_draw_flags);
 ImGui::Begin("Borders Test", 0, window_flags);

 ImGui::Checkbox("Title Bar", &has_title_bar);
 ImGui::Checkbox("Menu Bar", &has_menu_bar);

 ImGui::Checkbox("Top Left", &has_top_left_border);
 ImGui::Checkbox("Bottom Left", &has_bottom_left_border);
 ImGui::Checkbox("Top Right", &has_top_right_border);
 ImGui::Checkbox("Bottom Right", &has_bottom_right_border);

 ImGui::SetNextWindowBorderDrawFlags(border_draw_flags);
 ImGui::BeginChild("Child", ImGui::GetContentRegionAvail(), ImGuiChildFlags_Borders);

 ImGui::TextUnformatted("Child Text!");

 ImGui::EndChild();
 ```