### PR TITLE
Fix incorrect DisabledStackSize assertion in EndDisabledOverrideReenable

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -8258,8 +8258,8 @@ void ImGui::BeginDisabledOverrideReenable()
 void ImGui::EndDisabledOverrideReenable()
 {
     ImGuiContext& g = *GImGui;
-    g.DisabledStackSize--;
     IM_ASSERT(g.DisabledStackSize > 0);
+    g.DisabledStackSize--;
     g.ItemFlagsStack.pop_back();
     g.CurrentItemFlags = g.ItemFlagsStack.back();
     g.Style.Alpha = g.CurrentWindowStack.back().DisabledOverrideReenableAlphaBackup;


### PR DESCRIPTION
Calling EndDisabledOverrideReenable() can raise an assertion from ImGui::End() when using tooltips after pushing item flag 'ImGuiItemFlags_Disabled'.

Caused by an assertion and decrement being in the wrong order.
```cpp
void ImGui::EndDisabledOverrideReenable()
{
    ImGuiContext& g = *GImGui;
    g.DisabledStackSize--;
    IM_ASSERT(g.DisabledStackSize > 0); // expects DisabledStackSize to be > 0 post-decrement
    ...
```

sample code:
```cpp
	static bool disable = false;
	ImGui::Checkbox("Disable", &disable);

	if (disable)
		ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);

	ImGui::Button("Hello!");
	if (ImGui::BeginItemTooltip())
	{
		ImGui::TextUnformatted("This is a tooltip");
		ImGui::EndTooltip();
	}

	if (disable)
		ImGui::PopItemFlag();
```