### PR TITLE
Metrics/Debugger: Added DebugDrawCmdCallback + ImGuiDebugDrawCmdCallbackFn

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -17384,7 +17384,20 @@ void ImGui::DebugNodeDrawList(ImGuiWindow* window, ImGuiViewportP* viewport, con
     {
         if (pcmd->UserCallback)
         {
-            BulletText("Callback %p, user_data %p", pcmd->UserCallback, pcmd->UserCallbackData);
+            if (g.IO.DebugDrawCmdCallback)
+            {
+                char buf[300];
+                g.IO.DebugDrawCmdCallback(NULL, draw_list, pcmd, false, false, buf, IM_ARRAYSIZE(buf));
+                bool cb_node_open = TreeNode((void*)(pcmd - draw_list->CmdBuffer.begin()), "Callback: %s", buf);
+                if (IsItemHovered() && (cfg->ShowDrawCmdMesh || cfg->ShowDrawCmdBoundingBoxes) && fg_draw_list)
+                    g.IO.DebugDrawCmdCallback(fg_draw_list, draw_list, pcmd, cfg->ShowDrawCmdMesh, cfg->ShowDrawCmdBoundingBoxes, NULL, 0);
+                if (cb_node_open)
+                    TreePop();
+            }
+            else
+            {
+                BulletText("Callback %p, user_data %p", pcmd->UserCallback, pcmd->UserCallbackData);
+            }
             continue;
         }
 

--- a/imgui.h
+++ b/imgui.h
@@ -287,6 +287,7 @@ typedef int     (*ImGuiInputTextCallback)(ImGuiInputTextCallbackData* data);    
 typedef void    (*ImGuiSizeCallback)(ImGuiSizeCallbackData* data);              // Callback function for ImGui::SetNextWindowSizeConstraints()
 typedef void*   (*ImGuiMemAllocFunc)(size_t sz, void* user_data);               // Function signature for ImGui::SetAllocatorFunctions()
 typedef void    (*ImGuiMemFreeFunc)(void* ptr, void* user_data);                // Function signature for ImGui::SetAllocatorFunctions()
+typedef void    (*ImGuiDebugDrawCmdCallbackFn)(ImDrawList* overlay_draw_list, const ImDrawList* draw_list, const ImDrawCmd* draw_cmd, bool show_mesh, bool show_aabb, char* out_text, int text_size); // Debug callback for custom draw commands
 
 // ImVec2: 2D vector used to store positions, sizes etc. [Compile-time configurable type]
 // - This is a frequently used type in the API. Consider using IM_VEC2_CLASS_EXTRA to create implicit cast from/to our preferred type.
@@ -2509,6 +2510,11 @@ struct ImGuiIO
 
     // Option to audit .ini data
     bool        ConfigDebugIniSettings;         // = false          // Save .ini data with extra comments (particularly helpful for Docking, but makes saving slower)
+
+    // Debug callback for custom draw commands (callbacks) in the Metrics/Debugger draw list viewer.
+    // When set, callback draw commands will show a tree node with descriptive text and mesh/bbox overlay on hover,
+    // instead of just "Callback %p, user_data %p". See ImGuiDebugDrawCmdCallbackFn typedef for parameters.
+    ImGuiDebugDrawCmdCallbackFn DebugDrawCmdCallback; // = NULL
 
     //------------------------------------------------------------------
     // Platform Identifiers


### PR DESCRIPTION
When set, callback draw commands in the Metrics/Debugger's draw-list viewer show a descriptive TreeNode and optionally render mesh/bounding-box overlays on hover, instead of the opaque "Callback %p, user_data %p" bullet.

The callback receives the draw list, the draw command, the two overlay toggles (mesh / bbox) already exposed by the Metrics config, and a text buffer to fill with a short description for the tree label.

- Add ImGuiDebugDrawCmdCallbackFn typedef in imgui.h.
- Add DebugDrawCmdCallback field on ImGuiIO (defaults to NULL).
- In DebugNodeDrawList(), branch on the callback: descriptive TreeNode when set, previous BulletText fallback otherwise. Behaviour is unchanged for users that don't set the callback.

Only thing arbitrary I put 300 for default buffer size.

context: I'm using that on my branch [refacto of ](https://github.com/soufianekhiat/DearWidgets/tree/refacto) to do debug view the glyph in text renderer with slug.

Example of usage:
```cpp
void SlugDebugDrawCmdCallback(ImDrawList* overlay, const ImDrawList* /*draw_list*/,
                              const ImDrawCmd* cmd, bool show_mesh, bool show_aabb,
                              char* out_text, int text_size)
{
	// Only handle our own callbacks; leave others for default display
	if (cmd->UserCallback != SlugRawDraw) {
		if (out_text && text_size > 0) out_text[0] = 0;
		return;
	}
	SlugDrawCBData* d = (SlugDrawCBData*)cmd->UserCallbackData;
	if (!d) {
		if (out_text) ImFormatString(out_text, text_size, "Slug: (null data)");
		return;
	}
	// Fill descriptive text
	if (out_text)
		ImFormatString(out_text, text_size, "Slug: %d tris, BB (%.0f,%.0f)-(%.0f,%.0f)",
		               d->indexCount / 3, d->debugBBMin.x, d->debugBBMin.y, d->debugBBMax.x, d->debugBBMax.y);
	// Draw overlay
	if (overlay)
	{
		ImDrawListFlags backup = overlay->Flags;
		overlay->Flags &= ~ImDrawListFlags_AntiAliasedLines;
		if (show_aabb)
			overlay->AddRect(d->debugBBMin, d->debugBBMax, IM_COL32(255, 255, 0, 255));
		if (show_mesh && d->debugQuads)
		{
			for (int i = 0; i < d->debugQuadCount; i++)
			{
				const ImVec2* q = d->debugQuads + i * 4; // TL, TR, BR, BL
				overlay->AddPolyline(q, 4, IM_COL32(255, 255, 0, 255), ImDrawFlags_Closed, 1.0f);
			}
		}
		overlay->Flags = backup;
	}
}
```