### PR TITLE
Widgets: Fix multiplication result converted to larger type

### DIFF
--- a/imgui_widgets.cpp
+++ b/imgui_widgets.cpp
@@ -3091,7 +3091,7 @@ TYPE ImGui::ScaleValueFromRatioT(ImGuiDataType data_type, float t, TYPE v_min, T
             //   This code is carefully tuned to work with large values (e.g. high ranges of U64) while preserving this property..
             // - Not doing a *1.0 multiply at the end of a range as it tends to be lossy. While absolute aiming at a large s64/u64
             //   range is going to be imprecise anyway, with this check we at least make the edge values matches expected limits.
-            FLOATTYPE v_new_off_f = (SIGNEDTYPE)(v_max - v_min) * t;
+            FLOATTYPE v_new_off_f = (FLOATTYPE)(SIGNEDTYPE)(v_max - v_min) * (FLOATTYPE)t;
             result = (TYPE)((SIGNEDTYPE)v_min + (SIGNEDTYPE)(v_new_off_f + (FLOATTYPE)(v_min > v_max ? -0.5 : 0.5)));
         }
     }


### PR DESCRIPTION
Fix for an issue identified by automated code scanning by CodeQL:

<img width="872" height="715" alt="image" src="https://github.com/user-attachments/assets/bc1f5ed6-a5e5-4032-8d28-cc8a587f907c" />

<img width="879" height="319" alt="image" src="https://github.com/user-attachments/assets/647e58ee-d41c-4448-b670-79c468843800" />

Original alert on one of my projects that highlighted this: https://github.com/Armchair-Software/webgpu-demo2/security/code-scanning/3