### PR TITLE
Backends: WebGPU: use integer framebuffer size for viewport

### DIFF
--- a/backends/imgui_impl_wgpu.cpp
+++ b/backends/imgui_impl_wgpu.cpp
@@ -440,7 +440,7 @@ static void ImGui_ImplWGPU_SetupRenderState(ImDrawData* draw_data, WGPURenderPas
     }
 
     // Setup viewport
-    wgpuRenderPassEncoderSetViewport(ctx, 0, 0, draw_data->FramebufferScale.x * draw_data->DisplaySize.x, draw_data->FramebufferScale.y * draw_data->DisplaySize.y, 0, 1);
+    wgpuRenderPassEncoderSetViewport(ctx, 0, 0, (float)(int)(draw_data->DisplaySize.x * draw_data->FramebufferScale.x), (float)(int)(draw_data->DisplaySize.y * draw_data->FramebufferScale.y), 0, 1);
 
     // Bind shader and vertex buffers
     wgpuRenderPassEncoderSetVertexBuffer(ctx, 0, fr->VertexBuffer, 0, fr->VertexBufferSize * sizeof(ImDrawVert));


### PR DESCRIPTION
When the logical size doesn't divide the framebuffer size evenly, FramebufferScale*DisplaySize can round one ULP above the render target (ex. 2013.0001 for a 2013 target), which wgpu-native rejects.
Cast integer first to fix it.

Fixes #8628 