### PR TITLE
Backends: GLFW: Fix multi-monitor enumeration in ImGui_ImplGlfw_UpdateMonitors()

### DIFF
--- a/backends/imgui_impl_glfw.cpp
+++ b/backends/imgui_impl_glfw.cpp
@@ -1107,7 +1107,7 @@ static void ImGui_ImplGlfw_UpdateMonitors()
         // Happens on macOS sleeping (#5683) and seemingly occasionally on Windows (#9195)
         if (!updated_monitors)
             platform_io.Monitors.resize(0);
-        updated_monitors = false;
+        updated_monitors = true;
         platform_io.Monitors.push_back(monitor);
     }
 }


### PR DESCRIPTION
Fix `updated_monitors` flag in `ImGui_ImplGlfw_UpdateMonitors()` to retain all monitors on multi-monitor setups.

The `updated_monitors` variable on line 1110 is set to `false` when it should be `true`. Because it resets every iteration, the `resize(0)` guard on line 1108 fires on every loop pass, clearing the monitor list before each `push_back`. Only the last monitor survives.

Walk-through with 2 monitors:

| Iteration | `!updated_monitors` | Action | List after |
| --- | --- | --- | --- |
| 0   | `true` | `resize(0)`, push monitor 0 | `[mon0]` |
| 1   | `true` (bug) | `resize(0)`, push monitor 1 | `[mon1]` |

Monitor 0 is lost. With N monitors, only monitor N-1 is retained. Single-monitor setups are unaffected (loop runs once).

**Symptoms with `ImGuiConfigFlags_ViewportsEnable` on a multi-monitor setup:**

* Sub-windows (secondary viewports) are confined to a single monitor. They cannot be dragged past the edges of that monitor.
  
* The main application window moves freely between monitors (OS-managed, not clamped by ImGui).
  
* Resizing sub-windows across monitors works fine (`ClampWindowPos` only constrains position, not size).
  
```cpp
      // Before (bug):
      updated_monitors = false;
      
      // After (fix):
      updated_monitors = true;
```
  
The defensive behavior for empty monitor lists (#5683, #9195) is preserved: when monitors_count == 0, the loop doesn't execute and the old list is kept.

Environment: Windows 11, dual-monitor, GLFW backend, docking branch, MSVC 2022 (v143).