### PR TITLE
Add note about special case regarding ImGuiConfigFlags_NavEnableKeyboard

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -980,7 +980,7 @@ namespace ImGui
     // Disabling [BETA API]
     // - Disable all user interactions and dim items visuals (applying style.DisabledAlpha over current colors)
     // - Those can be nested but it cannot be used to enable an already disabled section (a single BeginDisabled(true) in the stack is enough to keep everything disabled)
-    // - Tooltips windows are automatically opted out of disabling. Note that IsItemHovered() by default returns false on disabled items, unless using ImGuiHoveredFlags_AllowWhenDisabled. 
+    // - Tooltips windows are automatically opted out of disabling. Note that IsItemHovered() by default returns false on disabled items, unless using ImGuiHoveredFlags_AllowWhenDisabled.
     // - BeginDisabled(false)/EndDisabled() essentially does nothing but is provided to facilitate use of boolean expressions (as a micro-optimization: if you have tens of thousands of BeginDisabled(false)/EndDisabled() pairs, you might want to reformulate your code to avoid making those calls)
     IMGUI_API void          BeginDisabled(bool disabled = true);
     IMGUI_API void          EndDisabled();
@@ -1239,7 +1239,7 @@ enum ImGuiItemFlags_
     ImGuiItemFlags_ButtonRepeat             = 1 << 3,   // false    // Any button-like behavior will have repeat mode enabled (based on io.KeyRepeatDelay and io.KeyRepeatRate values). Note that you can also call IsItemActive() after any button to tell if it is being held.
     ImGuiItemFlags_AutoClosePopups          = 1 << 4,   // true     // MenuItem()/Selectable() automatically close their parent popup window.
     ImGuiItemFlags_AllowDuplicateId         = 1 << 5,   // false    // Allow submitting an item with the same identifier as an item already submitted this frame without triggering a warning tooltip if io.ConfigDebugHighlightIdConflicts is set.
-    ImGuiItemFlags_Disabled                 = 1 << 6,   // false    // [Internal] Disable interactions. DOES NOT affect visuals. This is used by BeginDisabled()/EndDisabled() and only provided here so you can read back via GetItemFlags(). 
+    ImGuiItemFlags_Disabled                 = 1 << 6,   // false    // [Internal] Disable interactions. DOES NOT affect visuals. This is used by BeginDisabled()/EndDisabled() and only provided here so you can read back via GetItemFlags().
 };
 
 // Flags for ImGui::InputText()
@@ -1703,7 +1703,7 @@ enum ImGuiInputFlags_
 enum ImGuiConfigFlags_
 {
     ImGuiConfigFlags_None                   = 0,
-    ImGuiConfigFlags_NavEnableKeyboard      = 1 << 0,   // Master keyboard navigation enable flag. Enable full Tabbing + directional arrows + space/enter to activate.
+    ImGuiConfigFlags_NavEnableKeyboard      = 1 << 0,   // Master flag for keyboard navigation within a window. Enable full Tabbing + directional arrows + space/enter to activate. Note: disabling this does NOT disable navigation within the window using the Tab key.  See ImGuiWindowFlags_NoNavInputs
     ImGuiConfigFlags_NavEnableGamepad       = 1 << 1,   // Master gamepad navigation enable flag. Backend also needs to set ImGuiBackendFlags_HasGamepad.
     ImGuiConfigFlags_NoMouse                = 1 << 4,   // Instruct dear imgui to disable mouse inputs and interactions.
     ImGuiConfigFlags_NoMouseCursorChange    = 1 << 5,   // Instruct backend to not alter mouse cursor shape and visibility. Use if the backend cursor changes are interfering with yours and you don't want to use SetMouseCursor() to change mouse cursor. You may want to honor requests from imgui by reading GetMouseCursor() yourself instead.
@@ -1880,7 +1880,7 @@ enum ImGuiColorEditFlags_
     ImGuiColorEditFlags_NoTooltip       = 1 << 6,   //              // ColorEdit, ColorPicker, ColorButton: disable tooltip when hovering the preview.
     ImGuiColorEditFlags_NoLabel         = 1 << 7,   //              // ColorEdit, ColorPicker: disable display of inline text label (the label is still forwarded to the tooltip and picker).
     ImGuiColorEditFlags_NoSidePreview   = 1 << 8,   //              // ColorPicker: disable bigger color preview on right side of the picker, use small color square preview instead.
-    ImGuiColorEditFlags_NoDragDrop      = 1 << 9,   //              // ColorEdit: disable drag and drop target/source. ColorButton: disable drag and drop source. 
+    ImGuiColorEditFlags_NoDragDrop      = 1 << 9,   //              // ColorEdit: disable drag and drop target/source. ColorButton: disable drag and drop source.
     ImGuiColorEditFlags_NoBorder        = 1 << 10,  //              // ColorButton: disable border (which is enforced by default)
     ImGuiColorEditFlags_NoColorMarkers  = 1 << 11,  //              // ColorEdit: disable rendering R/G/B/A color marker. May also be disabled globally by setting style.ColorMarkerSize = 0.
 


### PR DESCRIPTION
## Motivation for adding documentation

In a game I'm developing, I was pressing the Tab key on my keyboard to control the player-character.  However, the Tab key was cycling through objects in my ImGui window (preventing the SDL event from being sent to my game UI code).  I did not want this ImGui behavior enabled, so I started browsing `imgui.h` for options to disable it.  I noticed the `ImGuiConfigFlags_NavEnableKeyboard` flag.  I printed the `io.ConfigFlags` every frame to ensure the bit was not set.  At this point, I was confused because I thought the Tab navigation should be disabled.

So I searched imgui source for `ImGuiConfigFlags_NavEnableKeyboard` and found a function in `imgui.cpp` named `void ImGui::NavUpdateCreateTabbingRequest()` which contains this note:
```cpp
    // Initiate tabbing request
    // (this is ALWAYS ENABLED, regardless of ImGuiConfigFlags_NavEnableKeyboard flag!)
    // See NavProcessItemForTabbingRequest() for a description of the various forward/backward tabbing cases with and without wrapping.
```

Given that `ImGuiConfigFlags_NavEnableKeyboard` has a special case where it doesn't control the tabbing navigation behavior, it seems nice to include a note in the header about this.

Also, it might be nice to include an explanation of why `NavUpdateCreateTabbingRequest` is ignoring the `ImGuiConfigFlags_NavEnableKeyboard` flag, but I'm not sure the reason.

* * *

## Considering other solutions instead of documentation

On the other hand, is it possible to just eliminate this special case?  I have a feeling the answer might be no because I just noticed this other note inside `void ImGui::NavUpdateCreateMoveRequest()`:
```cpp
    // Update PageUp/PageDown/Home/End scroll
    // FIXME-NAV: Consider enabling those keys even without the master ImGuiConfigFlags_NavEnableKeyboard flag?
    float scoring_page_offset_y = 0.0f;
    if (window && g.NavMoveDir == ImGuiDir_None && nav_keyboard_active)
        scoring_page_offset_y = NavUpdatePageUpPageDown();
```

So it appears there is a desire to make the navigation keys work even when the `ImGuiConfigFlags_NavEnableKeyboard` flags is not set.

Maybe it would be more clear to split the flag into two distinct flags?  e.g.

`ImGuiConfigFlags_NavEnableKeyboardBasic`

`ImGuiConfigFlags_NavEnableKeyboardExtra`

So users can configure the level of navigation they want to enable?