### PR TITLE
Emscripten Examples: add tabindex=-1 to canvas in shell_minimal.html

### DIFF
--- a/examples/libs/emscripten/shell_minimal.html
+++ b/examples/libs/emscripten/shell_minimal.html
@@ -29,7 +29,7 @@
     </style>
   </head>
   <body>
-    <canvas class="emscripten" id="canvas" oncontextmenu="event.preventDefault()"></canvas>
+    <canvas class="emscripten" id="canvas" oncontextmenu="event.preventDefault()" tabindex=-1></canvas>
     <script type='text/javascript'>
       var Module = {
         preRun: [],


### PR DESCRIPTION
Hi Omar,

This follows our discussion on the manual, where the Ctrl key could be stuck.

Without tabindex, the canvas element is not focusable in the DOM, so pongasoft/emscripten-glfw's focus/blur listeners on the canvas never fire. This means glfwSetWindowFocusCallback is never called, and ImGui_ImplGlfw_WindowFocusCallback never triggers io.AddFocusEvent(false) -> ClearInputKeys() + ClearInputMouse().

Result: modifier keys (Ctrl, Shift, Alt, Super) get stuck after Cmd-Tab / Alt-Tab window switching.

The default Emscripten shell already includes tabindex=-1.

Ref: https://github.com/pongasoft/emscripten-glfw/issues/29


