### PR TITLE
Add ImGuiTreeNodeFlags_NoFrameOuterPadding flag

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -1309,13 +1309,14 @@ enum ImGuiTreeNodeFlags_
     ImGuiTreeNodeFlags_LabelSpanAllColumns  = 1 << 15,  // Label will span all columns of its container table
     //ImGuiTreeNodeFlags_NoScrollOnOpen     = 1 << 16,  // FIXME: TODO: Disable automatic scroll on TreePop() if node got just open and contents is not visible
     ImGuiTreeNodeFlags_NavLeftJumpsToParent = 1 << 17,  // Nav: left arrow moves back to parent. This is processed in TreePop() when there's an unfulfilled Left nav request remaining.
+    ImGuiTreeNodeFlags_NoFrameOuterPadding  = 1 << 18,  // Don't apply outer padding on the header's frame so that it aligns with the contents.
     ImGuiTreeNodeFlags_CollapsingHeader     = ImGuiTreeNodeFlags_Framed | ImGuiTreeNodeFlags_NoTreePushOnOpen | ImGuiTreeNodeFlags_NoAutoOpenOnLog,
 
     // [EXPERIMENTAL] Draw lines connecting TreeNode hierarchy. Discuss in GitHub issue #2920.
     // Default value is pulled from style.TreeLinesFlags. May be overridden in TreeNode calls.
-    ImGuiTreeNodeFlags_DrawLinesNone        = 1 << 18,  // No lines drawn
-    ImGuiTreeNodeFlags_DrawLinesFull        = 1 << 19,  // Horizontal lines to child nodes. Vertical line drawn down to TreePop() position: cover full contents. Faster (for large trees).
-    ImGuiTreeNodeFlags_DrawLinesToNodes     = 1 << 20,  // Horizontal lines to child nodes. Vertical line drawn down to bottom-most child node. Slower (for large trees).
+    ImGuiTreeNodeFlags_DrawLinesNone        = 1 << 19,  // No lines drawn
+    ImGuiTreeNodeFlags_DrawLinesFull        = 1 << 20,  // Horizontal lines to child nodes. Vertical line drawn down to TreePop() position: cover full contents. Faster (for large trees).
+    ImGuiTreeNodeFlags_DrawLinesToNodes     = 1 << 21,  // Horizontal lines to child nodes. Vertical line drawn down to bottom-most child node. Slower (for large trees).
 
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
     ImGuiTreeNodeFlags_NavLeftJumpsBackHere = ImGuiTreeNodeFlags_NavLeftJumpsToParent,  // Renamed in 1.92.0

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -1057,10 +1057,16 @@ static void DemoWindowWidgetsCollapsingHeaders()
     IMGUI_DEMO_MARKER("Widgets/Collapsing Headers");
     if (ImGui::TreeNode("Collapsing Headers"))
     {
+        static bool no_outer_padding = false;
+        ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_None;
+        if (no_outer_padding)
+            flags |= ImGuiTreeNodeFlags_NoFrameOuterPadding;
+            
         static bool closable_group = true;
         ImGui::Checkbox("Show 2nd header", &closable_group);
-        if (ImGui::CollapsingHeader("Header", ImGuiTreeNodeFlags_None))
+        if (ImGui::CollapsingHeader("Header", flags))
         {
+            ImGui::Checkbox("Remove header outer padding", &no_outer_padding);
             ImGui::Text("IsItemHovered: %d", ImGui::IsItemHovered());
             for (int i = 0; i < 5; i++)
                 ImGui::Text("Some content %d", i);
@@ -4095,6 +4101,7 @@ static void DemoWindowWidgetsTreeNodes()
             ImGui::CheckboxFlags("ImGuiTreeNodeFlags_AllowOverlap", &base_flags, ImGuiTreeNodeFlags_AllowOverlap);
             ImGui::CheckboxFlags("ImGuiTreeNodeFlags_Framed", &base_flags, ImGuiTreeNodeFlags_Framed); ImGui::SameLine(); HelpMarker("Draw frame with background (e.g. for CollapsingHeader)");
             ImGui::CheckboxFlags("ImGuiTreeNodeFlags_FramePadding", &base_flags, ImGuiTreeNodeFlags_FramePadding);
+            ImGui::CheckboxFlags("ImGuiTreeNodeFlags_NoFrameOuterPadding", &base_flags, ImGuiTreeNodeFlags_NoFrameOuterPadding);
             ImGui::CheckboxFlags("ImGuiTreeNodeFlags_NavLeftJumpsToParent", &base_flags, ImGuiTreeNodeFlags_NavLeftJumpsToParent);
 
             HelpMarker("Default option for DrawLinesXXX is stored in style.TreeLinesFlags");

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -6844,7 +6844,7 @@ bool ImGui::TreeNodeBehavior(ImGuiID id, ImGuiTreeNodeFlags flags, const char* l
     frame_bb.Min.y = window->DC.CursorPos.y + (text_offset_y - padding.y);
     frame_bb.Max.x = span_all_columns ? window->ParentWorkRect.Max.x : (flags & ImGuiTreeNodeFlags_SpanLabelWidth) ? window->DC.CursorPos.x + text_width + padding.x : window->WorkRect.Max.x;
     frame_bb.Max.y = window->DC.CursorPos.y + (text_offset_y - padding.y) + frame_height;
-    if (display_frame)
+    if (display_frame && !(flags & ImGuiTreeNodeFlags_NoFrameOuterPadding))
     {
         const float outer_extend = IM_TRUNC(window->WindowPadding.x * 0.5f); // Framed header expand a little outside of current limits
         frame_bb.Min.x -= outer_extend;


### PR DESCRIPTION
Added ImGuiTreeNodeFlags_NoFrameOuterPadding.

**Why?**
I've had a few different projects where I've used CollapsingHeader and have not been a fan of the way the edges of the header leak outwards onto the side, there is currently no real solution to this besides hacky approaches. The current logic is to add this 'outer padding' if the 'ImGuiTreeNodeFlags_Framed' is applied.

In my UIs when this collapsible header lives on a sidebar I don't think it looks very nice when its misaligned with contents.

**Previous solution**
My previous solution to this was to access `window->WindowPadding` and set it to (0, 0) for the TreeNodeEx/CollapsingHeader function call, but this solution is ugly and hacky.

```cpp
	ImGuiWindow* window = GImGui->CurrentWindow;
	ImVec2 padding = window->WindowPadding;
	window->WindowPadding.x = window->WindowPadding.y = 0;
	bool configOpen = ImGui::CollapsingHeader("Configuration");
	window->WindowPadding = padding;
```

**New solution**
```cpp
if (ImGui::CollapsingHeader("Configuration", ImGuiTreeNodeFlags_NoFrameOuterPadding))
{
}
```

**Before**
<img width="365" height="82" alt="image" src="https://github.com/user-attachments/assets/71a6c6ff-cf22-4b41-b79d-c3d9dda40fc9" />
<img width="357" height="278" alt="image" src="https://github.com/user-attachments/assets/90e08561-eeb6-4ee3-877f-c605fad148af" />

**After**
Nicely aligned
<img width="362" height="77" alt="image" src="https://github.com/user-attachments/assets/0654c080-ed71-4935-a489-39b4a00277fb" />
<img width="355" height="276" alt="image" src="https://github.com/user-attachments/assets/a55b2073-9435-42bc-ba6e-d2762008c928" />

