### PR TITLE
Windows: fix double-click collapse toggle triggering an item moved under the mouse by the expand relayout

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -7714,7 +7714,12 @@ bool ImGui::Begin(const char* name, bool* p_open, ImGuiWindowFlags flags)
             ImRect title_bar_rect = window->TitleBarRect();
             if (g.HoveredWindow == window && g.HoveredId == 0 && g.HoveredIdPreviousFrame == 0 && g.ActiveId == 0 && IsMouseHoveringRect(title_bar_rect.Min, title_bar_rect.Max))
                 if (g.IO.MouseClickedCount[0] == 2 && GetKeyOwner(ImGuiKey_MouseLeft) == ImGuiKeyOwner_NoOwner)
+                {
                     window->WantCollapseToggle = true;
+                    // Claim the click until release: the toggle may relayout the window (e.g. auto-resizing window positioned with a bottom pivot expands upward)
+                    // and move an item under the still-pressed cursor, which would otherwise become active and get triggered on the mouse release.
+                    SetKeyOwner(ImGuiKey_MouseLeft, window->MoveId, ImGuiInputFlags_LockUntilRelease);
+                }
             if (window->WantCollapseToggle)
             {
                 window->Collapsed = !window->Collapsed;


### PR DESCRIPTION
**Version:** master (924f571), also reproduced on 1.92.8. Branch: master. Back-ends: imgui_impl_sdl3 + custom renderer (back-end independent). OS: Windows 11.

## Problem

When the double-click-on-title-bar collapse toggle causes the window to be laid out differently in the same frame, an item that the relayout moves under the still-pressed cursor becomes the active item, and the second click's *release* triggers it.

Typical setup: an auto-resizing window pinned to the bottom of the screen with a bottom pivot. When collapsed, only the title bar sits at the bottom edge; expanding makes the window grow *upward*, so the bottom rows of the window content teleport under the cursor that just double-clicked the title bar. If a button lands there, it fires on the release of the double-click.

## Repro (MCVE)

Paste into the demo main loop, double-click the collapsed title bar at the bottom-right of the screen:

```cpp
ImGuiIO& io = ImGui::GetIO();
ImGui::SetNextWindowPos(ImVec2(io.DisplaySize.x, io.DisplaySize.y), ImGuiCond_Always, ImVec2(1.0f, 1.0f));
ImGui::SetNextWindowCollapsed(true, ImGuiCond_Once);
ImGui::Begin("Pinned", NULL, ImGuiWindowFlags_AlwaysAutoResize);
for (int n = 0; n < 8; n++)
    ImGui::Text("Some content %d ..............", n);
if (ImGui::Button("Dangerous button ##wide", ImVec2(-FLT_MIN, 0.0f)))
    printf("Triggered by the double-click release!\n");
ImGui::End();
```

## Cause

The title-bar double-click path in `Begin()` (the "We don't use a regular button+id ... (mostly due to legacy reason, could be fixed)" block) sets `window->WantCollapseToggle` but doesn't claim the click. On that same frame:

- `g.HoveredWindow` was computed at `NewFrame()` from last frame's rects, so it still matches the window;
- `IsMouseClicked(0)` is still true for items submitted after the toggle relayouts the window.

So an item that the relayout places under the cursor passes `ItemHoverable()`, sees the click in `ButtonBehavior()`, takes `ActiveId`, and gets pressed on the release.

## Fix

Claim mouse-left ownership for the duration of the click when the toggle fires, mirroring what `ButtonBehavior()`/resize grips already do:

```cpp
SetKeyOwner(ImGuiKey_MouseLeft, window->MoveId, ImGuiInputFlags_LockUntilRelease);
```

`ButtonBehavior()` polls clicks through the key-owner test, so items revealed by the toggle ignore the in-flight press, while deliberate subsequent clicks work as before. Collapse/expand toggling itself is unaffected.

Verified in our app: the misfire is gone in both toggle directions, and normal interaction with the revealed items still works.
