### PR TITLE
SDL3 Backend: Add preprocessor IMGUI_IMPL_SDL3_DISABLE_GAMEPAD to disable gamepad processing

### DIFF
--- a/backends/imgui_impl_sdl3.cpp
+++ b/backends/imgui_impl_sdl3.cpp
@@ -126,10 +126,12 @@ struct ImGui_ImplSDL3_Data
     bool                    MouseCanUseGlobalState;
     bool                    MouseCanUseCapture;
 
+#ifndef IMGUI_IMPL_SDL3_DISABLE_GAMEPAD
     // Gamepad handling
     ImVector<SDL_Gamepad*>      Gamepads;
     ImGui_ImplSDL3_GamepadMode  GamepadMode;
     bool                        WantUpdateGamepadsList;
+#endif
 
     ImGui_ImplSDL3_Data()   { memset((void*)this, 0, sizeof(*this)); }
 };
@@ -469,12 +471,14 @@ bool ImGui_ImplSDL3_ProcessEvent(const SDL_Event* event)
             io.AddFocusEvent(event->type == SDL_EVENT_WINDOW_FOCUS_GAINED);
             return true;
         }
+#ifndef IMGUI_IMPL_SDL3_DISABLE_GAMEPAD
         case SDL_EVENT_GAMEPAD_ADDED:
         case SDL_EVENT_GAMEPAD_REMOVED:
         {
             bd->WantUpdateGamepadsList = true;
             return true;
         }
+#endif
         default:
             break;
     }
@@ -533,9 +537,11 @@ static bool ImGui_ImplSDL3_Init(SDL_Window* window, SDL_Renderer* renderer, void
     platform_io.Platform_SetImeDataFn = ImGui_ImplSDL3_PlatformSetImeData;
     platform_io.Platform_OpenInShellFn = [](ImGuiContext*, const char* url) { return SDL_OpenURL(url); };
 
+#ifndef IMGUI_IMPL_SDL3_DISABLE_GAMEPAD
     // Gamepad handling
     bd->GamepadMode = ImGui_ImplSDL3_GamepadMode_AutoFirst;
     bd->WantUpdateGamepadsList = true;
+#endif
 
     // Load mouse cursors
     bd->MouseCursors[ImGuiMouseCursor_Arrow] = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_DEFAULT);
@@ -607,7 +613,9 @@ bool ImGui_ImplSDL3_InitForOther(SDL_Window* window)
     return ImGui_ImplSDL3_Init(window, nullptr, nullptr);
 }
 
+#ifndef IMGUI_IMPL_SDL3_DISABLE_GAMEPAD
 static void ImGui_ImplSDL3_CloseGamepads();
+#endif
 
 void ImGui_ImplSDL3_Shutdown()
 {
@@ -620,7 +628,9 @@ void ImGui_ImplSDL3_Shutdown()
         SDL_free(bd->ClipboardTextData);
     for (ImGuiMouseCursor cursor_n = 0; cursor_n < ImGuiMouseCursor_COUNT; cursor_n++)
         SDL_DestroyCursor(bd->MouseCursors[cursor_n]);
+#ifndef IMGUI_IMPL_SDL3_DISABLE_GAMEPAD
     ImGui_ImplSDL3_CloseGamepads();
+#endif
 
     io.BackendPlatformName = nullptr;
     io.BackendPlatformUserData = nullptr;
@@ -703,6 +713,7 @@ static void ImGui_ImplSDL3_UpdateMouseCursor()
     }
 }
 
+#ifndef IMGUI_IMPL_SDL3_DISABLE_GAMEPAD
 static void ImGui_ImplSDL3_CloseGamepads()
 {
     ImGui_ImplSDL3_Data* bd = ImGui_ImplSDL3_GetBackendData();
@@ -805,6 +816,7 @@ static void ImGui_ImplSDL3_UpdateGamepads()
     ImGui_ImplSDL3_UpdateGamepadAnalog(bd, io, ImGuiKey_GamepadRStickUp,    SDL_GAMEPAD_AXIS_RIGHTY, -thumb_dead_zone, -32768);
     ImGui_ImplSDL3_UpdateGamepadAnalog(bd, io, ImGuiKey_GamepadRStickDown,  SDL_GAMEPAD_AXIS_RIGHTY, +thumb_dead_zone, +32767);
 }
+#endif
 
 static void ImGui_ImplSDL3_GetWindowSizeAndFramebufferScale(SDL_Window* window, ImVec2* out_size, ImVec2* out_framebuffer_scale)
 {
@@ -858,8 +870,10 @@ void ImGui_ImplSDL3_NewFrame()
     ImGui_ImplSDL3_UpdateMouseCursor();
     ImGui_ImplSDL3_UpdateIme();
 
+#ifndef IMGUI_IMPL_SDL3_DISABLE_GAMEPAD
     // Update game controllers (if enabled and available)
     ImGui_ImplSDL3_UpdateGamepads();
+#endif
 }
 
 //-----------------------------------------------------------------------------

--- a/backends/imgui_impl_sdl3.h
+++ b/backends/imgui_impl_sdl3.h
@@ -39,9 +39,11 @@ IMGUI_IMPL_API void     ImGui_ImplSDL3_Shutdown();
 IMGUI_IMPL_API void     ImGui_ImplSDL3_NewFrame();
 IMGUI_IMPL_API bool     ImGui_ImplSDL3_ProcessEvent(const SDL_Event* event);
 
+#ifndef IMGUI_IMPL_SDL3_DISABLE_GAMEPAD
 // Gamepad selection automatically starts in AutoFirst mode, picking first available SDL_Gamepad. You may override this.
 // When using manual mode, caller is responsible for opening/closing gamepad.
 enum ImGui_ImplSDL3_GamepadMode { ImGui_ImplSDL3_GamepadMode_AutoFirst, ImGui_ImplSDL3_GamepadMode_AutoAll, ImGui_ImplSDL3_GamepadMode_Manual };
 IMGUI_IMPL_API void     ImGui_ImplSDL3_SetGamepadMode(ImGui_ImplSDL3_GamepadMode mode, SDL_Gamepad** manual_gamepads_array = nullptr, int manual_gamepads_count = -1);
+#endif
 
 #endif // #ifndef IMGUI_DISABLE


### PR DESCRIPTION
TL;DR:  Steam Input API doesnt work, because SDL3 backend keeps reporting no gamepad, and unsetting `ImGuiBackendFlags_HasGamepad`, thus gamepad keys are reset and not processed.

We have a very basic Steam Input API implementation `io.AddKeyEvent(key, value);`, and we use that to poll for user input.
We also use SDL3 backend for Imgui windows/render, the imgui SDL3 backend doesnt (currently) allow partial usage (e.g opengl while disabling inputs). As a result, when `ImGui_ImplSDL3_NewFrame()` is called, gamepad is processed, since Steam Input API is active, SDL3 reports no gamepads which unsetting `ImGuiBackendFlags_HasGamepad`.

related issue https://github.com/ocornut/imgui/issues/9215 with different ideas I've explored to solve this issue
ultimately I think this is the best solution, since we also have our own SDL3 gamepad input provider and it's probably easier to  to manage button remapping, on side of the code.