### PR TITLE
Examples: SDL3+WGPU add missing static keyword on function declaration

### DIFF
--- a/examples/example_sdl3_wgpu/main.cpp
+++ b/examples/example_sdl3_wgpu/main.cpp
@@ -41,7 +41,7 @@ static int                      wgpu_surface_height = 800;
 
 // Forward declarations
 static bool InitWGPU(SDL_Window* window);
-WGPUSurface CreateWGPUSurface(const WGPUInstance& instance, SDL_Window* window);
+static WGPUSurface CreateWGPUSurface(const WGPUInstance& instance, SDL_Window* window);
 
 static void ResizeSurface(int width, int height)
 {


### PR DESCRIPTION
Missing `static` keyword on function declaration `CreateWGPUSurface(...)` causes declaration and definition difference and fails the [compilation](https://github.com/adembudak/CMakeForImGui/actions/runs/22155231244/job/64057174941). Nitpicky but adding it fixes the problem.