### PR TITLE
Tables: validate INI settings column count

### DIFF
--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -66,6 +66,7 @@ Other Changes:
   - Reworked `io.ConfigInputTextEnterKeepActive` mode so that pressing
     Ctrl+Enter or Shift+Enter still allows to deactivate. (#9239)
 - Tables:
+  - Fixed loading a corrupted Table .ini entry with an invalid column count potentially causing memory corruption.
   - Redesigned/rewrote code to reconcile columns and settings on topology changes. (#9108)
     - When a column label is passed to TableSetupColumn(), the underlying identifier
       is used to match live columns data and .ini settings data when changing.

--- a/imgui_tables.cpp
+++ b/imgui_tables.cpp
@@ -4167,7 +4167,7 @@ static void* TableSettingsHandler_ReadOpen(ImGuiContext*, ImGuiSettingsHandler*,
 {
     ImGuiID id = 0;
     int columns_count = 0;
-    if (sscanf(name, "0x%08X,%d", &id, &columns_count) < 2)
+    if (sscanf(name, "0x%08X,%d", &id, &columns_count) < 2 || columns_count <= 0 || columns_count >= IMGUI_TABLE_MAX_COLUMNS)
         return NULL;
     return ImGui::TableSettingsCreate(id, columns_count);
 }


### PR DESCRIPTION
## Summary

- Reject malformed Table INI section headers whose column count is outside the supported range.
- Keep valid saved table settings unchanged while avoiding wrapped allocations during settings loading.

## Verification

- Built and ran an MSVC regression probe: invalid counts `-1`, `0`, `512`, and `268435456` are ignored; a valid 511-column entry is preserved.
- Built and ran `examples/example_null` with MSVC and `/W4`.
