### PR TITLE
Fixed InputScalar not parsing user input when the display format is configured not to show the scalar value. 

### DIFF
--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -2378,9 +2378,17 @@ bool ImGui::DataTypeApplyFromText(const char* buf, ImGuiDataType data_type, void
     // - In theory could treat empty format as using default, but this would only cover rare/bizarre case of using InputScalar() + integer + format string without %.
     char format_sanitized[32];
     if (data_type == ImGuiDataType_Float || data_type == ImGuiDataType_Double)
+    {
         format = type_info->ScanFmt;
+    }
     else
+    {
         format = ImParseFormatSanitizeForScanning(format, format_sanitized, IM_COUNTOF(format_sanitized));
+
+        // Format doesn't want us to show the number currently, but we still need to parse the resulting input
+        if (format && format[0] == '\0')
+            format = type_info->ScanFmt;
+    }
 
     // Small types need a 32-bit buffer to receive the result from scanf()
     int v32 = 0;


### PR DESCRIPTION
Unifies inconsistent behaviour between InputFloat and InputScalar when passing in custom formats that purposefully do not display the value.

Consider the following code for context-
`static float v = 0;
ImGui::InputFloat("Label", &v, 0, 0, "-");`
The result of this code will display an input field that initially displays "-", but still allows the user the type and have their inputs processed into the "v" variable. 

In contrast to the following code-
`static int v = 0;
ImGui::InputScalar("Label", ImGuiDataType_S32, &v, nullptr, nullptr, "-");`
The behaviour is inconsistent with that of the InputFloat example above, as the user's input will not be processed in this example and the value of the "v" variable will remain the same no matter what the user types in the input field. 

The use-case I am using this for is for displaying "mixed" values, or a single input field that represents a collection of values that are different from each other (group selecting multiple entities and viewing their shared properties in an inspector).