### PR TITLE
ColorPicker4: add option to fix triangle in wheel picker

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -1907,8 +1907,9 @@ enum ImGuiColorEditFlags_
     ImGuiColorEditFlags_Float           = 1 << 24,  // [DataType]   // ColorEdit, ColorPicker, ColorButton: _display_ values formatted as 0.0f..1.0f floats instead of 0..255 integers. No round-trip of value via integers.
     ImGuiColorEditFlags_PickerHueBar    = 1 << 25,  // [Picker]     // ColorPicker: bar for Hue, rectangle for Sat/Value.
     ImGuiColorEditFlags_PickerHueWheel  = 1 << 26,  // [Picker]     // ColorPicker: wheel for Hue, triangle for Sat/Value.
-    ImGuiColorEditFlags_InputRGB        = 1 << 27,  // [Input]      // ColorEdit, ColorPicker: input and output data in RGB format.
-    ImGuiColorEditFlags_InputHSV        = 1 << 28,  // [Input]      // ColorEdit, ColorPicker: input and output data in HSV format.
+    ImGuiColorEditFlags_FixedTriangle   = 1 << 27,  // [Picker]     // ColorPicker: fix triangle position for PickerHueWheel.
+    ImGuiColorEditFlags_InputRGB        = 1 << 28,  // [Input]      // ColorEdit, ColorPicker: input and output data in RGB format.
+    ImGuiColorEditFlags_InputHSV        = 1 << 29,  // [Input]      // ColorEdit, ColorPicker: input and output data in HSV format.
 
     // Defaults Options. You can set application defaults using SetColorEditOptions(). The intent is that you probably don't want to
     // override them in most of your calls. Let the user choose via the option menu and/or call SetColorEditOptions() once during startup.

--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -6098,6 +6098,12 @@ bool ImGui::ColorPicker4(const char* label, float col[4], ImGuiColorEditFlags fl
     ImVec2 triangle_pa = ImVec2(triangle_r, 0.0f); // Hue point.
     ImVec2 triangle_pb = ImVec2(triangle_r * -0.5f, triangle_r * -0.866025f); // Black point.
     ImVec2 triangle_pc = ImVec2(triangle_r * -0.5f, triangle_r * +0.866025f); // White point.
+    if (flags & ImGuiColorEditFlags_FixedTriangle)
+    {
+        triangle_pa = ImVec2(triangle_r * +0.866025f, triangle_r * +0.5f); // Hue point.
+        triangle_pb = ImVec2(0.0f, -triangle_r); // Black point.
+        triangle_pc = ImVec2(triangle_r * -0.866025f, triangle_r * +0.5f); // White point.
+    }
 
     float H = col[0], S = col[1], V = col[2];
     float R = col[0], G = col[1], B = col[2];
@@ -6134,6 +6140,11 @@ bool ImGui::ColorPicker4(const char* label, float col[4], ImGuiColorEditFlags fl
             }
             float cos_hue_angle = ImCos(-H * 2.0f * IM_PI);
             float sin_hue_angle = ImSin(-H * 2.0f * IM_PI);
+            if (flags & ImGuiColorEditFlags_FixedTriangle)
+            {
+                cos_hue_angle = ImCos(-0.0 * 2.0f * IM_PI);
+                sin_hue_angle = ImSin(-0.0 * 2.0f * IM_PI);
+            }
             if (ImTriangleContainsPoint(triangle_pa, triangle_pb, triangle_pc, ImRotate(initial_off, cos_hue_angle, sin_hue_angle)))
             {
                 // Interacting with SV triangle
@@ -6342,6 +6353,11 @@ bool ImGui::ColorPicker4(const char* label, float col[4], ImGuiColorEditFlags fl
         draw_list->AddCircleFilled(hue_cursor_pos, hue_cursor_rad, hue_color32, hue_cursor_segments);
         draw_list->AddCircle(hue_cursor_pos, hue_cursor_rad + 1, col_midgrey, hue_cursor_segments);
         draw_list->AddCircle(hue_cursor_pos, hue_cursor_rad, col_white, hue_cursor_segments);
+        if (flags & ImGuiColorEditFlags_FixedTriangle)
+        {
+            cos_hue_angle = ImCos(-0.0 * 2.0f * IM_PI);
+            sin_hue_angle = ImSin(-0.0 * 2.0f * IM_PI);
+        }
 
         // Render SV triangle (rotated according to hue)
         ImVec2 tra = wheel_center + ImRotate(triangle_pa, cos_hue_angle, sin_hue_angle);


### PR DESCRIPTION
add option to add a non-rotating triangle picker for color with option ImGuiColorEditFlags_FixedTriangle.
triangle would be equilateral with base at bottom. 
top center - dark
bottom left - white
bottom right - hue
now easier to remember since changing from light to dark will be simply going bottom left to top in addition to being less distracting this behavior is seen in art programs such as Krita with options for either rotating or fixed

<img width="411" height="342" alt="fixed_triangle" src="https://github.com/user-attachments/assets/6f463496-8b6c-4206-9084-fd71f863916e" />
