### PR TITLE
Use SetProcessDpiAwarenessContext instead of SetThreadDpiAwarenessContext to fix the OpenGL3 Win32 example DPI scaling issue.

### DIFF
--- a/backends/imgui_impl_win32.cpp
+++ b/backends/imgui_impl_win32.cpp
@@ -885,7 +885,7 @@ DECLARE_HANDLE(DPI_AWARENESS_CONTEXT);
 #endif
 typedef HRESULT(WINAPI* PFN_SetProcessDpiAwareness)(PROCESS_DPI_AWARENESS);                     // Shcore.lib + dll, Windows 8.1+
 typedef HRESULT(WINAPI* PFN_GetDpiForMonitor)(HMONITOR, MONITOR_DPI_TYPE, UINT*, UINT*);        // Shcore.lib + dll, Windows 8.1+
-typedef DPI_AWARENESS_CONTEXT(WINAPI* PFN_SetThreadDpiAwarenessContext)(DPI_AWARENESS_CONTEXT); // User32.lib + dll, Windows 10 v1607+ (Creators Update)
+typedef BOOL(WINAPI* PFN_SetProcessDpiAwarenessContext)(DPI_AWARENESS_CONTEXT);                 // User32.lib + dll, Windows 10 v1703+ (Creators Update)
 
 // Helper function to enable DPI awareness without setting up a manifest
 void ImGui_ImplWin32_EnableDpiAwareness()
@@ -893,9 +893,9 @@ void ImGui_ImplWin32_EnableDpiAwareness()
     if (_IsWindows10OrGreater())
     {
         static HINSTANCE user32_dll = ::LoadLibraryA("user32.dll"); // Reference counted per-process
-        if (PFN_SetThreadDpiAwarenessContext SetThreadDpiAwarenessContextFn = (PFN_SetThreadDpiAwarenessContext)::GetProcAddress(user32_dll, "SetThreadDpiAwarenessContext"))
+        if (PFN_SetProcessDpiAwarenessContext SetProcessDpiAwarenessContextFn = (PFN_SetProcessDpiAwarenessContext)::GetProcAddress(user32_dll, "SetProcessDpiAwarenessContext"))
         {
-            SetThreadDpiAwarenessContextFn(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+            SetProcessDpiAwarenessContextFn(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
             return;
         }
     }


### PR DESCRIPTION
For my desktop with NVIDIA GeForce RTX 5060 Ti (Driver Version 596.49) and 4K display with 125% scaling, the GPU driver seems to use multithreading to render OpenGL content, which causes render issues with High DPI.

Before this fix

<img width="1583" height="992" alt="image" src="https://github.com/user-attachments/assets/1ecf7a0e-d24b-4c9b-acfa-c644a9e35bc5" />

After this fix

<img width="1583" height="992" alt="image" src="https://github.com/user-attachments/assets/3e44c572-626a-4c89-81a1-32c66c4e532e" />

Reference when I try to find the issue: https://stackoverflow.com/questions/47049651/opengl-and-windows-10-per-monitor-aware-dpi-scaling

Kenji Mouri