### PR TITLE
Add a feature to draw a border around the selected window

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -7548,7 +7548,18 @@ void ImGui::RenderWindowDecorations(ImGuiWindow* window, const ImRect& title_bar
 
         // Selected border
         const float border_size = window->WindowBorderSize;
-        bool is_window_selected = border_size > 0.0f && title_bar_is_highlight && !(window->Flags & (ImGuiWindowFlags_NoNavFocus | ImGuiWindowFlags_MenuBar));
+        bool is_window_selected = border_size > 0.0f;
+        if (!(window->Flags & (ImGuiWindowFlags_ChildMenu | ImGuiWindowFlags_Popup)))
+        {
+            // Regular window
+            is_window_selected &= g.WindowsFocusOrder.back() == window;
+        }
+        else
+        {
+            // BeginPopup/BeginMenu
+            is_window_selected &= g.OpenPopupStack.back().Window == window;
+        }
+        // When docked, only show selected border if the dock node is focused
         is_window_selected &= (!window->DockIsActive || window->DockNode->IsFocused);
         if (is_window_selected)
         {

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -7557,7 +7557,7 @@ void ImGui::RenderWindowDecorations(ImGuiWindow* window, const ImRect& title_bar
         else
         {
             // BeginPopup/BeginMenu
-            is_window_selected &= g.OpenPopupStack.back().Window == window;
+            is_window_selected &= g.OpenPopupStack.back().Window == window && g.WindowsFocusOrder.back() == window->RootWindow;
         }
         // When docked, only show selected border if the dock node is focused
         is_window_selected &= (!window->DockIsActive || window->DockNode->IsFocused);

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -3761,6 +3761,7 @@ const char* ImGui::GetStyleColorName(ImGuiCol idx)
     case ImGuiCol_ChildBg: return "ChildBg";
     case ImGuiCol_PopupBg: return "PopupBg";
     case ImGuiCol_Border: return "Border";
+    case ImGuiCol_BorderSelected: return "BorderSelected";
     case ImGuiCol_BorderShadow: return "BorderShadow";
     case ImGuiCol_FrameBg: return "FrameBg";
     case ImGuiCol_FrameBgHovered: return "FrameBgHovered";
@@ -7544,6 +7545,18 @@ void ImGui::RenderWindowDecorations(ImGuiWindow* window, const ImRect& title_bar
         // Borders (for dock node host they will be rendered over after the tab bar)
         if (handle_borders_and_resize_grips && !window->DockNodeAsHost)
             RenderWindowOuterBorders(window);
+
+        // Selected border
+        const float border_size = window->WindowBorderSize;
+        if (border_size > 0.0f && title_bar_is_highlight && !(flags & ImGuiWindowFlags_NoTitleBar)) {
+            if (!window->DockIsActive || window->DockNode->IsFocused) {
+                const ImU32 border_selected_col = GetColorU32(ImGuiCol_BorderSelected);
+                RenderWindowOuterSingleBorder(window, 0, border_selected_col, border_size);
+                RenderWindowOuterSingleBorder(window, 1, border_selected_col, border_size);
+                RenderWindowOuterSingleBorder(window, 2, border_selected_col, border_size);
+                RenderWindowOuterSingleBorder(window, 3, border_selected_col, border_size);
+            }
+        }
     }
     window->DC.NavLayerCurrent = ImGuiNavLayer_Main;
 }

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -3761,7 +3761,7 @@ const char* ImGui::GetStyleColorName(ImGuiCol idx)
     case ImGuiCol_ChildBg: return "ChildBg";
     case ImGuiCol_PopupBg: return "PopupBg";
     case ImGuiCol_Border: return "Border";
-    case ImGuiCol_BorderSelected: return "BorderSelected";
+    case ImGuiCol_WindowBorderSelected: return "WindowBorderSelected";
     case ImGuiCol_BorderShadow: return "BorderShadow";
     case ImGuiCol_FrameBg: return "FrameBg";
     case ImGuiCol_FrameBgHovered: return "FrameBgHovered";
@@ -7550,7 +7550,7 @@ void ImGui::RenderWindowDecorations(ImGuiWindow* window, const ImRect& title_bar
         const float border_size = window->WindowBorderSize;
         if (border_size > 0.0f && title_bar_is_highlight && !(flags & ImGuiWindowFlags_NoTitleBar)) {
             if (!window->DockIsActive || window->DockNode->IsFocused) {
-                const ImU32 border_selected_col = GetColorU32(ImGuiCol_BorderSelected);
+                const ImU32 border_selected_col = GetColorU32(ImGuiCol_WindowBorderSelected);
                 RenderWindowOuterSingleBorder(window, 0, border_selected_col, border_size);
                 RenderWindowOuterSingleBorder(window, 1, border_selected_col, border_size);
                 RenderWindowOuterSingleBorder(window, 2, border_selected_col, border_size);

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -7548,14 +7548,15 @@ void ImGui::RenderWindowDecorations(ImGuiWindow* window, const ImRect& title_bar
 
         // Selected border
         const float border_size = window->WindowBorderSize;
-        if (border_size > 0.0f && title_bar_is_highlight && !(flags & ImGuiWindowFlags_NoTitleBar)) {
-            if (!window->DockIsActive || window->DockNode->IsFocused) {
-                const ImU32 border_selected_col = GetColorU32(ImGuiCol_WindowBorderSelected);
-                RenderWindowOuterSingleBorder(window, 0, border_selected_col, border_size);
-                RenderWindowOuterSingleBorder(window, 1, border_selected_col, border_size);
-                RenderWindowOuterSingleBorder(window, 2, border_selected_col, border_size);
-                RenderWindowOuterSingleBorder(window, 3, border_selected_col, border_size);
-            }
+        bool is_window_selected = border_size > 0.0f && title_bar_is_highlight && !(window->Flags & (ImGuiWindowFlags_NoNavFocus | ImGuiWindowFlags_MenuBar));
+        is_window_selected &= (!window->DockIsActive || window->DockNode->IsFocused);
+        if (is_window_selected)
+        {
+            const ImU32 border_selected_col = GetColorU32(ImGuiCol_WindowBorderSelected);
+            RenderWindowOuterSingleBorder(window, 0, border_selected_col, border_size);
+            RenderWindowOuterSingleBorder(window, 1, border_selected_col, border_size);
+            RenderWindowOuterSingleBorder(window, 2, border_selected_col, border_size);
+            RenderWindowOuterSingleBorder(window, 3, border_selected_col, border_size);
         }
     }
     window->DC.NavLayerCurrent = ImGuiNavLayer_Main;

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -7552,7 +7552,10 @@ void ImGui::RenderWindowDecorations(ImGuiWindow* window, const ImRect& title_bar
         if (!(window->Flags & (ImGuiWindowFlags_ChildMenu | ImGuiWindowFlags_Popup)))
         {
             // Regular window
-            is_window_selected &= g.WindowsFocusOrder.back() == window;
+            if (!(window->Flags & (ImGuiWindowFlags_NoInputs | ImGuiWindowFlags_MenuBar)))
+                is_window_selected &= g.WindowsFocusOrder.back() == window;
+            else
+                is_window_selected = false;
         }
         else
         {

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -7564,10 +7564,7 @@ void ImGui::RenderWindowDecorations(ImGuiWindow* window, const ImRect& title_bar
         if (is_window_selected)
         {
             const ImU32 border_selected_col = GetColorU32(ImGuiCol_WindowBorderSelected);
-            RenderWindowOuterSingleBorder(window, 0, border_selected_col, border_size);
-            RenderWindowOuterSingleBorder(window, 1, border_selected_col, border_size);
-            RenderWindowOuterSingleBorder(window, 2, border_selected_col, border_size);
-            RenderWindowOuterSingleBorder(window, 3, border_selected_col, border_size);
+            window->DrawList->AddRect(window->Pos, window->Pos + window->Size, border_selected_col, window_rounding, 0, border_size);
         }
     }
     window->DC.NavLayerCurrent = ImGuiNavLayer_Main;

--- a/imgui.h
+++ b/imgui.h
@@ -1812,6 +1812,7 @@ enum ImGuiCol_
     ImGuiCol_ChildBg,               // Background of child windows
     ImGuiCol_PopupBg,               // Background of popups, menus, tooltips windows
     ImGuiCol_Border,
+    ImGuiCol_BorderSelected,
     ImGuiCol_BorderShadow,
     ImGuiCol_FrameBg,               // Background of checkbox, radio button, plot, slider, text input
     ImGuiCol_FrameBgHovered,

--- a/imgui.h
+++ b/imgui.h
@@ -1809,10 +1809,10 @@ enum ImGuiCol_
     ImGuiCol_Text,
     ImGuiCol_TextDisabled,
     ImGuiCol_WindowBg,              // Background of normal windows
+    ImGuiCol_WindowBorderSelected,  // border of selected normal windows
     ImGuiCol_ChildBg,               // Background of child windows
     ImGuiCol_PopupBg,               // Background of popups, menus, tooltips windows
     ImGuiCol_Border,
-    ImGuiCol_BorderSelected,
     ImGuiCol_BorderShadow,
     ImGuiCol_FrameBg,               // Background of checkbox, radio button, plot, slider, text input
     ImGuiCol_FrameBgHovered,

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -192,6 +192,7 @@ void ImGui::StyleColorsDark(ImGuiStyle* dst)
     colors[ImGuiCol_ChildBg]                = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
     colors[ImGuiCol_PopupBg]                = ImVec4(0.08f, 0.08f, 0.08f, 0.94f);
     colors[ImGuiCol_Border]                 = ImVec4(0.43f, 0.43f, 0.50f, 0.50f);
+    colors[ImGuiCol_BorderSelected]         = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
     colors[ImGuiCol_BorderShadow]           = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
     colors[ImGuiCol_FrameBg]                = ImVec4(0.16f, 0.29f, 0.48f, 0.54f);
     colors[ImGuiCol_FrameBgHovered]         = ImVec4(0.26f, 0.59f, 0.98f, 0.40f);
@@ -261,6 +262,7 @@ void ImGui::StyleColorsClassic(ImGuiStyle* dst)
     colors[ImGuiCol_ChildBg]                = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
     colors[ImGuiCol_PopupBg]                = ImVec4(0.11f, 0.11f, 0.14f, 0.92f);
     colors[ImGuiCol_Border]                 = ImVec4(0.50f, 0.50f, 0.50f, 0.50f);
+    colors[ImGuiCol_BorderSelected]         = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
     colors[ImGuiCol_BorderShadow]           = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
     colors[ImGuiCol_FrameBg]                = ImVec4(0.43f, 0.43f, 0.43f, 0.39f);
     colors[ImGuiCol_FrameBgHovered]         = ImVec4(0.47f, 0.47f, 0.69f, 0.40f);
@@ -331,6 +333,7 @@ void ImGui::StyleColorsLight(ImGuiStyle* dst)
     colors[ImGuiCol_ChildBg]                = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
     colors[ImGuiCol_PopupBg]                = ImVec4(1.00f, 1.00f, 1.00f, 0.98f);
     colors[ImGuiCol_Border]                 = ImVec4(0.00f, 0.00f, 0.00f, 0.30f);
+    colors[ImGuiCol_BorderSelected]         = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
     colors[ImGuiCol_BorderShadow]           = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
     colors[ImGuiCol_FrameBg]                = ImVec4(1.00f, 1.00f, 1.00f, 1.00f);
     colors[ImGuiCol_FrameBgHovered]         = ImVec4(0.26f, 0.59f, 0.98f, 0.40f);

--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -189,10 +189,10 @@ void ImGui::StyleColorsDark(ImGuiStyle* dst)
     colors[ImGuiCol_Text]                   = ImVec4(1.00f, 1.00f, 1.00f, 1.00f);
     colors[ImGuiCol_TextDisabled]           = ImVec4(0.50f, 0.50f, 0.50f, 1.00f);
     colors[ImGuiCol_WindowBg]               = ImVec4(0.06f, 0.06f, 0.06f, 0.94f);
+    colors[ImGuiCol_WindowBorderSelected]   = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
     colors[ImGuiCol_ChildBg]                = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
     colors[ImGuiCol_PopupBg]                = ImVec4(0.08f, 0.08f, 0.08f, 0.94f);
     colors[ImGuiCol_Border]                 = ImVec4(0.43f, 0.43f, 0.50f, 0.50f);
-    colors[ImGuiCol_BorderSelected]         = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
     colors[ImGuiCol_BorderShadow]           = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
     colors[ImGuiCol_FrameBg]                = ImVec4(0.16f, 0.29f, 0.48f, 0.54f);
     colors[ImGuiCol_FrameBgHovered]         = ImVec4(0.26f, 0.59f, 0.98f, 0.40f);
@@ -259,10 +259,10 @@ void ImGui::StyleColorsClassic(ImGuiStyle* dst)
     colors[ImGuiCol_Text]                   = ImVec4(0.90f, 0.90f, 0.90f, 1.00f);
     colors[ImGuiCol_TextDisabled]           = ImVec4(0.60f, 0.60f, 0.60f, 1.00f);
     colors[ImGuiCol_WindowBg]               = ImVec4(0.00f, 0.00f, 0.00f, 0.85f);
+    colors[ImGuiCol_WindowBorderSelected]   = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
     colors[ImGuiCol_ChildBg]                = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
     colors[ImGuiCol_PopupBg]                = ImVec4(0.11f, 0.11f, 0.14f, 0.92f);
     colors[ImGuiCol_Border]                 = ImVec4(0.50f, 0.50f, 0.50f, 0.50f);
-    colors[ImGuiCol_BorderSelected]         = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
     colors[ImGuiCol_BorderShadow]           = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
     colors[ImGuiCol_FrameBg]                = ImVec4(0.43f, 0.43f, 0.43f, 0.39f);
     colors[ImGuiCol_FrameBgHovered]         = ImVec4(0.47f, 0.47f, 0.69f, 0.40f);
@@ -330,10 +330,10 @@ void ImGui::StyleColorsLight(ImGuiStyle* dst)
     colors[ImGuiCol_Text]                   = ImVec4(0.00f, 0.00f, 0.00f, 1.00f);
     colors[ImGuiCol_TextDisabled]           = ImVec4(0.60f, 0.60f, 0.60f, 1.00f);
     colors[ImGuiCol_WindowBg]               = ImVec4(0.94f, 0.94f, 0.94f, 1.00f);
+    colors[ImGuiCol_WindowBorderSelected]   = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
     colors[ImGuiCol_ChildBg]                = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
     colors[ImGuiCol_PopupBg]                = ImVec4(1.00f, 1.00f, 1.00f, 0.98f);
     colors[ImGuiCol_Border]                 = ImVec4(0.00f, 0.00f, 0.00f, 0.30f);
-    colors[ImGuiCol_BorderSelected]         = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
     colors[ImGuiCol_BorderShadow]           = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
     colors[ImGuiCol_FrameBg]                = ImVec4(1.00f, 1.00f, 1.00f, 1.00f);
     colors[ImGuiCol_FrameBgHovered]         = ImVec4(0.26f, 0.59f, 0.98f, 0.40f);


### PR DESCRIPTION
I have implemented, in the docking branch, the option proposed in issue #3537 to draw a border when a window is selected.

The intent of this change is to provide an option that allows the selected window to be emphasized not only via `ImGuiCol_TitleBgActive`, but also through a border, similar to the behavior in Visual Studio 2026.

Please refer to the attached GIF for the behavior after the change.

![imgui_border_selected](https://github.com/user-attachments/assets/05671381-39b5-48b7-bd67-707a5e46fbd2)