### PR TITLE
hotfix(ImDrawFlags_InvalidMask): use signed integer to prevent errors in Go

### DIFF
--- a/imgui.h
+++ b/imgui.h
@@ -3262,7 +3262,7 @@ enum ImDrawFlags_
     ImDrawFlags_RoundCornersMask_           = ImDrawFlags_RoundCornersAll | ImDrawFlags_RoundCornersNone,
 
     ImDrawFlags_Closed                      = 1 << 9, // PathStroke(), AddPolyline(): specify that shape should be closed.
-    ImDrawFlags_InvalidMask_                = (ImDrawFlags)0x8000000F,
+    ImDrawFlags_InvalidMask_                = (ImDrawFlags)-0x7FFFFFF1,
 };
 
 // Flags for ImDrawList instance. Those are set automatically by ImGui:: functions from ImGuiIO settings, and generally not manipulated directly.


### PR DESCRIPTION
This is supposed to fix #9396.
Because Go can't freely reinterpred unsigned integers as signed, trying to assign 0x8000000F value in ImDrawFlags_InvalidMask enum caused a compilation error.
In this PR I've changed the 0x8000000F value to -0x7FFFFFF1 which is technically equal but should not cause issues on Go side.
