### PR TITLE
Backends: DX12: Disable breaking on the D3D12_MESSAGE_ID_FENCE_ZERO_WAIT warning

### DIFF
--- a/examples/example_win32_directx12/main.cpp
+++ b/examples/example_win32_directx12/main.cpp
@@ -371,6 +371,16 @@ bool CreateDeviceD3D(HWND hWnd)
         pInfoQueue->SetBreakOnSeverity(D3D12_MESSAGE_SEVERITY_ERROR, true);
         pInfoQueue->SetBreakOnSeverity(D3D12_MESSAGE_SEVERITY_CORRUPTION, true);
         pInfoQueue->SetBreakOnSeverity(D3D12_MESSAGE_SEVERITY_WARNING, true);
+
+        // Disable breaking on this warning because of a suspected bug in the D3D12 SDK layer, see https://github.com/ocornut/imgui/discussions/9084 for details.
+        D3D12_MESSAGE_ID disabledMessages[] = { D3D12_MESSAGE_ID_FENCE_ZERO_WAIT };
+
+        D3D12_INFO_QUEUE_FILTER filter = {};
+        filter.DenyList.NumIDs = 1;
+        filter.DenyList.pIDList = disabledMessages;
+
+        pInfoQueue->AddStorageFilterEntries(&filter);
+
         pInfoQueue->Release();
         pdx12Debug->Release();
     }


### PR DESCRIPTION
Fix https://github.com/ocornut/imgui/discussions/9084

Apparently for some users, the D3D12_MESSAGE_ID_FENCE_ZERO_WAIT is being triggered even when it shouldn't. This warning says that we're trying to wait on a fence value of 0, which is harmless but also pointless since a value of 0 means no work has been submitted to the GPU yet, so waiting on it is unnecessary.

In our case this warning is incorrect: under the current synchronization logic there is no path that will lead to waiting with a fence value of 0. I suspect a bug in the d3d12 debug layer, and I found a discussion on the Unreal Engine dev forum describing the same issue, with an Epic Games rendering engineer reaching the same conclusion : https://forums.unrealengine.com/t/running-a-game-with-d3ddebug-spams-with-fence-zero-wait/2618843/2

Therefore, to avoid unnecessary breaks for users affected by this issue, this PR disables breaking on that warning.