### PR TITLE
DrawCmd: Added ForbidMerging boolean

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -5777,7 +5777,8 @@ static void ImGui::RenderDimmedBackgroundBehindWindow(ImGuiWindow* window, ImU32
         ImDrawList* draw_list = window->RootWindow->DrawList;
         if (draw_list->CmdBuffer.Size == 0)
             draw_list->AddDrawCmd();
-        draw_list->PushClipRect(viewport_rect.Min - ImVec2(1, 1), viewport_rect.Max + ImVec2(1, 1), false); // FIXME: Need to stricty ensure ImDrawCmd are not merged (ElemCount==6 checks below will verify that)
+        draw_list->CmdBuffer.back().ForbidMerging = true; // Strictly ensure ImDrawCmd are not merged
+		draw_list->PushClipRect(viewport_rect.Min - ImVec2(1, 1), viewport_rect.Max + ImVec2(1, 1), false);
         draw_list->AddRectFilled(viewport_rect.Min, viewport_rect.Max, col);
         ImDrawCmd cmd = draw_list->CmdBuffer.back();
         IM_ASSERT(cmd.ElemCount == 6);

--- a/imgui.h
+++ b/imgui.h
@@ -3144,6 +3144,7 @@ struct ImDrawCmd
     void*           UserCallbackData;   // 4-8  // Callback user data (when UserCallback != NULL). If called AddCallback() with size == 0, this is a copy of the AddCallback() argument. If called AddCallback() with size > 0, this is pointing to a buffer where data is stored.
     int             UserCallbackDataSize;  // 4 // Size of callback user data when using storage, otherwise 0.
     int             UserCallbackDataOffset;// 4 // [Internal] Offset of callback user data when using storage, otherwise -1.
+    bool			ForbidMerging;      // 1    // Whether to allow merging with previous ImDrawCmd or not
 
     ImDrawCmd()     { memset(this, 0, sizeof(*this)); } // Also ensure our padding fields are zeroed
 

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -587,7 +587,7 @@ void ImDrawList::_OnChangedClipRect()
 
     // Try to merge with previous command if it matches, else use current command
     ImDrawCmd* prev_cmd = curr_cmd - 1;
-    if (curr_cmd->ElemCount == 0 && CmdBuffer.Size > 1 && ImDrawCmd_HeaderCompare(&_CmdHeader, prev_cmd) == 0 && ImDrawCmd_AreSequentialIdxOffset(prev_cmd, curr_cmd) && prev_cmd->UserCallback == NULL)
+    if ((prev_cmd->ForbidMerging || curr_cmd->ForbidMerging) == false && curr_cmd->ElemCount == 0 && CmdBuffer.Size > 1 && ImDrawCmd_HeaderCompare(&_CmdHeader, prev_cmd) == 0 && ImDrawCmd_AreSequentialIdxOffset(prev_cmd, curr_cmd) && prev_cmd->UserCallback == NULL)
     {
         CmdBuffer.pop_back();
         return;


### PR DESCRIPTION
Hello,

We've been using ImGui at work for some time and while extending our usage recently I came upon an issue in `ImGui::RenderDimmedBackgroundBehindWindow` where the assert making sure that the draw commands were not merged fired. The circumstances seemed to meet when attempting to draw the window selection widget while moving another window into a new viewport/window with a gamepad (I'm sure some other specifics were involved but I don't know what they are). I saw the FIXME so I tried finding a way to avoid the issue without changing everything. This is working for us and I thought that it could work for others too, but I haven't found much discussion around that issue (possibly our setup really is that rare?).

For more context we're using [this Unreal Engine plugin](https://github.com/VesCodes/ImGui) with a few minor changes to it (but AFAIK the issue is present in vanilla too).

One thing I don't know is if there's other places to check for that newly created boolean.

Hopefully this can be useful, thanks for this great piece of software!