### PR TITLE
Use ImGuiKey_Menu and Shift + F10 to invoke the context menu via keyboard

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -12496,7 +12496,11 @@ void ImGui::OpenPopupOnItemClick(const char* str_id, ImGuiPopupFlags popup_flags
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = g.CurrentWindow;
     ImGuiMouseButton mouse_button = GetMouseButtonFromPopupFlags(popup_flags);
-    if (IsMouseReleased(mouse_button) && IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup))
+    bool isMouseInvocation = IsMouseReleased(mouse_button) && IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup);
+    bool isKeyboardInvocation = false;
+    if ((g.IO.ConfigFlags & ImGuiConfigFlags_NavEnableKeyboard) && IsItemFocused())
+        isKeyboardInvocation = IsKeyReleased(ImGuiKey_Menu) || (IsKeyReleased(ImGuiKey_F10) && g.IO.KeyShift);
+    if (isKeyboardInvocation || isMouseInvocation)
     {
         ImGuiID id = str_id ? window->GetID(str_id) : g.LastItemData.ID;    // If user hasn't passed an ID, we can use the LastItemID. Using LastItemID as a Popup ID won't conflict!
         IM_ASSERT(id != 0);                                             // You cannot pass a NULL str_id if the last item has no identifier (e.g. a Text() item)
@@ -12529,7 +12533,11 @@ bool ImGui::BeginPopupContextItem(const char* str_id, ImGuiPopupFlags popup_flag
     ImGuiID id = str_id ? window->GetID(str_id) : g.LastItemData.ID;    // If user hasn't passed an ID, we can use the LastItemID. Using LastItemID as a Popup ID won't conflict!
     IM_ASSERT(id != 0);                                             // You cannot pass a NULL str_id if the last item has no identifier (e.g. a Text() item)
     ImGuiMouseButton mouse_button = GetMouseButtonFromPopupFlags(popup_flags);
-    if (IsMouseReleased(mouse_button) && IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup))
+    bool isMouseInvocation = IsMouseReleased(mouse_button) && IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup);
+    bool isKeyboardInvocation = false;
+    if ((g.IO.ConfigFlags & ImGuiConfigFlags_NavEnableKeyboard) && IsItemFocused())
+        isKeyboardInvocation = IsKeyReleased(ImGuiKey_Menu) || (IsKeyReleased(ImGuiKey_F10) && g.IO.KeyShift);
+    if (isKeyboardInvocation || isMouseInvocation)
         OpenPopupEx(id, popup_flags);
     return BeginPopupEx(id, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoSavedSettings);
 }
@@ -12542,8 +12550,12 @@ bool ImGui::BeginPopupContextWindow(const char* str_id, ImGuiPopupFlags popup_fl
         str_id = "window_context";
     ImGuiID id = window->GetID(str_id);
     ImGuiMouseButton mouse_button = GetMouseButtonFromPopupFlags(popup_flags);
-    if (IsMouseReleased(mouse_button) && IsWindowHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup))
-        if (!(popup_flags & ImGuiPopupFlags_NoOpenOverItems) || !IsAnyItemHovered())
+    bool isMouseInvocation = IsMouseReleased(mouse_button) && IsWindowHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup);
+    bool isKeyboardInvocation = false;
+    if ((g.IO.ConfigFlags & ImGuiConfigFlags_NavEnableKeyboard) && IsWindowFocused())
+        isKeyboardInvocation = IsKeyReleased(ImGuiKey_Menu) || (IsKeyReleased(ImGuiKey_F10) && g.IO.KeyShift);
+    if (isMouseInvocation || isKeyboardInvocation)
+        if (!(popup_flags & ImGuiPopupFlags_NoOpenOverItems) || !IsAnyItemHovered() || isKeyboardInvocation)
             OpenPopupEx(id, popup_flags);
     return BeginPopupEx(id, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoSavedSettings);
 }


### PR DESCRIPTION
I have been experimenting with this for better keyboard accessibility. I'd suggest allowing the use of `ImGuiKey_Menu` for this since that is the exact reason this key exists. 

This issue was also was discussed in https://github.com/ocornut/imgui/issues/8803 and it was mentioned that the windows convention for this is Shift + F10. I also implemented it as an alternative for keyboards that don't have `ImGuiKey_Menu`.

I'm not familiar enough with ImGui internals to know if this causes any issues so consider this mostly a draft to discuss potential issues or a better implementation

Most content in the demo window works with these changes, but there are a couple of issues still open:
- Popups attached to non-selectable items can't be opened since the nav cursor can't highlight those UI components. Example: https://github.com/ocornut/imgui/blob/ba84d2d37253c89b17b2cb7b357e130093b79ef5/imgui_demo.cpp#L5412-L5413 
- `BeginPopupContextWindow` opens the context menu near the mouse cursor rather than next to the nav cursor, this is not an issue but just an annoyance. One such example is the asset browser https://github.com/ocornut/imgui/blob/ba84d2d37253c89b17b2cb7b357e130093b79ef5/imgui_demo.cpp#L10996-L10998
- What about items that have different popups depending on which button is pressed? I didn't find any such case in the demo window and I'd argue this is an anti-pattern since there is no meaningful way to make it keyboard-accessible. It's not something that should be encouraged.
- Lots of code is repeated, maybe it needs an helper function to check for the keypresses?

