### PR TITLE
fix(metal backend): avoid redundant vertex buffer bind in SetupRenderState

### DIFF
--- a/backends/imgui_impl_metal.mm
+++ b/backends/imgui_impl_metal.mm
@@ -215,8 +215,7 @@ static void ImGui_ImplMetal_SetupRenderState(ImDrawData* draw_data, id<MTLComman
 
     [commandEncoder setRenderPipelineState:renderPipelineState];
 
-    [commandEncoder setVertexBuffer:vertexBuffer.buffer offset:0 atIndex:0];
-    [commandEncoder setVertexBufferOffset:vertexBufferOffset atIndex:0];
+    [commandEncoder setVertexBuffer:vertexBuffer.buffer offset:vertexBufferOffset atIndex:0];
 }
 
 // Metal Render function.


### PR DESCRIPTION
Fixes a Metal validation issue.

Setup called `setVertexBuffer` at 0 then `setVertexBufferOffset` with the same effective offset when `vertexBufferOffset` is 0. Metal warns (vertex buffer offset / unused binding at index 0 / redundant buffer).

repro:
```bash
export MTL_DEBUG_LAYER=1
export MTL_DEBUG_LAYER_ERROR_MODE=assert
export MTL_DEBUG_LAYER_WARNING_MODE=assert
cd examples/example_apple_metal
make
./example_apple_metal
```

```
-[MTLDebugRenderCommandEncoder setVertexBufferOffset:attributeStride:atIndex:]:1919: failed assertion `Set Vertex Buffer Offset Validation
unused binding in encoder at Buffer index 0.
```