### PR TITLE
Avoid focusing default window

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -5703,7 +5703,7 @@ void ImGui::NewFrame()
     // This fallback is particularly important as it prevents ImGui:: calls from crashing.
     g.WithinFrameScopeWithImplicitWindow = true;
     SetNextWindowSize(ImVec2(400, 400), ImGuiCond_FirstUseEver);
-    Begin("Debug##Default");
+    Begin("Debug##Default", NULL, ImGuiWindowFlags_NoFocusOnAppearing);
     IM_ASSERT(g.CurrentWindow->IsFallbackWindow == true);
 
     // Store stack sizes


### PR DESCRIPTION
Dear ImGui capture keyboard focus even if no ImGui windows was created at all.
I see this behaviour strange and undesirable.

How to reproduce:
- use any example from examples/
- remove all code responsible for creating windows (usually `ImGui::Begin`, etc)
- rebuild
=> on app startup `ImGui::GetIO().WantCaptureKeyboard == true`

If required, I can create small example to reproduce.

Also, I noticed same problem in docking branch with `ImGui::DockSpaceOverViewport` function. If current solution acceptable I will create similar PR for docking too
