### PR TITLE
Settings: apply automatic INI cleanup after loading

### DIFF
--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -135,6 +135,7 @@ Other Changes:
   - Added bool io.ConfigIniSettingsSaveLastUsedDate to disable saving that info. (#9460)
   - Added int io.ConfigIniSettingsAutoDiscardMonths to enable a mode where unused settings
     are automatically discard after xx months. (#9460)
+  - Fixed io.ConfigIniSettingsAutoDiscardMonths not removing expired or undated settings on load.
   - Added a trimming tool under Metrics->Settings, along with a yet-unexposed function.
   - The current system date is fed through ImGuiPlatformIO::Platform_SessionDate,
     which is automatically set by a call to time() done during context creation. (#9460)

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -15808,8 +15808,12 @@ void ImGui::LoadIniSettingsFromMemory(const char* ini_data, size_t ini_size)
 
     // Call post-read handlers
     ImGuiSettingsCleanupArgs cleanup_args;
-    if (g.IO.ConfigIniSettingsAutoDiscardMonths > 0)
+    if (g.IO.ConfigIniSettingsAutoDiscardMonths > 0 && g.PlatformIO.Platform_SessionDate != 0)
+    {
         cleanup_args.DiscardOlderThanMonths = g.IO.ConfigIniSettingsAutoDiscardMonths;
+        cleanup_args.DiscardWhenMissingDate = true;
+        CleanupIniSettings(&cleanup_args);
+    }
     for (ImGuiSettingsHandler& handler : g.SettingsHandlers)
         if (handler.ApplyAllFn != NULL)
             handler.ApplyAllFn(&g, &handler);


### PR DESCRIPTION
## Summary

- Run configured automatic INI cleanup after loading settings and before applying them.
- Discard legacy entries without a last-used date when automatic cleanup is enabled, as documented.

## Verification

- Built and ran a focused MSVC probe covering expired and date-less Window/Table entries, plus the no-session-date path.
- Built and ran `examples/example_null` with MSVC and `/W4`.
