### PR TITLE
Add labeled border child

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -6805,17 +6805,22 @@ static const ImGuiResizeBorderDef resize_border_def[4] =
     { ImVec2(0, -1), ImVec2(1, 1), ImVec2(0, 1), IM_PI * 0.50f }  // Down
 };
 
-static ImRect GetResizeBorderRect(ImGuiWindow* window, int border_n, float perp_padding, float thickness)
+static inline ImRect GetResizeBorderRect(ImRect rect, int border_n, float perp_padding, float thickness)
 {
-    ImRect rect = window->Rect();
     if (thickness == 0.0f)
         rect.Max -= ImVec2(1, 1);
-    if (border_n == ImGuiDir_Left)  { return ImRect(rect.Min.x - thickness,    rect.Min.y + perp_padding, rect.Min.x + thickness,    rect.Max.y - perp_padding); }
-    if (border_n == ImGuiDir_Right) { return ImRect(rect.Max.x - thickness,    rect.Min.y + perp_padding, rect.Max.x + thickness,    rect.Max.y - perp_padding); }
-    if (border_n == ImGuiDir_Up)    { return ImRect(rect.Min.x + perp_padding, rect.Min.y - thickness,    rect.Max.x - perp_padding, rect.Min.y + thickness);    }
-    if (border_n == ImGuiDir_Down)  { return ImRect(rect.Min.x + perp_padding, rect.Max.y - thickness,    rect.Max.x - perp_padding, rect.Max.y + thickness);    }
+    if (border_n == ImGuiDir_Left) { return ImRect(rect.Min.x - thickness, rect.Min.y + perp_padding, rect.Min.x + thickness, rect.Max.y - perp_padding); }
+    if (border_n == ImGuiDir_Right) { return ImRect(rect.Max.x - thickness, rect.Min.y + perp_padding, rect.Max.x + thickness, rect.Max.y - perp_padding); }
+    if (border_n == ImGuiDir_Up) { return ImRect(rect.Min.x + perp_padding, rect.Min.y - thickness, rect.Max.x - perp_padding, rect.Min.y + thickness); }
+    if (border_n == ImGuiDir_Down) { return ImRect(rect.Min.x + perp_padding, rect.Max.y - thickness, rect.Max.x - perp_padding, rect.Max.y + thickness); }
     IM_ASSERT(0);
     return ImRect();
+}
+
+static inline ImRect GetResizeBorderRect(ImGuiWindow* window, int border_n, float perp_padding, float thickness)
+{
+    ImRect rect = window->Rect();
+    return GetResizeBorderRect(rect, border_n, perp_padding, thickness);
 }
 
 // 0..3: corners (Lower-right, Lower-left, Unused, Unused)

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -6906,17 +6906,22 @@ static const ImGuiResizeBorderDef resize_border_def[4] =
     { ImVec2(0, -1), ImVec2(1, 1), ImVec2(0, 1), IM_PI * 0.50f }  // Down
 };
 
-static ImRect GetResizeBorderRect(ImGuiWindow* window, int border_n, float perp_padding, float thickness)
+static inline ImRect GetResizeBorderRect(ImRect rect, int border_n, float perp_padding, float thickness)
 {
-    ImRect rect = window->Rect();
     if (thickness == 0.0f)
         rect.Max -= ImVec2(1, 1);
-    if (border_n == ImGuiDir_Left)  { return ImRect(rect.Min.x - thickness,    rect.Min.y + perp_padding, rect.Min.x + thickness,    rect.Max.y - perp_padding); }
-    if (border_n == ImGuiDir_Right) { return ImRect(rect.Max.x - thickness,    rect.Min.y + perp_padding, rect.Max.x + thickness,    rect.Max.y - perp_padding); }
-    if (border_n == ImGuiDir_Up)    { return ImRect(rect.Min.x + perp_padding, rect.Min.y - thickness,    rect.Max.x - perp_padding, rect.Min.y + thickness);    }
-    if (border_n == ImGuiDir_Down)  { return ImRect(rect.Min.x + perp_padding, rect.Max.y - thickness,    rect.Max.x - perp_padding, rect.Max.y + thickness);    }
+    if (border_n == ImGuiDir_Left) { return ImRect(rect.Min.x - thickness, rect.Min.y + perp_padding, rect.Min.x + thickness, rect.Max.y - perp_padding); }
+    if (border_n == ImGuiDir_Right) { return ImRect(rect.Max.x - thickness, rect.Min.y + perp_padding, rect.Max.x + thickness, rect.Max.y - perp_padding); }
+    if (border_n == ImGuiDir_Up) { return ImRect(rect.Min.x + perp_padding, rect.Min.y - thickness, rect.Max.x - perp_padding, rect.Min.y + thickness); }
+    if (border_n == ImGuiDir_Down) { return ImRect(rect.Min.x + perp_padding, rect.Max.y - thickness, rect.Max.x - perp_padding, rect.Max.y + thickness); }
     IM_ASSERT(0);
     return ImRect();
+}
+
+static inline ImRect GetResizeBorderRect(ImGuiWindow* window, int border_n, float perp_padding, float thickness)
+{
+    ImRect rect = window->Rect();
+    return GetResizeBorderRect(rect, border_n, perp_padding, thickness);
 }
 
 // 0..3: corners (Lower-right, Lower-left, Unused, Unused)

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -6457,7 +6457,7 @@ bool ImGui::BeginChildEx(const char* name, ImGuiID id, const ImVec2& size_arg, I
     IM_ASSERT(id != 0);
 
     // Sanity check as it is likely that some user will accidentally pass ImGuiWindowFlags into the ImGuiChildFlags argument.
-    const ImGuiChildFlags ImGuiChildFlags_SupportedMask_ = ImGuiChildFlags_Borders | ImGuiChildFlags_AlwaysUseWindowPadding | ImGuiChildFlags_ResizeX | ImGuiChildFlags_ResizeY | ImGuiChildFlags_AutoResizeX | ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_AlwaysAutoResize | ImGuiChildFlags_FrameStyle | ImGuiChildFlags_NavFlattened;
+    const ImGuiChildFlags ImGuiChildFlags_SupportedMask_ = ImGuiChildFlags_Borders | ImGuiChildFlags_AlwaysUseWindowPadding | ImGuiChildFlags_ResizeX | ImGuiChildFlags_ResizeY | ImGuiChildFlags_AutoResizeX | ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_AlwaysAutoResize | ImGuiChildFlags_FrameStyle | ImGuiChildFlags_NavFlattened | ImGuiChildFlags_TopLabel;
     IM_UNUSED(ImGuiChildFlags_SupportedMask_);
     IM_ASSERT((child_flags & ~ImGuiChildFlags_SupportedMask_) == 0 && "Illegal ImGuiChildFlags value. Did you pass ImGuiWindowFlags values instead of ImGuiChildFlags?");
     IM_ASSERT((window_flags & ImGuiWindowFlags_AlwaysAutoResize) == 0 && "Cannot specify ImGuiWindowFlags_AlwaysAutoResize for BeginChild(). Use ImGuiChildFlags_AlwaysAutoResize!");
@@ -6465,6 +6465,10 @@ bool ImGui::BeginChildEx(const char* name, ImGuiID id, const ImVec2& size_arg, I
     {
         IM_ASSERT((child_flags & (ImGuiChildFlags_ResizeX | ImGuiChildFlags_ResizeY)) == 0 && "Cannot use ImGuiChildFlags_ResizeX or ImGuiChildFlags_ResizeY with ImGuiChildFlags_AlwaysAutoResize!");
         IM_ASSERT((child_flags & (ImGuiChildFlags_AutoResizeX | ImGuiChildFlags_AutoResizeY)) != 0 && "Must use ImGuiChildFlags_AutoResizeX or ImGuiChildFlags_AutoResizeY with ImGuiChildFlags_AlwaysAutoResize!");
+    }
+    if (child_flags & ImGuiChildFlags_TopLabel)
+    {
+        IM_ASSERT((!!name || (ImStrlen(name) > 0)) && "Cannot use ImGuiChildFlags_TopLabel without a name");
     }
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
     //if (window_flags & ImGuiWindowFlags_AlwaysUseWindowPadding) { child_flags |= ImGuiChildFlags_AlwaysUseWindowPadding; }
@@ -6491,7 +6495,13 @@ bool ImGui::BeginChildEx(const char* name, ImGuiID id, const ImVec2& size_arg, I
         PushStyleVar(ImGuiStyleVar_ChildBorderSize, g.Style.FrameBorderSize);
         PushStyleVar(ImGuiStyleVar_WindowPadding, g.Style.FramePadding);
         child_flags |= ImGuiChildFlags_Borders | ImGuiChildFlags_AlwaysUseWindowPadding;
+        child_flags &= ~ImGuiChildFlags_TopLabel;
         window_flags |= ImGuiWindowFlags_NoMove;
+    }
+
+    if (child_flags & ImGuiChildFlags_TopLabel && !(child_flags & ImGuiChildFlags_Borders))
+    {
+        child_flags &= ~ImGuiChildFlags_TopLabel;
     }
 
     // Forward size
@@ -6533,10 +6543,20 @@ bool ImGui::BeginChildEx(const char* name, ImGuiID id, const ImVec2& size_arg, I
     /*if (name && parent_window->IDStack.back() == parent_window->ID)
         ImFormatStringToTempBuffer(&temp_window_name, NULL, "%s/%s", parent_window->Name, name); // May omit ID if in root of ID stack
     else*/
+    int labelOffset = 0;
+    int labelLen = 0;
     if (name)
+    {
         ImFormatStringToTempBuffer(&temp_window_name, NULL, "%s/%s_%08X", parent_window->Name, name, id);
+        labelLen = static_cast<int>(FindRenderedTextEnd(name) - name);
+        if (labelLen)
+        {
+            labelOffset = static_cast<int>(ImStrlen(parent_window->Name) + 1); // len of "%s/" % parent_window-Name
+        }
+    }
     else
         ImFormatStringToTempBuffer(&temp_window_name, NULL, "%s/%08X", parent_window->Name, id);
+
 
     // Set style
     const float backup_border_size = g.Style.ChildBorderSize;
@@ -6556,6 +6576,10 @@ bool ImGui::BeginChildEx(const char* name, ImGuiID id, const ImVec2& size_arg, I
 
     ImGuiWindow* child_window = g.CurrentWindow;
     child_window->ChildId = id;
+
+    // Problem: this only has an effect next frame! So for the first frame, an empty label is used
+    child_window->LabelOffset = labelOffset;
+    child_window->LabelLen = labelLen;
 
     // Set the cursor to handle case where the user called SetNextWindowPos()+BeginChild() manually.
     // While this is not really documented/defined, it seems that the expected thing to do.
@@ -6634,6 +6658,23 @@ ImGuiWindow* ImGui::FindFrontMostVisibleChildWindow(ImGuiWindow* window)
         if (IsWindowActiveAndVisible(window->DC.ChildWindows[n]))
             return FindFrontMostVisibleChildWindow(window->DC.ChildWindows[n]);
     return window;
+}
+
+static inline bool WindowUsesLabeledBorder(const ImGuiWindow* window)
+{
+    bool res = false;
+    res |= (((window->Flags & ImGuiWindowFlags_ChildWindow) == ImGuiWindowFlags_ChildWindow) && ((window->ChildFlags & ImGuiChildFlags_TopLabel) == ImGuiChildFlags_TopLabel));
+    return res;
+}
+
+static inline ImRect GetWindowBorderRect(const ImGuiWindow* window)
+{
+    ImRect res = window->Rect();
+    if (WindowUsesLabeledBorder(window))
+    {
+        res.Min.y = ImMin(res.Min.y + window->BorderDecoOffset, res.Max.y);
+    }
+    return res;
 }
 
 static void SetWindowConditionAllowFlags(ImGuiWindow* window, ImGuiCond flags, bool enabled)
@@ -7161,14 +7202,58 @@ static inline void ClampWindowPos(ImGuiWindow* window, const ImRect& visibility_
     window->Pos = ImClamp(window->Pos, visibility_rect.Min - size_for_clamping, visibility_rect.Max);
 }
 
-static void RenderWindowOuterSingleBorder(ImGuiWindow* window, int border_n, ImU32 border_col, float border_size)
+static inline void RenderLabeledFrame(ImDrawList* draw_list, const char* label, const char* label_end, ImRect const& frame_rect, ImU32 col, float thickness, float rounding, ImVec2 label_align, ImVec2 padding = ImVec2(0, 0), ImVec2 spacing = ImVec2(1, 1), float extra_w = 0)
+{
+    if (!label_end) label_end = ImGui::FindRenderedTextEnd(label);
+    ImVec2 label_size = ImGui::CalcTextSize(label, label_end, true);
+    float padding2 = ImMax(padding.x, rounding);
+    float frame_width = frame_rect.GetWidth();
+    float label_avail_w = ImMax(0.0f, frame_width - padding2 * 2.0f);
+    const ImVec2 label_pos = frame_rect.GetTL() + ImVec2(padding2 + ImMax(0.0f, label_avail_w - label_size.x - extra_w) * label_align.x, padding.y);
+    ImRect rect = frame_rect;
+    rect.Min.y += padding.y + ImFloor(label_align.y * label_size.y);
+
+    // Draw frame rect, with a space for the label
+    if((col & IM_COL32_A_MASK) != 0)
+    {
+        rect.Min += ImVec2(0.50f, 0.50f);
+        if (draw_list->Flags & ImDrawListFlags_AntiAliasedLines)
+            rect.Max -= ImVec2(0.50f, 0.50f);
+        else
+            rect.Max -= ImVec2(0.49f, 0.49f); // Better looking lower-right corner and rounded non-AA shapes.
+        float label_left = label_pos.x - spacing.x;
+        float label_right = label_pos.x + label_size.x + spacing.x + extra_w;
+        if (label_right < (rect.GetTR().x - rounding))
+            draw_list->PathLineTo(ImVec2(label_right, rect.GetTR().y));
+        if (rounding < 0.5f)
+        {
+            draw_list->PathLineTo(rect.GetTR());
+            draw_list->PathLineTo(rect.GetBR());
+            draw_list->PathLineTo(rect.GetBL());
+            draw_list->PathLineTo(rect.GetTL());
+        }
+        else
+        {
+            draw_list->PathArcToFast(rect.GetTR() + ImVec2(-rounding, +rounding), rounding, 9, 12);
+            draw_list->PathArcToFast(rect.GetBR() + ImVec2(-rounding, -rounding), rounding, 0, 3);
+            draw_list->PathArcToFast(rect.GetBL() + ImVec2(+rounding, -rounding), rounding, 3, 6);
+            draw_list->PathArcToFast(rect.GetTL() + ImVec2(+rounding, +rounding), rounding, 6, 9);
+        }
+        if (label_left > (rect.GetTL().x + rounding))
+            draw_list->PathLineTo(ImVec2(label_left, rect.GetTL().y));
+        draw_list->PathStroke(col, thickness, ImDrawFlags_None);
+    }
+
+    ImGui::RenderTextEllipsis(draw_list, label_pos, ImVec2(frame_rect.Max.x, label_pos.y + label_size.y + ImMax(1.0f, spacing.y)), frame_rect.Max.x, label, label_end, &label_size);
+}
+
+static void RenderWindowOuterSingleBorder(ImDrawList* draw_list, ImRect const& window_rect, int border_n, ImU32 border_col, float border_size, float rounding)
 {
     const ImGuiResizeBorderDef& def = resize_border_def[border_n];
-    const float rounding = window->WindowRounding;
-    const ImRect border_r = GetResizeBorderRect(window, border_n, rounding, 0.0f);
-    window->DrawList->PathArcTo(ImLerp(border_r.Min, border_r.Max, def.SegmentN1) + ImVec2(0.5f, 0.5f) + def.InnerDir * rounding, rounding, def.OuterAngle - IM_PI * 0.25f, def.OuterAngle);
-    window->DrawList->PathArcTo(ImLerp(border_r.Min, border_r.Max, def.SegmentN2) + ImVec2(0.5f, 0.5f) + def.InnerDir * rounding, rounding, def.OuterAngle, def.OuterAngle + IM_PI * 0.25f);
-    window->DrawList->PathStroke(border_col, border_size);
+    ImRect border_r = GetResizeBorderRect(window_rect, border_n, rounding, 0.0f);
+    draw_list->PathArcTo(ImLerp(border_r.Min, border_r.Max, def.SegmentN1) + ImVec2(0.5f, 0.5f) + def.InnerDir * rounding, rounding, def.OuterAngle - IM_PI * 0.25f, def.OuterAngle);
+    draw_list->PathArcTo(ImLerp(border_r.Min, border_r.Max, def.SegmentN2) + ImVec2(0.5f, 0.5f) + def.InnerDir * rounding, rounding, def.OuterAngle, def.OuterAngle + IM_PI * 0.25f);
+    draw_list->PathStroke(border_col, border_size, ImDrawFlags_None);
 }
 
 static void ImGui::RenderWindowOuterBorders(ImGuiWindow* window)
@@ -7176,20 +7261,35 @@ static void ImGui::RenderWindowOuterBorders(ImGuiWindow* window)
     ImGuiContext& g = *GImGui;
     const float border_size = window->WindowBorderSize;
     const ImU32 border_col = GetColorU32(ImGuiCol_Border);
+    ImRect window_rect = GetWindowBorderRect(window);
     if (border_size > 0.0f && (window->Flags & ImGuiWindowFlags_NoBackground) == 0)
-        window->DrawList->AddRect(window->Pos, window->Pos + window->Size, border_col, window->WindowRounding, window->WindowBorderSize);
+    {
+        if (WindowUsesLabeledBorder(window))
+        {
+            ImVec2 label_align = g.Style.SeparatorTextAlign;
+            ImVec2 padding = ImVec2(g.Style.SeparatorTextPadding.x, g.Style.FramePadding.y);
+            ImVec2 spacing = g.Style.ItemSpacing;
+            const char* label = window->Name + window->LabelOffset;
+            const char* label_end = label + window->LabelLen;
+            RenderLabeledFrame(window->DrawList, label, label_end, window->Rect(), border_col, window->WindowBorderSize, window->WindowRounding, label_align, padding, spacing);
+        }
+        else
+        {
+            window->DrawList->AddRect(window_rect.Min, window_rect.Max, border_col, window->WindowRounding, window->WindowBorderSize);
+        }
+    }
     else if (border_size > 0.0f)
     {
         if (window->ChildFlags & ImGuiChildFlags_ResizeX) // Similar code as 'resize_border_mask' computation in UpdateWindowManualResize() but we specifically only always draw explicit child resize border.
-            RenderWindowOuterSingleBorder(window, 1, border_col, border_size);
+            RenderWindowOuterSingleBorder(window->DrawList, window_rect, 1, border_col, border_size, window->WindowRounding);
         if (window->ChildFlags & ImGuiChildFlags_ResizeY)
-            RenderWindowOuterSingleBorder(window, 3, border_col, border_size);
+            RenderWindowOuterSingleBorder(window->DrawList, window_rect, 3, border_col, border_size, window->WindowRounding);
     }
     if (window->ResizeBorderHovered != -1 || window->ResizeBorderHeld != -1)
     {
         const int border_n = (window->ResizeBorderHeld != -1) ? window->ResizeBorderHeld : window->ResizeBorderHovered;
         const ImU32 border_col_resizing = GetColorU32((window->ResizeBorderHeld != -1) ? ImGuiCol_SeparatorActive : ImGuiCol_SeparatorHovered);
-        RenderWindowOuterSingleBorder(window, border_n, border_col_resizing, ImMax(2.0f, window->WindowBorderSize)); // Thicker than usual
+        RenderWindowOuterSingleBorder(window->DrawList, window_rect, border_n, border_col_resizing, ImMax(2.0f, window->WindowBorderSize), window->WindowRounding); // Thicker than usual
     }
     if (g.Style.FrameBorderSize > 0 && !(window->Flags & ImGuiWindowFlags_NoTitleBar))
     {
@@ -7241,7 +7341,7 @@ void ImGui::RenderWindowDecorations(ImGuiWindow* window, const ImRect& title_bar
                 bg_col = (bg_col & ~IM_COL32_A_MASK) | (IM_F32_TO_INT8_SAT(alpha) << IM_COL32_A_SHIFT);
             if (bg_col & IM_COL32_A_MASK)
             {
-                ImRect bg_rect(window->Pos + ImVec2(0, window->TitleBarHeight), window->Pos + window->Size);
+                ImRect bg_rect = GetWindowBorderRect(window);
                 ImDrawFlags bg_rounding_flags = (flags & ImGuiWindowFlags_NoTitleBar) ? ImDrawFlags_RoundCornersAll : ImDrawFlags_RoundCornersBottom;
                 ImDrawList* bg_draw_list = window->DrawList;
                 bg_draw_list->AddRectFilled(bg_rect.Min, bg_rect.Max, bg_col, window_rounding, bg_rounding_flags);
@@ -7260,6 +7360,7 @@ void ImGui::RenderWindowDecorations(ImGuiWindow* window, const ImRect& title_bar
         {
             ImRect menu_bar_rect = window->MenuBarRect();
             menu_bar_rect.ClipWith(window->Rect());  // Soft clipping, in particular child window don't have minimum size covering the menu bar so this is useful for them.
+            menu_bar_rect.Min.y -= (window->TitleBarHeight - window->BorderDecoOffset);
             window->DrawList->AddRectFilled(menu_bar_rect.Min, menu_bar_rect.Max, GetColorU32(ImGuiCol_MenuBarBg), (flags & ImGuiWindowFlags_NoTitleBar) ? window_rounding : 0.0f, ImDrawFlags_RoundCornersTop);
             if (style.FrameBorderSize > 0.0f && menu_bar_rect.Max.y < window->Pos.y + window->Size.y)
                 window->DrawList->AddLineH(menu_bar_rect.Min.x + window_border_size * 0.5f, menu_bar_rect.Max.x - window_border_size * 0.5f, menu_bar_rect.Max.y, GetColorU32(ImGuiCol_Border), style.FrameBorderSize);
@@ -7745,8 +7846,18 @@ bool ImGui::Begin(const char* name, bool* p_open, ImGuiWindowFlags flags)
         // Outer Decoration Sizes
         // (we need to clear ScrollbarSize immediately as CalcWindowAutoFitSize() needs it and can be called from other locations).
         const ImVec2 scrollbar_sizes_from_last_frame = window->ScrollbarSizes;
+        window->BorderDecoOffset = 0.0f;
         window->DecoOuterSizeX1 = 0.0f;
         window->DecoOuterSizeX2 = 0.0f;
+        if (WindowUsesLabeledBorder(window))
+        {
+            const float padding = g.Style.FramePadding.y;
+            const float align = g.Style.SeparatorTextAlign.y;
+            const float f = g.FontSize;
+            // To Render the window background (in RenderWindowDecorations())under the top border, which is lowered by the align
+            window->TitleBarHeight += (padding * 2 + f);
+            window->BorderDecoOffset = (padding + ImFloor(f * align));
+        }
         window->DecoOuterSizeY1 = window->TitleBarHeight + window->MenuBarHeight;
         window->DecoOuterSizeY2 = 0.0f;
         window->ScrollbarSizes = ImVec2(0.0f, 0.0f);

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -7311,6 +7311,8 @@ void ImGui::RenderWindowDecorations(ImGuiWindow* window, const ImRect& title_bar
     window->SkipItems = false;
     window->DC.NavLayerCurrent = ImGuiNavLayer_Menu;
 
+    const bool enable_labeled_border_background_hack = true;
+
     // Draw window + handle manual resize
     // As we highlight the title bar when want_focus is set, multiple reappearing windows will have their title bar highlighted on their reappearing frame.
     const float window_rounding = window->WindowRounding;
@@ -7342,7 +7344,15 @@ void ImGui::RenderWindowDecorations(ImGuiWindow* window, const ImRect& title_bar
             if (bg_col & IM_COL32_A_MASK)
             {
                 ImRect bg_rect = GetWindowBorderRect(window);
-                ImDrawFlags bg_rounding_flags = (flags & ImGuiWindowFlags_NoTitleBar) ? ImDrawFlags_RoundCornersAll : ImDrawFlags_RoundCornersBottom;
+                if (enable_labeled_border_background_hack && WindowUsesLabeledBorder(window) && window->WindowBorderSize == 1.0f)
+                {
+                    // Hack: The border of the window is centered on the edge of the rect, with the size equaly spread both sides of the edge.
+                    // But if the border is 1px wide, the background should not overlap the border (it looks better).
+                    // -> Reduce the backgroud rect to be inside the boders in this case.
+                    bg_rect.Min += ImVec2(1, 1);
+                    bg_rect.Max -= ImVec2(1, 1);
+                }
+                ImDrawFlags bg_rounding_flags = (flags & ImGuiWindowFlags_NoTitleBar) ? 0 : ImDrawFlags_RoundCornersBottom;
                 ImDrawList* bg_draw_list = window->DrawList;
                 bg_draw_list->AddRectFilled(bg_rect.Min, bg_rect.Max, bg_col, window_rounding, bg_rounding_flags);
             }
@@ -7361,6 +7371,11 @@ void ImGui::RenderWindowDecorations(ImGuiWindow* window, const ImRect& title_bar
             ImRect menu_bar_rect = window->MenuBarRect();
             menu_bar_rect.ClipWith(window->Rect());  // Soft clipping, in particular child window don't have minimum size covering the menu bar so this is useful for them.
             menu_bar_rect.Min.y -= (window->TitleBarHeight - window->BorderDecoOffset);
+            if (enable_labeled_border_background_hack && WindowUsesLabeledBorder(window) && window->WindowBorderSize == 1.0f)
+            {
+                // See background Hack above
+                menu_bar_rect.Min.y += 1;
+            }
             window->DrawList->AddRectFilled(menu_bar_rect.Min, menu_bar_rect.Max, GetColorU32(ImGuiCol_MenuBarBg), (flags & ImGuiWindowFlags_NoTitleBar) ? window_rounding : 0.0f, ImDrawFlags_RoundCornersTop);
             if (style.FrameBorderSize > 0.0f && menu_bar_rect.Max.y < window->Pos.y + window->Size.y)
                 window->DrawList->AddLineH(menu_bar_rect.Min.x + window_border_size * 0.5f, menu_bar_rect.Max.x - window_border_size * 0.5f, menu_bar_rect.Max.y, GetColorU32(ImGuiCol_Border), style.FrameBorderSize);

--- a/imgui.h
+++ b/imgui.h
@@ -1221,7 +1221,7 @@ enum ImGuiChildFlags_
     ImGuiChildFlags_AlwaysAutoResize        = 1 << 6,   // Combined with AutoResizeX/AutoResizeY. Always measure size even when child is hidden, always return true, always disable clipping optimization! NOT RECOMMENDED.
     ImGuiChildFlags_FrameStyle              = 1 << 7,   // Style the child window like a framed item: use FrameBg, FrameRounding, FrameBorderSize, FramePadding instead of ChildBg, ChildRounding, ChildBorderSize, WindowPadding.
     ImGuiChildFlags_NavFlattened            = 1 << 8,   // [BETA] Share focus scope, allow keyboard/gamepad navigation to cross over parent border to this child or between sibling child windows.
-
+    ImGuiChildFlags_TopLabel                = 1 << 9,
     // Obsolete names
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
     //ImGuiChildFlags_Border                = ImGuiChildFlags_Borders,  // Renamed in 1.91.1 (August 2024) for consistency.

--- a/imgui.h
+++ b/imgui.h
@@ -1227,7 +1227,7 @@ enum ImGuiChildFlags_
     ImGuiChildFlags_AlwaysAutoResize        = 1 << 6,   // Combined with AutoResizeX/AutoResizeY. Always measure size even when child is hidden, always return true, always disable clipping optimization! NOT RECOMMENDED.
     ImGuiChildFlags_FrameStyle              = 1 << 7,   // Style the child window like a framed item: use FrameBg, FrameRounding, FrameBorderSize, FramePadding instead of ChildBg, ChildRounding, ChildBorderSize, WindowPadding.
     ImGuiChildFlags_NavFlattened            = 1 << 8,   // [BETA] Share focus scope, allow keyboard/gamepad navigation to cross over parent border to this child or between sibling child windows.
-
+    ImGuiChildFlags_TopLabel                = 1 << 9,
     // Obsolete names
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
     //ImGuiChildFlags_Border                = ImGuiChildFlags_Borders,  // Renamed in 1.91.1 (August 2024) for consistency.

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -4356,8 +4356,10 @@ static void DemoWindowLayout()
         HelpMarker("Use child windows to begin into a self-contained independent scrolling/clipping regions within a host window.");
         static bool disable_mouse_wheel = false;
         static bool disable_menu = false;
+        static bool enable_top_label = false;
         ImGui::Checkbox("Disable Mouse Wheel", &disable_mouse_wheel);
         ImGui::Checkbox("Disable Menu", &disable_menu);
+        ImGui::Checkbox("Enable Top Label", &enable_top_label);
 
         // Child 1: no border, enable horizontal scrollbar
         {
@@ -4375,12 +4377,15 @@ static void DemoWindowLayout()
         // Child 2: rounded border
         {
             ImGuiWindowFlags window_flags = ImGuiWindowFlags_None;
+            ImGuiChildFlags child_flags = ImGuiChildFlags_None;
             if (disable_mouse_wheel)
                 window_flags |= ImGuiWindowFlags_NoScrollWithMouse;
             if (!disable_menu)
                 window_flags |= ImGuiWindowFlags_MenuBar;
+            if(enable_top_label)
+                child_flags |= ImGuiChildFlags_TopLabel;
             ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 5.0f);
-            ImGui::BeginChild("ChildR", ImVec2(0, 260), ImGuiChildFlags_Borders, window_flags);
+            ImGui::BeginChild("ChildR", ImVec2(0, 260), ImGuiChildFlags_Borders | child_flags, window_flags);
             if (!disable_menu && ImGui::BeginMenuBar())
             {
                 if (ImGui::BeginMenu("Menu"))
@@ -4461,6 +4466,7 @@ static void DemoWindowLayout()
             ImGui::SameLine(); HelpMarker("Style the child window like a framed item: use FrameBg, FrameRounding, FrameBorderSize, FramePadding instead of ChildBg, ChildRounding, ChildBorderSize, WindowPadding.");
             if (child_flags & ImGuiChildFlags_FrameStyle)
                 override_bg_color = false;
+            ImGui::CheckboxFlags("ImGuiChildFlags_TopLabel", &child_flags, ImGuiChildFlags_TopLabel);
 
             ImGui::SetCursorPosX(ImGui::GetCursorPosX() + (float)offset_x);
             if (override_bg_color)

--- a/imgui_demo.cpp
+++ b/imgui_demo.cpp
@@ -4465,8 +4465,10 @@ static void DemoWindowLayout()
         HelpMarker("Use child windows to begin into a self-contained independent scrolling/clipping regions within a host window.");
         static bool disable_mouse_wheel = false;
         static bool disable_menu = false;
+        static bool enable_top_label = false;
         ImGui::Checkbox("Disable Mouse Wheel", &disable_mouse_wheel);
         ImGui::Checkbox("Disable Menu", &disable_menu);
+        ImGui::Checkbox("Enable Top Label", &enable_top_label);
 
         // Child 1: no border, enable horizontal scrollbar
         {
@@ -4484,12 +4486,15 @@ static void DemoWindowLayout()
         // Child 2: rounded border
         {
             ImGuiWindowFlags window_flags = ImGuiWindowFlags_None;
+            ImGuiChildFlags child_flags = ImGuiChildFlags_None;
             if (disable_mouse_wheel)
                 window_flags |= ImGuiWindowFlags_NoScrollWithMouse;
             if (!disable_menu)
                 window_flags |= ImGuiWindowFlags_MenuBar;
+            if(enable_top_label)
+                child_flags |= ImGuiChildFlags_TopLabel;
             ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 5.0f);
-            ImGui::BeginChild("ChildR", ImVec2(0, 260), ImGuiChildFlags_Borders, window_flags);
+            ImGui::BeginChild("ChildR", ImVec2(0, 260), ImGuiChildFlags_Borders | child_flags, window_flags);
             if (!disable_menu && ImGui::BeginMenuBar())
             {
                 if (ImGui::BeginMenu("Menu"))
@@ -4570,6 +4575,7 @@ static void DemoWindowLayout()
             ImGui::SameLine(); HelpMarker("Style the child window like a framed item: use FrameBg, FrameRounding, FrameBorderSize, FramePadding instead of ChildBg, ChildRounding, ChildBorderSize, WindowPadding.");
             if (child_flags & ImGuiChildFlags_FrameStyle)
                 override_bg_color = false;
+            ImGui::CheckboxFlags("ImGuiChildFlags_TopLabel", &child_flags, ImGuiChildFlags_TopLabel);
 
             ImGui::SetCursorPosX(ImGui::GetCursorPosX() + (float)offset_x);
             if (override_bg_color)

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -2651,10 +2651,13 @@ struct IMGUI_API ImGuiWindow
     float                   WindowRounding;                     // Window rounding at the time of Begin(). May be clamped lower to avoid rendering artifacts with title bar, menu bar etc.
     float                   WindowBorderSize;                   // Window border size at the time of Begin().
     float                   TitleBarHeight, MenuBarHeight;      // Note that those used to be function before 2024/05/28. If you have old code calling TitleBarHeight() you can change it to TitleBarHeight.
+    float                   BorderDecoOffset;                   // Vertical offset of the top border from the top of the window frame (used when rendering the window with a labled frame)
     float                   DecoOuterSizeX1, DecoOuterSizeY1;   // Left/Up offsets. Sum of non-scrolling outer decorations (X1 generally == 0.0f. Y1 generally = TitleBarHeight + MenuBarHeight). Locked during Begin().
     float                   DecoOuterSizeX2, DecoOuterSizeY2;   // Right/Down offsets (X2 generally == ScrollbarSize.x, Y2 == ScrollbarSizes.y).
     float                   DecoInnerSizeX1, DecoInnerSizeY1;   // Applied AFTER/OVER InnerRect. Specialized for Tables as they use specialized form of clipping and frozen rows/columns are inside InnerRect (and not part of regular decoration sizes).
     int                     NameBufLen;                         // Size of buffer storing Name. May be larger than strlen(Name)!
+    int                     LabelOffset;                        // Where the label of the child window is stored in the Name buffer
+    int                     LabelLen;                           // Len of the child window label
     ImGuiID                 MoveId;                             // == window->GetID("#MOVE")
     ImGuiID                 ChildId;                            // ID of corresponding item in parent window (for navigation to return from child window to parent window)
     ImGuiID                 PopupId;                            // ID in the popup stack when this window is used as a popup/menu (because we use generic Name/ID for recycling)

--- a/imgui_internal.h
+++ b/imgui_internal.h
@@ -2689,10 +2689,13 @@ struct IMGUI_API ImGuiWindow
     float                   WindowRounding;                     // Window rounding at the time of Begin(). May be clamped lower to avoid rendering artifacts with title bar, menu bar etc.
     float                   WindowBorderSize;                   // Window border size at the time of Begin().
     float                   TitleBarHeight, MenuBarHeight;      // Note that those used to be function before 2024/05/28. If you have old code calling TitleBarHeight() you can change it to TitleBarHeight.
+    float                   BorderDecoOffset;                   // Vertical offset of the top border from the top of the window frame (used when rendering the window with a labled frame)
     float                   DecoOuterSizeX1, DecoOuterSizeY1;   // Left/Up offsets. Sum of non-scrolling outer decorations (X1 generally == 0.0f. Y1 generally = TitleBarHeight + MenuBarHeight). Locked during Begin().
     float                   DecoOuterSizeX2, DecoOuterSizeY2;   // Right/Down offsets (X2 generally == ScrollbarSize.x, Y2 == ScrollbarSizes.y).
     float                   DecoInnerSizeX1, DecoInnerSizeY1;   // Applied AFTER/OVER InnerRect. Specialized for Tables as they use specialized form of clipping and frozen rows/columns are inside InnerRect (and not part of regular decoration sizes).
     int                     NameBufLen;                         // Size of buffer storing Name. May be larger than strlen(Name)!
+    int                     LabelOffset;                        // Where the label of the child window is stored in the Name buffer
+    int                     LabelLen;                           // Len of the child window label
     ImGuiID                 MoveId;                             // == window->GetID("#MOVE")
     ImGuiID                 ChildId;                            // ID of corresponding item in parent window (for navigation to return from child window to parent window)
     ImGuiID                 PopupId;                            // ID in the popup stack when this window is used as a popup/menu (because we use generic Name/ID for recycling)


### PR DESCRIPTION
I am proposing to add labeled border to child windows.

-----------------
### Motivation

Child windows rendered with a border (using `ImGuiChildFlags_Borders`) often need to be labeled.
This can be done using a `SeparatorText(label)` at the begining, but this is not the most elegant solution.
GUI APIs generaly provide a way to render a labeled border (fieldset in HTML, TitledBorder in java.swing or QGroupBox in Qt to name a few), but I haven't found a way to do it with imgui.
It is possible to construct a labled border with a custom wrapper arround `Begin/EndChild()` (as mentioned in the comments of #9181, not sure how it interacts with other window decorations), but I think it makes sense for imgui to support this feature "natively".

![Example of labled border section](https://github.com/user-attachments/assets/ca6efd89-367d-434c-bb30-344c1f5d2882 "Peak GUI design")

-----------------
### Solution

I propose to add a new child flag to decorate the child with a labled border: `ImGuiChildFlags_TopLabel` (must be used with `ImGuiChildFlags_Borders`).
This does not introduce any breaking change.
This is then handled by the backend code for rendering window's border / decoration.

![Simple example of a labled border](https://github.com/user-attachments/assets/cb2f398e-7263-49ac-9941-63eba2fe2a44 "Simple example of a labled border") ![Simple example of a rounded labled border](https://github.com/user-attachments/assets/4f312394-a744-4268-9d41-a7072fe17562 "Simple example of a rounded labled border")

The labeled border depends on several parameters:
- child window name (the one passed to `BeginChild(const char* name)`, not the constructed child name) for the label.
- child window rect (`window->Rect()`)
- the border color is controlled by `ImGuiCol_Border` like with the classic border.
- The label is rendered with `RenderTextEllipsis()` (like `SeparatorText()`) (so indirectly colored with `ImGuiCol_Text`).
- The border size is set by `window->WindowBorderSize` (set by `style.ChildBorderSize`).
- The border can be rounded with `window->WindowBorderSize` (set by `style.ChildBorderSize`).
- The label alignment is controlled by `Style.SeparatorTextAlign`. I think it makes sense to re-use separator control variables here.
- The horizontal label padding is controlled by `Style.SeparatorTextPadding.x`, same argument as above.
- The vertical label padding is controlled by `Style.FramePadding.y`, because this is not a separatorn but a frame.
- The spacing (space (in pixel) between the label and the horizontal bars left and right) is controlled by `Style.ItemSpacing` (same as `SeparatorText()`)

I had to add three members to `ImGuiWindow`:
- `BorderDecoOffset` is the vertical offset (in pixel) at which the top border starts.
- `LabelOffset` and `LabelLen` to store the label of the child window (Since the window name of the child is some combination of the parent name, name and the id). As noted in the code, there is a little issue where this label is not available at the first frame of the window creation.

I added a helper `RenderLabeledFrame()` which is essentialy a mashup between `DrawList::AddRect()` and `SeparatorText()`.
Currently it is only declared in `imgui.cpp`, but it could be worth declaring it in a header as part of the imgui API.

There are some interaction with other child rendering features:
- background / menu bar rect must adjusted to the new border rect.
- resize handles must adjusted to the new border rect.

##### API discussion:
One could argue that it is not necessary to add a new flag `ImGuiChildFlags_TopLabel` to use a bordered label:
If the `BeginChild` is called with `ImGuiChildFlags_Borders` and a name with a non empty rendering name (according to `FindRenderedTextEnd()`), then a labeled border should be used.
```cpp
ImGui::BeginChild("##Child", ImVec2(0, 0), ImGuiChildFlags_Borders); // Regular child with a plain border
ImGui::BeginChild("Child", ImVec2(0, 0), ImGuiChildFlags_Borders); // Child with a labeled border
```
The main issue is that this would be a breaking change.



-----------------
### Background rendering tweak
I did some tweaks (in de7e90c5a63e6ccd4e97f247cbd94b62fff1bfbe) to improve the visuals when the child window has a background (or a menu bar).
The issue is best explained visually:

![Without tweak](https://github.com/user-attachments/assets/98527af9-8451-4203-a6d8-05428ac68993 "Without tweak") Without tweak.
![With tweak](https://github.com/user-attachments/assets/fbabf757-acb3-4019-8729-391f8b72980e "With tweak") With tweak.



The background rect is the same as the border rect. But with labled border, there is hole in the border arround the label.
When the border is one pixel thick, the background is in the continuation of the border in the label region, which is less pleasantly looking than when the background is "contained" one pixel below with the tweak.
The solution is to manually crop by one pixel the edges of the background rectange.
A similar tweak is also aplied for the menu bar:

![Menu without tweak](https://github.com/user-attachments/assets/1e589359-f66d-48b6-84e2-09a1834ee0e9 "Menu without tweak") Without tweak.
![Menu with tweak](https://github.com/user-attachments/assets/569cb44e-f825-4f25-a0ec-4c00c6146a1c "Menu with tweak") With tweak.



-----------------
### Possible extensions

Here are some ideas for potential improvements I did not include in this PR:
- #### Collapsing child window:
	Windows can be collapsed, but that requires a title bar (which is currently explicitely disabled for child windows). I think it would make sense to allow child window collapsing, and it would fit well with labled border. When collapsed, only the top border with the label would be shown (essentialy a `SeparatorText()` with a symbol indicating that it can be opened like a `TreeNode()`).
- #### Tootips:
	Tooltips already have a border. It would be possible to decorate the top border with a label (with a vertical alignment forced to zero).
- #### Header and Footer labels:
	We could add an option to label the top border or (inclusive) the bottom border (with a mirror alignment).
- #### Using the space in the top border
	`SeparatorText()` provides an `extra_w` parameter to reserve some space in the separator bar (and sets the cursor there). Maybe a similar mechanism could be done with labeled border, given that its similarity with `SeparatorText()`.
