### PR TITLE
Fix MSVC ARM64EC build: exclude ARM64EC from SSE <immintrin.h> include

### DIFF
--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -60,15 +60,13 @@ Index of this file:
 #include <limits.h>     // INT_MIN, INT_MAX
 
 // Enable SSE intrinsics if available
-#if (defined __SSE__ || defined __x86_64__ || (defined(_M_X64) && !defined(_M_ARM64EC)) || (defined(_M_IX86_FP) && (_M_IX86_FP >= 1))) && !defined(IMGUI_DISABLE_SSE)
+#if (defined __SSE__ || defined __x86_64__ || defined _M_X64 || (defined(_M_IX86_FP) && (_M_IX86_FP >= 1))) && !defined(IMGUI_DISABLE_SSE) && !defined(_M_ARM64) && !defined(_M_ARM64EC)
 #define IMGUI_ENABLE_SSE
 #include <immintrin.h>
 #if (defined __AVX__ || defined __SSE4_2__)
 #define IMGUI_ENABLE_SSE4_2
 #include <nmmintrin.h>
 #endif
-#elif ( defined(_M_ARM64) || defined(_M_ARM64EC))
-#include <intrin.h> 
 #endif
 // Emscripten has partial SSE 4.2 support where _mm_crc32_u32 is not available. See https://emscripten.org/docs/porting/simd.html#id11 and #8213
 #if defined(IMGUI_ENABLE_SSE4_2) && !defined(IMGUI_USE_LEGACY_CRC32_ADLER) && !defined(__EMSCRIPTEN__)


### PR DESCRIPTION
### Summary
Fix Windows ARM64EC builds with MSVC by avoiding direct inclusion of <immintrin.h> and using  <intrin.h> as required by the toolchain.

### Problem
Building ImGui from current "master" with Visual Studio 2022 using the "ARM64EC" configuration fails during compilation with:

>C:\Program Files\Microsoft Visual Studio\2022\VC\Tools\MSVC\****\include\immintrin.h(19,1): error C1189: #error:  this header should only be included through <intrin.h>
1>(compiling source file '../imgui_widgets.cpp')

### Root cause
For MSVC ARM64EC, the compiler toolchain enforces that intrinsics must be reached through  <intrin.h>. Direct inclusion of  <immintrin.h> causes prevents successful builds.

### Solution
Update the include/guard logic for Windows + MSVC ARM64EC builds so that intrinsics are included via  <intrin.h> (and avoid directly including  <immintrin.h> for ARM64EC).

### Impact
- Affects:  Windows + MSVC + ARM64EC
- Does not change runtime behavior
- No impact expected on non-Windows, non-MSVC, or non-ARM64EC builds

### Reproduction
- Visual Studio 2022 (MSVC v143)
- Configuration: Release | ARM64EC

### Testing
  - Verified successful compilation after the change using:
  - Visual Studio 2022 (v143)
  - Release | ARM64EC and ARM64 configuration
  - Release | ARM64: build sanity check