### PR TITLE
Backends: GLFW: sync clamped viewport positions

### DIFF
--- a/backends/imgui_impl_glfw.cpp
+++ b/backends/imgui_impl_glfw.cpp
@@ -31,6 +31,7 @@
 
 // CHANGELOG
 // (minor and older changes stripped away, please see git history for details)
+//  2026-XX-XX: [Docking] Multi-viewport: treat different window position reported after glfwSetWindowPos() as an actual platform move. (#9356, #9398)
 //  2026-XX-XX: Platform: Added support for multiple windows via the ImGuiPlatformIO interface.
 //  2026-04-21: Added a Win32-specific implementation of ImGui_ImplGlfw_GetContentScaleXXXX functions for legacy GLFW 3.2.
 //  2026-03-25: Mouse cursor is properly restored if changed by user app/code while using glfwSetInputMode(..., GLFW_CURSOR_DISABLED) or ImGuiConfigFlags_NoMouseCursorChange. Amend change from 2025-12-10.
@@ -1314,7 +1315,7 @@ static void ImGui_ImplGlfw_WindowCloseCallback(GLFWwindow* window)
 // - on Linux it is queued and invoked during glfwPollEvents()
 // Because the event doesn't always fire on glfwSetWindowXXX() we use a frame counter tag to only
 // ignore recent glfwSetWindowXXX() calls.
-static void ImGui_ImplGlfw_WindowPosCallback(GLFWwindow* window, int, int)
+static void ImGui_ImplGlfw_WindowPosCallback(GLFWwindow* window, int x, int y)
 {
     if (ImGuiViewport* viewport = ImGui::FindViewportByPlatformHandle(window))
     {
@@ -1322,7 +1323,10 @@ static void ImGui_ImplGlfw_WindowPosCallback(GLFWwindow* window, int, int)
         {
             bool ignore_event = (ImGui::GetFrameCount() <= vd->IgnoreWindowPosEventFrame + 1);
             //data->IgnoreWindowPosEventFrame = -1;
-            if (ignore_event)
+            // The event may report a different position than requested when the window manager
+            // clamps/moves the platform window (e.g. Linux/X11 near monitor edges). In that case
+            // keep the viewport in sync with the real platform position instead of ignoring it.
+            if (ignore_event && x == (int)viewport->Pos.x && y == (int)viewport->Pos.y)
                 return;
         }
         viewport->PlatformRequestMove = true;


### PR DESCRIPTION
## Summary

Fix a GLFW multi-viewport position sync issue on Linux/X11 when the window manager clamps a secondary viewport to a monitor edge.

Issue: https://github.com/ocornut/imgui/issues/9442

Confirmed from at least Dear ImGui 1.90 through current docking HEAD, using GCC 13 and GCC 14, on Debian 13, Ubuntu 24.04, Ubuntu under WSL, Red Hat Enterprise Linux 8/9, and Rocky Linux 8/9.

The GLFW backend currently ignores window-position callbacks for one frame after calling `glfwSetWindowPos()`, so ordinary echo events from the backend do not set `PlatformRequestMove`. On X11 window managers such as Mutter, the requested position may be refused or clamped near monitor edges. In that case GLFW reports a different actual position, but the callback is still ignored and Dear ImGui keeps using the requested position internally.

This patch keeps the existing ignore behavior when GLFW reports the exact position Dear ImGui requested. If the callback reports a different position, it is treated as an actual platform move so the viewport can be synchronized back to the real platform window position.

## Related Issues

- https://github.com/ocornut/imgui/issues/9356
- https://github.com/ocornut/imgui/issues/9398
- https://github.com/ocornut/imgui/issues/8330
- https://github.com/ocornut/imgui/issues/8251

## Repro

Minimal repro repository:

https://github.com/KBentley57/imgui-viewport-edge-repro

Build the repro once against `v1.92.8-docking` and once against this branch. With the affected backend, the detached viewport can report a cached ImGui viewport position that differs from `glfwGetWindowPos()` after requesting/dragging near a monitor edge. With this branch, the backend no longer discards the clamped position callback.

## Validation

- Built the minimal GLFW/OpenGL repro with Dear ImGui sources compiled directly into the target.
- Verified the patch is limited to `backends/imgui_impl_glfw.cpp`.
