### PR TITLE
DrawList: Fix erroneous segment count for small arcs on large circles… (#9313)

### DIFF
--- a/imgui_draw.cpp
+++ b/imgui_draw.cpp
@@ -1312,7 +1312,7 @@ void ImDrawList::PathArcTo(const ImVec2& center, float radius, float a_min, floa
     {
         const float arc_length = ImAbs(a_max - a_min);
         const int circle_segment_count = _CalcCircleAutoSegmentCount(radius);
-        const int arc_segment_count = ImMax((int)ImCeil(circle_segment_count * arc_length / (IM_PI * 2.0f)), (int)(2.0f * IM_PI / arc_length));
+        const int arc_segment_count = ImMax((int)ImCeil(circle_segment_count * arc_length / (IM_PI * 2.0f)), 1);
         _PathArcToN(center, radius, a_min, a_max, arc_segment_count);
     }
 }


### PR DESCRIPTION
… feed to _PathArcToN (#9313) (thx @epajarre)

This address issue #9313 reported by @epajarre:

ImDrawList::PathArcTo segment count approaches infinite when difference between arc parameters a_min and a_max gets smaller #9313

Basically, for large circles where we are outside fast-arc optimization code and small arcs code incorrectly counted 'how many times this arc fit on a circle', which will grow to infinity when arcs are getting smaller. Calculated was taken as segment count.
That was removed and minimum number of emitted segments is now 1.