### PR TITLE
fix scrollbars partly covering top window border

### DIFF
--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -977,7 +977,7 @@ ImRect ImGui::GetWindowScrollbarRect(ImGuiWindow* window, ImGuiAxis axis)
     const float scrollbar_size = window->ScrollbarSizes[axis ^ 1]; // (ScrollbarSizes.x = width of Y scrollbar; ScrollbarSizes.y = height of X scrollbar)
     IM_ASSERT(scrollbar_size >= 0.0f);
     const float border_size = IM_ROUND(window->WindowBorderSize * 0.5f);
-    const float border_top = (window->Flags & ImGuiWindowFlags_MenuBar) ? IM_ROUND(g.Style.FrameBorderSize * 0.5f) : 0.0f;
+    const float border_top = (window->Flags & ImGuiWindowFlags_MenuBar) ? IM_ROUND(g.Style.FrameBorderSize * 0.5f) : border_size;
     if (axis == ImGuiAxis_X)
         return ImRect(inner_rect.Min.x + border_size, ImMax(outer_rect.Min.y + border_size, outer_rect.Max.y - border_size - scrollbar_size), inner_rect.Max.x - border_size, outer_rect.Max.y - border_size);
     else


### PR DESCRIPTION
The problem was only noticeable when using thick window borders. It's a tiny fix that I don't think should break anything :)

Before:
<img width="30" height="416" alt="image" src="https://github.com/user-attachments/assets/d61daddf-771a-4ff5-ac34-5ff92638d259" />

After: 
<img width="30" height="416" alt="image" src="https://github.com/user-attachments/assets/50280957-54ea-43ea-bbd2-e107bdac7d70" />
