### PR TITLE
Added nullptr safety check in ImHashStr

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -2380,6 +2380,11 @@ ImGuiID ImHashData(const void* data_p, size_t data_size, ImGuiID seed)
 // FIXME-OPT: Replace with e.g. FNV1a hash? CRC32 pretty much randomly access 1KB. Need to do proper measurements.
 ImGuiID ImHashStr(const char* data_p, size_t data_size, ImGuiID seed)
 {
+    if (data_p == nullptr)
+    {
+        return seed;
+    }
+    
     seed = ~seed;
     ImU32 crc = seed;
     const unsigned char* data = (const unsigned char*)data_p;


### PR DESCRIPTION
This change adds a safety check at the start of ImHashStr to immediately return the seed if the input pointer data_p is nullptr. This prevents potential undefined behavior or crashes when hashing a null string.