### PR TITLE
TextAlignedV(): better handling of cursor position and DC boundary

### DIFF
--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -342,18 +342,20 @@ void ImGui::TextWrappedV(const char* fmt, va_list args)
         PopTextWrapPos();
 }
 
-void ImGui::TextAligned(float align_x, float size_x, const char* fmt, ...)
+void ImGui::TextAligned(float align_x, float width, const char* fmt, ...)
 {
     va_list args;
     va_start(args, fmt);
-    TextAlignedV(align_x, size_x, fmt, args);
+    TextAlignedV(align_x, width, fmt, args);
     va_end(args);
 }
 
 // align_x: 0.0f = left, 0.5f = center, 1.0f = right.
-// size_x : 0.0f = shortcut for GetContentRegionAvail().x
+// width :
+//   - 0.0f: shortcut for CalcTextSize().x
+//   - negative: shortcut for GetContentRegionAvail().x
 // FIXME-WIP: Works but API is likely to be reworked. This is designed for 1 item on the line. (#7024)
-void ImGui::TextAlignedV(float align_x, float size_x, const char* fmt, va_list args)
+void ImGui::TextAlignedV(float align_x, float width, const char* fmt, va_list args)
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -362,23 +364,19 @@ void ImGui::TextAlignedV(float align_x, float size_x, const char* fmt, va_list a
     const char* text, *text_end;
     ImFormatStringToTempBufferV(&text, &text_end, fmt, args);
     const ImVec2 text_size = CalcTextSize(text, text_end);
-    size_x = CalcItemSize(ImVec2(size_x, 0.0f), 0.0f, text_size.y).x;
+    const ImVec2 widget_size = CalcItemSize(ImVec2(width, 0.0f), text_size.x, text_size.y);
 
-    ImVec2 pos(window->DC.CursorPos.x, window->DC.CursorPos.y + window->DC.CurrLineTextBaseOffset);
-    ImVec2 pos_max(pos.x + size_x, window->ClipRect.Max.y);
-    ImVec2 size(ImMin(size_x, text_size.x), text_size.y);
-    window->DC.CursorMaxPos.x = ImMax(window->DC.CursorMaxPos.x, pos.x + text_size.x);
-    window->DC.IdealMaxPos.x = ImMax(window->DC.IdealMaxPos.x, pos.x + text_size.x);
-    if (align_x > 0.0f && text_size.x < size_x)
-        pos.x += ImTrunc((size_x - text_size.x) * align_x);
-    RenderTextEllipsis(window->DrawList, pos, pos_max, pos_max.x, text, text_end, &text_size);
+    const ImVec2 start_pos(window->DC.CursorPos.x, window->DC.CursorPos.y + window->DC.CurrLineTextBaseOffset);
+    ImVec2 text_pos = start_pos;
+    if (align_x > 0.0f && text_size.x < widget_size.x)
+        text_pos.x += ImTrunc((widget_size.x - text_size.x) * align_x);
+    ImVec2 pos_max(start_pos.x + widget_size.x, window->ClipRect.Max.y);
+    RenderTextEllipsis(window->DrawList, text_pos, pos_max, pos_max.x, text, text_end, &text_size);
 
-    const ImVec2 backup_max_pos = window->DC.CursorMaxPos;
-    ItemSize(size);
-    ItemAdd(ImRect(pos, pos + size), 0);
-    window->DC.CursorMaxPos.x = backup_max_pos.x; // Cancel out extending content size because right-aligned text would otherwise mess it up.
+    ItemSize(widget_size);
+    ItemAdd(ImRect(start_pos, start_pos + widget_size), 0);
 
-    if (size_x < text_size.x && IsItemHovered(ImGuiHoveredFlags_NoNavOverride | ImGuiHoveredFlags_AllowWhenDisabled | ImGuiHoveredFlags_ForTooltip))
+    if (widget_size.x < text_size.x && IsItemHovered(ImGuiHoveredFlags_NoNavOverride | ImGuiHoveredFlags_AllowWhenDisabled | ImGuiHoveredFlags_ForTooltip))
         SetTooltip("%.*s", (int)(text_end - text), text);
 }
 


### PR DESCRIPTION
The current `TextAlignedV()` leaves the position and boundary in an inconsistent state, that limits its usefulness.

With this PR:
- The widget always has `width` width (parameter was called `size_x` before), unless:
  - `width == 0` means the real text width, as obtained by `CalcTextSize().x`. Before, `size_x == 0` was giving me no rendered output, as if it was actually clipping the text to a zero-width region.
  - `width < 0` means `ContentRegionAvail().x`.
- Cursor position actually matches the right of the displayed text.
- DC boundary is updated according to the actual displayed text.

Here's a test code (call `test_text_aligned()` from any example code), showing the bounding box, cursor position behavior, and how it behaves inside table cells:

```cpp
void show_bounding_box()
{
    ImVec2 min = ImGui::GetItemRectMin();
    ImVec2 max = ImGui::GetItemRectMax();
    ImU32 col = ImGui::GetColorU32(ImVec4{1.0f, 0.0f, 0.0f, 0.5f});
    ImDrawList* draw_list = ImGui::GetCurrentWindow()->DrawList;
    draw_list->AddRect(min, max, col);
}

void test_text_aligned()
{
    static float width = 200.0f;
    static float align = 0.0f;
    if (ImGui::Begin("Test TextAligned()")) {

        ImGui::TextWrapped("Test cursor positioning and bounding box.");

        ImVec2 available = ImGui::GetContentRegionAvail();
        ImGui::SliderFloat("align", &align, 0.0f, 1.0f);
        ImGui::DragFloat("width", &width, 1.0f, -1.0f, available.x, "%.0f");
        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, {0, 0});
        if (ImGui::BeginChild("container", {},
                              ImGuiChildFlags_Borders | ImGuiChildFlags_AutoResizeY,
                              ImGuiWindowFlags_HorizontalScrollbar)) {
            ImGui::AlignTextToFramePadding();
            ImGui::TextAligned(align, width, "Irish wristwatch");
            show_bounding_box();
            ImGui::SameLine();
            ImGui::Button("##test", {10, 0});

            ImGui::Button("##test2", {10, 0});
            ImGui::SameLine();
            ImGui::TextAligned(align, width, "Rear wheel drive");
            show_bounding_box();
        }
        ImGui::EndChild();
        ImGui::PopStyleVar();

        ImGui::Separator();

        ImGui::TextWrapped("Test inside a table.");

        if (ImGui::BeginTable("table", 3,
                              ImGuiTableFlags_Borders |
                              ImGuiTableFlags_Resizable)) {

            static float apple_align  = 0.0f;
            static float banana_align = 0.5f;
            static float cherry_align = 1.0f;

            ImGui::TableNextRow(ImGuiTableRowFlags_Headers);
            ImGui::TableNextColumn();
            ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
            ImGui::SliderFloat("##apple_align", &apple_align, 0.0f, 1.0f);
            ImGui::TableNextColumn();
            ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
            ImGui::SliderFloat("##banana_align", &banana_align, 0.0f, 1.0f);
            ImGui::TableNextColumn();
            ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
            ImGui::SliderFloat("##cherry_align", &cherry_align, 0.0f, 1.0f);

            ImGui::TableNextRow();
            ImGui::TableNextColumn();
            ImGui::TextAligned(apple_align, -1.0f, "Apple");
            ImGui::TableNextColumn();
            ImGui::TextAligned(banana_align, -1.0f, "Banana");
            ImGui::TableNextColumn();
            ImGui::TextAligned(cherry_align, -1.0f, "Cherry");

            ImGui::EndTable();
        }
    }
    ImGui::End();
}
```

Here are images showing different outputs:

<img width="486" height="360" alt="Screenshot from 2026-06-25 21-38-16" src="https://github.com/user-attachments/assets/86d07000-1f05-4f62-a093-388ea02981de" />

<img width="486" height="360" alt="Screenshot from 2026-06-25 21-38-30" src="https://github.com/user-attachments/assets/1e8cde05-9a90-4a67-920e-3f1573bb2694" />

<img width="486" height="360" alt="Screenshot from 2026-06-25 21-38-44" src="https://github.com/user-attachments/assets/9a1816c0-16c8-410e-ac17-5af5f78533ce" />

<img width="486" height="360" alt="Screenshot from 2026-06-25 21-39-30" src="https://github.com/user-attachments/assets/1a6d3913-fa41-4f08-a2f2-ebd38fddaa4c" />
