### PR TITLE
Android: Clear mouse pos on touch release (#6627) + SDL2: Restore StartTextInput for Android (#7636)

### DIFF
--- a/backends/imgui_impl_android.cpp
+++ b/backends/imgui_impl_android.cpp
@@ -23,6 +23,7 @@
 
 // CHANGELOG
 // (minor and older changes stripped away, please see git history for details)
+//  2026-07-15: Inputs: Clear mouse position on touch release (AMOTION_EVENT_ACTION_UP) to prevent buttons from staying in hovered/pressed state. (#6627)
 //  2022-09-26: Inputs: Renamed ImGuiKey_ModXXX introduced in 1.87 to ImGuiMod_XXX (old names still supported).
 //  2022-01-26: Inputs: replaced short-lived io.AddKeyModsEvent() (added two weeks ago) with io.AddKeyEvent() using ImGuiKey_ModXXX flags. Sorry for the confusion.
 //  2022-01-17: Inputs: calling new io.AddMousePosEvent(), io.AddMouseButtonEvent(), io.AddMouseWheelEvent() API (1.87+).
@@ -230,6 +231,10 @@ int32_t ImGui_ImplAndroid_HandleInputEvent(const AInputEvent* input_event)
             {
                 io.AddMousePosEvent(AMotionEvent_getX(input_event, event_pointer_index), AMotionEvent_getY(input_event, event_pointer_index));
                 io.AddMouseButtonEvent(0, event_action == AMOTION_EVENT_ACTION_DOWN);
+                // Clear mouse position on touch release so buttons don't stay in hovered state. (#6627)
+                // On touchscreens there is no "hover" — after release the pointer is gone.
+                if (event_action == AMOTION_EVENT_ACTION_UP)
+                    io.AddMousePosEvent(-FLT_MAX, -FLT_MAX);
             }
             break;
         }

--- a/backends/imgui_impl_sdl2.cpp
+++ b/backends/imgui_impl_sdl2.cpp
@@ -21,6 +21,7 @@
 
 // CHANGELOG
 // (minor and older changes stripped away, please see git history for details)
+//  2026-07-15: Platform: Restore SDL_StartTextInput()/SDL_StopTextInput() in IME handler for on-screen keyboard support on Android/mobile. (#7636)
 //  2026-04-16: Made ImGui_ImplSDL2_GetContentScaleForWindow(), ImGui_ImplSDL2_GetContentScaleForDisplay() helpers return a minimum of 1.0f, as some Linux setup seems to report <1.0f value and this breaks scaling border size. (#9369)
 //  2026-02-13: Inputs: systems other than X11 are back to starting mouse capture on mouse down (reverts 2025-02-26 change). Only X11 requires waiting for a drag by default (not ideal, but a better default for X11 users). Added ImGui_ImplSDL2_SetMouseCaptureMode() for X11 debugger users. (#3650, #6410, #9235)
 //  2026-01-15: Changed GetClipboardText() handler to return nullptr on error aka clipboard contents is not text. Consistent with other backends. (#9168)
@@ -205,6 +206,13 @@ static void ImGui_ImplSDL2_PlatformSetImeData(ImGuiContext*, ImGuiViewport*, ImG
         r.w = 1;
         r.h = (int)data->InputLineHeight;
         SDL_SetTextInputRect(&r);
+        // SDL_StartTextInput() is needed on Android (and some other platforms) to show the on-screen keyboard. (#7636)
+        // It was removed in a7703fe6 due to concerns about its relation to desktop IME, but is required on mobile.
+        SDL_StartTextInput();
+    }
+    else
+    {
+        SDL_StopTextInput();
     }
 }
 

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -150,6 +150,10 @@ Other Changes:
 - Misc:
   - Added IM_DEBUG_BREAK() handler for GCC+AArch64/ARM64. [@tom-seddon]
 - Backends:
+  - Android: Clear mouse position on touch release (AMOTION_EVENT_ACTION_UP)
+    to prevent buttons from staying in hovered/pressed state. (#6627)
+  - SDL2: Restore SDL_StartTextInput()/SDL_StopTextInput() in IME handler
+    for on-screen keyboard support on Android. (#7636)
   - Metal4:
     - Added new Metal 4 backend (forked from Metal 3 backend). (#9458, #9451) [@AmelieHeinrich]
     - Added Metal-cpp support enabled with `IMGUI_IMPL_METAL_CPP` define. (#9461) [@MERL10N]


### PR DESCRIPTION
## Summary

Fixes two open Android-labeled issues with minimal, surgical changes.

## Issue #6627: Android: button rendered as clicked after being released

**Problem:** After tapping a button on Android, it stays in the hovered/pressed state until another item is clicked. This affects all ImGui buttons on touchscreen.

**Root cause:** The Android backend sends `AddMouseButtonEvent(0, false)` on `AMOTION_EVENT_ACTION_UP` but does not clear the mouse position. ImGui still thinks the pointer is hovering over the button.

**Fix:** After `AMOTION_EVENT_ACTION_UP` for `FINGER`/`UNKNOWN` tool types, call `io.AddMousePosEvent(-FLT_MAX, -FLT_MAX)` to clear the mouse position. On touchscreens there is no hover — the pointer is gone after release.

**Omar's confirmation:** In the issue comments, @ocornut said: *"It's not a rendering issue it is that the backend should submit a mouse leaving (AddMousePosEvent(-FLT_MAX,-FLT_MAX)) invalid position) event after the touch release."*

The fix only applies to `FINGER` and `UNKNOWN` tool types — physical mouse and pen input are unaffected.

**File:** `backends/imgui_impl_android.cpp` — 4 lines added

## Issue #7636: SDL2 text input using Android onscreen keyboard

**Problem:** When using SDL2 on Android, tapping on `InputText` does not bring up the on-screen keyboard. Text input is impossible.

**Root cause:** `SDL_StartTextInput()`/`SDL_StopTextInput()` calls were removed from the SDL2 IME handler in commit a7703fe6 (2023-04-06) due to concerns about desktop IME. However, these calls are required on Android/mobile to show the on-screen keyboard. The equivalent fix was already applied to SDL3 in fab96a6e, but not SDL2.

**Fix:** Restore `SDL_StartTextInput()` when `data->WantVisible` is true, and `SDL_StopTextInput()` when it becomes false, in `ImGui_ImplSDL2_PlatformSetImeData()`.

**File:** `backends/imgui_impl_sdl2.cpp` — 7 lines added

## Changes

| File | Lines | Change |
|------|-------|--------|
| `backends/imgui_impl_android.cpp` | +5 | Clear mouse pos on touch UP + changelog |
| `backends/imgui_impl_sdl2.cpp` | +8 | Restore StartTextInput/StopTextInput + changelog |
| `docs/CHANGELOG.txt` | +4 | Backend entries for both fixes |

**Total: 17 lines added, 0 removed.**

## Testing

- Cannot compile/test on this host (no Android NDK or SDL2 dev libs)
- Both fixes are based on confirmed solutions from issue commenters and Omar's guidance
- The Android touch fix matches the exact pattern Omar described
- The SDL2 fix mirrors the SDL3 fix already merged upstream

## Issues addressed

- Fixes #6627
- Fixes #7636
- Related: #5686 (keyboard issues — the SDL2 fix also helps)