### PR TITLE
Fix issue #9001 Make ConfigInputTextEnterKeepActive compatible with IsItemDeactivatedAfterEdit

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -4281,6 +4281,7 @@ ImGuiContext::ImGuiContext(ImFontAtlas* shared_font_atlas)
     MouseStationaryTimer = 0.0f;
 
     InputTextPasswordFontBackupFlags = ImFontFlags_None;
+    InputTextReactivateID = 0;
     TempInputId = 0;
     memset(&DataTypeZeroValue, 0, sizeof(DataTypeZeroValue));
     BeginMenuDepth = BeginComboDepth = 0;

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -2461,6 +2461,7 @@ struct ImGuiContext
     ImGuiInputTextDeactivatedState InputTextDeactivatedState;
     ImFontBaked             InputTextPasswordFontBackupBaked;
     ImFontFlags             InputTextPasswordFontBackupFlags;
+    ImGuiID                 InputTextReactivateID;              // ID of InputText to reactivate on next frame (for ConfigInputTextEnterKeepActive behavior)
     ImGuiID                 TempInputId;                        // Temporary text input when using Ctrl+Click on a slider, etc.
     ImGuiDataTypeStorage    DataTypeZeroValue;                  // 0 for all data types
     int                     BeginMenuDepth;

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -4762,6 +4762,11 @@ bool ImGui::InputTextEx(const char* label, const char* hint, char* buf, int buf_
 
     const bool input_requested_by_nav = (g.ActiveId != id) && ((g.NavActivateId == id) && ((g.NavActivateFlags & ImGuiActivateFlags_PreferInput) || (g.NavInputSource == ImGuiInputSource_Keyboard)));
 
+    // Check if this InputText should be reactivated (for ConfigInputTextEnterKeepActive)
+    const bool input_requested_by_reactivate = (g.InputTextReactivateID == id);
+    if (input_requested_by_reactivate)
+        g.InputTextReactivateID = 0; // Clear the flag
+
     const bool user_clicked = hovered && io.MouseClicked[0];
     const bool user_scroll_finish = is_multiline && state != NULL && g.ActiveId == 0 && g.ActiveIdPreviousFrame == GetWindowScrollbarID(draw_window, ImGuiAxis_Y);
     const bool user_scroll_active = is_multiline && state != NULL && g.ActiveId == GetWindowScrollbarID(draw_window, ImGuiAxis_Y);
@@ -4772,7 +4777,7 @@ bool ImGui::InputTextEx(const char* label, const char* hint, char* buf, int buf_
 
     const bool init_reload_from_user_buf = (state != NULL && state->WantReloadUserBuf);
     const bool init_changed_specs = (state != NULL && state->Stb->single_line != !is_multiline); // state != NULL means its our state.
-    const bool init_make_active = (user_clicked || user_scroll_finish || input_requested_by_nav);
+    const bool init_make_active = (user_clicked || user_scroll_finish || input_requested_by_nav || input_requested_by_reactivate);
     const bool init_state = (init_make_active || user_scroll_active);
     if (init_reload_from_user_buf)
     {
@@ -5111,7 +5116,12 @@ bool ImGui::InputTextEx(const char* label, const char* hint, char* buf, int buf_
             {
                 validated = true;
                 if (io.ConfigInputTextEnterKeepActive && !is_multiline)
+                {
+                    // Deactivate for one frame to trigger IsItemDeactivatedAfterEdit(), then reactivate
                     state->SelectAll(); // No need to scroll
+                    clear_active_id = true;
+                    g.InputTextReactivateID = id; // Mark for reactivation on next frame
+                }
                 else
                     clear_active_id = true;
             }


### PR DESCRIPTION
Fixes #9001.

### Summary

When `io.ConfigInputTextEnterKeepActive` is enabled, pressing Enter on a single-line `InputText` keeps the widget active and selects the contents.  
However, in this mode the item is never considered "deactivated", so `IsItemDeactivatedAfterEdit()` never fires and existing undo/finalization logic breaks.

### Issue

- Without `ConfigInputTextEnterKeepActive`:  
  - Pressing Enter deactivates the item, and `IsItemDeactivatedAfterEdit()` becomes true for one frame.
- With `ConfigInputTextEnterKeepActive`:  
  - Pressing Enter keeps the item active, and `IsItemDeactivatedAfterEdit()` is never triggered.
- This is the situation described in #9001, where code that relies on `IsItemDeactivatedAfterEdit()` to finalize edits stops working.

### Fix

- On Enter, when `ConfigInputTextEnterKeepActive` is set, I:
  - Let the widget go through the normal "deactivated after edit" path so that `IsItemDeactivatedAfterEdit()` is signaled as usual.
  - Immediately reactivate the same `InputText` for the next frame and select its contents.
- This preserves the existing idiomatic use of `IsItemDeactivatedAfterEdit()` while keeping the behavior promised by `ConfigInputTextEnterKeepActive`.

### Testing

- Reproduced the behavior described in #9001:
  - `IsItemDeactivatedAfterEdit()` never triggered with `ConfigInputTextEnterKeepActive` enabled.
- Verified after the patch:
  - `IsItemDeactivatedAfterEdit()` is true for one frame when pressing Enter, even with the config flag set.
  - Focus remains on the input and text is selected as before.
- Also checked:
  - Pressing Enter without `ConfigInputTextEnterKeepActive` (unchanged behavior).
  - Clicking outside the widget to deactivate.
  - No regressions observed in basic `InputText` examples.
