### PR TITLE
Metal 4 Backend: metal-cpp support

### DIFF
--- a/backends/imgui_impl_metal4.h
+++ b/backends/imgui_impl_metal4.h
@@ -6,8 +6,8 @@
 //  [X] Renderer: User texture binding. Use 'MTLTexture.gpuResourceID' as texture identifier. Read the FAQ about ImTextureID/ImTextureRef!
 //  [X] Renderer: Large meshes support (64k+ vertices) even with 16-bit indices (ImGuiBackendFlags_RendererHasVtxOffset).
 //  [X] Renderer: Texture updates support for dynamic font atlas (ImGuiBackendFlags_RendererHasTextures).
+//  [X] Metal-cpp support.
 // Missing features or Issues:
-//  [ ] Metal-cpp support.
 //  [ ] Texture view pool support? Reevaluate which type to use for ImtextureID.
 
 // You can use unmodified imgui_impl_* files in your project. See examples/ folder for examples of using this.
@@ -51,6 +51,48 @@ IMGUI_IMPL_API void ImGui_ImplMetal4_DestroyDeviceObjects();
 // (Advanced) Use e.g. if you need to precisely control the timing of texture updates (e.g. for staged rendering), by setting ImDrawData::Textures = nullptr to handle this manually.
 IMGUI_IMPL_API void ImGui_ImplMetal4_UpdateTexture(ImTextureData* tex);
 
+#endif
+
+//-----------------------------------------------------------------------------
+// C++ API
+//-----------------------------------------------------------------------------
+
+// Enable Metal C++ binding support with '#define IMGUI_IMPL_METAL_CPP' in your imconfig.h file
+// More info about using Metal from C++: https://developer.apple.com/metal/cpp/
+
+#ifdef IMGUI_IMPL_METAL_CPP
+#ifndef __OBJC__
+
+// Forward declare relevant classes from the MTL and MTL4 namespace
+namespace MTL
+{
+  class Device;
+}
+
+namespace MTL4
+{
+    class CommandQueue;
+    class CommandBuffer;
+    class RenderPassDescriptor;
+    class RenderCommandEncoder;
+}
+
+// Follow "Getting Started" link and check examples/ folder to learn about using backends!
+IMGUI_IMPL_API bool ImGui_ImplMetal4_Init(MTL::Device* device, MTL4::CommandQueue* commandQueue, int framesInFlight);
+IMGUI_IMPL_API void ImGui_ImplMetal4_Shutdown();
+IMGUI_IMPL_API void ImGui_ImplMetal4_NewFrame(MTL4::RenderPassDescriptor* renderPassDescriptor, int frameInFlightIndex);
+IMGUI_IMPL_API void ImGui_ImplMetal4_RenderDrawData(ImDrawData* draw_data,
+                                                   MTL4::CommandBuffer* commandBuffer,
+                                                   MTL4::RenderCommandEncoder* commandEncoder);
+
+// Called by Init/NewFrame/Shutdown
+IMGUI_IMPL_API bool ImGui_ImplMetal4_CreateDeviceObjects(MTL::Device* device);
+IMGUI_IMPL_API void ImGui_ImplMetal4_DestroyDeviceObjects();
+
+// (Advanced) Use e.g. if you need to precisely control the timing of texture updates (e.g. for staged rendering), by setting ImDrawData::Textures = nullptr to handle this manually.
+IMGUI_IMPL_API void ImGui_ImplMetal4_UpdateTexture(ImTextureData* tex);
+
+#endif
 #endif
 
 //-----------------------------------------------------------------------------

--- a/backends/imgui_impl_metal4.mm
+++ b/backends/imgui_impl_metal4.mm
@@ -240,9 +240,6 @@ void ImGui_ImplMetal4_RenderDrawData(ImDrawData* draw_data, id<MTL4CommandBuffer
     ImVec2 clip_off = draw_data->DisplayPos;         // (0,0) unless using multi-viewports
     ImVec2 clip_scale = draw_data->FramebufferScale; // (1,1) unless using retina display which are often (2,2)
 
-    // Before rendering command lists, commit residency set
-    [bd->SharedMetalContext.residencySet commit];
-
     // Render command lists
     size_t vertexBufferOffset = 0;
     size_t indexBufferOffset = 0;
@@ -293,6 +290,7 @@ void ImGui_ImplMetal4_RenderDrawData(ImDrawData* draw_data, id<MTL4CommandBuffer
                 if (tex_id != ImTextureID_Invalid)
                 {
                     id<MTLTexture> texture = (__bridge id<MTLTexture>)(void*)(intptr_t)tex_id;
+                    [bd->SharedMetalContext.residencySet addAllocation:texture];
                     [bd->SharedMetalContext.argumentTable setTexture:texture.gpuResourceID atIndex:0];
                 }
 
@@ -318,6 +316,9 @@ void ImGui_ImplMetal4_RenderDrawData(ImDrawData* draw_data, id<MTL4CommandBuffer
         [slotCache addObject:vertexBuffer];
         [slotCache addObject:indexBuffer];
     }
+    
+    // Commit residency set
+    [bd->SharedMetalContext.residencySet commit];
     bd->RenderCommandEncoder = nil;
 }
 

--- a/backends/imgui_impl_metal4.mm
+++ b/backends/imgui_impl_metal4.mm
@@ -6,8 +6,8 @@
 //  [X] Renderer: User texture binding. Use 'MTLTexture' as texture identifier. Read the FAQ about ImTextureID/ImTextureRef!
 //  [X] Renderer: Large meshes support (64k+ vertices) even with 16-bit indices (ImGuiBackendFlags_RendererHasVtxOffset).
 //  [X] Renderer: Texture updates support for dynamic font atlas (ImGuiBackendFlags_RendererHasTextures).
+//  [X] Metal-cpp support.
 // Missing features or Issues:
-//  [ ] Metal-cpp support.
 //  [ ] Texture view pool support? Reevaluate which type to use for ImtextureID.
 
 // You can use unmodified imgui_impl_* files in your project. See examples/ folder for examples of using this.
@@ -27,6 +27,10 @@
 #include "imgui_impl_metal4.h"
 #import <time.h>
 #import <Metal/Metal.h>
+
+#ifdef IMGUI_IMPL_METAL_CPP
+#include <Metal/Metal.hpp>
+#endif
 
 #pragma mark - Support classes and structs
 
@@ -94,6 +98,37 @@ static ImGui_ImplMetal4_Data*    ImGui_ImplMetal4_GetBackendData()    { return I
 static void                      ImGui_ImplMetal4_DestroyBackendData(){ IM_DELETE(ImGui_ImplMetal4_GetBackendData()); }
 
 static inline CFTimeInterval    GetMachAbsoluteTimeInSeconds()      { return (CFTimeInterval)(double)(clock_gettime_nsec_np(CLOCK_UPTIME_RAW) / 1e9); }
+
+#ifdef IMGUI_IMPL_METAL_CPP
+
+#pragma mark - Dear ImGui Metal C++ Backend API
+
+bool ImGui_ImplMetal4_Init(MTL::Device* device, MTL4::CommandQueue* commandQueue, int framesInFlight)
+{
+    return ImGui_ImplMetal4_Init((__bridge id<MTLDevice>)(device),(__bridge id<MTL4CommandQueue>)(commandQueue), framesInFlight);
+}
+
+void ImGui_ImplMetal4_NewFrame(MTL4::RenderPassDescriptor* renderPassDescriptor, int frameInFlightIndex)
+{
+    ImGui_ImplMetal4_NewFrame((__bridge MTL4RenderPassDescriptor*)(renderPassDescriptor), frameInFlightIndex);
+}
+
+void ImGui_ImplMetal4_RenderDrawData(ImDrawData* draw_data,
+                                    MTL4::CommandBuffer* commandBuffer,
+                                    MTL4::RenderCommandEncoder* commandEncoder)
+{
+    ImGui_ImplMetal4_RenderDrawData(draw_data,
+                                   (__bridge id<MTL4CommandBuffer>)(commandBuffer),
+                                   (__bridge id<MTL4RenderCommandEncoder>)(commandEncoder));
+
+}
+
+bool ImGui_ImplMetal_CreateDeviceObjects(MTL::Device* device)
+{
+    return ImGui_ImplMetal4_CreateDeviceObjects((__bridge id<MTLDevice>)(device));
+}
+
+#endif // #ifdef IMGUI_IMPL_METAL_CPP
 
 #pragma mark - Dear ImGui Metal Backend API
 


### PR DESCRIPTION
This builds upon the previous Metal 4 PR by adding additional functions in the Metal 4 backend to support metal-cpp. I am running on macOS 26.5.2 and have tested the metal-cpp binding functions on my game engine and it ran successfully.

TODO:
- Add a missing addAllocation function call to make `ImTextureID tex_id` resident to the GPU (This can be a separate PR if preferred)