### PR TITLE
SDLRenderer3: reset sampler state to linear

### DIFF
--- a/backends/imgui_impl_sdlrenderer3.cpp
+++ b/backends/imgui_impl_sdlrenderer3.cpp
@@ -25,6 +25,7 @@
 
 // CHANGELOG
 // (minor and older changes stripped away, please see git history for details)
+//  2026-07-13: Fixed default sampler state being nearest instead of linear.
 //  2026-04-23: Added support for standard draw callbacks (in platform_io): DrawCallback_ResetRenderState, DrawCallback_SetSamplerLinear, DrawCallback_SetSamplerNearest. (#9378)
 //  2026-03-12: Fixed invalid assert in ImGui_ImplSDLRenderer3_UpdateTexture() if ImTextureID_Invalid is defined to be != 0, which became the default since 2026-03-12. (#9295)
 //  2025-09-18: Call platform_io.ClearRendererHandlers() on shutdown.
@@ -77,6 +78,8 @@ static ImGui_ImplSDLRenderer3_Data* ImGui_ImplSDLRenderer3_GetBackendData()
 // Functions
 static void ImGui_ImplSDLRenderer3_SetupRenderState(SDL_Renderer* renderer)
 {
+    ImGui_ImplSDLRenderer3_GetBackendData()->CurrentScaleMode = SDL_SCALEMODE_LINEAR;
+
     // Clear out any viewports and cliprect set by the user
     // FIXME: Technically speaking there are lots of other things we could backup/setup/restore during our render process.
     SDL_SetRenderViewport(renderer, nullptr);


### PR DESCRIPTION
## Summary

- Reset SDLRenderer3 sampler state to linear with the rest of its render state.
- Prevent the zero-initialized sampler cache from overriding linear sampling for the font atlas and normal UI draws.

## Verification

- Built and ran `examples/example_null` with MSVC and `/W4`.
- Syntax-checked `imgui_impl_sdlrenderer3.cpp` with MSVC `/W4` against current SDL3 headers.
