### PR TITLE
Backends: Opengl3: Support GLSL 410 shader when GLSL version is auto-detected.

### DIFF
--- a/backends/imgui_impl_opengl3.cpp
+++ b/backends/imgui_impl_opengl3.cpp
@@ -1049,6 +1049,8 @@ bool    ImGui_ImplOpenGL3_Init(const char* glsl_version)
         glsl_version = "#version 150";
 #else
         glsl_version = "#version 130";
+		if (bd->GlVersion >= 410)
+			glsl_version = "#version 410";
 #endif
     }
     IM_ASSERT((int)strlen(glsl_version) + 2 < IM_COUNTOF(bd->GlslVersionString));


### PR DESCRIPTION
Add the GLSL 410 shader and ensure it is selected when the GLSL version is auto-detected (i.e. when glsl_version is nullptr). Previously the GLSL 410 shader was only used if a GLSL version string was passed manually to ImGui_ImplOpenGL3_Init. Now the backend detects the GL/GLSL version at runtime and will pick the GLSL 410 shader when the context supports it.

https://github.com/ocornut/imgui/commit/fc737d233391c781f6cf5882149ddfa22fcd84cd
