### PR TITLE
Prevent assert/crash on destroying texture

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -3509,7 +3509,7 @@ struct ImTextureData
     // - Call SetTexID() and SetStatus() after honoring texture requests. Never modify TexID and Status directly!
     // - A backend may decide to destroy a texture that we did not request to destroy, which is fine (e.g. freeing resources), but we immediately set the texture back in _WantCreate mode.
     void    SetTexID(ImTextureID tex_id)            { TexID = tex_id; }
-    void    SetStatus(ImTextureStatus status)       { Status = status; if (status == ImTextureStatus_Destroyed && !WantDestroyNextFrame) Status = ImTextureStatus_WantCreate; }
+    void    SetStatus(ImTextureStatus status)       { Status = status; if (status == ImTextureStatus_Destroyed && !WantDestroyNextFrame && Pixels != nullptr) Status = ImTextureStatus_WantCreate; }
 };
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
When a texture is set to destroy but the flag 'destroy on next frame' has been unset, the setstatus function attempts to recreate it on next frame, which causes problem if pixel data has already been freed. Added a null pixels test before allowing 'WanteCreate' status change.

