### PR TITLE
BeginCombo(): arrow direction reflects open/close state

### DIFF
--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -1951,7 +1951,7 @@ bool ImGui::BeginCombo(const char* label, const char* preview_value, ImGuiComboF
         ImU32 text_col = GetColorU32(ImGuiCol_Text);
         window->DrawList->AddRectFilled(ImVec2(value_x2, bb.Min.y), bb.Max, bg_col, style.FrameRounding, (w <= arrow_size) ? ImDrawFlags_RoundCornersAll : ImDrawFlags_RoundCornersRight);
         if (value_x2 + arrow_size - style.FramePadding.x <= bb.Max.x)
-            RenderArrow(window->DrawList, ImVec2(value_x2 + style.FramePadding.y, bb.Min.y + style.FramePadding.y), text_col, ImGuiDir_Down, 1.0f);
+            RenderArrow(window->DrawList, ImVec2(value_x2 + style.FramePadding.y, bb.Min.y + style.FramePadding.y), text_col, popup_open ? ImGuiDir_Down : ImGuiDir_Right, 1.0f);
     }
     RenderFrameBorder(bb.Min, bb.Max, style.FrameRounding);
 


### PR DESCRIPTION
This change makes the arrow in BeginCombo() reflect the popup open state.
Previously, it always pointed down, even when the combo was open.

Minimal change: only the arrow direction is modified.
Behavior and layout of other widgets remain unchanged.

Reproduces with any backend.

Closes #9244 

