### PR TITLE
Fixes the scaling issue in example_sdl2_wgpu

### DIFF
--- a/examples/example_sdl2_wgpu/main.cpp
+++ b/examples/example_sdl2_wgpu/main.cpp
@@ -53,7 +53,7 @@ int main(int, char**)
 
     // Create window with graphics context
     float main_scale = ImGui_ImplSDL2_GetContentScaleForDisplay(0);
-    SDL_WindowFlags window_flags = SDL_WINDOW_RESIZABLE;
+    SDL_WindowFlags window_flags = static_cast<SDL_WindowFlags>(SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
     SDL_Window* window = SDL_CreateWindow("Dear ImGui SDL2+WebGPU example", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, wgpu_surface_width, wgpu_surface_height, window_flags);
     if (window == nullptr)
     {
@@ -143,7 +143,7 @@ int main(int, char**)
 
         // React to changes in screen size
         int width, height;
-        SDL_GetWindowSize(window, &width, &height);
+        SDL_GetWindowSizeInPixels(window, &width, &height);
         if (width != wgpu_surface_width || height != wgpu_surface_height)
             ResizeSurface(width, height);
 


### PR DESCRIPTION
@ocornut This is a PR for the issues you expressed in this [comment](https://github.com/ocornut/imgui/pull/9281#issuecomment-4024619038) (_SDL2+WGPU looks extremely bad (screenshot)._)

I checked the code and was able to find a fix that is pretty small. I tested it on Windows with scaling as well as on macOS with retina display.



- enable HIGHDPI support (window flag)
- use SDL_GetWindowSizeInPixels which returns the size to give to the WebGPU buffer (account for scaling factor)

