### PR TITLE
Check if TARGET_OS_OSX is defined before evaluating its value

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -16225,7 +16225,7 @@ static void Platform_SetClipboardTextFn_DefaultImpl(ImGuiContext*, const char* t
     ::CloseClipboard();
 }
 
-#elif defined(__APPLE__) && TARGET_OS_OSX && defined(IMGUI_ENABLE_OSX_DEFAULT_CLIPBOARD_FUNCTIONS)
+#elif defined(__APPLE__) && defined(TARGET_OS_OSX) && TARGET_OS_OSX && defined(IMGUI_ENABLE_OSX_DEFAULT_CLIPBOARD_FUNCTIONS)
 
 #include <Carbon/Carbon.h>  // Use old API to avoid need for separate .mm file
 static PasteboardRef main_clipboard = 0;


### PR DESCRIPTION
Solves a case where __APPLE__ is defined, but TARGET_OS_OSX isn't, causing a compile error. Happens on my OS X 10.9 setup with MacPorts Clang 16 instead of the Xcode Clang 6.

Compile log before fix:
```
error: 'TARGET_OS_OSX' is not defined, evaluates to 0 [-Werror,-Wundef-prefix=TARGET_OS_]
#elif defined(__APPLE__) && TARGET_OS_OSX && defined(IMGUI_ENABLE_OSX_DEFAULT_CLIPBOARD_FUNCTIONS)
                            ^
1 error generated.
```

<img width="1183" height="284" alt="image" src="https://github.com/user-attachments/assets/0f3063e7-bc0a-4701-bca3-ff3aa36db7e8" />
